### PR TITLE
Fix 'task-mark-analysing' property updates

### DIFF
--- a/profiles/default/systems/mcp/tools/task-mark-analysing/script.ps1
+++ b/profiles/default/systems/mcp/tools/task-mark-analysing/script.ps1
@@ -87,7 +87,7 @@ function Invoke-TaskMarkAnalysing {
     # Read task content
     $taskContent = Get-Content -Path $taskFile.FullName -Raw | ConvertFrom-Json
 
-    # Update task properties (older task files may not have all fields yet)
+    # Update task properties
     Set-OrAddProperty -Object $taskContent -Name 'status' -Value 'analysing'
     Set-OrAddProperty -Object $taskContent -Name 'updated_at' -Value ((Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'"))
 


### PR DESCRIPTION
After defining the tasks, dotbot got stuck and I could not proceed:
<img width="4676" height="2338" alt="CleanShot 2026-02-24 at 11 09 47@2x" src="https://github.com/user-attachments/assets/d92c9e5e-189f-4e96-8cbc-3455e9b450a3" />

On the command line it showed:
```bash
╭─ PROCESS: WORKFLOW ────────────────────────────╮
│ ID:    proc-f128fa                             │
│ Model: Opus                                    │
│ Type:  workflow                                │
╰────────────────────────────────────────────────╯
◆ Fetching next task...
✓ Task: Implement SyncMode and related enums for ETL configuration
[task-mark-analysing] tasksBaseDir=C:\Users\Carlos.Pedreira\Code\Bedrock\.bot\workspace\tasks exists=True
SetValueInvocationException: C:\Users\Carlos.Pedreira\Code\Bedrock\.bot\systems\mcp\tools\task-mark-analysing\script.ps1:78
Line |
  78 |      $taskContent.updated_at = (Get-Date).ToUniversalTime().ToString(" …
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exception setting "updated_at": "The property 'updated_at' cannot be found on this object. Verify that the
     | property exists and can be set."

› Process proc-f128fa finished with status: completed
```

This fix addresses this issue by ensuring the property exists before doing the assignment in the Powershell script.

_Note: I noticed this pattern in other files, but kept this PR simple to make review easier. I can submit a follow-up PR to update the other scripts._