### PR TITLE
feat: auto-install powershell-yaml during global install

### DIFF
--- a/scripts/install-global.ps1
+++ b/scripts/install-global.ps1
@@ -437,6 +437,17 @@ exec pwsh -NoProfile -File "$(dirname "$0")/dotbot.ps1" "$@"
     }
 }
 
+# Ensure powershell-yaml module is available
+if (-not $DryRun) {
+    if (-not (Get-Module -ListAvailable powershell-yaml -ErrorAction SilentlyContinue)) {
+        Write-Status "Installing powershell-yaml module..."
+        Install-Module -Name powershell-yaml -Repository PSGallery -Scope CurrentUser -Force -AllowClobber
+        Write-Success "powershell-yaml module installed"
+    } else {
+        Write-Success "powershell-yaml module already installed"
+    }
+}
+
 # Add to PATH
 if (-not $DryRun) {
     Add-ToPath -Directory $BinDir


### PR DESCRIPTION
## Summary
- Installer (`install-global.ps1`) now automatically installs the `powershell-yaml` module if missing
- Uses the same `Install-Module` pattern already proven in CI workflows
- Removes manual setup step — keeps installation simple

Supersedes #106 by handling the dependency in the installer rather than documenting a manual step.

## Test plan
- [x] `pwsh install.ps1` — shows "powershell-yaml module already installed" when present
- [x] All tests pass (layers 1-3): 922 passed, 0 failed