### PR TITLE
fix: remove unnecessary async from synchronous callback in TeamsDeliv…

### DIFF
--- a/server/src/Dotbot.Server/Services/Delivery/TeamsDeliveryProvider.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/TeamsDeliveryProvider.cs
@@ -208,12 +208,13 @@ public class TeamsDeliveryProvider : IQuestionDeliveryProvider
                 serviceUrl,
                 "https://api.botframework.com",
                 parameters,
-                async (turnContext, innerCt) =>
+                (turnContext, innerCt) =>
                 {
                     var convoRef = turnContext.Activity.GetConversationReference();
                     _convoStore.AddOrUpdate(userId, convoRef);
                     _logger.LogInformation(
                         "Created and stored conversation reference for user {UserId}", userId);
+                    return Task.CompletedTask;
                 },
                 ct);
         }


### PR DESCRIPTION
This pull request makes a minor update to the conversation creation logic in `TeamsDeliveryProvider`. The change simplifies the callback used when creating a conversation by removing the unnecessary use of an async lambda.

- Refactored the callback in `await channelAdapter.CreateConversationAsync` to use a synchronous lambda and return `Task.CompletedTask` instead of being marked as `async` with an implicit `Task` return. This makes the code simpler and avoids unnecessary state machine generation.…eryProvider

The CreateConversationAsync callback was marked async but contained no await calls. Replaced with synchronous lambda returning Task.CompletedTask.


Exception information:

```
PS C:\Code\dotbot-v3\server> .\scripts\Deploy.ps1
Building Dotbot.Server...
Restore complete (0.9s)
  Dotbot.Server failed with 1 error(s) (16.0s)
    C:\Code\dotbot-v3\server\src\Dotbot.Server\Services\Delivery\TeamsDeliveryProvider.cs(211,46): error CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.

Build failed with 1 error(s) in 18.5s
Build failed!

```