### PR TITLE
Fix: Launch Additional Instances of Dotbot

### DIFF
--- a/profiles/default/go.ps1
+++ b/profiles/default/go.ps1
@@ -41,16 +41,26 @@ if (Test-Path $uiPortFile) {
         try {
             $resp = Invoke-WebRequest -Uri "http://localhost:$existingPort/api/info" -TimeoutSec 2 -ErrorAction Stop
             if ($resp.StatusCode -eq 200) {
-                $url = "http://localhost:$existingPort"
-                Write-Host "  Server already running on port $existingPort" -ForegroundColor Green
-                if (Get-Command Open-Url -ErrorAction SilentlyContinue) {
-                    Open-Url $url
+                # Verify the server belongs to THIS project, not a different one
+                $thisProjectRoot = (Resolve-Path (Join-Path $BotDir "..")).Path
+                $serverInfo = $resp.Content | ConvertFrom-Json
+                $serverProjectRoot = $serverInfo.project_root
+                if ($serverProjectRoot -and ($serverProjectRoot -ne $thisProjectRoot)) {
+                    # Different project's server on this port — start a new instance
+                    Write-Host "  Port $existingPort is used by a different project ($serverProjectRoot)" -ForegroundColor Yellow
+                    Write-Host "  Starting a new server instance..." -ForegroundColor Yellow
                 } else {
-                    Start-Process $url
+                    $url = "http://localhost:$existingPort"
+                    Write-Host "  Server already running on port $existingPort" -ForegroundColor Green
+                    if (Get-Command Open-Url -ErrorAction SilentlyContinue) {
+                        Open-Url $url
+                    } else {
+                        Start-Process $url
+                    }
+                    Write-Host "  Browser opened at $url" -ForegroundColor Green
+                    Write-Host ""
+                    exit 0
                 }
-                Write-Host "  Browser opened at $url" -ForegroundColor Green
-                Write-Host ""
-                exit 0
             }
         } catch {
             # Server not responding — stale port file, continue with fresh start


### PR DESCRIPTION
# Fix: Launch Additional Instances of Dotbot

## Problem

When running multiple dotbot projects side by side, launching `.bot\go.ps1` in a second project would open the browser pointing to the **first** project's dashboard instead of starting a new server instance.

### Root Cause

The `go.ps1` script checks the `.bot/.control/ui-port` file for a previously used port number, then pings `http://localhost:{port}/api/info` to see if a server is already running. If it gets a `200 OK` response, it assumes the server belongs to the current project and simply opens the browser — skipping server startup entirely.

The problem is that the liveness check **never verified which project** the responding server belonged to. So when Project B's `ui-port` file contained port `8686` (from a previous run), and Project A's server was already running on that same port, `go.ps1` would get a successful response from Project A's server and redirect the browser there.

### How It Was Fixed

The fix adds a **project identity check** to the liveness probe in `go.ps1`. After receiving a `200 OK` from `/api/info`, it now:

1. Resolves the current project's root directory
2. Parses the `project_root` field from the `/api/info` JSON response
3. Compares the two paths

If they **match** — the server belongs to this project, reuse it (existing behavior).
If they **don't match** — a different project owns that port, so fall through to start a new server instance on the next available port (8687, 8688, etc.) via the existing `Find-AvailablePort` auto-selection in `server.ps1`.

### Result

Each project gets its own dedicated server instance on its own port, with the same seamless launch experience regardless of how many dotbot instances are running concurrently.
