### PR TITLE
fix: resolve Task.Run ambiguous overload on macOS PowerShell

### DIFF
--- a/profiles/default/systems/runtime/ClaudeCLI/ClaudeCLI.psm1
+++ b/profiles/default/systems/runtime/ClaudeCLI/ClaudeCLI.psm1
@@ -581,7 +581,7 @@ function Invoke-ClaudeStream {
     # Drain stderr line-by-line in a background task to prevent buffer deadlock.
     # Unlike ReadToEndAsync(), this avoids accumulating the full stderr in memory
     # and surfaces diagnostics when -ShowDebugJson is enabled.
-    $stderrDrain = [System.Threading.Tasks.Task]::Run({
+    $stderrDrain = [System.Threading.Tasks.Task]::Run([Action]{
         try {
             while (-not $claudeProc.HasExited) {
                 $line = $claudeProc.StandardError.ReadLine()


### PR DESCRIPTION
Cast scriptblock to [Action] to disambiguate [System.Threading.Tasks.Task]::Run() overload resolution, which fails on macOS PowerShell 7.4 but not Windows.