### PR TITLE
fix: remove $isWindows assignment that fails under iex on PS 7+

### DIFF
--- a/install-remote.ps1
+++ b/install-remote.ps1
@@ -42,9 +42,8 @@ if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
     return
 }
 
-# Determine archive format based on platform
-$isWindows = $PSVersionTable.Platform -eq 'Win32NT' -or [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
-$archiveExt = if ($isWindows) { "zip" } else { "tar.gz" }
+# Determine archive format based on platform (PS 7+ provides $IsWindows automatically)
+$archiveExt = if ($IsWindows) { "zip" } else { "tar.gz" }
 
 # Fetch latest release info from GitHub API
 Write-Host "  Fetching latest release..." -ForegroundColor Cyan


### PR DESCRIPTION
$IsWindows is a read-only automatic variable in PS 7+. Assigning to it via Invoke-Expression (irm ... | iex) runs in the global scope and throws "Invoke-Expression: Cannot overwrite variable IsWindows because it is read-only or constant.". Since the script already requires PS 7+, use the automatic variable directly.