### PR TITLE
fix: switch install-global.ps1 from blocklist to allowlist (#141)

### DIFF
--- a/scripts/install-global.ps1
+++ b/scripts/install-global.ps1
@@ -44,17 +44,24 @@ if ($resolvedBase -and ($resolvedSource -eq $resolvedBase)) {
             New-Item -ItemType Directory -Force -Path $BaseDir | Out-Null
         }
         
-        # Copy all files except .git, .vs, and studio-ui (handled separately)
-        $itemsToCopy = Get-ChildItem -Path $SourceDir -Exclude ".git", ".vs", "studio-ui"
+        # Allowlist: only copy directories and files needed at runtime.
+        # Everything else (server, ideas, tests, docs, assets, etc.) stays in the repo.
+        $allowedDirs = @("scripts", "workflows", "stacks")
+        $allowedFiles = @("version.json", "dotbot.psm1", "dotbot.psd1", "install.ps1", "install-remote.ps1")
 
-        foreach ($item in $itemsToCopy) {
-            $dest = Join-Path $BaseDir $item.Name
-
-            if ($item.PSIsContainer) {
+        foreach ($dirName in $allowedDirs) {
+            $src = Join-Path $SourceDir $dirName
+            if (Test-Path $src) {
+                $dest = Join-Path $BaseDir $dirName
                 if (Test-Path $dest) { Remove-Item -Path $dest -Recurse -Force }
-                Copy-Item -Path $item.FullName -Destination $dest -Recurse -Force
-            } else {
-                Copy-Item -Path $item.FullName -Destination $dest -Force
+                Copy-Item -Path $src -Destination $dest -Recurse -Force
+            }
+        }
+
+        foreach ($fileName in $allowedFiles) {
+            $src = Join-Path $SourceDir $fileName
+            if (Test-Path $src) {
+                Copy-Item -Path $src -Destination (Join-Path $BaseDir $fileName) -Force
             }
         }
 


### PR DESCRIPTION
## Summary

Switches install-global.ps1 from a blocklist to an explicit allowlist of runtime dependencies. This reduces the global install size from ~330MB to ~6.5MB (98% reduction).

## Problem

The installer used a blocklist (excluding only .git, .vs, studio-ui) which copied everything else in the repo to ~/dotbot -- including server/ (298MB of Terraform providers and .NET build output), ideas/ (18MB of node_modules), tests/, docs/, assets/, .serena/, etc.

The blocklist never kept pace with new directories added to the repo.

## Change

Replace the blocklist with an allowlist:

- Directories: scripts, workflows, stacks
- Files: version.json, dotbot.psm1, dotbot.psd1, install.ps1, install-remote.ps1
- studio-ui: server.ps1, StudioAPI.psm1, static/ (unchanged, already handled separately)

## Verification

- Deleted ~/dotbot, ran install.ps1 -- clean install, 6.5MB, 380 files
- All CLI commands (dotbot init, dotbot list, dotbot status, dotbot studio) rely only on allowlisted paths

Closes #141

---
[Warp conversation](https://app.warp.dev/conversation/1a0b4a14-70d0-4d92-b9f4-d2357baa4a14)