### PR TITLE
Fix stale task files accumulating in todo folder after completion

### DIFF
--- a/profiles/default/systems/runtime/modules/WorktreeManager.psm1
+++ b/profiles/default/systems/runtime/modules/WorktreeManager.psm1
@@ -639,8 +639,10 @@ function Complete-TaskWorktree {
         git -C $ProjectRoot checkout -- .bot/workspace/tasks/ 2>$null
         git -C $ProjectRoot clean -fd -- .bot/workspace/tasks/ 2>$null
 
-        # Stash all remaining dirty state (e.g. .gitignore, user edits) so merge can proceed
-        $stashOutput = git -C $ProjectRoot stash push -u -m "dotbot-pre-merge-$TaskId" 2>&1
+        # Stash remaining dirty state EXCLUDING task files (task state is managed by backup-restore).
+        # Including task files in the stash causes stale state to be reintroduced after the state commit
+        # when git stash pop runs, contaminating the next task's backup.
+        $stashOutput = git -C $ProjectRoot stash push -u -m "dotbot-pre-merge-$TaskId" -- ':!.bot/workspace/tasks/' 2>&1
         $wasStashed = $LASTEXITCODE -eq 0 -and "$stashOutput" -notmatch 'No local changes'
 
         # Validate task branch still exists before attempting merge (Fix: branch_not_found)
@@ -732,6 +734,34 @@ function Complete-TaskWorktree {
         }
 
         $mergeCommit = git -C $ProjectRoot rev-parse HEAD 2>$null
+
+        # Remove duplicate task files: if a task exists in both a non-terminal directory
+        # and done/, the non-terminal copy is stale and must be removed before committing.
+        # This is a defensive measure against any mechanism that reintroduces stale files
+        # (stash pop, junction race conditions, Reset function edge cases).
+        $doneDir = Join-Path $ProjectRoot ".bot\workspace\tasks\done"
+        $todoDir = Join-Path $ProjectRoot ".bot\workspace\tasks\todo"
+        if ((Test-Path $doneDir) -and (Test-Path $todoDir)) {
+            $doneFileNames = @{}
+            Get-ChildItem $doneDir -Filter "*.json" -File -ErrorAction SilentlyContinue | ForEach-Object {
+                $doneFileNames[$_.Name] = $true
+            }
+            Get-ChildItem $todoDir -Filter "*.json" -File -ErrorAction SilentlyContinue | ForEach-Object {
+                if ($doneFileNames.ContainsKey($_.Name)) {
+                    Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue
+                }
+            }
+            foreach ($intermediateDir in @('analysing', 'analysed', 'in-progress', 'needs-input')) {
+                $dirPath = Join-Path $ProjectRoot ".bot\workspace\tasks\$intermediateDir"
+                if (Test-Path $dirPath) {
+                    Get-ChildItem $dirPath -Filter "*.json" -File -ErrorAction SilentlyContinue | ForEach-Object {
+                        if ($doneFileNames.ContainsKey($_.Name)) {
+                            Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue
+                        }
+                    }
+                }
+            }
+        }
 
         # Commit current task state on main — changes accumulate via junctions
         # but were previously only "accidentally" committed via task branches

--- a/profiles/default/systems/runtime/modules/task-reset.ps1
+++ b/profiles/default/systems/runtime/modules/task-reset.ps1
@@ -44,6 +44,13 @@ function Reset-InProgressTasks {
             $taskId = $taskContent.id
             $taskName = $taskContent.name
 
+            # Check if this task was already completed — if so, just delete the orphan
+            $doneFile = Join-Path $TasksBaseDir "done" $taskFile.Name
+            if (Test-Path $doneFile) {
+                Remove-Item -Path $taskFile.FullName -Force -ErrorAction SilentlyContinue
+                continue
+            }
+
             # If task has analysis data, return to analysed; otherwise to todo
             $hasAnalysis = $taskContent.analysis -and $taskContent.analysis.PSObject.Properties.Count -gt 0
             if ($hasAnalysis) {
@@ -127,6 +134,13 @@ function Reset-SkippedTasks {
             $skipCount = ($taskContent.skip_history | Measure-Object).Count
             if ($skipCount -ge 3) {
                 Write-Warning "Task '$taskName' skipped $skipCount times - leaving in skipped for manual review"
+                continue
+            }
+
+            # Check if this task was already completed — if so, just delete the orphan
+            $doneFile = Join-Path $TasksBaseDir "done" $taskFile.Name
+            if (Test-Path $doneFile) {
+                Remove-Item -Path $taskFile.FullName -Force -ErrorAction SilentlyContinue
                 continue
             }
 
@@ -261,7 +275,14 @@ function Reset-AnalysingTasks {
                 if ($updatedAt -gt $stalenessThreshold) { continue }
             }
 
-            # This task is orphaned - recover it
+            # Check if this task was already completed — if so, just delete the orphan
+            $doneFile = Join-Path $TasksBaseDir "done" $taskFile.Name
+            if (Test-Path $doneFile) {
+                Remove-Item -Path $taskFile.FullName -Force -ErrorAction SilentlyContinue
+                continue
+            }
+
+            # This task is orphaned and not yet done - recover it to todo
             $todoDir = Join-Path $TasksBaseDir "todo"
             if (-not (Test-Path $todoDir)) {
                 New-Item -ItemType Directory -Path $todoDir -Force | Out-Null


### PR DESCRIPTION
# fix: Prevent stale task files from accumulating in `todo/` after completion

## Table of Contents

- [1. Problem Description](#1-problem-description)
- [2. Proposed Fixes (High-Level)](#2-proposed-fixes-high-level)
- [3. Detailed Investigation and Evidence](#3-detailed-investigation-and-evidence)
  - [3.1 Symptom: Workflow stuck with "Waiting for new tasks..."](#31-symptom-workflow-stuck-with-waiting-for-new-tasks)
  - [3.2 Immediate cause: TaskIndexCache dedup hides all todo tasks](#32-immediate-cause-taskindexcache-dedup-hides-all-todo-tasks)
  - [3.3 Deeper cause: Duplicate task files in both `todo/` and `done/`](#33-deeper-cause-duplicate-task-files-in-both-todo-and-done)
  - [3.4 Root cause: `git stash pop` after state commit in Complete-TaskWorktree](#34-root-cause-git-stash-pop-after-state-commit-in-complete-taskworktree)
  - [3.5 Contributing factor: Reset functions re-create `todo/` files at workflow startup](#35-contributing-factor-reset-functions-re-create-todo-files-at-workflow-startup)
  - [3.6 Timeline reconstruction from git history](#36-timeline-reconstruction-from-git-history)
- [4. Detailed Fix Descriptions](#4-detailed-fix-descriptions)
  - [4.1 Fix A: Exclude task files from `git stash` in Complete-TaskWorktree](#41-fix-a-exclude-task-files-from-git-stash-in-complete-taskworktree)
  - [4.2 Fix B: Add dedup cleanup before the state commit in Complete-TaskWorktree](#42-fix-b-add-dedup-cleanup-before-the-state-commit-in-complete-taskworktree)
  - [4.3 Fix C: Guard Reset functions against resurrecting already-done tasks](#43-fix-c-guard-reset-functions-against-resurrecting-already-done-tasks)

---

## 1. Problem Description

The dotbot workflow process gets permanently stuck displaying "Waiting for new tasks..." even though there are dozens of task files present in the `.bot/workspace/tasks/todo/` directory. This happens because completed tasks leave behind stale copies in the `todo/` directory. The TaskIndexCache dedup logic sees the same task ID in both `done/` and `todo/`, keeps the `done/` entry (higher priority bucket), and silently removes the `todo/` entry. Once every `todo/` task has a corresponding `done/` duplicate, the index reports zero eligible tasks and the workflow stalls.

The stale `todo/` files accumulate over the life of a workflow session due to a bug in the `Complete-TaskWorktree` function within `WorktreeManager.psm1`. Specifically, a `git stash pop` executed **after** the state commit re-introduces stale task file state onto main's working directory. The next task's backup-restore cycle then captures and commits this contaminated state, permanently embedding the duplicates in git history.

A secondary contributing factor is the task Reset functions (`Reset-AnalysingTasks`, `Reset-InProgressTasks`, `Reset-SkippedTasks`) in `task-reset.ps1`, which move orphaned tasks back to `todo/` at workflow startup without checking whether those tasks have already been completed (i.e., exist in `done/`).

## 2. Proposed Fixes (High-Level)

Three fixes, ordered by impact:

1. **Fix A (Primary - Root Cause):** Exclude `.bot/workspace/tasks/` from the `git stash push` command in `Complete-TaskWorktree`. The task state is already managed by a dedicated backup-restore mechanism; it should never enter the stash. This eliminates the primary vector by which stale task files re-enter the working directory after the state commit.

2. **Fix B (Defensive - Safety Net):** Add a dedup cleanup step in `Complete-TaskWorktree` just before the state commit (`git add .bot/workspace/tasks/`). This step scans for any task file that exists simultaneously in `todo/` and `done/` (same filename) and removes the `todo/` copy. This catches contamination from any source, including edge cases not covered by Fix A.

3. **Fix C (Preventive - Upstream):** Modify the three Reset functions (`Reset-AnalysingTasks`, `Reset-InProgressTasks`, `Reset-SkippedTasks`) to check whether a task already exists in `done/` before moving it back to `todo/`. If the task is already done, the orphaned copy in `analysing/`/`in-progress/`/`skipped/` should simply be deleted rather than resurrected into `todo/`.

---

## 3. Detailed Investigation and Evidence

### 3.1 Symptom: Workflow stuck with "Waiting for new tasks..."

The workflow process (`proc-190864` in the investigated repo) had `tasks_completed: 5` and `status: "running"`, but was polling for new tasks indefinitely. The `todo/` directory contained 33 task JSON files. The process was healthy; it simply believed there was nothing to do.

### 3.2 Immediate cause: TaskIndexCache dedup hides all todo tasks

The `TaskIndexCache` module (file: `.bot/systems/mcp/modules/TaskIndexCache.psm1`, function `Update-TaskIndex`) contains deduplication logic that iterates state buckets in priority order: Done, Skipped, Cancelled, Split, InProgress, Analysed, NeedsInput, Analysing, Todo. For each task ID, it keeps the entry in the highest-priority bucket and removes it from all others.

The relevant code (approximately lines 124-145 in the investigated version):

```powershell
$seenIds = @{}
foreach ($bucket in @(
    $script:TaskIndex.Done,      # checked FIRST (highest priority)
    $script:TaskIndex.Skipped,
    $script:TaskIndex.Cancelled,
    $script:TaskIndex.Split,
    $script:TaskIndex.InProgress,
    $script:TaskIndex.Analysed,
    $script:TaskIndex.NeedsInput,
    $script:TaskIndex.Analysing,
    $script:TaskIndex.Todo       # checked LAST (lowest priority)
)) {
    foreach ($taskId in @($bucket.Keys)) {
        if ($seenIds.ContainsKey($taskId)) {
            $bucket.Remove($taskId)    # removes from lower-priority bucket
        } else {
            $seenIds[$taskId] = $true
        }
    }
}
```

Because every task in `todo/` also existed in `done/`, the dedup removed every entry from the Todo bucket, leaving it empty. `Get-NextTask()` returned nothing.

This dedup logic is **correct by design** — it is a safety mechanism to prevent double-pickup. The bug is that duplicate files exist on disk in the first place.

### 3.3 Deeper cause: Duplicate task files in both `todo/` and `done/`

All 33 task files in `todo/` had corresponding files with the same filename in `done/`. For example, task `32fdbb84`:

| Directory | `status` field | `updated_at` | `completed_at` |
|-----------|---------------|--------------|-----------------|
| `todo/create-business-user-guide-...-32fdbb84.json` | `"todo"` | `2026-03-12T07:29:21Z` | `null` |
| `done/create-business-user-guide-...-32fdbb84.json` | `"done"` | (set) | `2026-03-12T07:46:54Z` |

The `updated_at` timestamp on the stale `todo/` copy (`07:29:21`) matched **exactly** the `started_at` of an interrupted workflow process (`proc-6f0338`), pointing to the Reset functions as the origin (see section 3.5).

Tracing through git history confirmed that `todo/` file counts barely decreased despite tasks completing. In some state commits, `todo/` count actually **increased** (e.g., from 35 to 36 between consecutive state commits), meaning stale files were being re-added.

### 3.4 Root cause: `git stash pop` after state commit in Complete-TaskWorktree

The `Complete-TaskWorktree` function in `WorktreeManager.psm1` orchestrates the squash-merge lifecycle. The relevant sequence (line numbers from the investigated version):

| Step | Lines | Operation | Purpose |
|------|-------|-----------|---------|
| 1 | 409-419 | Backup live task state into `$taskBackup` hashtable | Capture correct filesystem state before git operations |
| 2 | 422-423 | `git checkout -- .bot/workspace/tasks/` + `git clean -fd` | Reset task files to HEAD so merge can proceed |
| 3 | 426 | `git stash push -u -m "dotbot-pre-merge-$TaskId"` | Stash remaining dirty state |
| 4 | 430 | `git merge --squash $branchName` | Squash merge task branch |
| 5 | 452 | `git checkout HEAD -- .bot/workspace/tasks/` | Discard task state from merge |
| 6 | 453-458 | Restore from `$taskBackup` | Apply correct live task state |
| 7 | 460-471 | Orphan cleanup (delete files not in backup) | Remove stale files from merge |
| 8 | 474-476 | `git commit -m "feat: ..."` | Feat commit (staged code changes) |
| 9 | 491-492 | `git add .bot/workspace/tasks/` + `git commit "chore: update task state"` | State commit |
| 10 | **509** | **`git stash pop`** | **Restore stashed state — BUG** |

**The bug:** Step 10 runs `git stash pop` **after** the state commit (step 9). The stash was created at step 3, after `git checkout --` reset task files to HEAD. However, the stash still contains task file modifications because MCP tools running through worktree junctions write to main's filesystem. Between `git checkout` (step 2) and `git stash push` (step 3), there is a timing window where junction-based writes can modify task files, which then get captured in the stash.

When `git stash pop` runs at step 10, it restores these stale task file modifications to the working directory. The state commit has already happened, so this contamination is NOT captured in the current state commit — but it persists on the working directory.

When the **next** task's `Complete-TaskWorktree` runs, step 1 (backup) reads main's working directory and captures the contaminated state, including stale `todo/` files. This state then gets committed in the next state commit, permanently embedding the duplicates.

**Evidence from the investigated repo:**

The stash `b370ef8` (created for task `dc50d2ac` at 08:35:07) was still in the stash list (pop either failed or was never fully applied). Examining it revealed:

- The stash contained **404 modified files** under `.bot/workspace/tasks/todo/`
- It contained `todo/create-business-user-guide-...-32fdbb84.json` with `status: "todo"` and `updated_at: "2026-03-12T07:29:21Z"` — a task that had been completed hours earlier
- The same task also existed in `done/` within the stash

At the HEAD commit when this stash was created (`0d488fd`), both `todo/32fdbb84.json` AND `done/32fdbb84.json` were already committed — confirming the contamination had already propagated through previous stash pop cycles.

### 3.5 Contributing factor: Reset functions re-create `todo/` files at workflow startup

When a workflow process starts, `launch-process.ps1` calls three Reset functions (from `task-reset.ps1`) to recover orphaned tasks:

- **`Reset-AnalysingTasks`**: Moves tasks from `analysing/` to `todo/` if no live process owns them and they are older than 5 minutes
- **`Reset-InProgressTasks`**: Moves tasks from `in-progress/` back to `todo/` (or `analysed/` if analysis data exists)
- **`Reset-SkippedTasks`**: Moves tasks from `skipped/` back to `todo/` (up to 3 skip attempts)

These are called at two locations in `launch-process.ps1`:
1. Around line 753-758 (for the first workflow type, analysis-only calls `Reset-AnalysingTasks`, execution calls all three)
2. Around line 1326-1328 (for the combined workflow type, calls all three)

**The problem:** None of these functions check whether the task already exists in `done/`. If a previous workflow was interrupted after a task was marked as `analysing` or `in-progress`, and a subsequent workflow then completed that task (moving it to `done/`), the next workflow restart finds the stale `analysing/`/`in-progress/` copy (which persists on the filesystem through various mechanisms) and creates a new `todo/` file.

In the investigated case, `proc-6f0338` (started at `2026-03-12T07:29:21Z`) called these Reset functions at startup, creating `todo/` files with `updated_at: "2026-03-12T07:29:21Z"` — this exact timestamp was found on all 33 stale `todo/` files.

### 3.6 Timeline reconstruction from git history

The following git history shows the cascading effect across consecutive state commits. Task `32fdbb84` is used as the tracer:

```
b8e7a4f  07:47:07  chore: update task state   ← task 32fdbb84 completed; todo/32fdbb84 CORRECTLY removed
dd10e2c  07:47:06  feat: Create business user guide [task:32fdbb84]

f80dacb  07:51:34  chore: update task state   ← todo/32fdbb84 REAPPEARS (updated_at=07:29:21, status=todo)
6695732  07:51:33  feat: Implement smoke tests [task:663c6082]

0d488fd  08:29:13  chore: update task state   ← todo/32fdbb84 still present alongside done/32fdbb84
018ec31  08:29:12  feat: Create UpdateTsAndCs.yml [task:ffa2af00]

... (pattern continues through all subsequent state commits)

27918f3  10:35:38  chore: update task state   ← FINAL commit; 33 duplicated tasks; workflow stalls
```

Between `b8e7a4f` and `f80dacb`:
- The feat commit `6695732` has `todo_count=35` (same as `b8e7a4f`) — the stale file was NOT introduced by the squash merge
- The state commit `f80dacb` has `todo_count=36` — the stale file was picked up by `git add .bot/workspace/tasks/` from the contaminated working directory
- `git diff b8e7a4f f80dacb --name-status` showed: `A todo/32fdbb84.json` — the file was ADDED in this state commit

This proves the file appeared on main's working directory between the feat commit and the state commit (i.e., during the backup-restore cycle), or was already present from a prior stash pop and was captured by the backup.

---

## 4. Detailed Fix Descriptions

### 4.1 Fix A: Exclude task files from `git stash` in Complete-TaskWorktree

**File:** `WorktreeManager.psm1` (or equivalent module containing the `Complete-TaskWorktree` function)

**What to change:** The `git stash push` command that stashes remaining dirty state before the squash merge.

**Current code** (approximately line 426 in the function):
```powershell
# Stash all remaining dirty state (e.g. .gitignore, user edits) so merge can proceed
$stashOutput = git -C $ProjectRoot stash push -u -m "dotbot-pre-merge-$TaskId" 2>&1
$wasStashed = $LASTEXITCODE -eq 0 -and "$stashOutput" -notmatch 'No local changes'
```

**New code:**
```powershell
# Stash remaining dirty state EXCLUDING task files (task state is managed by backup-restore).
# Including task files in the stash causes stale state to be reintroduced after the state commit
# when git stash pop runs, contaminating the next task's backup.
$stashOutput = git -C $ProjectRoot stash push -u -m "dotbot-pre-merge-$TaskId" -- ':!.bot/workspace/tasks/' 2>&1
$wasStashed = $LASTEXITCODE -eq 0 -and "$stashOutput" -notmatch 'No local changes'
```

**Why this works:** The `-- ':!.bot/workspace/tasks/'` pathspec excludes all files under `.bot/workspace/tasks/` from the stash. The task state is already correctly managed by the backup-restore mechanism (steps 1, 6, 7 in the sequence). The stash's original purpose is to save non-task dirty state (e.g., `.gitignore` changes, user edits) so the merge can proceed cleanly. Task files should never enter the stash because `git checkout` + `git clean` already handles them, and the stash pop after the state commit would re-introduce stale copies.

**Edge cases to consider:**
- The `git stash push` with pathspec exclusion syntax (`':!path'`) requires git >= 2.13. This should not be an issue for any modern installation.
- If the pathspec causes `git stash push` to find nothing to stash, it will output "No local changes to save" and `$wasStashed` will correctly be `$false`, so the `stash pop` at the end will be skipped.
- There is also a `git stash pop` in the merge-failure error path (around line 434). That code path returns early before any task state is committed, so it is less dangerous. However, for consistency and safety, you may want to also apply the same pathspec exclusion to the stash created before that error path. Since it's the same stash (created at the same line), this is already handled by this fix.

### 4.2 Fix B: Add dedup cleanup before the state commit in Complete-TaskWorktree

**File:** `WorktreeManager.psm1` (or equivalent module containing the `Complete-TaskWorktree` function)

**What to change:** Insert a deduplication step between the orphan cleanup (step 7) and the state commit (step 9). The best location is immediately before the `git add .bot/workspace/tasks/` line.

**Current code** (approximately lines 489-492):
```powershell
# Commit current task state on main — changes accumulate via junctions
# but were previously only "accidentally" committed via task branches
git -C $ProjectRoot add .bot/workspace/tasks/ 2>$null
git -C $ProjectRoot commit --quiet -m "chore: update task state" 2>$null
```

**New code:**
```powershell
# Remove duplicate task files: if a task exists in both a non-terminal directory
# and done/, the non-terminal copy is stale and must be removed before committing.
# This is a defensive measure against any mechanism that reintroduces stale files
# (stash pop, junction race conditions, Reset function edge cases).
$doneDir = Join-Path $ProjectRoot ".bot\workspace\tasks\done"
$todoDir = Join-Path $ProjectRoot ".bot\workspace\tasks\todo"
if ((Test-Path $doneDir) -and (Test-Path $todoDir)) {
    $doneFileNames = @{}
    Get-ChildItem $doneDir -Filter "*.json" -File -ErrorAction SilentlyContinue | ForEach-Object {
        $doneFileNames[$_.Name] = $true
    }
    Get-ChildItem $todoDir -Filter "*.json" -File -ErrorAction SilentlyContinue | ForEach-Object {
        if ($doneFileNames.ContainsKey($_.Name)) {
            Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue
        }
    }
    foreach ($intermediateDir in @('analysing', 'analysed', 'in-progress', 'needs-input')) {
        $dirPath = Join-Path $ProjectRoot ".bot\workspace\tasks\$intermediateDir"
        if (Test-Path $dirPath) {
            Get-ChildItem $dirPath -Filter "*.json" -File -ErrorAction SilentlyContinue | ForEach-Object {
                if ($doneFileNames.ContainsKey($_.Name)) {
                    Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue
                }
            }
        }
    }
}

# Commit current task state on main — changes accumulate via junctions
# but were previously only "accidentally" committed via task branches
git -C $ProjectRoot add .bot/workspace/tasks/ 2>$null
git -C $ProjectRoot commit --quiet -m "chore: update task state" 2>$null
```

**Why this works:** This is a defensive "last line of defense" that runs just before the state commit. Regardless of how stale files were reintroduced (stash pop, junction writes, Reset functions, etc.), this step ensures no task exists simultaneously in `todo/` (or any intermediate state directory) and `done/`. The comparison is by filename, which encodes the task slug and short ID, making it a reliable dedup key.

**Design notes:**
- The filename-based matching works because dotbot uses a consistent naming convention: `{task-name-slug}-{short-id}.json`. The filename is the same across all state directories.
- The check also covers `analysing/`, `analysed/`, `in-progress/`, and `needs-input/` for completeness. A task in `done/` should not have copies in any of these intermediate directories.
- Skipped and cancelled directories are intentionally excluded — a task could theoretically be both skipped once and then re-created and done, depending on business logic. Adjust if needed.
- This dedup step is cheap (two directory listings, set lookup) and adds negligible overhead.

### 4.3 Fix C: Guard Reset functions against resurrecting already-done tasks

**File:** `task-reset.ps1` (or equivalent module containing the Reset functions)

**What to change:** Each of the three Reset functions (`Reset-AnalysingTasks`, `Reset-InProgressTasks`, `Reset-SkippedTasks`) should check whether a task already exists in `done/` before moving it back to `todo/`. If the task is already done, the orphaned copy should simply be deleted.

#### 4.3.1 `Reset-AnalysingTasks`

**Current code** (inside the `foreach ($taskFile in $analysingTasks)` loop, approximately at line 264):
```powershell
# This task is orphaned - recover it
$todoDir = Join-Path $TasksBaseDir "todo"
if (-not (Test-Path $todoDir)) {
    New-Item -ItemType Directory -Path $todoDir -Force | Out-Null
}
$todoPath = Join-Path $todoDir $taskFile.Name

# Update status and timestamps
$taskContent.status = "todo"
$taskContent.updated_at = $now.ToString("yyyy-MM-ddTHH:mm:ssZ")
# ... (clear analysis_started_at, close sessions, etc.)

# Write to todo directory
$taskContent | ConvertTo-Json -Depth 10 | Set-Content -Path $todoPath -Force

# Remove from analysing
Remove-Item -Path $taskFile.FullName -Force -ErrorAction SilentlyContinue
```

**New code:**
```powershell
# Check if this task was already completed — if so, just delete the orphan
$doneFile = Join-Path $TasksBaseDir "done" $taskFile.Name
if (Test-Path $doneFile) {
    Remove-Item -Path $taskFile.FullName -Force -ErrorAction SilentlyContinue
    continue
}

# This task is orphaned and not yet done - recover it to todo
$todoDir = Join-Path $TasksBaseDir "todo"
if (-not (Test-Path $todoDir)) {
    New-Item -ItemType Directory -Path $todoDir -Force | Out-Null
}
$todoPath = Join-Path $todoDir $taskFile.Name

# Update status and timestamps
$taskContent.status = "todo"
$taskContent.updated_at = $now.ToString("yyyy-MM-ddTHH:mm:ssZ")
# ... (keep existing code for clearing analysis_started_at, closing sessions, etc.)

# Write to todo directory
$taskContent | ConvertTo-Json -Depth 10 | Set-Content -Path $todoPath -Force

# Remove from analysing
Remove-Item -Path $taskFile.FullName -Force -ErrorAction SilentlyContinue
```

The guard (`Test-Path $doneFile`) should be inserted **before** any writes occur. The `continue` skips the rest of the loop body for that task.

#### 4.3.2 `Reset-InProgressTasks`

**Current code** (inside the `foreach ($taskFile in $inProgressTasks)` loop, approximately at line 47):
```powershell
$taskContent = Get-Content -Path $taskFile.FullName -Raw | ConvertFrom-Json
$taskId = $taskContent.id
$taskName = $taskContent.name

# If task has analysis data, return to analysed; otherwise to todo
$hasAnalysis = $taskContent.analysis -and ...
```

**New code** — insert the done-check immediately after reading the task content:
```powershell
$taskContent = Get-Content -Path $taskFile.FullName -Raw | ConvertFrom-Json
$taskId = $taskContent.id
$taskName = $taskContent.name

# Check if this task was already completed — if so, just delete the orphan
$doneFile = Join-Path $TasksBaseDir "done" $taskFile.Name
if (Test-Path $doneFile) {
    Remove-Item -Path $taskFile.FullName -Force -ErrorAction SilentlyContinue
    continue
}

# If task has analysis data, return to analysed; otherwise to todo
$hasAnalysis = $taskContent.analysis -and ...
```

#### 4.3.3 `Reset-SkippedTasks`

**Current code** (inside the `foreach ($taskFile in $skippedTasks)` loop, after the skip-count guard):
```powershell
# Guard against infinite skip loops
$skipCount = ($taskContent.skip_history | Measure-Object).Count
if ($skipCount -ge 3) {
    Write-Warning "Task '$taskName' skipped $skipCount times - leaving in skipped for manual review"
    continue
}

# Move to todo directory
$todoDir = Join-Path $TasksBaseDir "todo"
```

**New code** — insert done-check after the skip-count guard:
```powershell
# Guard against infinite skip loops
$skipCount = ($taskContent.skip_history | Measure-Object).Count
if ($skipCount -ge 3) {
    Write-Warning "Task '$taskName' skipped $skipCount times - leaving in skipped for manual review"
    continue
}

# Check if this task was already completed — if so, just delete the orphan
$doneFile = Join-Path $TasksBaseDir "done" $taskFile.Name
if (Test-Path $doneFile) {
    Remove-Item -Path $taskFile.FullName -Force -ErrorAction SilentlyContinue
    continue
}

# Move to todo directory
$todoDir = Join-Path $TasksBaseDir "todo"
```

**Why this works:** The Reset functions are designed to recover orphaned tasks after a workflow interruption. However, if a task has already been completed by a subsequent workflow run, moving it back to `todo/` creates a duplicate that the rest of the system cannot clean up (as demonstrated by this bug). The done-check prevents this by recognizing that the task has already reached its terminal state.

**Design notes:**
- The check uses `Test-Path` on the expected filename in `done/`, which is the same filename convention used throughout dotbot (slug + short-ID).
- The check must be placed **before** any filesystem writes to avoid the window where both `todo/` and `done/` copies exist simultaneously.
- Consider also checking the `cancelled/` directory if your task lifecycle allows tasks to be cancelled as a terminal state. In the investigated version, only `done/` was relevant.
- You may want to add a log line (e.g., `Write-Warning "Task '$taskName' already completed — removing orphaned copy from $sourceDir"`) for observability.
