### PR TITLE
docs: document powershell-yaml as a required dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ dotbot wraps AI-assisted coding in a managed, transparent workflow where every s
 - **Git** - [Download](https://git-scm.com/downloads)
 - **AI CLI** (at least one) - [Claude CLI](https://docs.anthropic.com/en/docs/claude-cli), [Codex CLI](https://github.com/openai/codex), or [Gemini CLI](https://github.com/google-gemini/gemini-cli)
 
+**Required PowerShell modules:**
+> **powershell-yaml** - YAML parsing. Install via:
+> ``` powershell
+> Install-Module -Name powershell-yaml -Scope CurrentUser
+> ```
+
 **Recommended MCP servers:**
 - **[Playwright MCP](https://github.com/anthropics/anthropic-quickstarts/tree/main/mcp-playwright)** - Browser automation for UI testing and verification.
 - **[Context7 MCP](https://github.com/upstash/context7)** - Library documentation lookup to reduce hallucination.


### PR DESCRIPTION
Adds powershell-yaml to the Prerequisites section of the README under a dedicated Required PowerShell modules heading. The module is used across the runtime, tests, and scripts on all platforms, so it belongs as a cross-platform prerequisite rather than a Windows-only note.