### PR TITLE
Fix: Correctly Remove Junctions and Symlinks on Linux and macOS

### DIFF
--- a/profiles/default/systems/runtime/modules/WorktreeManager.psm1
+++ b/profiles/default/systems/runtime/modules/WorktreeManager.psm1
@@ -240,13 +240,21 @@ function Remove-Junctions {
     )
     $failures = @()
     foreach ($jp in $junctionPaths) {
-        if ((Test-Path $jp) -and (Get-Item $jp).Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
-            # cmd rmdir removes the junction link without following into target
-            cmd /c rmdir "$jp" 2>$null
+        if (-not (Test-Path -LiteralPath $jp)) { continue }
+        $item = Get-Item -LiteralPath $jp -Force
+        $isJunctionOrSymlink = ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -or $item.LinkType
+        if ($isJunctionOrSymlink) {
+            if ($IsWindows) {
+                # cmd rmdir removes the junction link without following into target
+                cmd /c rmdir "$jp" 2>$null
+            } else {
+                # On Linux/macOS, New-Item -ItemType Junction creates a symlink;
+                # Remove-Item correctly unlinks it without touching the target
+                Remove-Item -LiteralPath $jp -Force -ErrorAction SilentlyContinue
+            }
 
-            # Verify the junction is actually gone
-            if (Test-Path $jp) {
-                # Fallback: use .NET to remove the junction
+            # Fallback: use .NET to remove the junction
+            if (Test-Path -LiteralPath $jp) {
                 try {
                     [System.IO.Directory]::Delete($jp, $false)
                 } catch {
@@ -255,7 +263,7 @@ function Remove-Junctions {
             }
 
             # Final check
-            if (Test-Path $jp) {
+            if (Test-Path -LiteralPath $jp) {
                 $failures += $jp
             }
         }


### PR DESCRIPTION
# Fix: Correctly Remove Junctions and Symlinks on Linux and macOS

## Problem

`Remove-Junctions` in `WorktreeManager.psm1` was effectively a no-op on Linux and macOS, silently skipping cleanup of worktree junction paths.

Two bugs combined to cause this:

**1. Windows-only detection.** The function checked for the `ReparsePoint` file attribute to identify junctions:

```powershell
if ((Test-Path $jp) -and (Get-Item $jp).Attributes -band [System.IO.FileAttributes]::ReparsePoint)
```

The `ReparsePoint` attribute is an NTFS concept. On Linux and macOS, PowerShell's `New-Item -ItemType Junction` silently falls back to creating a directory symlink instead, and symlinks do not carry the `ReparsePoint` attribute. So the condition always evaluated to `$false` on non-Windows platforms, and every junction path was skipped without any error.

**2. Windows-only removal.** Even if a junction had been detected, the removal command was `cmd /c rmdir` — a Windows-only tool that does not exist on Linux or macOS.

The companion function `Test-JunctionsExist` did not share this blind spot: it already used a dual-check (`ReparsePoint` attribute **or** `$item.LinkType`) and correctly detected both NTFS junctions on Windows and directory symlinks on Linux/macOS. `Remove-Junctions` was simply never updated to match.

The practical consequence: on Linux and macOS, worktree cleanup left behind dangling symlinks. Since `Test-JunctionsExist` is used as a defense-in-depth gate before `git worktree remove --force`, a failed cleanup would also block the worktree from being removed at all.

## Fixes

### 1. Cross-platform junction/symlink detection

Replaced the `ReparsePoint`-only check with the same dual-check already used by `Test-JunctionsExist`:

```powershell
$item = Get-Item -LiteralPath $jp -Force
$isJunctionOrSymlink = ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -or $item.LinkType
```

`$item.LinkType` is set to `"Junction"` on Windows and `"SymbolicLink"` on Linux/macOS — both are truthy, so detection now works on all platforms.

### 2. Platform-specific removal

Replaced the unconditional `cmd /c rmdir` with a platform branch:

```powershell
if ($IsWindows) {
    # cmd rmdir removes the junction link without following into target
    cmd /c rmdir "$jp" 2>$null
} else {
    # On Linux/macOS, New-Item -ItemType Junction creates a symlink;
    # Remove-Item correctly unlinks it without touching the target
    Remove-Item -LiteralPath $jp -Force -ErrorAction SilentlyContinue
}
```

On Linux/macOS, `Remove-Item` without `-Recurse` removes only the symlink node, leaving the target directory untouched — which is exactly the same safety property that `cmd /c rmdir` provides for NTFS junctions on Windows.

The existing `.NET` fallback (`[System.IO.Directory]::Delete($jp, $false)`) is also safe on Linux/macOS: non-recursive `Directory.Delete` on a symlink removes the link, not the target.

### 3. Consistent use of `-LiteralPath`

All `Test-Path` and `Get-Item` calls inside `Remove-Junctions` were updated to use `-LiteralPath`, matching the convention already established in `Test-JunctionsExist`. This prevents PowerShell from interpreting wildcard characters (`[`, `]`, `*`, `?`) in path strings, which could produce false negatives on paths that happen to contain those characters.
