### PR TITLE
fix: conditionally open kickstart modal or run workflow

### DIFF
--- a/workflows/default/systems/ui/static/modules/controls.js
+++ b/workflows/default/systems/ui/static/modules/controls.js
@@ -325,7 +325,11 @@ function initControlButtons() {
 
         switch (action) {
             case 'start-workflow':
-                await launchWorkflow();
+                if (typeof openKickstartModal === 'function') {
+                    openKickstartModal();
+                } else {
+                    await launchWorkflow();
+                }
                 break;
             case 'stop-workflow':
                 await stopProcessesByType('workflow');
@@ -460,7 +464,13 @@ function renderWorkflowControls(workflows) {
         const led = row.querySelector('.wf-led');
         if (led) led.id = `wf-led-${wf.name}`;
         const runBtn = row.querySelector('.wf-run-btn');
-        if (runBtn) runBtn.addEventListener('click', () => runWorkflow(wf.name));
+        if (runBtn) runBtn.addEventListener('click', () => {
+            if (typeof openKickstartModal === 'function') {
+                openKickstartModal();
+            } else {
+                runWorkflow(wf.name);
+            }
+        });
         const stopBtn = row.querySelector('.wf-stop-btn');
         if (stopBtn) stopBtn.addEventListener('click', () => stopWorkflow(wf.name));
     });

--- a/workflows/default/systems/ui/static/modules/kickstart.js
+++ b/workflows/default/systems/ui/static/modules/kickstart.js
@@ -320,7 +320,7 @@ function renderWorkflowCardGrid(container) {
         const wfName = names[index];
         if (!wfName) return;
         const runBtn = card.querySelector('.wf-run-btn');
-        if (runBtn) runBtn.addEventListener('click', () => runWorkflow(wfName));
+        if (runBtn) runBtn.addEventListener('click', () => openKickstartModal());
         const stopBtn = card.querySelector('.wf-stop-btn');
         if (stopBtn) stopBtn.addEventListener('click', () => stopWorkflow(wfName));
     });


### PR DESCRIPTION
Kickstart from Jira workflow was broken, it was not displayin initial UI to get prompt, file upload etc.
This PR fixes that

This pull request updates the workflow control buttons to optionally open a kickstart modal before starting a workflow, depending on whether the `openKickstartModal` function is available. This adds flexibility for UI flows that require user input or confirmation before launching workflows.

**Workflow control and modal integration:**

* Updated the 'start workflow' and 'run workflow' button handlers in `controls.js` to check for the existence of `openKickstartModal`. If the function is present, it opens the modal instead of immediately starting the workflow; otherwise, it proceeds with the original workflow launch logic. [[1]](diffhunk://#diff-1f1cb32aebcd48640eaff83d7b8fcdb14e3a50d5ac0f7431724d900cafd9f4c0R328-R332) [[2]](diffhunk://#diff-1f1cb32aebcd48640eaff83d7b8fcdb14e3a50d5ac0f7431724d900cafd9f4c0L463-R473)
* Modified the workflow card grid in `kickstart.js` so that clicking the 'run workflow' button always triggers `openKickstartModal`, ensuring a consistent user experience when starting workflows from the card view.