### PR TITLE
Bug/UI settings not loaded

### DIFF
--- a/profiles/default/systems/runtime/launch-process.ps1
+++ b/profiles/default/systems/runtime/launch-process.ps1
@@ -131,6 +131,16 @@ if (Test-Path $settingsPath) {
     try { $settings = Get-Content $settingsPath -Raw | ConvertFrom-Json } catch {}
 }
 
+# Override model selections from UI settings (ui-settings.json)
+$uiSettingsPath = Join-Path $botRoot ".control\ui-settings.json"
+if (Test-Path $uiSettingsPath) {
+    try {
+        $uiSettings = Get-Content $uiSettingsPath -Raw | ConvertFrom-Json
+        if ($uiSettings.analysisModel) { $settings.analysis.model = $uiSettings.analysisModel }
+        if ($uiSettings.executionModel) { $settings.execution.model = $uiSettings.executionModel }
+    } catch {}
+}
+
 # Load provider config
 $providerConfig = Get-ProviderConfig
 


### PR DESCRIPTION
**Issue: Even I set sonnet in UI, it was using Opus 4.6 every time**

This pull request introduces a mechanism to allow model selections set in the UI to override those specified in default settings. Specifically, it checks for a `.control/ui-settings.json` file and, if present, updates the analysis and execution model settings accordingly before loading provider configuration.

Enhancements to settings override logic:

* Added logic to read `.control/ui-settings.json` and override `analysis.model` and `execution.model` in `$settings` if corresponding values are set in the UI settings.
