### PR TITLE
Fix default workflow listing after overlay init #101

### DIFF
--- a/workflows/default/systems/ui/server.ps1
+++ b/workflows/default/systems/ui/server.ps1
@@ -1646,7 +1646,7 @@ try {
                                 if ($sd.PSObject.Properties['workflow'] -and $sd.workflow -and $sd.workflow -ne 'default' -and $sd.workflow -ne $defaultName) {
                                     $skipDefault = $true
                                 }
-                            } catch { <# settings unreadable - keep default visible #> }
+                            } catch { Write-BotLog "Failed to read settings for workflow check: $_" }
                         }
                     }
 

--- a/workflows/default/systems/ui/server.ps1
+++ b/workflows/default/systems/ui/server.ps1
@@ -1643,10 +1643,11 @@ try {
                         if (Test-Path $settingsFile) {
                             try {
                                 $sd = Get-Content $settingsFile -Raw | ConvertFrom-Json
-                                if ($sd.PSObject.Properties['workflow'] -and $sd.workflow -and $sd.workflow -ne 'default' -and $sd.workflow -ne $defaultName) {
+                                $activeWf = if ($sd.PSObject.Properties['workflow']) { $sd.workflow } else { $sd.profile }
+                                if ($activeWf -and $activeWf -ne 'default' -and $activeWf -ne $defaultName) {
                                     $skipDefault = $true
                                 }
-                            } catch { Write-BotLog "Failed to read settings for workflow check: $_" }
+                            } catch { Write-BotLog -Level 'Warn' -Message 'Failed to read settings for workflow check' -Exception $_ }
                         }
                     }
 

--- a/workflows/default/systems/ui/server.ps1
+++ b/workflows/default/systems/ui/server.ps1
@@ -1637,6 +1637,19 @@ try {
                     $defaultName = if ($defaultManifest) { $defaultManifest.name } else { 'default' }
                     $skipDefault = $installedWfNames -contains $defaultName
 
+                    # Also skip default when an overlay workflow was applied during init
+                    if (-not $skipDefault) {
+                        $settingsFile = Join-Path $botRoot "settings\settings.default.json"
+                        if (Test-Path $settingsFile) {
+                            try {
+                                $sd = Get-Content $settingsFile -Raw | ConvertFrom-Json
+                                if ($sd.PSObject.Properties['workflow'] -and $sd.workflow -and $sd.workflow -ne 'default' -and $sd.workflow -ne $defaultName) {
+                                    $skipDefault = $true
+                                }
+                            } catch { <# settings unreadable - keep default visible #> }
+                        }
+                    }
+
                     if (-not $skipDefault) {
                         $defaultTasks = if ($tasksByWorkflow.ContainsKey('__default__')) { $tasksByWorkflow['__default__'] } else { @{ todo = 0; in_progress = 0; done = 0; total = 0 } }
 


### PR DESCRIPTION
## Summary
- Hide the "default" workflow from the Workflow tab when an overlay workflow was applied during `dotbot init -Workflow <name>`
- Reads the `workflow` field from `settings.default.json` — if it differs from "default", the default has been replaced and is excluded from the listing

## Why
When a project is initialized with a specific workflow (dotbot init -Workflow kickstart-via-jira), the default workflow serves as the base layer and the named workflow customizes it. However, the Workflow tab was listing both "default" and the named workflow as if they were separate, independent workflows. This is misleading — users should only see the workflow they chose. This change detects when a named workflow was applied and hides the redundant "default" entry.

## Test plan
- [ ] `dotbot init -Workflow kickstart-via-jira` → default should NOT appear in Workflow tab
- [ ] Plain `dotbot init` → default should still appear
- [ ] `dotbot workflow add <name>` (no overlay) → default should still appear alongside added workflow
- [ ] Layers 1-3 tests pass

Closes #101 