### PR TITLE
Update model resolution logic to use `Resolve-ProviderModelId`

### DIFF
--- a/profiles/default/systems/runtime/launch-process.ps1
+++ b/profiles/default/systems/runtime/launch-process.ps1
@@ -1142,7 +1142,12 @@ elseif ($Type -eq 'workflow') {
 
             # Use analysis model from settings
             $analysisModel = if ($settings.analysis?.model) { $settings.analysis.model }  else { $providerConfig.default_model }
-            $analysisModelName = Resolve-ProviderModelId -ModelAlias $analysisModel
+            try {
+                $analysisModelName = Resolve-ProviderModelId -ModelAlias $analysisModel
+            } catch {
+                Write-Warning "Model '$analysisModel' not valid for active provider. Falling back to '$($providerConfig.default_model)'."
+                $analysisModelName = Resolve-ProviderModelId -ModelAlias $providerConfig.default_model
+            }
 
             $fullAnalysisPrompt = @"
 $analysisPrompt
@@ -1322,7 +1327,12 @@ Do NOT implement the task. Your job is research and preparation only.
 
             # Use execution model from settings
             $executionModel = if ($settings.execution?.model) { $settings.execution.model } else { $providerConfig.default_model }
-            $executionModelName = Resolve-ProviderModelId -ModelAlias $executionModel
+            try {
+                $executionModelName = Resolve-ProviderModelId -ModelAlias $executionModel
+            } catch {
+                Write-Warning "Model '$executionModel' not valid for active provider. Falling back to '$($providerConfig.default_model)'."
+                $executionModelName = Resolve-ProviderModelId -ModelAlias $providerConfig.default_model
+            }
 
             # Build execution prompt
             $executionPrompt = Build-TaskPrompt `
@@ -1635,8 +1645,13 @@ elseif ($Type -eq 'kickstart') {
             $questionsPath = Join-Path $productDir "clarification-questions.json"
             $summaryPath = Join-Path $productDir "interview-summary.md"
 
-            # Use Opus for interview quality
-            $interviewModel = Resolve-ProviderModelId -ModelAlias 'Opus'
+            # Use best-quality model for interview
+            try {
+                $interviewModel = Resolve-ProviderModelId -ModelAlias 'Opus'
+            } catch {
+                Write-Warning "Model 'Opus' not valid for active provider. Falling back to '$($providerConfig.default_model)'."
+                $interviewModel = Resolve-ProviderModelId -ModelAlias $providerConfig.default_model
+            }
 
             do {
                 $interviewRound++


### PR DESCRIPTION
This pull request refactors how model selection is handled in the `profiles/default/systems/runtime/launch-process.ps1` script. The main improvement is to use a provider-based model resolution function (`Resolve-ProviderModelId`) rather than relying on a static mapping, making model selection more flexible and consistent across different workflow types.

**Model selection improvements:**

* Updated analysis and execution model selection to use `$providerConfig.default_model` as the fallback instead of hardcoding `'Opus'`, and replaced static mapping (`$modelMap`) with dynamic resolution via `Resolve-ProviderModelId`. [[1]](diffhunk://#diff-b9b336c79649be23adc37cf047f86c9e50e837ed44413d4d301f857a47c88ec0L1144-R1145) [[2]](diffhunk://#diff-b9b336c79649be23adc37cf047f86c9e50e837ed44413d4d301f857a47c88ec0L1324-R1325)

* Changed interview model selection to use `Resolve-ProviderModelId` for the `'Opus'` alias, ensuring consistent model resolution for interview quality.
* Fixes below issue
<img width="1611" height="572" alt="image" src="https://github.com/user-attachments/assets/b4050a63-0d1a-4c29-b67d-d95360725395" />
