### PR TITLE
fix: add assertions to workflow condition integration test (#157)

### DIFF
--- a/tests/Test-WorkflowIntegration.ps1
+++ b/tests/Test-WorkflowIntegration.ps1
@@ -453,7 +453,12 @@ try {
 
             foreach ($task in $conditionedTasks) {
                 $condResult = Test-ManifestCondition -ProjectRoot $testProjectConditions -Condition $task.condition
-                Write-TestResult -Name "Task '$($task.name)' condition evaluates without error" -Status Pass
+                Assert-True -Name "Task '$($task.name)' condition returns boolean result" `
+                    -Condition ($condResult -is [bool]) `
+                    -Message "Expected boolean but got: $($condResult)"
+                Assert-True -Name "Task '$($task.name)' condition evaluates to true after init" `
+                    -Condition ($condResult -eq $true) `
+                    -Message "Condition evaluated to false; expected true after project init"
             }
         } else {
             # Default workflow uses depends_on (not condition) — verify tasks have dependencies instead


### PR DESCRIPTION
## Summary
- Replace no-op `Write-TestResult -Status Pass` with real `Assert-True` checks in the workflow condition integration test
- Test now validates that `Test-ManifestCondition` returns a boolean and evaluates to `$true` after project init

## Problem
The existing test recorded a pass as long as `Test-ManifestCondition` didn't throw — it never inspected the return value. This meant a silently wrong result (e.g. `$null` or `$false`) would still show green.

## Changes
- `tests/Test-WorkflowIntegration.ps1` — replaced the single `Write-TestResult` call with two `Assert-True` calls:
  1. **Type check** — confirms the result is `[bool]`
  2. **Value check** — confirms the result is `$true`

Closes #157