### PR TITLE
fix: surface task_mark_done failures and improve completion guidance

### DIFF
--- a/profiles/default/prompts/workflows/99-autonomous-task.md
+++ b/profiles/default/prompts/workflows/99-autonomous-task.md
@@ -99,6 +99,18 @@ You are working in a **git worktree** on branch `{{BRANCH_NAME}}`.
    - Use conventional commit messages
    - Include task ID: `[task:XXXXXXXX]` (first 8 chars of {{TASK_ID}})
    - Include workspace tag: `[bot:XXXXXXXX]` (first 8 chars of {{INSTANCE_ID}})
+   - **Commit ALL modified files** — including any files modified as a side-effect of running commands during the task. Package managers, build tools, code generators, and formatters all produce files you must commit. Common examples by ecosystem:
+     - **Node.js / Bun**: `package.json`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb`
+     - **Python**: `Pipfile.lock`, `poetry.lock`, `uv.lock`, `requirements.txt`
+     - **.NET / NuGet**: `*.csproj`, `packages.lock.json`, `NuGet.lock.json`, `global.json`
+     - **Go**: `go.mod`, `go.sum`
+     - **Ruby**: `Gemfile.lock`
+     - **Rust**: `Cargo.lock`
+     - **Java / Kotlin / Scala**: `pom.xml`, `build.gradle`, `gradle.lockfile`, `gradle/wrapper/gradle-wrapper.properties`
+     - **PHP**: `composer.lock`
+     - **Any stack**: generated code, migration files, auto-formatted source files, scaffolded configuration
+
+     The `01-git-clean.ps1` verification will fail if any non-`.bot/` file is left uncommitted when you call `task_mark_done`.
    - Example:
      ```
      Add CalendarEvent entity with EF Core configuration
@@ -118,9 +130,15 @@ You are working in a **git worktree** on branch `{{BRANCH_NAME}}`.
    pwsh -ExecutionPolicy Bypass -File ".bot/hooks/verify/01-git-clean.ps1" 2>&1
    ```
 
+   Before running `01-git-clean.ps1`, confirm your working tree is fully clean:
+   ```bash
+   git status --porcelain
+   ```
+   There must be **zero** uncommitted non-`.bot/` files. If you ran any package manager, build tool, or code generator (`npm install`, `pip install`, `go get`, `dotnet restore`, `bundle install`, `cargo build`, `composer install`, etc.), make sure all resulting manifest and lock file changes are staged and committed before this check.
+
 3. **Handle failures:**
    - Privacy scan: Fix ALL violations (use repo-relative paths, never absolute paths)
-   - Git clean: Fix implementation files, ignore `.bot/workspace/tasks/`
+   - Git clean: Stage and commit ALL modified non-`.bot/` files. Pay particular attention to package manager side-effects: lock files, updated manifests, generated code, and auto-formatted files — these vary by tech stack but `git status --porcelain` will reveal them all.
    - Build/format: Always fix before proceeding
 
 ### Phase 4: Completion

--- a/profiles/default/systems/mcp/tools/task-mark-done/script.ps1
+++ b/profiles/default/systems/mcp/tools/task-mark-done/script.ps1
@@ -4,6 +4,46 @@ Import-Module (Join-Path $global:DotbotProjectRoot ".bot\systems\mcp\modules\Ses
 # Import path sanitizer for stripping absolute paths from activity logs
 Import-Module (Join-Path $global:DotbotProjectRoot ".bot\systems\mcp\modules\PathSanitizer.psm1") -Force
 
+# Helper: append a diagnostic entry to the shared activity log so the operator
+# can see task_mark_done failures in the dashboard activity stream.
+function Write-TaskMarkDoneFailure {
+    param(
+        [string]$TaskId,
+        [string]$Message,
+        [array]$VerificationResults = @()
+    )
+
+    try {
+        $controlDir  = Join-Path $global:DotbotProjectRoot ".bot\.control"
+        $activityFile = Join-Path $controlDir "activity.jsonl"
+        if (-not (Test-Path $controlDir)) { return }
+
+        # Build a human-readable detail string from failed scripts
+        $failedScripts = @($VerificationResults | Where-Object { $_.success -eq $false -and -not $_.skipped })
+        if ($failedScripts.Count -gt 0) {
+            $detail = ($failedScripts | ForEach-Object {
+                $failLines = if ($_.failures) {
+                    ($_.failures | ForEach-Object { $_.issue }) -join '; '
+                } else { $_.message }
+                "$($_.script): $failLines"
+            }) -join ' | '
+            $Message = "$Message — $detail"
+        }
+
+        $entry = [ordered]@{
+            type       = "text"
+            timestamp  = (Get-Date).ToUniversalTime().ToString("o")
+            message    = $Message
+            task_id    = $TaskId
+            phase      = "execution"
+            process_id = $env:DOTBOT_PROCESS_ID
+        }
+        ($entry | ConvertTo-Json -Compress) | Add-Content -Path $activityFile -Encoding UTF8
+    } catch {
+        # Non-fatal — logging failure must never block the MCP tool response
+    }
+}
+
 # Helper function to extract execution-phase activity logs
 function Get-ExecutionActivityLog {
     param(
@@ -209,6 +249,7 @@ function Invoke-TaskMarkDone {
     }
     
     if (-not $taskFile) {
+        Write-TaskMarkDoneFailure -TaskId $taskId -Message "task_mark_done failed: task '$taskId' not found in todo/, in-progress/, or done/"
         throw "Task with ID '$taskId' not found"
     }
     
@@ -229,6 +270,9 @@ function Invoke-TaskMarkDone {
     $verificationResults = Invoke-VerificationScripts -TaskId $taskId -Category $taskContent.category -ProjectRoot $projectRoot
     
     if (-not $verificationResults.AllPassed) {
+        # Log to activity stream so the operator can see the failure in the dashboard
+        Write-TaskMarkDoneFailure -TaskId $taskId -Message "task_mark_done blocked: verification failed for '$($taskContent.name)'" -VerificationResults $verificationResults.Scripts
+
         # Verification failed - return error with details
         return @{
             success = $false

--- a/profiles/default/systems/runtime/launch-process.ps1
+++ b/profiles/default/systems/runtime/launch-process.ps1
@@ -1384,6 +1384,19 @@ elseif ($Type -eq 'workflow') {
     $todoCount = if ($initIndex.Todo) { $initIndex.Todo.Count } else { 0 }
     $analysedCount = if ($initIndex.Analysed) { $initIndex.Analysed.Count } else { 0 }
     Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task index loaded: $todoCount todo, $analysedCount analysed"
+    
+    # Pre-flight: warn if main repo has uncommitted non-.bot/ files.
+    # These don't block execution (verification runs in the worktree) but can
+    # complicate the squash-merge stash/pop if left unresolved.
+    try {
+        $mainDirtyStatus = git -C $projectRoot status --porcelain 2>$null
+        $mainDirtyFiles  = @($mainDirtyStatus | Where-Object { $_ -notmatch '\.bot/' })
+        if ($mainDirtyFiles.Count -gt 0) {
+            $fileList = ($mainDirtyFiles | ForEach-Object { $_.Substring(3).Trim() }) -join ', '
+            Write-Status "Pre-flight: Main repo has $($mainDirtyFiles.Count) uncommitted non-.bot/ file(s). Commit them to avoid squash-merge complications: $fileList" -Type Warn
+            Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Pre-flight warning: Main repo has $($mainDirtyFiles.Count) uncommitted file(s) outside .bot/ ($fileList). Consider committing before workflow."
+        }
+    } catch {}
 
     $tasksProcessed = 0
     $maxRetriesPerTask = 2
@@ -1845,6 +1858,26 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
                     Invoke-SessionIncrementCompleted -Arguments @{} | Out-Null
                     $taskSuccess = $true
                     break
+                }
+
+                # Task not completed - log diagnostic to help distinguish failure modes:
+                # (a) task_mark_done was called but verification blocked it  → task still in in-progress/
+                # (b) task_mark_done was never called (agent forgot)          → task not in any terminal dir
+                $inProgressDir = Join-Path $tasksBaseDir "in-progress"
+                $stillInProgress = $false
+                try {
+                    $stillInProgress = $null -ne (
+                        Get-ChildItem -Path $inProgressDir -Filter "*.json" -File -ErrorAction SilentlyContinue |
+                        Where-Object {
+                            try { (Get-Content $_.FullName -Raw | ConvertFrom-Json).id -eq $task.id } catch { $false }
+                        } | Select-Object -First 1
+                    )
+                } catch {}
+
+                if ($stillInProgress) {
+                    Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Completion check failed (attempt $attemptNumber): '$($task.name)' still in in-progress/. Check activity log: if a 'task_mark_done blocked' entry exists, verification failed; otherwise task_mark_done was likely never called."
+                } else {
+                    Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Completion check failed (attempt $attemptNumber): '$($task.name)' not found in in-progress/ or done/ (unexpected state)."
                 }
 
                 # Task not completed - handle failure


### PR DESCRIPTION
# fix: surface task_mark_done failures and improve completion guidance

## What this fixes

When an autonomous task failed to complete, the runtime had no way to distinguish between two very different failure modes:

- **Verification blocked it** — the agent called `task_mark_done` but `01-git-clean.ps1` (or another hook) rejected the attempt, leaving the task in `in-progress/`
- **Agent never called it** — the agent finished its Claude session without ever invoking `task_mark_done`

Both cases looked identical from the operator's perspective: the task just didn't move to `done/`. The only recourse was to dig through raw log files.

## Changes

### `task-mark-done/script.ps1`
Adds a `Write-TaskMarkDoneFailure` helper that writes a structured entry to `activity.jsonl` whenever `task_mark_done` is blocked. This surfaces the failure — including which verification script failed and why — directly in the dashboard activity stream. Two call sites:
- Task not found in `todo/`, `in-progress/`, or `done/`
- Verification scripts returned a non-passing result

The helper is fully wrapped in `try/catch` so a logging failure can never block the MCP tool response.

### `launch-process.ps1`
Two diagnostic additions:

1. **Pre-flight check** — after loading the task index, warns (without blocking) if the main repo has uncommitted non-`.bot/` files. These don't affect execution (which runs in a worktree) but can complicate the squash-merge stash/pop if left unresolved.

2. **Completion diagnostics** — after each failed completion check, inspects whether the task file is still in `in-progress/` and logs a targeted message: if it is, the operator knows to look for a `task_mark_done blocked` entry in the activity log; if it isn't, the state is flagged as unexpected.

### `99-autonomous-task.md`
Strengthens the agent's pre-completion checklist:
- Explicit reminder to commit **all** modified files — including `package.json`, lock files, and other package-manager output — before calling `task_mark_done`
- Adds a `git status --porcelain` step immediately before running `01-git-clean.ps1` so the agent self-verifies the working tree is clean
- Sharpens the git-clean failure guidance to call out package manager files specifically
