### PR TITLE
fix: detect dependency deadlock from skipped task dependencies

### DIFF
--- a/profiles/default/systems/mcp/modules/TaskIndexCache.psm1
+++ b/profiles/default/systems/mcp/modules/TaskIndexCache.psm1
@@ -754,6 +754,68 @@ function Get-NextAnalysedTask {
     }
 }
 
+function Get-DeadlockedTasks {
+    <#
+    .SYNOPSIS
+    Returns info about todo tasks that are blocked by at least one skipped dependency.
+
+    .DESCRIPTION
+    Called when Get-NextTask returns null to distinguish a dependency deadlock from a
+    genuine wait (e.g. analysis still running). Returns a PSCustomObject with BlockedCount
+    (number of blocked todo tasks) and BlockerNames (skipped task names causing the block).
+    #>
+
+    $index = Get-TaskIndex
+    if ($index.Todo.Count   -eq 0) { return [PSCustomObject]@{ BlockedCount = 0; BlockerNames = @() } }
+    if ($index.Skipped.Count -eq 0) { return [PSCustomObject]@{ BlockedCount = 0; BlockerNames = @() } }
+
+    # Build a case-insensitive lookup set covering id, name, and slug of every
+    # skipped task so dependency strings can be matched in one Contains() call.
+    $skippedLookup = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase
+    )
+    # Map from any form (id/name/slug) back to the task name for reporting.
+    $skippedNameMap = @{}
+    foreach ($t in $index.Skipped.Values) {
+        $skippedLookup.Add($t.id)   | Out-Null
+        $skippedLookup.Add($t.name) | Out-Null
+        $slug = ($t.name -replace '[^a-zA-Z0-9\s-]', '' -replace '\s+', '-').ToLower()
+        $skippedLookup.Add($slug)   | Out-Null
+        $skippedNameMap[$t.id]   = $t.name
+        $skippedNameMap[$t.name] = $t.name
+        $skippedNameMap[$slug]   = $t.name
+    }
+
+    $count = 0
+    $blockerNames = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase
+    )
+    foreach ($task in $index.Todo.Values) {
+        $deps = if     ($task.dependencies -is [array]) { @($task.dependencies) }
+                elseif ($task.dependencies)              { @($task.dependencies) }
+                else                                     { @() }
+
+        foreach ($dep in $deps) {
+            if (-not $dep) { continue }
+
+            # If the dependency is already satisfied by a done/split task, skip it.
+            if (Test-DependencyMet -Dependency $dep `
+                    -DoneNames $index.DoneNames `
+                    -DoneSlugs $index.DoneSlugs `
+                    -DoneIds   $index.DoneIds) { continue }
+
+            # The dependency is unmet — is the blocker a skipped task?
+            if ($skippedLookup.Contains($dep)) {
+                $count++
+                $blockerNames.Add($skippedNameMap[$dep]) | Out-Null
+                break  # count each blocked task only once
+            }
+        }
+    }
+
+    return [PSCustomObject]@{ BlockedCount = $count; BlockerNames = @($blockerNames | Sort-Object) }
+}
+
 function Test-TaskDone {
     param(
         [Parameter(Mandatory = $true)]
@@ -913,6 +975,7 @@ Export-ModuleMember -Function @(
     'Get-AllTasks',
     'Get-NextTask',
     'Get-NextAnalysedTask',
+    'Get-DeadlockedTasks',
     'Test-TaskDone',
     'Test-DependencyMet',
     'Test-AllDependenciesMet',

--- a/profiles/default/systems/runtime/launch-process.ps1
+++ b/profiles/default/systems/runtime/launch-process.ps1
@@ -527,6 +527,22 @@ Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Process $procId
 Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Preflight OK: $($preflight.checks -join '; ')"
 
 
+# --- Helper: Detect dependency deadlock from skipped tasks blocking the todo queue ---
+function Test-DependencyDeadlock {
+    param(
+        [string]$ProcessId
+    )
+    $deadlock = Get-DeadlockedTasks
+    if ($deadlock.BlockedCount -gt 0) {
+        $blockers    = $deadlock.BlockerNames -join ', '
+        $deadlockMsg = "Dependency deadlock: $($deadlock.BlockedCount) todo task(s) are blocked by skipped prerequisite(s) [$blockers]. Workflow cannot continue automatically — reset or re-implement the skipped tasks to unblock the queue."
+        Write-Status $deadlockMsg -Type Error
+        Write-ProcessActivity -Id $ProcessId -ActivityType "text" -Message $deadlockMsg
+        return $true
+    }
+    return $false
+}
+
 # --- Helper: Interview loop (reusable for Phase 0 and interview-type phases) ---
 function Invoke-InterviewLoop {
     param(
@@ -892,6 +908,8 @@ if ($Type -in @('analysis', 'execution')) {
                             $taskResult = Invoke-TaskGetNext -Arguments @{ verbose = $true }
                         }
                         if ($taskResult.task) { $foundTask = $true; break }
+
+                        if (Test-DependencyDeadlock -ProcessId $procId) { break }
                     }
                     if (-not $foundTask) { break }
                 } else {
@@ -1440,6 +1458,8 @@ elseif ($Type -eq 'workflow') {
                         Reset-TaskIndex
                         $taskResult = Get-NextWorkflowTask -Verbose
                         if ($taskResult.task) { $foundTask = $true; break }
+
+                        if (Test-DependencyDeadlock -ProcessId $procId) { break }
                     }
                     if (-not $foundTask) {
                         Write-Diag "EXIT: No task found after wait loop (foundTask=$foundTask)"

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -501,6 +501,108 @@ finally {
     }
 }
 
+# ─── Get-DeadlockedTasks tests ───────────────────────────────────────────────
+
+$testProject = $null
+try {
+    $testProject = New-SourceBackedTestProject -RepoRoot $repoRoot
+    $botDir       = Join-Path $testProject ".bot"
+    $tasksBaseDir = Join-Path $botDir "workspace\tasks"
+    $todoDir      = Join-Path $tasksBaseDir "todo"
+    $skippedDir   = Join-Path $tasksBaseDir "skipped"
+
+    $taskIndexModule = Join-Path $botDir "systems\mcp\modules\TaskIndexCache.psm1"
+    Import-Module $taskIndexModule -Force
+
+    # Verify export
+    Assert-True -Name "TaskIndexCache exports Get-DeadlockedTasks" `
+        -Condition ((Get-Command -Module TaskIndexCache).Name -contains 'Get-DeadlockedTasks') `
+        -Message "Expected Get-DeadlockedTasks to be an exported function"
+
+    # ── Scenario 1: No deadlock — no skipped tasks at all ──
+    New-TestTaskFile -TasksTodoDir $todoDir `
+        -TaskId "dl-free-1" -Name "Free task" `
+        -Description "No dependencies" -Priority 10 | Out-Null
+
+    Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
+    $result1 = Get-DeadlockedTasks
+    Assert-Equal -Name "No deadlock when no skipped tasks exist" `
+        -Expected 0 -Actual $result1.BlockedCount
+
+    # ── Scenario 2: Deadlock — todo task depends on a skipped task ──
+    $skippedTask = [ordered]@{
+        id = "dl-skipped-prereq"
+        name = "Skipped prerequisite"
+        description = "Was skipped"
+        category = "feature"
+        priority = 5
+        effort = "S"
+        status = "skipped"
+        dependencies = @()
+        acceptance_criteria = @()
+        steps = @()
+        applicable_standards = @()
+        applicable_agents = @()
+        created_at = "2026-03-06T12:00:00Z"
+        updated_at = "2026-03-06T12:00:00Z"
+        completed_at = $null
+    }
+    $skippedTask | ConvertTo-Json -Depth 10 | Set-Content `
+        -Path (Join-Path $skippedDir "dl-skipped-prereq.json") -Encoding UTF8
+
+    # Add a todo task that depends on the skipped task
+    New-TestTaskFile -TasksTodoDir $todoDir `
+        -TaskId "dl-blocked-1" -Name "Blocked by skipped" `
+        -Description "Depends on skipped prerequisite" -Priority 20 `
+        -Dependencies @("dl-skipped-prereq") | Out-Null
+
+    Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
+    $result2 = Get-DeadlockedTasks
+    Assert-Equal -Name "Deadlock detected: one todo task blocked by skipped prerequisite" `
+        -Expected 1 -Actual $result2.BlockedCount
+    Assert-True -Name "Deadlock reports correct blocker name" `
+        -Condition ($result2.BlockerNames -contains "Skipped prerequisite") `
+        -Message "Expected blocker name 'Skipped prerequisite', got: $($result2.BlockerNames -join ', ')"
+
+    # ── Scenario 3: No deadlock — todo task has no deps (should not count) ──
+    # dl-free-1 (no deps) is still in todo alongside dl-blocked-1 (blocked).
+    # BlockedCount should still be 1, not 2.
+    Assert-Equal -Name "Unblocked todo tasks are not counted as deadlocked" `
+        -Expected 1 -Actual $result2.BlockedCount
+
+    # ── Scenario 4: Dependency satisfied by done task — not a deadlock ──
+    $doneTask = [ordered]@{
+        id = "dl-skipped-prereq"
+        name = "Skipped prerequisite"
+        description = "Was skipped but then completed"
+        category = "feature"
+        priority = 5
+        effort = "S"
+        status = "done"
+        dependencies = @()
+        acceptance_criteria = @()
+        steps = @()
+        applicable_standards = @()
+        applicable_agents = @()
+        created_at = "2026-03-06T12:00:00Z"
+        updated_at = "2026-03-06T12:00:00Z"
+        completed_at = "2026-03-06T13:00:00Z"
+    }
+    $doneDir = Join-Path $tasksBaseDir "done"
+    $doneTask | ConvertTo-Json -Depth 10 | Set-Content `
+        -Path (Join-Path $doneDir "dl-skipped-prereq.json") -Encoding UTF8
+
+    Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
+    $result4 = Get-DeadlockedTasks
+    Assert-Equal -Name "No deadlock when dependency is satisfied by done task" `
+        -Expected 0 -Actual $result4.BlockedCount
+}
+finally {
+    if ($testProject) {
+        Remove-TestProject -Path $testProject
+    }
+}
+
 $allPassed = Write-TestSummary -LayerName "Task Action Source Tests"
 
 if (-not $allPassed) {


### PR DESCRIPTION
# Improvement: Dependency Deadlock — Skipped Tasks Block Dependent TODO Tasks Forever

## Summary

When a task is **skipped** (for any reason: `max-retries`, `non-recoverable`, or manually), it is **never added to the dependency-satisfied set** (`DoneIds`). Any TODO task whose `dependencies` list references a skipped task will be permanently blocked: `Get-NextTask` will never return it. If all remaining TODO tasks are blocked this way, the `workflow` process's "waiting for tasks" polling loop has **no exit condition** and will spin indefinitely — polling every 5 seconds forever — until a human manually stops the process.
