### PR TITLE
Worktree Branch Safety: Prevent wrong-branch merges, silent cleanup failures, and concurrent map corruption

### DIFF
--- a/profiles/default/systems/runtime/launch-process.ps1
+++ b/profiles/default/systems/runtime/launch-process.ps1
@@ -945,6 +945,10 @@ if ($Type -in @('analysis', 'execution')) {
                     $branchName = $wtInfo.branch_name
                     Write-Status "Using worktree: $worktreePath" -Type Info
                 } else {
+                    # Guard: ensure main repo is on base branch before creating a new worktree (Fix: wrong-branch merge)
+                    try { Assert-OnBaseBranch -ProjectRoot $projectRoot | Out-Null } catch {
+                        Write-Status "Branch guard warning: $($_.Exception.Message)" -Type Warn
+                    }
                     $wtResult = New-TaskWorktree -TaskId $task.id -TaskName $task.name `
                         -ProjectRoot $projectRoot -BotRoot $botRoot
                     if ($wtResult.success) {
@@ -1269,13 +1273,21 @@ Do NOT implement the task. Your job is research and preparation only.
                 # Clean up worktree for failed/skipped tasks to unblock analysis
                 if ($Type -eq 'execution' -and $worktreePath) {
                     Write-Status "Cleaning up worktree for failed task..." -Type Info
-                    Remove-Junctions -WorktreePath $worktreePath | Out-Null
-                    git -C $projectRoot worktree remove $worktreePath --force 2>$null
-                    git -C $projectRoot branch -D $branchName 2>$null
-                    Initialize-WorktreeMap -BotRoot $botRoot
-                    $map = Read-WorktreeMap
-                    $map.Remove($task.id)
-                    Write-WorktreeMap -Map $map
+                    try {
+                        Remove-Junctions -WorktreePath $worktreePath -ErrorOnFailure $false | Out-Null
+                        git -C $projectRoot worktree remove $worktreePath --force 2>$null
+                        git -C $projectRoot branch -D $branchName 2>$null
+                    } finally {
+                        # Map removal always runs even if junction/worktree cleanup throws (Fix: inconsistent registry)
+                        Initialize-WorktreeMap -BotRoot $botRoot
+                        Invoke-WorktreeMapLocked -Action {
+                            $cleanupMap = Read-WorktreeMap
+                            $cleanupMap.Remove($task.id)
+                            Write-WorktreeMap -Map $cleanupMap
+                        }
+                        # Re-assert base branch after failed-task cleanup (Fix: wrong-branch merge)
+                        try { Assert-OnBaseBranch -ProjectRoot $projectRoot | Out-Null } catch {}
+                    }
                 }
 
                 # Update session failure counters (execution only)
@@ -1717,6 +1729,10 @@ Do NOT implement the task. Your job is research and preparation only.
                     $branchName = $wtInfo.branch_name
                     Write-Status "Using worktree: $worktreePath" -Type Info
                 } else {
+                    # Guard: ensure main repo is on base branch before creating a new worktree (Fix: wrong-branch merge)
+                    try { Assert-OnBaseBranch -ProjectRoot $projectRoot | Out-Null } catch {
+                        Write-Status "Branch guard warning: $($_.Exception.Message)" -Type Warn
+                    }
                     $wtResult = New-TaskWorktree -TaskId $task.id -TaskName $task.name `
                         -ProjectRoot $projectRoot -BotRoot $botRoot
                     if ($wtResult.success) {
@@ -1978,13 +1994,21 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
                 # Clean up worktree for failed/skipped tasks
                 if ($worktreePath) {
                     Write-Status "Cleaning up worktree for failed task..." -Type Info
-                    Remove-Junctions -WorktreePath $worktreePath | Out-Null
-                    git -C $projectRoot worktree remove $worktreePath --force 2>$null
-                    git -C $projectRoot branch -D $branchName 2>$null
-                    Initialize-WorktreeMap -BotRoot $botRoot
-                    $map = Read-WorktreeMap
-                    $map.Remove($task.id)
-                    Write-WorktreeMap -Map $map
+                    try {
+                        Remove-Junctions -WorktreePath $worktreePath -ErrorOnFailure $false | Out-Null
+                        git -C $projectRoot worktree remove $worktreePath --force 2>$null
+                        git -C $projectRoot branch -D $branchName 2>$null
+                    } finally {
+                        # Map removal always runs even if junction/worktree cleanup throws (Fix: inconsistent registry)
+                        Initialize-WorktreeMap -BotRoot $botRoot
+                        Invoke-WorktreeMapLocked -Action {
+                            $cleanupMap = Read-WorktreeMap
+                            $cleanupMap.Remove($task.id)
+                            Write-WorktreeMap -Map $cleanupMap
+                        }
+                        # Re-assert base branch after failed-task cleanup (Fix: wrong-branch merge)
+                        try { Assert-OnBaseBranch -ProjectRoot $projectRoot | Out-Null } catch {}
+                    }
                 }
 
                 # Update session failure counters

--- a/profiles/default/systems/runtime/modules/WorktreeManager.psm1
+++ b/profiles/default/systems/runtime/modules/WorktreeManager.psm1
@@ -100,6 +100,94 @@ function Write-WorktreeMap {
     }
 }
 
+function Resolve-MainBranch {
+    <#
+    .SYNOPSIS
+    Find the canonical integration branch (main or master) by explicit name lookup.
+    Never reads symbolic HEAD — safe to call when the main repo may be on a task branch.
+    #>
+    param([string]$ProjectRoot)
+    foreach ($candidate in @('main', 'master')) {
+        git -C $ProjectRoot rev-parse --verify $candidate 2>$null | Out-Null
+        if ($LASTEXITCODE -eq 0) { return $candidate }
+    }
+    return $null
+}
+
+function Assert-OnBaseBranch {
+    <#
+    .SYNOPSIS
+    Ensure the main repo is checked out on the specified branch (or the canonical
+    main/master if none is specified). Checks out the branch if not already on it.
+    Throws if the branch cannot be found or checked out.
+    Returns the confirmed base branch name.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [string]$BranchName
+    )
+    if (-not $BranchName) {
+        $BranchName = Resolve-MainBranch -ProjectRoot $ProjectRoot
+    }
+    if (-not $BranchName) {
+        throw "Cannot find base branch in $ProjectRoot"
+    }
+    $currentBranch = git -C $ProjectRoot rev-parse --abbrev-ref HEAD 2>$null
+    if ($currentBranch -ne $BranchName) {
+        git -C $ProjectRoot checkout $BranchName 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to checkout $BranchName in $ProjectRoot (currently on: $currentBranch)"
+        }
+    }
+    return $BranchName
+}
+
+function Invoke-WorktreeMapLocked {
+    <#
+    .SYNOPSIS
+    Execute a script block with an exclusive lock on the worktree map file.
+    Uses [System.IO.File]::Open with FileMode::CreateNew for atomic, cross-platform
+    locking (Windows: CreateFile CREATE_NEW; Linux/macOS: open O_CREAT|O_EXCL).
+    Retries on contention with linear backoff up to TimeoutSeconds.
+    #>
+    param(
+        [Parameter(Mandatory)][scriptblock]$Action,
+        [int]$TimeoutSeconds = 10
+    )
+    if (-not $script:WorktreeMapPath) { & $Action; return }
+    $lockFile = "$($script:WorktreeMapPath).lock"
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    $attempt = 0
+    while ($true) {
+        $lockStream = $null
+        try {
+            $lockStream = [System.IO.File]::Open(
+                $lockFile,
+                [System.IO.FileMode]::CreateNew,
+                [System.IO.FileAccess]::ReadWrite,
+                [System.IO.FileShare]::None)
+            # Lock acquired — run the action
+            & $Action
+            return
+        } catch [System.IO.IOException] {
+            # Lock held by another process — wait and retry
+            if ([DateTime]::UtcNow -ge $deadline) {
+                # Timed out — assume stale lock, remove and try once more
+                Remove-Item $lockFile -Force -ErrorAction SilentlyContinue
+                & $Action
+                return
+            }
+            $attempt++
+            Start-Sleep -Milliseconds ([Math]::Min(50 * $attempt, 500))
+        } finally {
+            if ($lockStream) {
+                $lockStream.Dispose()
+                Remove-Item $lockFile -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}
+
 function Get-TaskSlug {
     param([string]$TaskName)
     $slug = $TaskName.ToLower()
@@ -305,15 +393,19 @@ function New-TaskWorktree {
         $gitMarker = Join-Path $worktreePath ".git"
         if (Test-Path $gitMarker) {
             # Valid worktree — ensure map entry exists and return it
-            $map = Read-WorktreeMap
-            if (-not $map.ContainsKey($TaskId)) {
-                $map[$TaskId] = @{
-                    worktree_path = $worktreePath
-                    branch_name   = $branchName
-                    task_name     = $TaskName
-                    created_at    = (Get-Date).ToUniversalTime().ToString("o")
+            $existingBaseBranch = Resolve-MainBranch -ProjectRoot $ProjectRoot
+            Invoke-WorktreeMapLocked -Action {
+                $lockedMap = Read-WorktreeMap
+                if (-not $lockedMap.ContainsKey($TaskId)) {
+                    $lockedMap[$TaskId] = @{
+                        worktree_path = $worktreePath
+                        branch_name   = $branchName
+                        base_branch   = $existingBaseBranch
+                        task_name     = $TaskName
+                        created_at    = (Get-Date).ToUniversalTime().ToString("o")
+                    }
+                    Write-WorktreeMap -Map $lockedMap
                 }
-                Write-WorktreeMap -Map $map
             }
             return @{
                 worktree_path = $worktreePath
@@ -420,15 +512,18 @@ function New-TaskWorktree {
         # Copy non-noisy gitignored build artifacts
         Copy-BuildArtifacts -ProjectRoot $ProjectRoot -WorktreePath $worktreePath
 
-        # Register in worktree map
-        $map = Read-WorktreeMap
-        $map[$TaskId] = @{
-            worktree_path = $worktreePath
-            branch_name   = $branchName
-            task_name     = $TaskName
-            created_at    = (Get-Date).ToUniversalTime().ToString("o")
+        # Register in worktree map (locked read-modify-write to prevent concurrent entry loss)
+        Invoke-WorktreeMapLocked -Action {
+            $lockedMap = Read-WorktreeMap
+            $lockedMap[$TaskId] = @{
+                worktree_path = $worktreePath
+                branch_name   = $branchName
+                base_branch   = $baseBranch
+                task_name     = $TaskName
+                created_at    = (Get-Date).ToUniversalTime().ToString("o")
+            }
+            Write-WorktreeMap -Map $lockedMap
         }
-        Write-WorktreeMap -Map $map
 
         return @{
             worktree_path = $worktreePath
@@ -479,13 +574,13 @@ function Complete-TaskWorktree {
     $shortId = $TaskId.Substring(0, [Math]::Min(8, $TaskId.Length))
 
     try {
-        # Ensure main repo is on its base branch
-        $baseBranch = Get-BaseBranch -ProjectRoot $ProjectRoot
-        $currentBranch = git -C $ProjectRoot rev-parse --abbrev-ref HEAD 2>$null
-        if ($currentBranch -ne $baseBranch) {
-            git -C $ProjectRoot checkout $baseBranch 2>&1 | Out-Null
-            if ($LASTEXITCODE -ne 0) { throw "Failed to checkout $baseBranch branch" }
-        }
+        # Determine target base branch — prefer the value recorded at worktree creation
+        # (immune to HEAD drift on the main repo); fall back to explicit main/master lookup.
+        $baseBranch = if ($entry.base_branch) { $entry.base_branch } else { Resolve-MainBranch -ProjectRoot $ProjectRoot }
+        if (-not $baseBranch) { throw "Cannot determine base branch for task $TaskId" }
+
+        # Assert main repo is on the base branch before any git operation (Fix: wrong-branch merge)
+        Assert-OnBaseBranch -ProjectRoot $ProjectRoot -BranchName $baseBranch | Out-Null
 
         # Kill any processes still running in the worktree (dev servers, file watchers, etc.)
         $killedCount = Stop-WorktreeProcesses -WorktreePath $worktreePath
@@ -540,10 +635,30 @@ function Complete-TaskWorktree {
         $stashOutput = git -C $ProjectRoot stash push -u -m "dotbot-pre-merge-$TaskId" 2>&1
         $wasStashed = $LASTEXITCODE -eq 0 -and "$stashOutput" -notmatch 'No local changes'
 
+        # Validate task branch still exists before attempting merge (Fix: branch_not_found)
+        git -C $ProjectRoot rev-parse --verify $branchName 2>$null | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            if ($wasStashed) { git -C $ProjectRoot stash pop 2>$null }
+            foreach ($key in $taskBackup.Keys) {
+                $restorePath = Join-Path $ProjectRoot ".bot\workspace\tasks\$key"
+                $restoreDir = Split-Path $restorePath -Parent
+                if (-not (Test-Path $restoreDir)) { New-Item $restoreDir -ItemType Directory -Force | Out-Null }
+                $taskBackup[$key] | Set-Content $restorePath -Encoding UTF8
+            }
+            return @{
+                success        = $false
+                merge_commit   = $null
+                message        = "Branch $branchName no longer exists — cannot merge task $TaskId"
+                conflict_files = @()
+            }
+        }
+
         # Squash merge into main
         $mergeOutput = git -C $ProjectRoot merge --squash $branchName 2>&1
         if ($LASTEXITCODE -ne 0) {
             git -C $ProjectRoot reset --hard HEAD 2>$null
+            # Re-assert base branch after reset — leaves repo in a known good state (Fix: wrong-branch merge)
+            Assert-OnBaseBranch -ProjectRoot $ProjectRoot -BranchName $baseBranch | Out-Null
             if ($wasStashed) {
                 git -C $ProjectRoot stash pop 2>$null
             }
@@ -589,6 +704,16 @@ function Complete-TaskWorktree {
         if ($staged) {
             git -C $ProjectRoot commit -m "feat: $taskName [task:$shortId]" 2>&1 | Out-Null
             if ($LASTEXITCODE -ne 0) {
+                git -C $ProjectRoot reset --hard HEAD 2>$null
+                # Re-assert base branch after reset (Fix: wrong-branch merge)
+                Assert-OnBaseBranch -ProjectRoot $ProjectRoot -BranchName $baseBranch | Out-Null
+                if ($wasStashed) { git -C $ProjectRoot stash pop 2>$null }
+                foreach ($key in $taskBackup.Keys) {
+                    $restorePath = Join-Path $ProjectRoot ".bot\workspace\tasks\$key"
+                    $restoreDir = Split-Path $restorePath -Parent
+                    if (-not (Test-Path $restoreDir)) { New-Item $restoreDir -ItemType Directory -Force | Out-Null }
+                    $taskBackup[$key] | Set-Content $restorePath -Encoding UTF8
+                }
                 return @{
                     success        = $false
                     merge_commit   = $null
@@ -641,11 +766,18 @@ function Complete-TaskWorktree {
             }
             git -C $ProjectRoot worktree remove $worktreePath 2>$null
         }
+        # Verify worktree is actually gone (Fix: silent removal failures)
+        if (Test-Path $worktreePath) {
+            Write-Warning "Worktree removal incomplete — path still exists: $worktreePath. Will be retried on next startup."
+        }
         git -C $ProjectRoot branch -D $branchName 2>$null
 
-        # Remove from registry
-        $map.Remove($TaskId)
-        Write-WorktreeMap -Map $map
+        # Remove from registry (locked read-modify-write to prevent concurrent entry loss)
+        Invoke-WorktreeMapLocked -Action {
+            $lockedMap = Read-WorktreeMap
+            $lockedMap.Remove($TaskId)
+            Write-WorktreeMap -Map $lockedMap
+        }
 
         return @{
             success        = $true
@@ -793,7 +925,9 @@ function Remove-OrphanWorktrees {
     if ($map.Count -eq 0) { return }
 
     $tasksBaseDir = Join-Path $BotRoot "workspace\tasks"
-    $activeDirs = @('todo', 'analysing', 'needs-input', 'analysed', 'in-progress')
+    # 'done' is included: tasks that just completed execution may still have a live worktree
+    # pending squash-merge by Complete-TaskWorktree. Removing them here would race with that.
+    $activeDirs = @('todo', 'analysing', 'needs-input', 'analysed', 'in-progress', 'done')
     $orphanIds = @()
 
     foreach ($taskId in @($map.Keys)) {
@@ -847,13 +981,20 @@ function Remove-OrphanWorktrees {
             }
             git -C $ProjectRoot worktree remove $worktreePath 2>$null
         }
+        # Verify worktree is actually gone (Fix: silent removal failures)
+        if ($worktreePath -and (Test-Path $worktreePath)) {
+            Write-Warning "Orphan worktree removal incomplete — path still exists: $worktreePath"
+        }
         git -C $ProjectRoot branch -D $branchName 2>$null
-
-        $map.Remove($taskId)
     }
 
     if ($orphanIds.Count -gt 0) {
-        Write-WorktreeMap -Map $map
+        # Locked read-modify-write — prevents concurrent processes from losing map entries
+        Invoke-WorktreeMapLocked -Action {
+            $lockedMap = Read-WorktreeMap
+            foreach ($id in $orphanIds) { $lockedMap.Remove($id) }
+            Write-WorktreeMap -Map $lockedMap
+        }
     }
 }
 
@@ -862,6 +1003,9 @@ Export-ModuleMember -Function @(
     'Initialize-WorktreeMap'
     'Read-WorktreeMap'
     'Write-WorktreeMap'
+    'Invoke-WorktreeMapLocked'
+    'Resolve-MainBranch'
+    'Assert-OnBaseBranch'
     'Stop-WorktreeProcesses'
     'Remove-Junctions'
     'New-TaskWorktree'


### PR DESCRIPTION
# Worktree Branch Safety: Prevent wrong-branch merges, silent cleanup failures, and concurrent map corruption

## Root Issue

When dotbot completes a task, it squash-merges the task branch into `main` from the main repo working directory. The key vulnerability is that the code determines which branch to merge into by calling `Get-BaseBranch`, which reads `git symbolic-ref HEAD` — i.e., whatever branch the main repo is *currently on*. If a prior failed merge, exception mid-operation, or concurrent process left the main repo on a task branch instead of `main`, the next task's merge silently targets the wrong branch. All subsequent tasks compound the problem.

Secondary risks compound this: orphan cleanup can delete a live worktree, the worktree map has no write locking so concurrent processes lose entries, and worktree removal failures are silently swallowed while the map is updated anyway.

---

## Issues Fixed

### 1. `Get-BaseBranch` reads current HEAD — wrong for merge context (Critical)
**File:** `WorktreeManager.psm1`

`Get-BaseBranch` uses `symbolic-ref HEAD` on the main repo. In `Complete-TaskWorktree`, this should never trust HEAD — it should resolve `main`/`master` by explicit name. If the main repo is accidentally on a task branch, `Get-BaseBranch` returns the task branch name, and the next squash merge targets it instead of `main`.

**Implemented:**
- Added `Resolve-MainBranch` — finds `main`/`master` by explicit `rev-parse --verify`, never reads HEAD. Safe to call even when the main repo is on a task branch.
- Added `Assert-OnBaseBranch` — takes `$ProjectRoot` + optional `$BranchName`; checks out the branch if not already on it; throws on failure; returns the confirmed name.
- `Complete-TaskWorktree` now reads `base_branch` from the stored map entry (set at creation time) and falls back to `Resolve-MainBranch`. The old `Get-BaseBranch` + HEAD read is gone from the merge path entirely.
- `base_branch` is now stored in every worktree map entry written by `New-TaskWorktree` (both the normal creation path and the existing-worktree recovery path).

---

### 2. No re-assertion that main repo is on base branch after failed merge (Critical)
**File:** `WorktreeManager.psm1` — `Complete-TaskWorktree`

The failed-merge path did `git reset --hard HEAD` and returned `success = false`, but never re-checked or re-asserted that the main repo was back on the base branch.

**Implemented:**
- `Assert-OnBaseBranch` is called at the top of `Complete-TaskWorktree` (pre-condition) before any git operation.
- After the squash-merge failure path (`git reset --hard HEAD`), `Assert-OnBaseBranch` is called again before returning.
- After the commit failure path (which now also does `git reset --hard HEAD`), `Assert-OnBaseBranch` is called before returning.

---

### 3. No guard before `New-TaskWorktree` in the task loop (Critical)
**File:** `launch-process.ps1` — execution loop and kickstart loop

After `Complete-TaskWorktree` returned (success or failure), the loop immediately called `New-TaskWorktree` without verifying the main repo was on `main`.

**Implemented:**
- `Assert-OnBaseBranch` guard added immediately before each `New-TaskWorktree` call in both the execution loop (~line 948) and the kickstart loop (~line 1720). Logged as a warning (non-fatal) so a transient git issue doesn't kill the whole process.

---

### 4. Orphan cleanup deletes live worktrees whose tasks just moved to `done/` (Critical)
**File:** `WorktreeManager.psm1` — `Remove-OrphanWorktrees`

`$activeDirs` was `@('todo', 'analysing', 'needs-input', 'analysed', 'in-progress')`. Tasks that just completed (moved to `done/`) were not in this list. If orphan cleanup ran concurrently between task completion and `Complete-TaskWorktree`, it deleted the worktree that `Complete-TaskWorktree` still needed to merge.

**Implemented:**
- `'done'` added to `$activeDirs`. Tasks in `done/` still have a valid worktree that must be merged by `Complete-TaskWorktree`. The entry is removed from the map only after `Complete-TaskWorktree` completes its merge and cleanup.

---

### 5. Concurrent read-modify-write on `worktree-map.json` loses entries (High)
**File:** `WorktreeManager.psm1`

The temp-file-then-move pattern prevented partial writes but not lost updates. Two processes doing read-modify-write concurrently could silently overwrite each other's changes, dropping map entries.

**Implemented:**
- Added `Invoke-WorktreeMapLocked` — wraps a scriptblock with an exclusive file lock using `[System.IO.File]::Open($lockFile, FileMode::CreateNew, FileAccess::ReadWrite, FileShare::None)`. This is atomic and cross-platform (Windows: `CreateFile CREATE_NEW`; Linux/macOS: `open O_CREAT|O_EXCL`). Retries with linear backoff up to 10 seconds; removes stale lock on timeout.
- All map mutation sites now use `Invoke-WorktreeMapLocked` with a fresh read-modify-write inside the lock:
  - `New-TaskWorktree` (both creation paths)
  - `Complete-TaskWorktree` (final map removal)
  - `Remove-OrphanWorktrees` (batch removal at the end)
- Exported from the module for use in `launch-process.ps1` cleanup blocks.

---

### 6. Worktree removal failures silently swallowed; map updated anyway (High)
**File:** `WorktreeManager.psm1` — `Complete-TaskWorktree` and `Remove-OrphanWorktrees`

`git worktree remove ... 2>$null` discarded errors. The map was updated immediately after, even if removal failed. The worktree stayed on disk but disappeared from the registry, becoming permanently invisible to cleanup.

**Implemented:**
- After each `git worktree remove` call in both `Complete-TaskWorktree` and `Remove-OrphanWorktrees`, `Test-Path $worktreePath` is checked. If the path still exists, a `Write-Warning` is emitted. The map update still proceeds (the merge succeeded; git's own `worktree prune` can handle the physical cleanup on next run).

---

### 7. Branch never validated to exist before squash merge (Medium)
**File:** `WorktreeManager.psm1` — `Complete-TaskWorktree`

`merge --squash $branchName` ran against whatever branch name was in the map without verifying it existed. A manually deleted or corrupted branch produced a cryptic merge failure.

**Implemented:**
- `git -C $ProjectRoot rev-parse --verify $branchName` is called before the squash merge. On failure, stash is popped, task state is restored, and a clear `"Branch $branchName no longer exists"` error is returned.

---

### 8. Failed-task worktree cleanup skips map update when junction removal throws (High)
**File:** `launch-process.ps1` — failed task cleanup in both loops

When an execution task failed, `Remove-Junctions` was called without `-ErrorOnFailure $false`, so a junction removal error would throw and skip the `git worktree remove` and map cleanup entirely — leaving the task registered with a broken worktree state.

**Implemented:**
- Both failed-task cleanup blocks (execution loop ~line 1270 and kickstart loop ~line 1979) are now wrapped in `try/finally`.
- `Remove-Junctions` is called with `-ErrorOnFailure $false` (non-throwing).
- The `finally` block always runs: locked map removal via `Invoke-WorktreeMapLocked`, followed by an `Assert-OnBaseBranch` call (swallowed on error) to leave the main repo in a known state.

---

## Files Changed

- `profiles/default/systems/runtime/modules/WorktreeManager.psm1`
- `profiles/default/systems/runtime/launch-process.ps1`

## New Exported Functions

| Function | Purpose |
|----------|---------|
| `Resolve-MainBranch` | Find `main`/`master` by explicit name, never from HEAD |
| `Assert-OnBaseBranch` | Checkout + verify the base branch; throws on failure |
| `Invoke-WorktreeMapLocked` | Atomic cross-platform lock for map read-modify-write |

## Test Results

All 515 tests pass across layers 1–3 (structure, components, mock-Claude integration). No regressions.

- Layer 1 (Structure): 180 passed
- Layer 1b (Compilation & Module Validation): 219 passed, 1 skipped
- Layer 2 (Components): 107 passed
- Layer 3 (Mock Claude Integration): 9 passed
