### PR TITLE
fix: align deep dive output path with downstream consumers

### DIFF
--- a/profiles/multi-repo/prompts/research/repo-deep-dive.md
+++ b/profiles/multi-repo/prompts/research/repo-deep-dive.md
@@ -1,6 +1,6 @@
 # Research Methodology: Repository Deep Dive
 
-## Objective: Generate `research-repo-{RepoName}-summary.md`
+## Objective: Generate `briefing/repos/{RepoName}.md`
 
 You are a Research AI Agent with access to a locally cloned repository and the tools necessary to explore its full source tree (file listing, pattern search, symbol navigation, file reading).
 
@@ -16,7 +16,7 @@ Dotbot task management tools were also loaded in Phase 0. Do not call ToolSearch
 
 Your task is to conduct a thorough code-level analysis of a single repository and produce a structured deep-dive report saved as:
 
-`.bot/workspace/product/research-repo-{RepoName}-summary.md`
+`.bot/workspace/product/briefing/repos/{RepoName}.md`
 
 where `{RepoName}` matches the repository name exactly as it appears in Azure DevOps.
 
@@ -413,7 +413,7 @@ Prefer symbol navigation over reading entire files — get method signatures and
 
 Output must be a single Markdown file per repository:
 
-`.bot/workspace/product/research-repo-{RepoName}-summary.md`
+`.bot/workspace/product/briefing/repos/{RepoName}.md`
 
 Well-structured, evidence-based, and suitable for an implementation engineer to use as a detailed work breakdown reference.
 

--- a/profiles/multi-repo/prompts/workflows/04-create-deep-dive-tasks.md
+++ b/profiles/multi-repo/prompts/workflows/04-create-deep-dive-tasks.md
@@ -57,7 +57,7 @@ mcp__dotbot__task_create_bulk({
     // For each MEDIUM+ repo:
     {
       "name": "Deep dive: {RepoName}",
-      "description": "Conduct a thorough code-level analysis of the {RepoName} repository. Clone the repo, analyse source code, database scripts, configuration, and tests. Produce a structured deep-dive report.\n\nTier: {TIER}\nImpact: {IMPACT}\nProject: {PROJECT}\nPurpose: {PURPOSE}\n\nOutput: .bot/workspace/product/research-repo-{RepoName}-summary.md",
+      "description": "Conduct a thorough code-level analysis of the {RepoName} repository. Clone the repo, analyse source code, database scripts, configuration, and tests. Produce a structured deep-dive report.\n\nTier: {TIER}\nImpact: {IMPACT}\nProject: {PROJECT}\nPurpose: {PURPOSE}\n\nOutput: .bot/workspace/product/briefing/repos/{RepoName}.md",
       "category": "research",
       "effort": "{EFFORT_BASED_ON_IMPACT}",
       "priority": "{PRIORITY_BASED_ON_ORDER}",
@@ -72,7 +72,7 @@ mcp__dotbot__task_create_bulk({
       "working_dir": "repos/{RepoName}",
       "acceptance_criteria": [
         "Repo cloned to repos/{RepoName}/ on initiative branch",
-        "Deep dive report written to .bot/workspace/product/research-repo-{RepoName}-summary.md",
+        "Deep dive report written to .bot/workspace/product/briefing/repos/{RepoName}.md",
         "Reference implementation file inventory complete",
         "Files requiring changes identified with change types",
         "New files needed listed with proposed paths",
@@ -91,7 +91,7 @@ mcp__dotbot__task_create_bulk({
         "Analyse database impact",
         "Review API contracts and test coverage",
         "Identify dependencies on other repos",
-        "Write structured deep-dive report to .bot/workspace/product/research-repo-{RepoName}-summary.md",
+        "Write structured deep-dive report to .bot/workspace/product/briefing/repos/{RepoName}.md",
         "Create per-repo workspace: repos/{RepoName}/.bot/workspace/{product,tasks}/"
       ],
       "applicable_standards": [".bot/prompts/standards/global/research-output.md"],


### PR DESCRIPTION
The research methodology and task creation wrote to research-repo-{RepoName}-summary.md but all downstream workflows (05, 06, 07, 11) and the verification hook read from briefing/repos/{RepoName}.md — causing silent pipeline failures.