### PR TITLE
Added new skill for writing Test Plan for QA/ UAT Teams.

### DIFF
--- a/profiles/default/prompts/skills/write-test-plan/SKILL.md
+++ b/profiles/default/prompts/skills/write-test-plan/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: write-test-plan
+description: Generate a QA/UAT test plan from product specifications and task definitions, covering acceptance testing, integration flows, and exploratory testing. Unit tests are out of scope (handled by write-unit-tests skill).
+auto_invoke: false
+---
+
+# Write Test Plan
+
+Guide for producing a QA/UAT test plan that maps every acceptance criterion and feature scope item to verifiable test scenarios at the integration, acceptance, and exploratory levels.
+
+## Prerequisites
+
+Both of these must exist before writing a test plan:
+
+1. **Product specifications** — at least one of: `mission.md`, `entity-model.md`, PRD, change request, or interview summary
+2. **Task definitions** — task list with acceptance criteria (via `task_list` + `task_get` MCP calls, or `task-groups.json`)
+
+If either is missing, stop and surface the gap to the operator. A test plan written without full scope is incomplete by definition.
+
+## Inputs to Collect
+
+```
+.bot/workspace/product/mission.md              # core goals and principles
+.bot/workspace/product/entity-model.md         # data model and relationships
+.bot/workspace/product/tech-stack.md           # runtime, frameworks, E2E tooling
+.bot/workspace/product/task-groups.json        # group-level scope and acceptance criteria
+.bot/workspace/product/prd.md                  # if present
+.bot/workspace/product/change-request-*.md     # if present (for change-scoped plans)
+task_list (MCP)                                # all tasks with names, categories, criteria
+```
+
+Read every relevant file first, then call `task_list` to pull the live task queue. Do not write the plan until all inputs are loaded.
+
+## Test Plan Structure
+
+Output file: `.bot/workspace/product/test-plan.md`
+
+### Required Sections
+
+#### 1. Overview
+- What this plan covers (product / feature / change request)
+- Date and version
+- Target audience: QA engineers, product owners, UAT participants
+- Test approach summary
+
+#### 2. Scope
+- **In scope**: features, workflows, integrations, and user-facing behaviours covered
+- **Out of scope**: unit/component-level testing (covered by write-unit-tests), explicitly excluded areas
+- Derive both lists directly from `mission.md` and task group scopes — nothing implied
+
+#### 3. Test Strategy
+
+| Level | What is tested | Tooling | Who |
+|-------|---------------|---------|-----|
+| Integration | Multi-component flows, API contracts, DB state | (from tech-stack.md) | QA |
+| E2E / Acceptance | Full user journeys from UI to persistence | (from tech-stack.md) | QA |
+| UAT | Business scenarios validated against real requirements | Manual | Product owner / stakeholders |
+| Exploratory | Edge cases, UX, error recovery, accessibility | Manual | QA |
+
+Fill the tooling column from `tech-stack.md`. If no E2E tool is listed, mark that row as `Manual`.
+
+#### 4. Test Scenarios
+
+For each **task group** (and for significant individual tasks), produce a scenario block:
+
+```
+### [Group Name] — [group id]
+
+**Acceptance criteria covered:**
+- [ ] <criterion from task or group>
+
+**Integration scenarios:**
+| ID | Scenario | Setup | Expected outcome |
+|----|----------|-------|-----------------|
+| I-01 | ... | ... | ... |
+
+**E2E / Acceptance scenarios:**
+| ID | Scenario | Steps | Pass condition |
+|----|----------|-------|---------------|
+| E-01 | ... | ... | ... |
+
+**UAT scenarios:**
+| ID | Business scenario | Actor | Pass condition |
+|----|------------------|-------|---------------|
+| UAT-01 | ... | ... | ... |
+
+**Exploratory notes:**
+- Areas to probe manually: <list edge cases, error paths, UX concerns>
+```
+
+Rules:
+- Every acceptance criterion from every task must map to at least one scenario ID
+- Scenario IDs are globally unique (I-01…I-nn, E-01…E-nn, UAT-01…UAT-nn)
+- Integration scenarios: specify what's real vs. stubbed (e.g., "real DB, stubbed email service")
+- E2E scenarios: written as observable user steps with a clear pass/fail condition
+- UAT scenarios: written in business language, not technical terms — stakeholders must be able to run them without developer help
+- Exploratory notes: list areas QA should probe freely, not scripted steps
+
+#### 5. Risk Areas
+
+List areas where coverage is hardest or most critical:
+- Complex business rules with many conditional paths
+- External integrations and third-party APIs
+- Async / background processes (jobs, notifications, webhooks)
+- Security-sensitive paths (auth, authorisation, data visibility)
+- Data migrations or schema changes visible to users
+
+For each risk, note the mitigation (extra E2E coverage, manual regression gate, contract tests, etc.).
+
+#### 6. Test Data Requirements
+
+- User accounts and roles needed for UAT
+- Seed data for integration and E2E scenarios
+- External service stubs, recordings, or sandbox credentials
+- Environment variables or feature flags required for test runs
+- Any data privacy constraints (no real PII in test environments)
+
+#### 7. Entry and Exit Criteria
+
+**Entry** (test execution can begin when):
+- [ ] All tasks in the group are marked `done`
+- [ ] Deployment to test environment is complete
+- [ ] Test data is seeded
+- [ ] Unit tests pass (prerequisite, not this plan's responsibility)
+
+**Exit** (group is considered QA-complete when):
+- [ ] All integration scenarios pass
+- [ ] All E2E / acceptance scenarios pass
+- [ ] All UAT scenarios signed off by product owner
+- [ ] No open critical or high-severity defects
+- [ ] No acceptance criterion is unmapped
+
+## Derivation Rules
+
+### From acceptance criteria → test scenarios
+Each criterion becomes ≥1 integration or E2E scenario. Criteria describing user-visible behaviour also need a UAT scenario written in plain business language.
+
+### From entity model → integration scenarios
+Every entity relationship with a constraint (FK, unique, cascade delete) needs at least one integration scenario that validates the constraint is enforced end-to-end, not just at the unit level.
+
+### From tech stack → tooling column
+Read the testing section of `tech-stack.md`. If it lists an E2E framework (e.g., Playwright, Cypress, Selenium), use it in the strategy table. If none is listed, write `Manual`.
+
+### From risk areas → coverage weighting
+High-risk areas get additional exploratory notes and explicit regression scenarios. Call this out in the Risk Areas section.
+
+## Output Checklist
+
+- [ ] All task acceptance criteria are mapped to at least one scenario ID
+- [ ] All task groups have a scenario block
+- [ ] Scope section lists both in-scope and out-of-scope items
+- [ ] Strategy table has tooling filled from tech-stack
+- [ ] UAT scenarios are written in plain business language (no code references)
+- [ ] Risk areas section is populated
+- [ ] Test data requirements are listed
+- [ ] Entry and exit criteria are defined
+- [ ] Scenario IDs are globally unique and sequential
+- [ ] No absolute local paths in the document
+- [ ] No secrets, tokens, or real PII in test data examples

--- a/profiles/default/prompts/workflows/04-plan-test-plan.md
+++ b/profiles/default/prompts/workflows/04-plan-test-plan.md
@@ -1,0 +1,128 @@
+# Workflow: Plan Test Plan
+
+Generate a project-level QA/UAT test plan from product specifications and the defined task list.
+
+## When to Invoke
+
+Run this workflow **after**:
+- `03b-expand-task-group.md` has been executed for all task groups (tasks fully defined), OR
+- A change request has been processed via `91-new-tasks.md` and tasks are created
+
+Run this workflow **before** implementation begins. A test plan created mid-sprint is reactive; created up front it shapes what tasks need to deliver.
+
+## Prerequisites Check
+
+Before generating the plan, verify both pillars are in place:
+
+1. **Specifications exist** — confirm at least one of:
+   - `.bot/workspace/product/mission.md`
+   - `.bot/workspace/product/prd.md`
+   - `.bot/workspace/product/change-request-*.md`
+
+2. **Tasks are defined** — call `task_list` and confirm tasks exist with acceptance criteria
+
+If either pillar is missing, stop. Output a gap report:
+```
+## Prerequisites not met
+
+- [ ] Product specifications: <found / NOT FOUND>
+- [ ] Tasks with acceptance criteria: <N tasks found / NOT FOUND>
+
+Action required: complete planning phases 00–03b before generating a test plan.
+```
+
+## Execution Steps
+
+### Step 1 — Load product context
+
+Read all available specification files:
+```
+.bot/workspace/product/mission.md
+.bot/workspace/product/tech-stack.md
+.bot/workspace/product/entity-model.md
+.bot/workspace/product/task-groups.json
+.bot/workspace/product/prd.md                  (if present)
+.bot/workspace/product/interview-summary.md    (if present)
+.bot/workspace/product/change-request-*.md     (all, if present)
+```
+
+### Step 2 — Load task context
+
+Call MCP tools to pull the live task queue:
+```
+task_list           → all tasks, grouped by status
+task_get_stats      → counts by category and status
+```
+
+For each task group in `task-groups.json`, call `task_list` filtered to that group and collect:
+- Task names
+- Acceptance criteria
+- Categories
+- Dependencies
+
+### Step 3 — Invoke write-test-plan skill
+
+Apply the `write-test-plan` skill using all loaded context.
+
+The skill will:
+- Map every acceptance criterion to a scenario
+- Produce integration / E2E scenario tables per group
+- Identify risk areas
+- Define test data requirements
+- Emit a Definition of Done checklist
+
+### Step 4 — Write output
+
+Write the generated test plan to:
+```
+.bot/workspace/product/test-plan.md
+```
+
+### Step 5 — Validate coverage
+
+After writing, perform a coverage cross-check:
+
+1. List all acceptance criteria across all tasks
+2. Verify each one appears in at least one scenario row in the plan
+3. If any criterion is unmapped, add the missing scenario and note it was added during validation
+
+Report the coverage summary:
+```
+Test plan written: .bot/workspace/product/test-plan.md
+
+Coverage summary:
+- Task groups covered: N
+- Total acceptance criteria: N
+- Mapped to scenarios: N  ← must equal total
+- Integration scenarios: N
+- E2E / acceptance scenarios: N
+- UAT scenarios: N
+- Unmapped criteria fixed during validation: N
+```
+
+### Step 6 — Commit (if in autonomous mode)
+
+If running inside an autonomous execution session, commit the test plan file:
+```
+docs: add project test plan
+
+[task:XXXXXXXX]
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+If running interactively, present the summary and let the operator decide whether to commit.
+
+## Integration Points
+
+| When | How |
+|------|-----|
+| After full roadmap generation (03b) | Run this workflow before any task moves to `analysing` |
+| After a change request (91-new-tasks) | Re-run this workflow to extend the existing plan with new scenarios |
+| During task analysis (98-analyse-task) | Reference `.bot/workspace/product/test-plan.md` to extract relevant scenario IDs for the task being analysed — do not regenerate the whole plan |
+
+## Anti-Patterns
+
+- **Do not generate the plan from tasks alone** — missing product context means missing scope items
+- **Do not regenerate the plan per task** — one plan covers the project; per-task analysis reads from it
+- **Do not skip the prerequisites check** — a plan built on incomplete task definitions will have coverage gaps
+- **Do not leave acceptance criteria unmapped** — every criterion must trace to a scenario ID


### PR DESCRIPTION
Add test plan workflow and write-test-plan skill                                                                                                                                                                      
Introduces a structured QA/UAT test planning capability to the pre-implementation workflow:               
  - 04-plan-test-plan.md — New workflow that generates a project-level test plan from product specs and task
   definitions. Runs after task groups are fully expanded (post-03b) and before implementation begins.      
  Validates prerequisites, invokes the write-test-plan skill, performs coverage cross-check, and writes     
  output to .bot/workspace/product/test-plan.md.
  - write-test-plan/SKILL.md — New reusable skill that maps every acceptance criterion to verifiable        
  scenarios across integration, E2E/acceptance, UAT, and exploratory testing levels. Produces a structured  
  plan with risk areas, test data requirements, and entry/exit criteria.