### PR TITLE
Update analyse-task tech stack example to .NET 10

### DIFF
--- a/profiles/default/prompts/workflows/98-analyse-task.md
+++ b/profiles/default/prompts/workflows/98-analyse-task.md
@@ -229,7 +229,7 @@ Extract ONLY the product context needed for this task.
   "product_context": {
     "mission_summary": "Personal productivity app for managing time and tasks",
     "entity_definitions": "CalendarEvent: Represents a scheduled event with start/end time, title, and optional recurrence",
-    "tech_stack_relevant": ".NET 8, EF Core 8, SQLite"
+    "tech_stack_relevant": ".NET 10, EF Core 10, SQLite"
   }
 }
 ```


### PR DESCRIPTION
When creating a backend with dotbot, it only suggested .net 8:
<img width="1050" height="534" alt="CleanShot 2026-02-24 at 17 21 11@2x" src="https://github.com/user-attachments/assets/273fee01-b8fe-4c28-bc6d-d31796a26f21" />

I don’t believe this will fix the issue, as it appears to be related to the model’s intrinsic knowledge (Opus). However, it’s still better to use the latest LTS version.