### PR TITLE
fix: strip ANSI sequences from process heartbeat status

### DIFF
--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -226,6 +226,7 @@ if ((Test-Path $fileWatcherModule) -and (Test-Path $processApiModule) -and (Test
 
     $testProcId = "proc-ansi-sanitize"
     $testProcFile = Join-Path $testProcessesDir "$testProcId.json"
+    $testActivityFile = Join-Path $testProcessesDir "$testProcId.activity.jsonl"
     $esc = [char]27
 
     try {
@@ -349,9 +350,25 @@ if ((Test-Path $fileWatcherModule) -and (Test-Path $processApiModule) -and (Test
         Assert-Equal -Name "dead PID rewrite returns stopped process" `
             -Expected "stopped" `
             -Actual $listedProc.status
+
+        @(
+            (@{
+                timestamp = (Get-Date).ToUniversalTime().ToString("o")
+                type = "text"
+                message = "[38;2;56;52;44m[12:28:39][0m [38;2;112;104;92mGET[0m [kickstart]"
+            } | ConvertTo-Json -Compress)
+        ) | Set-Content -Path $testActivityFile -Encoding utf8NoBOM
+
+        $outputData = Get-ProcessOutput -ProcessId $testProcId -Position 0 -Tail 50
+        Assert-Equal -Name "Get-ProcessOutput strips ANSI fragments from activity messages" `
+            -Expected "[12:28:39] GET [kickstart]" `
+            -Actual $outputData.events[0].message
     } finally {
         if (Test-Path $testProcFile) {
             Remove-Item $testProcFile -Force -ErrorAction SilentlyContinue
+        }
+        if (Test-Path $testActivityFile) {
+            Remove-Item $testActivityFile -Force -ErrorAction SilentlyContinue
         }
     }
 } else {

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -262,6 +262,12 @@ if ((Test-Path $fileWatcherModule) -and (Test-Path $processApiModule) -and (Test
         Assert-Equal -Name "Console sanitizer preserves plain bracketed text" `
             -Expected "[1]" `
             -Actual (ConvertTo-SanitizedConsoleText "[1]")
+        Assert-Equal -Name "Console sanitizer preserves bracketed words" `
+            -Expected "[kickstart] phase 1" `
+            -Actual (ConvertTo-SanitizedConsoleText "[kickstart] phase 1")
+        Assert-True -Name "Console sanitizer strips parameterless orphaned reset fragment" `
+            -Condition ($null -eq (ConvertTo-SanitizedConsoleText "[m")) `
+            -Message "Expected parameterless reset fragment to be removed"
 
         $heartbeatBlankResult = Invoke-SteeringHeartbeat -Arguments @{
             session_id = "test-session-ansi"

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -205,6 +205,7 @@ $testProcessesDir = Join-Path $testControlDir "processes"
 $testLogsDir = Join-Path $testControlDir "logs"
 
 if ((Test-Path $fileWatcherModule) -and (Test-Path $processApiModule) -and (Test-Path $stateBuilderModule) -and (Test-Path $steeringHeartbeatScript) -and (Test-Path $dotBotLogModule) -and (Test-Path $consoleSanitizerModule)) {
+    Import-Module $consoleSanitizerModule -Force
     Import-Module $dotBotLogModule -Force
     Import-Module $fileWatcherModule -Force
     Import-Module $processApiModule -Force
@@ -258,6 +259,9 @@ if ((Test-Path $fileWatcherModule) -and (Test-Path $processApiModule) -and (Test
         Assert-Equal -Name "steering_heartbeat strips ANSI from stored heartbeat_next_action" `
             -Expected "Wait" `
             -Actual $storedProc.heartbeat_next_action
+        Assert-Equal -Name "Console sanitizer preserves plain bracketed text" `
+            -Expected "[1]" `
+            -Actual (ConvertTo-SanitizedConsoleText "[1]")
 
         $heartbeatBlankResult = Invoke-SteeringHeartbeat -Arguments @{
             session_id = "test-session-ansi"
@@ -319,6 +323,26 @@ if ((Test-Path $fileWatcherModule) -and (Test-Path $processApiModule) -and (Test
         Assert-True -Name "Get-BotState normalizes empty execution next_action to null" `
             -Condition ($null -eq $state.instances.execution.next_action) `
             -Message "Expected execution next_action to be null after sanitization"
+
+        $storedProc.status = "running"
+        $storedProc.pid = 999999
+        $storedProc | Add-Member -NotePropertyName failed_at -NotePropertyValue $null -Force
+        $storedProc | Add-Member -NotePropertyName error -NotePropertyValue $null -Force
+        $storedProc.heartbeat_status = "[38;2;56;52;44mIdle[0m"
+        $storedProc.heartbeat_next_action = "[0m"
+        $storedProc | ConvertTo-Json -Depth 10 | Set-Content -Path $testProcFile -Encoding utf8NoBOM
+
+        $listedProc = @((Get-ProcessList).processes | Where-Object { $_.id -eq $testProcId }) | Select-Object -First 1
+        $rewrittenProc = Get-Content $testProcFile -Raw | ConvertFrom-Json
+        Assert-Equal -Name "dead PID rewrite persists sanitized heartbeat_status" `
+            -Expected "Idle" `
+            -Actual $rewrittenProc.heartbeat_status
+        Assert-True -Name "dead PID rewrite persists null heartbeat_next_action" `
+            -Condition ($null -eq $rewrittenProc.heartbeat_next_action) `
+            -Message "Expected heartbeat_next_action to be null after dead PID rewrite"
+        Assert-Equal -Name "dead PID rewrite returns stopped process" `
+            -Expected "stopped" `
+            -Actual $listedProc.status
     } finally {
         if (Test-Path $testProcFile) {
             Remove-Item $testProcFile -Force -ErrorAction SilentlyContinue

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -199,11 +199,12 @@ $processApiModule = Join-Path $botDir "systems\ui\modules\ProcessAPI.psm1"
 $stateBuilderModule = Join-Path $botDir "systems\ui\modules\StateBuilder.psm1"
 $steeringHeartbeatScript = Join-Path $botDir "systems\mcp\tools\steering-heartbeat\script.ps1"
 $dotBotLogModule = Join-Path $botDir "systems\runtime\modules\DotBotLog.psm1"
+$consoleSanitizerModule = Join-Path $botDir "systems\runtime\modules\ConsoleSequenceSanitizer.psm1"
 $testControlDir = Join-Path $botDir ".control"
 $testProcessesDir = Join-Path $testControlDir "processes"
 $testLogsDir = Join-Path $testControlDir "logs"
 
-if ((Test-Path $fileWatcherModule) -and (Test-Path $processApiModule) -and (Test-Path $stateBuilderModule) -and (Test-Path $steeringHeartbeatScript) -and (Test-Path $dotBotLogModule)) {
+if ((Test-Path $fileWatcherModule) -and (Test-Path $processApiModule) -and (Test-Path $stateBuilderModule) -and (Test-Path $steeringHeartbeatScript) -and (Test-Path $dotBotLogModule) -and (Test-Path $consoleSanitizerModule)) {
     Import-Module $dotBotLogModule -Force
     Import-Module $fileWatcherModule -Force
     Import-Module $processApiModule -Force
@@ -258,6 +259,25 @@ if ((Test-Path $fileWatcherModule) -and (Test-Path $processApiModule) -and (Test
             -Expected "Wait" `
             -Actual $storedProc.heartbeat_next_action
 
+        $heartbeatBlankResult = Invoke-SteeringHeartbeat -Arguments @{
+            session_id = "test-session-ansi"
+            process_id = $testProcId
+            status = "${esc}[0m"
+            next_action = "${esc}[0m"
+        }
+
+        Assert-True -Name "steering_heartbeat accepts control-only heartbeat updates" `
+            -Condition ($heartbeatBlankResult.success -eq $true) `
+            -Message "Expected heartbeat tool to succeed"
+
+        $storedProc = Get-Content $testProcFile -Raw | ConvertFrom-Json
+        Assert-True -Name "steering_heartbeat normalizes empty heartbeat_status to null" `
+            -Condition ($null -eq $storedProc.heartbeat_status) `
+            -Message "Expected heartbeat_status to be null after sanitization"
+        Assert-True -Name "steering_heartbeat normalizes empty heartbeat_next_action to null" `
+            -Condition ($null -eq $storedProc.heartbeat_next_action) `
+            -Message "Expected heartbeat_next_action to be null after sanitization"
+
         $storedProc.heartbeat_status = "[38;2;56;52;44mIdle[0m"
         $storedProc.heartbeat_next_action = "[38;2;112;104;92mWait[0m"
         $storedProc | ConvertTo-Json -Depth 10 | Set-Content -Path $testProcFile -Encoding utf8NoBOM
@@ -270,6 +290,7 @@ if ((Test-Path $fileWatcherModule) -and (Test-Path $processApiModule) -and (Test
             -Expected "Wait" `
             -Actual $listedProc.heartbeat_next_action
 
+        Clear-StateCache
         $state = Get-BotState
         Assert-Equal -Name "Get-BotState exposes sanitized execution status" `
             -Expected "Idle" `
@@ -277,6 +298,27 @@ if ((Test-Path $fileWatcherModule) -and (Test-Path $processApiModule) -and (Test
         Assert-Equal -Name "Get-BotState exposes sanitized execution next_action" `
             -Expected "Wait" `
             -Actual $state.instances.execution.next_action
+
+        $storedProc.heartbeat_status = "[0m"
+        $storedProc.heartbeat_next_action = "[0m"
+        $storedProc | ConvertTo-Json -Depth 10 | Set-Content -Path $testProcFile -Encoding utf8NoBOM
+
+        $listedProc = @((Get-ProcessList).processes | Where-Object { $_.id -eq $testProcId }) | Select-Object -First 1
+        Assert-True -Name "Get-ProcessList normalizes empty heartbeat_status to null" `
+            -Condition ($null -eq $listedProc.heartbeat_status) `
+            -Message "Expected heartbeat_status to be null after sanitization"
+        Assert-True -Name "Get-ProcessList normalizes empty heartbeat_next_action to null" `
+            -Condition ($null -eq $listedProc.heartbeat_next_action) `
+            -Message "Expected heartbeat_next_action to be null after sanitization"
+
+        Clear-StateCache
+        $state = Get-BotState
+        Assert-True -Name "Get-BotState normalizes empty execution status to null" `
+            -Condition ($null -eq $state.instances.execution.status) `
+            -Message "Expected execution status to be null after sanitization"
+        Assert-True -Name "Get-BotState normalizes empty execution next_action to null" `
+            -Condition ($null -eq $state.instances.execution.next_action) `
+            -Message "Expected execution next_action to be null after sanitization"
     } finally {
         if (Test-Path $testProcFile) {
             Remove-Item $testProcFile -Force -ErrorAction SilentlyContinue

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -195,6 +195,7 @@ Write-Host "  PROCESS STATUS SANITIZATION" -ForegroundColor Cyan
 Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
 
 $fileWatcherModule = Join-Path $botDir "systems\ui\modules\FileWatcher.psm1"
+$controlApiModule = Join-Path $botDir "systems\ui\modules\ControlAPI.psm1"
 $processApiModule = Join-Path $botDir "systems\ui\modules\ProcessAPI.psm1"
 $stateBuilderModule = Join-Path $botDir "systems\ui\modules\StateBuilder.psm1"
 $steeringHeartbeatScript = Join-Path $botDir "systems\mcp\tools\steering-heartbeat\script.ps1"
@@ -204,10 +205,11 @@ $testControlDir = Join-Path $botDir ".control"
 $testProcessesDir = Join-Path $testControlDir "processes"
 $testLogsDir = Join-Path $testControlDir "logs"
 
-if ((Test-Path $fileWatcherModule) -and (Test-Path $processApiModule) -and (Test-Path $stateBuilderModule) -and (Test-Path $steeringHeartbeatScript) -and (Test-Path $dotBotLogModule) -and (Test-Path $consoleSanitizerModule)) {
+if ((Test-Path $fileWatcherModule) -and (Test-Path $controlApiModule) -and (Test-Path $processApiModule) -and (Test-Path $stateBuilderModule) -and (Test-Path $steeringHeartbeatScript) -and (Test-Path $dotBotLogModule) -and (Test-Path $consoleSanitizerModule)) {
     Import-Module $consoleSanitizerModule -Force
     Import-Module $dotBotLogModule -Force
     Import-Module $fileWatcherModule -Force
+    Import-Module $controlApiModule -Force
     Import-Module $processApiModule -Force
     Import-Module $stateBuilderModule -Force
     $global:DotbotProjectRoot = $testProject
@@ -221,12 +223,14 @@ if ((Test-Path $fileWatcherModule) -and (Test-Path $processApiModule) -and (Test
     }
     Initialize-DotBotLog -LogDir $testLogsDir -ControlDir $testControlDir -ProjectRoot $testProject
     Initialize-FileWatchers -BotRoot $botDir
+    Initialize-ControlAPI -ControlDir $testControlDir -ProcessesDir $testProcessesDir -BotRoot $botDir
     Initialize-ProcessAPI -ProcessesDir $testProcessesDir -BotRoot $botDir -ControlDir $testControlDir
     Initialize-StateBuilder -BotRoot $botDir -ControlDir $testControlDir -ProcessesDir $testProcessesDir
 
     $testProcId = "proc-ansi-sanitize"
     $testProcFile = Join-Path $testProcessesDir "$testProcId.json"
     $testActivityFile = Join-Path $testProcessesDir "$testProcId.activity.jsonl"
+    $globalActivityFile = Join-Path $testControlDir "activity.jsonl"
     $esc = [char]27
 
     try {
@@ -363,12 +367,28 @@ if ((Test-Path $fileWatcherModule) -and (Test-Path $processApiModule) -and (Test
         Assert-Equal -Name "Get-ProcessOutput strips ANSI fragments from activity messages" `
             -Expected "[12:28:39] GET [kickstart]" `
             -Actual $outputData.events[0].message
+
+        @(
+            (@{
+                timestamp = (Get-Date).ToUniversalTime().ToString("o")
+                type = "text"
+                message = "[38;2;56;52;44m[12:28:39][0m [38;2;112;104;92mGET[0m [kickstart]"
+            } | ConvertTo-Json -Compress)
+        ) | Set-Content -Path $globalActivityFile -Encoding utf8NoBOM
+
+        $activityTail = Get-ActivityTail -Position 0 -TailLines 50
+        Assert-Equal -Name "Get-ActivityTail strips ANSI fragments from global activity messages" `
+            -Expected "[12:28:39] GET [kickstart]" `
+            -Actual $activityTail.events[0].message
     } finally {
         if (Test-Path $testProcFile) {
             Remove-Item $testProcFile -Force -ErrorAction SilentlyContinue
         }
         if (Test-Path $testActivityFile) {
             Remove-Item $testActivityFile -Force -ErrorAction SilentlyContinue
+        }
+        if (Test-Path $globalActivityFile) {
+            Remove-Item $globalActivityFile -Force -ErrorAction SilentlyContinue
         }
     }
 } else {

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -188,6 +188,106 @@ if (Test-Path $extractCommitInfoScript) {
 
 Write-Host ""
 
+# PROCESS STATUS SANITIZATION
+# ═══════════════════════════════════════════════════════════════════
+
+Write-Host "  PROCESS STATUS SANITIZATION" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$fileWatcherModule = Join-Path $botDir "systems\ui\modules\FileWatcher.psm1"
+$processApiModule = Join-Path $botDir "systems\ui\modules\ProcessAPI.psm1"
+$stateBuilderModule = Join-Path $botDir "systems\ui\modules\StateBuilder.psm1"
+$steeringHeartbeatScript = Join-Path $botDir "systems\mcp\tools\steering-heartbeat\script.ps1"
+$dotBotLogModule = Join-Path $botDir "systems\runtime\modules\DotBotLog.psm1"
+$testControlDir = Join-Path $botDir ".control"
+$testProcessesDir = Join-Path $testControlDir "processes"
+$testLogsDir = Join-Path $testControlDir "logs"
+
+if ((Test-Path $fileWatcherModule) -and (Test-Path $processApiModule) -and (Test-Path $stateBuilderModule) -and (Test-Path $steeringHeartbeatScript) -and (Test-Path $dotBotLogModule)) {
+    Import-Module $dotBotLogModule -Force
+    Import-Module $fileWatcherModule -Force
+    Import-Module $processApiModule -Force
+    Import-Module $stateBuilderModule -Force
+    $global:DotbotProjectRoot = $testProject
+    . $steeringHeartbeatScript
+
+    if (-not (Test-Path $testLogsDir)) {
+        New-Item -Path $testLogsDir -ItemType Directory -Force | Out-Null
+    }
+    if (-not (Test-Path $testProcessesDir)) {
+        New-Item -Path $testProcessesDir -ItemType Directory -Force | Out-Null
+    }
+    Initialize-DotBotLog -LogDir $testLogsDir -ControlDir $testControlDir -ProjectRoot $testProject
+    Initialize-FileWatchers -BotRoot $botDir
+    Initialize-ProcessAPI -ProcessesDir $testProcessesDir -BotRoot $botDir -ControlDir $testControlDir
+    Initialize-StateBuilder -BotRoot $botDir -ControlDir $testControlDir -ProcessesDir $testProcessesDir
+
+    $testProcId = "proc-ansi-sanitize"
+    $testProcFile = Join-Path $testProcessesDir "$testProcId.json"
+    $esc = [char]27
+
+    try {
+        @{
+            id = $testProcId
+            type = "execution"
+            status = "running"
+            pid = $PID
+            started_at = (Get-Date).ToUniversalTime().ToString("o")
+            last_heartbeat = (Get-Date).ToUniversalTime().ToString("o")
+            last_whisper_index = 0
+            heartbeat_status = $null
+            heartbeat_next_action = $null
+        } | ConvertTo-Json -Depth 10 | Set-Content -Path $testProcFile -Encoding utf8NoBOM
+
+        $heartbeatResult = Invoke-SteeringHeartbeat -Arguments @{
+            session_id = "test-session-ansi"
+            process_id = $testProcId
+            status = "${esc}[38;2;56;52;44mIdle${esc}[0m"
+            next_action = "${esc}[38;2;112;104;92mWait${esc}[0m"
+        }
+
+        Assert-True -Name "steering_heartbeat accepts ANSI-bearing status text" `
+            -Condition ($heartbeatResult.success -eq $true) `
+            -Message "Expected heartbeat tool to succeed"
+
+        $storedProc = Get-Content $testProcFile -Raw | ConvertFrom-Json
+        Assert-Equal -Name "steering_heartbeat strips ANSI from stored heartbeat_status" `
+            -Expected "Idle" `
+            -Actual $storedProc.heartbeat_status
+        Assert-Equal -Name "steering_heartbeat strips ANSI from stored heartbeat_next_action" `
+            -Expected "Wait" `
+            -Actual $storedProc.heartbeat_next_action
+
+        $storedProc.heartbeat_status = "[38;2;56;52;44mIdle[0m"
+        $storedProc.heartbeat_next_action = "[38;2;112;104;92mWait[0m"
+        $storedProc | ConvertTo-Json -Depth 10 | Set-Content -Path $testProcFile -Encoding utf8NoBOM
+
+        $listedProc = @((Get-ProcessList).processes | Where-Object { $_.id -eq $testProcId }) | Select-Object -First 1
+        Assert-Equal -Name "Get-ProcessList strips orphaned ANSI fragments from heartbeat_status" `
+            -Expected "Idle" `
+            -Actual $listedProc.heartbeat_status
+        Assert-Equal -Name "Get-ProcessList strips orphaned ANSI fragments from heartbeat_next_action" `
+            -Expected "Wait" `
+            -Actual $listedProc.heartbeat_next_action
+
+        $state = Get-BotState
+        Assert-Equal -Name "Get-BotState exposes sanitized execution status" `
+            -Expected "Idle" `
+            -Actual $state.instances.execution.status
+        Assert-Equal -Name "Get-BotState exposes sanitized execution next_action" `
+            -Expected "Wait" `
+            -Actual $state.instances.execution.next_action
+    } finally {
+        if (Test-Path $testProcFile) {
+            Remove-Item $testProcFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+} else {
+    Write-TestResult -Name "Process status sanitization test modules exist" -Status Fail -Message "One or more UI/process modules were not found in $botDir"
+}
+
+Write-Host ""
+
 # MCP SERVER BOOT
 # ═══════════════════════════════════════════════════════════════════
 
@@ -2219,4 +2319,3 @@ $allPassed = Write-TestSummary -LayerName "Layer 2: Components"
 if (-not $allPassed) {
     exit 1
 }
-

--- a/workflows/default/systems/mcp/tools/steering-heartbeat/script.ps1
+++ b/workflows/default/systems/mcp/tools/steering-heartbeat/script.ps1
@@ -1,18 +1,4 @@
-$script:ConsoleSequencePattern = "(\x1B\[[0-9;?]*[ -/]*[@-~])|(\[[0-9;?]*[ -/]*[@-~])"
-
-function Remove-ConsoleSequences {
-    param(
-        [AllowNull()]
-        [object]$Text
-    )
-
-    if ($null -eq $Text) {
-        return $null
-    }
-
-    $clean = [regex]::Replace([string]$Text, $script:ConsoleSequencePattern, "")
-    return $clean.Trim()
-}
+Import-Module (Join-Path $PSScriptRoot "..\..\..\runtime\modules\ConsoleSequenceSanitizer.psm1") -Force
 
 function Invoke-SteeringHeartbeat {
     <#
@@ -120,13 +106,13 @@ function Invoke-SteeringHeartbeat {
     }
 
     # Update process file with heartbeat info (atomic write)
-    $sanitizedStatus = Remove-ConsoleSequences $status
-    $sanitizedNextAction = Remove-ConsoleSequences $nextAction
+    $sanitizedStatus = Normalize-ConsoleSequenceText $status
+    $sanitizedNextAction = Normalize-ConsoleSequenceText $nextAction
 
     $processData.last_heartbeat = (Get-Date).ToUniversalTime().ToString("o")
     $processData.last_whisper_index = $currentIndex
     $processData.heartbeat_status = $sanitizedStatus
-    $processData.heartbeat_next_action = if ([string]::IsNullOrWhiteSpace($sanitizedNextAction)) { $null } else { $sanitizedNextAction }
+    $processData.heartbeat_next_action = $sanitizedNextAction
 
     try {
         $tempFile = "$processFile.tmp"

--- a/workflows/default/systems/mcp/tools/steering-heartbeat/script.ps1
+++ b/workflows/default/systems/mcp/tools/steering-heartbeat/script.ps1
@@ -1,4 +1,4 @@
-Import-Module (Join-Path $PSScriptRoot "..\..\..\runtime\modules\ConsoleSequenceSanitizer.psm1") -Force
+Import-Module (Join-Path $PSScriptRoot "..\..\..\runtime\modules\ConsoleSequenceSanitizer.psm1")
 
 function Invoke-SteeringHeartbeat {
     <#
@@ -106,8 +106,8 @@ function Invoke-SteeringHeartbeat {
     }
 
     # Update process file with heartbeat info (atomic write)
-    $sanitizedStatus = Normalize-ConsoleSequenceText $status
-    $sanitizedNextAction = Normalize-ConsoleSequenceText $nextAction
+    $sanitizedStatus = ConvertTo-SanitizedConsoleText $status
+    $sanitizedNextAction = ConvertTo-SanitizedConsoleText $nextAction
 
     $processData.last_heartbeat = (Get-Date).ToUniversalTime().ToString("o")
     $processData.last_whisper_index = $currentIndex

--- a/workflows/default/systems/mcp/tools/steering-heartbeat/script.ps1
+++ b/workflows/default/systems/mcp/tools/steering-heartbeat/script.ps1
@@ -1,3 +1,19 @@
+$script:ConsoleSequencePattern = "(\x1B\[[0-9;?]*[ -/]*[@-~])|(\[[0-9;?]*[ -/]*[@-~])"
+
+function Remove-ConsoleSequences {
+    param(
+        [AllowNull()]
+        [object]$Text
+    )
+
+    if ($null -eq $Text) {
+        return $null
+    }
+
+    $clean = [regex]::Replace([string]$Text, $script:ConsoleSequencePattern, "")
+    return $clean.Trim()
+}
+
 function Invoke-SteeringHeartbeat {
     <#
     .SYNOPSIS
@@ -104,10 +120,13 @@ function Invoke-SteeringHeartbeat {
     }
 
     # Update process file with heartbeat info (atomic write)
+    $sanitizedStatus = Remove-ConsoleSequences $status
+    $sanitizedNextAction = Remove-ConsoleSequences $nextAction
+
     $processData.last_heartbeat = (Get-Date).ToUniversalTime().ToString("o")
     $processData.last_whisper_index = $currentIndex
-    $processData.heartbeat_status = $status
-    $processData.heartbeat_next_action = if ($nextAction) { $nextAction } else { $null }
+    $processData.heartbeat_status = $sanitizedStatus
+    $processData.heartbeat_next_action = if ([string]::IsNullOrWhiteSpace($sanitizedNextAction)) { $null } else { $sanitizedNextAction }
 
     try {
         $tempFile = "$processFile.tmp"

--- a/workflows/default/systems/runtime/modules/ConsoleSequenceSanitizer.psm1
+++ b/workflows/default/systems/runtime/modules/ConsoleSequenceSanitizer.psm1
@@ -9,9 +9,9 @@ rendering paths.
 #>
 
 # The second alternative intentionally strips orphaned CSI fragments after the
-# ESC byte is lost, but limits the final byte to letters so plain text like
-# "[1]" is preserved. Keep this sanitizer scoped to process heartbeat text.
-$script:ConsoleSequencePattern = "(\x1B\[[0-9;?]*[ -/]*[@-~])|(\[[0-9;?]*[ -/]*[A-Za-z])"
+# ESC byte is lost, but requires CSI-like parameter content or the common
+# parameterless "[m" reset fragment so plain bracketed words are preserved.
+$script:ConsoleSequencePattern = "(\x1B\[[0-9;?]*[ -/]*[@-~])|(\[(?:[0-9?][0-9;?]*[ -/]*[A-Za-z]|m))"
 
 function Remove-ConsoleSequences {
     param(

--- a/workflows/default/systems/runtime/modules/ConsoleSequenceSanitizer.psm1
+++ b/workflows/default/systems/runtime/modules/ConsoleSequenceSanitizer.psm1
@@ -9,8 +9,9 @@ rendering paths.
 #>
 
 # The second alternative intentionally strips orphaned CSI fragments after the
-# ESC byte is lost. Keep this sanitizer scoped to process heartbeat text.
-$script:ConsoleSequencePattern = "(\x1B\[[0-9;?]*[ -/]*[@-~])|(\[[0-9;?]*[ -/]*[@-~])"
+# ESC byte is lost, but limits the final byte to letters so plain text like
+# "[1]" is preserved. Keep this sanitizer scoped to process heartbeat text.
+$script:ConsoleSequencePattern = "(\x1B\[[0-9;?]*[ -/]*[@-~])|(\[[0-9;?]*[ -/]*[A-Za-z])"
 
 function Remove-ConsoleSequences {
     param(

--- a/workflows/default/systems/runtime/modules/ConsoleSequenceSanitizer.psm1
+++ b/workflows/default/systems/runtime/modules/ConsoleSequenceSanitizer.psm1
@@ -1,0 +1,41 @@
+<#
+.SYNOPSIS
+Console/control sequence sanitization helpers.
+
+.DESCRIPTION
+Strips ANSI escape sequences and orphaned CSI fragments from status text so
+terminal formatting artifacts do not leak into persisted process metadata or UI
+rendering paths.
+#>
+
+$script:ConsoleSequencePattern = "(\x1B\[[0-9;?]*[ -/]*[@-~])|(\[[0-9;?]*[ -/]*[@-~])"
+
+function Remove-ConsoleSequences {
+    param(
+        [AllowNull()]
+        [object]$Text
+    )
+
+    if ($null -eq $Text) {
+        return $null
+    }
+
+    $clean = [regex]::Replace([string]$Text, $script:ConsoleSequencePattern, "")
+    return $clean.Trim()
+}
+
+function Normalize-ConsoleSequenceText {
+    param(
+        [AllowNull()]
+        [object]$Text
+    )
+
+    $clean = Remove-ConsoleSequences $Text
+    if ([string]::IsNullOrWhiteSpace($clean)) {
+        return $null
+    }
+
+    return $clean
+}
+
+Export-ModuleMember -Function @('Remove-ConsoleSequences', 'Normalize-ConsoleSequenceText')

--- a/workflows/default/systems/runtime/modules/ConsoleSequenceSanitizer.psm1
+++ b/workflows/default/systems/runtime/modules/ConsoleSequenceSanitizer.psm1
@@ -8,6 +8,8 @@ terminal formatting artifacts do not leak into persisted process metadata or UI
 rendering paths.
 #>
 
+# The second alternative intentionally strips orphaned CSI fragments after the
+# ESC byte is lost. Keep this sanitizer scoped to process heartbeat text.
 $script:ConsoleSequencePattern = "(\x1B\[[0-9;?]*[ -/]*[@-~])|(\[[0-9;?]*[ -/]*[@-~])"
 
 function Remove-ConsoleSequences {
@@ -24,7 +26,7 @@ function Remove-ConsoleSequences {
     return $clean.Trim()
 }
 
-function Normalize-ConsoleSequenceText {
+function ConvertTo-SanitizedConsoleText {
     param(
         [AllowNull()]
         [object]$Text
@@ -38,4 +40,21 @@ function Normalize-ConsoleSequenceText {
     return $clean
 }
 
-Export-ModuleMember -Function @('Remove-ConsoleSequences', 'Normalize-ConsoleSequenceText')
+function Update-ProcessHeartbeatFields {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Process
+    )
+
+    if ($Process.PSObject.Properties['heartbeat_status']) {
+        $Process.heartbeat_status = ConvertTo-SanitizedConsoleText $Process.heartbeat_status
+    }
+
+    if ($Process.PSObject.Properties['heartbeat_next_action']) {
+        $Process.heartbeat_next_action = ConvertTo-SanitizedConsoleText $Process.heartbeat_next_action
+    }
+
+    return $Process
+}
+
+Export-ModuleMember -Function @('ConvertTo-SanitizedConsoleText', 'Update-ProcessHeartbeatFields')

--- a/workflows/default/systems/ui/modules/ControlAPI.psm1
+++ b/workflows/default/systems/ui/modules/ControlAPI.psm1
@@ -8,6 +8,21 @@ operator whisper channel, and activity log tail streaming.
 Extracted from server.ps1 for modularity.
 #>
 
+Import-Module (Join-Path $PSScriptRoot "..\..\runtime\modules\ConsoleSequenceSanitizer.psm1")
+
+function Update-ActivityEventFields {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Event
+    )
+
+    if ($Event.PSObject.Properties['message']) {
+        $Event.message = ConvertTo-SanitizedConsoleText $Event.message
+    }
+
+    return $Event
+}
+
 $script:Config = @{
     ControlDir = $null
     ProcessesDir = $null
@@ -284,7 +299,7 @@ function Get-ActivityTail {
             foreach ($line in $allLines) {
                 if ($line) {
                     try {
-                        $events += ($line | ConvertFrom-Json)
+                        $events += (Update-ActivityEventFields -Event ($line | ConvertFrom-Json))
                     } catch {
                         # Skip malformed lines
                     }
@@ -311,7 +326,7 @@ function Get-ActivityTail {
                 $line = $reader.ReadLine()
                 if ($line) {
                     try {
-                        $events += ($line | ConvertFrom-Json)
+                        $events += (Update-ActivityEventFields -Event ($line | ConvertFrom-Json))
                     } catch {
                         # Skip malformed lines
                     }

--- a/workflows/default/systems/ui/modules/ProcessAPI.psm1
+++ b/workflows/default/systems/ui/modules/ProcessAPI.psm1
@@ -16,6 +16,19 @@ $script:Config = @{
 
 Import-Module (Join-Path $PSScriptRoot "..\..\runtime\modules\ConsoleSequenceSanitizer.psm1")
 
+function Update-ActivityEventFields {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Event
+    )
+
+    if ($Event.PSObject.Properties['message']) {
+        $Event.message = ConvertTo-SanitizedConsoleText $Event.message
+    }
+
+    return $Event
+}
+
 function Initialize-ProcessAPI {
     param(
         [Parameter(Mandatory)] [string]$ProcessesDir,
@@ -110,7 +123,7 @@ function Get-ProcessOutput {
             $events = @()
             $startIdx = if ($Position -gt 0) { $Position } else { [Math]::Max(0, $totalLines - $Tail) }
             for ($li = $startIdx; $li -lt $totalLines; $li++) {
-                try { $events += ($allLines[$li] | ConvertFrom-Json) } catch { Write-BotLog -Level Debug -Message "Malformed JSONL line in activity log" -Exception $_ }
+                try { $events += (Update-ActivityEventFields -Event ($allLines[$li] | ConvertFrom-Json)) } catch { Write-BotLog -Level Debug -Message "Malformed JSONL line in activity log" -Exception $_ }
             }
 
             return @{

--- a/workflows/default/systems/ui/modules/ProcessAPI.psm1
+++ b/workflows/default/systems/ui/modules/ProcessAPI.psm1
@@ -65,6 +65,7 @@ function Get-ProcessList {
                     $proc.status = 'stopped'
                     $proc.failed_at = $now.ToString("o")
                     $proc | Add-Member -NotePropertyName 'error' -NotePropertyValue "Process terminated unexpectedly" -Force
+                    $proc = Update-ProcessHeartbeatFields -Process $proc
                     $proc | ConvertTo-Json -Depth 10 | Set-Content -Path $pf.FullName -Force -ErrorAction Stop
 
                     # Write activity log so the PROCESSES tab output shows what happened

--- a/workflows/default/systems/ui/modules/ProcessAPI.psm1
+++ b/workflows/default/systems/ui/modules/ProcessAPI.psm1
@@ -14,21 +14,7 @@ $script:Config = @{
     ControlDir = $null
 }
 
-$script:ConsoleSequencePattern = "(\x1B\[[0-9;?]*[ -/]*[@-~])|(\[[0-9;?]*[ -/]*[@-~])"
-
-function Remove-ConsoleSequences {
-    param(
-        [AllowNull()]
-        [object]$Text
-    )
-
-    if ($null -eq $Text) {
-        return $null
-    }
-
-    $clean = [regex]::Replace([string]$Text, $script:ConsoleSequencePattern, "")
-    return $clean.Trim()
-}
+Import-Module (Join-Path $PSScriptRoot "..\..\runtime\modules\ConsoleSequenceSanitizer.psm1") -Force
 
 function Sanitize-ProcessDisplayFields {
     param(
@@ -37,12 +23,11 @@ function Sanitize-ProcessDisplayFields {
     )
 
     if ($Process.PSObject.Properties['heartbeat_status']) {
-        $Process.heartbeat_status = Remove-ConsoleSequences $Process.heartbeat_status
+        $Process.heartbeat_status = Normalize-ConsoleSequenceText $Process.heartbeat_status
     }
 
     if ($Process.PSObject.Properties['heartbeat_next_action']) {
-        $cleanNextAction = Remove-ConsoleSequences $Process.heartbeat_next_action
-        $Process.heartbeat_next_action = if ([string]::IsNullOrWhiteSpace($cleanNextAction)) { $null } else { $cleanNextAction }
+        $Process.heartbeat_next_action = Normalize-ConsoleSequenceText $Process.heartbeat_next_action
     }
 
     return $Process

--- a/workflows/default/systems/ui/modules/ProcessAPI.psm1
+++ b/workflows/default/systems/ui/modules/ProcessAPI.psm1
@@ -14,24 +14,7 @@ $script:Config = @{
     ControlDir = $null
 }
 
-Import-Module (Join-Path $PSScriptRoot "..\..\runtime\modules\ConsoleSequenceSanitizer.psm1") -Force
-
-function Sanitize-ProcessDisplayFields {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Process
-    )
-
-    if ($Process.PSObject.Properties['heartbeat_status']) {
-        $Process.heartbeat_status = Normalize-ConsoleSequenceText $Process.heartbeat_status
-    }
-
-    if ($Process.PSObject.Properties['heartbeat_next_action']) {
-        $Process.heartbeat_next_action = Normalize-ConsoleSequenceText $Process.heartbeat_next_action
-    }
-
-    return $Process
-}
+Import-Module (Join-Path $PSScriptRoot "..\..\runtime\modules\ConsoleSequenceSanitizer.psm1")
 
 function Initialize-ProcessAPI {
     param(
@@ -91,7 +74,7 @@ function Get-ProcessList {
                 }
             }
 
-            $processList += (Sanitize-ProcessDisplayFields -Process $proc)
+            $processList += (Update-ProcessHeartbeatFields -Process $proc)
         } catch { Write-BotLog -Level Debug -Message "Logging operation failed" -Exception $_ }
     }
 
@@ -294,7 +277,7 @@ function Get-ProcessDetail {
 
     $procFile = Join-Path $processesDir "$ProcessId.json"
     if (Test-Path $procFile) {
-        return Sanitize-ProcessDisplayFields -Process (Get-Content $procFile -Raw | ConvertFrom-Json)
+        return Update-ProcessHeartbeatFields -Process (Get-Content $procFile -Raw | ConvertFrom-Json)
     } else {
         return @{ _statusCode = 404; error = "Process not found: $ProcessId" }
     }

--- a/workflows/default/systems/ui/modules/ProcessAPI.psm1
+++ b/workflows/default/systems/ui/modules/ProcessAPI.psm1
@@ -14,6 +14,40 @@ $script:Config = @{
     ControlDir = $null
 }
 
+$script:ConsoleSequencePattern = "(\x1B\[[0-9;?]*[ -/]*[@-~])|(\[[0-9;?]*[ -/]*[@-~])"
+
+function Remove-ConsoleSequences {
+    param(
+        [AllowNull()]
+        [object]$Text
+    )
+
+    if ($null -eq $Text) {
+        return $null
+    }
+
+    $clean = [regex]::Replace([string]$Text, $script:ConsoleSequencePattern, "")
+    return $clean.Trim()
+}
+
+function Sanitize-ProcessDisplayFields {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Process
+    )
+
+    if ($Process.PSObject.Properties['heartbeat_status']) {
+        $Process.heartbeat_status = Remove-ConsoleSequences $Process.heartbeat_status
+    }
+
+    if ($Process.PSObject.Properties['heartbeat_next_action']) {
+        $cleanNextAction = Remove-ConsoleSequences $Process.heartbeat_next_action
+        $Process.heartbeat_next_action = if ([string]::IsNullOrWhiteSpace($cleanNextAction)) { $null } else { $cleanNextAction }
+    }
+
+    return $Process
+}
+
 function Initialize-ProcessAPI {
     param(
         [Parameter(Mandatory)] [string]$ProcessesDir,
@@ -72,7 +106,7 @@ function Get-ProcessList {
                 }
             }
 
-            $processList += $proc
+            $processList += (Sanitize-ProcessDisplayFields -Process $proc)
         } catch { Write-BotLog -Level Debug -Message "Logging operation failed" -Exception $_ }
     }
 
@@ -275,7 +309,7 @@ function Get-ProcessDetail {
 
     $procFile = Join-Path $processesDir "$ProcessId.json"
     if (Test-Path $procFile) {
-        return Get-Content $procFile -Raw | ConvertFrom-Json
+        return Sanitize-ProcessDisplayFields -Process (Get-Content $procFile -Raw | ConvertFrom-Json)
     } else {
         return @{ _statusCode = 404; error = "Process not found: $ProcessId" }
     }

--- a/workflows/default/systems/ui/modules/StateBuilder.psm1
+++ b/workflows/default/systems/ui/modules/StateBuilder.psm1
@@ -15,21 +15,7 @@ $script:Config = @{
     ProcessesDir = $null
 }
 
-$script:ConsoleSequencePattern = "(\x1B\[[0-9;?]*[ -/]*[@-~])|(\[[0-9;?]*[ -/]*[@-~])"
-
-function Remove-ConsoleSequences {
-    param(
-        [AllowNull()]
-        [object]$Text
-    )
-
-    if ($null -eq $Text) {
-        return $null
-    }
-
-    $clean = [regex]::Replace([string]$Text, $script:ConsoleSequencePattern, "")
-    return $clean.Trim()
-}
+Import-Module (Join-Path $PSScriptRoot "..\..\runtime\modules\ConsoleSequenceSanitizer.psm1") -Force
 
 function Sanitize-ProcessHeartbeatFields {
     param(
@@ -38,12 +24,11 @@ function Sanitize-ProcessHeartbeatFields {
     )
 
     if ($Process.PSObject.Properties['heartbeat_status']) {
-        $Process.heartbeat_status = Remove-ConsoleSequences $Process.heartbeat_status
+        $Process.heartbeat_status = Normalize-ConsoleSequenceText $Process.heartbeat_status
     }
 
     if ($Process.PSObject.Properties['heartbeat_next_action']) {
-        $cleanNextAction = Remove-ConsoleSequences $Process.heartbeat_next_action
-        $Process.heartbeat_next_action = if ([string]::IsNullOrWhiteSpace($cleanNextAction)) { $null } else { $cleanNextAction }
+        $Process.heartbeat_next_action = Normalize-ConsoleSequenceText $Process.heartbeat_next_action
     }
 
     return $Process

--- a/workflows/default/systems/ui/modules/StateBuilder.psm1
+++ b/workflows/default/systems/ui/modules/StateBuilder.psm1
@@ -15,24 +15,7 @@ $script:Config = @{
     ProcessesDir = $null
 }
 
-Import-Module (Join-Path $PSScriptRoot "..\..\runtime\modules\ConsoleSequenceSanitizer.psm1") -Force
-
-function Sanitize-ProcessHeartbeatFields {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Process
-    )
-
-    if ($Process.PSObject.Properties['heartbeat_status']) {
-        $Process.heartbeat_status = Normalize-ConsoleSequenceText $Process.heartbeat_status
-    }
-
-    if ($Process.PSObject.Properties['heartbeat_next_action']) {
-        $Process.heartbeat_next_action = Normalize-ConsoleSequenceText $Process.heartbeat_next_action
-    }
-
-    return $Process
-}
+Import-Module (Join-Path $PSScriptRoot "..\..\runtime\modules\ConsoleSequenceSanitizer.psm1")
 
 function Initialize-StateBuilder {
     param(
@@ -544,7 +527,7 @@ function Get-BotState {
         foreach ($pf in $procFiles) {
             try {
                 $proc = Get-Content $pf.FullName -Raw | ConvertFrom-Json
-                $proc = Sanitize-ProcessHeartbeatFields -Process $proc
+                $proc = Update-ProcessHeartbeatFields -Process $proc
 
                 # Count processes waiting for interview answers
                 if ($proc.status -eq 'needs-input' -and $proc.pending_questions) {

--- a/workflows/default/systems/ui/modules/StateBuilder.psm1
+++ b/workflows/default/systems/ui/modules/StateBuilder.psm1
@@ -15,6 +15,40 @@ $script:Config = @{
     ProcessesDir = $null
 }
 
+$script:ConsoleSequencePattern = "(\x1B\[[0-9;?]*[ -/]*[@-~])|(\[[0-9;?]*[ -/]*[@-~])"
+
+function Remove-ConsoleSequences {
+    param(
+        [AllowNull()]
+        [object]$Text
+    )
+
+    if ($null -eq $Text) {
+        return $null
+    }
+
+    $clean = [regex]::Replace([string]$Text, $script:ConsoleSequencePattern, "")
+    return $clean.Trim()
+}
+
+function Sanitize-ProcessHeartbeatFields {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Process
+    )
+
+    if ($Process.PSObject.Properties['heartbeat_status']) {
+        $Process.heartbeat_status = Remove-ConsoleSequences $Process.heartbeat_status
+    }
+
+    if ($Process.PSObject.Properties['heartbeat_next_action']) {
+        $cleanNextAction = Remove-ConsoleSequences $Process.heartbeat_next_action
+        $Process.heartbeat_next_action = if ([string]::IsNullOrWhiteSpace($cleanNextAction)) { $null } else { $cleanNextAction }
+    }
+
+    return $Process
+}
+
 function Initialize-StateBuilder {
     param(
         [Parameter(Mandatory)] [string]$BotRoot,
@@ -525,6 +559,7 @@ function Get-BotState {
         foreach ($pf in $procFiles) {
             try {
                 $proc = Get-Content $pf.FullName -Raw | ConvertFrom-Json
+                $proc = Sanitize-ProcessHeartbeatFields -Process $proc
 
                 # Count processes waiting for interview answers
                 if ($proc.status -eq 'needs-input' -and $proc.pending_questions) {

--- a/workflows/default/systems/ui/static/modules/activity.js
+++ b/workflows/default/systems/ui/static/modules/activity.js
@@ -25,7 +25,7 @@ function updateTextDisplay(event, isRateLimit = false) {
     const textEl = document.getElementById('text-output');
     if (!textEl) return;
 
-    let msg = event.message || '';
+    let msg = stripConsoleSequences(event.message || '');
     if (msg.length > 150) {
         msg = msg.substring(0, 147) + '...';
     }
@@ -51,7 +51,7 @@ function updateCommandDisplay(event) {
     const cmdEl = document.getElementById('command-text');
     const pillEl = document.getElementById('tool-pill');
 
-    let msg = event.message || '';
+    let msg = stripConsoleSequences(event.message || '');
 
     // Clean up shell commands
     if (msg.length > 80) {

--- a/workflows/default/systems/ui/static/modules/controls.js
+++ b/workflows/default/systems/ui/static/modules/controls.js
@@ -1766,8 +1766,13 @@ function updateSteeringStatus(instances) {
     } else if (inst.status) {
         const statusText = stripConsoleSequences(inst.status);
         const nextActionText = stripConsoleSequences(inst.next_action);
-        textEl.textContent = statusText + (nextActionText ? `\n→ ${nextActionText}` : '');
-        textEl.className = 'steering-text';
+        if (statusText) {
+            textEl.textContent = statusText + (nextActionText ? `\n→ ${nextActionText}` : '');
+            textEl.className = 'steering-text';
+        } else {
+            textEl.textContent = 'Awaiting heartbeat...';
+            textEl.className = 'steering-text muted';
+        }
     } else {
         textEl.textContent = 'Awaiting heartbeat...';
         textEl.className = 'steering-text muted';

--- a/workflows/default/systems/ui/static/modules/controls.js
+++ b/workflows/default/systems/ui/static/modules/controls.js
@@ -1764,7 +1764,9 @@ function updateSteeringStatus(instances) {
         textEl.textContent = `${selectedInstance} not running`;
         textEl.className = 'steering-text muted';
     } else if (inst.status) {
-        textEl.textContent = inst.status + (inst.next_action ? `\n→ ${inst.next_action}` : '');
+        const statusText = stripConsoleSequences(inst.status);
+        const nextActionText = stripConsoleSequences(inst.next_action);
+        textEl.textContent = statusText + (nextActionText ? `\n→ ${nextActionText}` : '');
         textEl.className = 'steering-text';
     } else {
         textEl.textContent = 'Awaiting heartbeat...';

--- a/workflows/default/systems/ui/static/modules/processes.js
+++ b/workflows/default/systems/ui/static/modules/processes.js
@@ -298,10 +298,11 @@ function renderOutputHtml(events) {
     for (const evt of events) {
         const ts = evt.timestamp ? new Date(evt.timestamp).toLocaleTimeString() : '';
         const typeClass = evt.type === 'rate_limit' ? 'warning' : (evt.type === 'text' ? 'text' : 'tool');
+        const messageText = stripConsoleSequences(evt.message || '');
         html += `<div class="process-output-line ${typeClass}">`;
         html += `  <span class="output-time">${ts}</span>`;
         html += `  <span class="output-type">${escapeHtml(evt.type || '')}</span>`;
-        html += `  <span class="output-msg">${escapeHtml(evt.message || '')}</span>`;
+        html += `  <span class="output-msg">${escapeHtml(messageText)}</span>`;
         html += `</div>`;
     }
     return html;

--- a/workflows/default/systems/ui/static/modules/processes.js
+++ b/workflows/default/systems/ui/static/modules/processes.js
@@ -162,9 +162,12 @@ function renderProcessList(processes) {
 
             html += `  </div>`;
 
+            const heartbeatStatusText = stripConsoleSequences(proc.heartbeat_status);
+            const heartbeatNextActionText = stripConsoleSequences(proc.heartbeat_next_action);
+
             // Heartbeat subtitle — visible without expanding
-            if (isActive && proc.heartbeat_status) {
-                html += `<div class="process-heartbeat-subtitle">${escapeHtml(stripConsoleSequences(proc.heartbeat_status))}</div>`;
+            if (isActive && heartbeatStatusText) {
+                html += `<div class="process-heartbeat-subtitle">${escapeHtml(heartbeatStatusText)}</div>`;
             }
 
             // Expanded detail panel
@@ -175,11 +178,11 @@ function renderProcessList(processes) {
                 html += `<div class="process-meta">`;
                 html += `  <span class="process-meta-item"><b>Model:</b> ${proc.model || '--'}</span>`;
                 html += `  <span class="process-meta-item"><b>Tasks:</b> ${proc.tasks_completed || 0}</span>`;
-                if (proc.heartbeat_status) {
-                    html += `  <span class="process-meta-item"><b>Status:</b> ${escapeHtml(stripConsoleSequences(proc.heartbeat_status))}</span>`;
+                if (heartbeatStatusText) {
+                    html += `  <span class="process-meta-item"><b>Status:</b> ${escapeHtml(heartbeatStatusText)}</span>`;
                 }
-                if (proc.heartbeat_next_action) {
-                    html += `  <span class="process-meta-item"><b>Next:</b> ${escapeHtml(stripConsoleSequences(proc.heartbeat_next_action))}</span>`;
+                if (heartbeatNextActionText) {
+                    html += `  <span class="process-meta-item"><b>Next:</b> ${escapeHtml(heartbeatNextActionText)}</span>`;
                 }
                 html += `</div>`;
 

--- a/workflows/default/systems/ui/static/modules/processes.js
+++ b/workflows/default/systems/ui/static/modules/processes.js
@@ -164,7 +164,7 @@ function renderProcessList(processes) {
 
             // Heartbeat subtitle — visible without expanding
             if (isActive && proc.heartbeat_status) {
-                html += `<div class="process-heartbeat-subtitle">${escapeHtml(proc.heartbeat_status)}</div>`;
+                html += `<div class="process-heartbeat-subtitle">${escapeHtml(stripConsoleSequences(proc.heartbeat_status))}</div>`;
             }
 
             // Expanded detail panel
@@ -176,10 +176,10 @@ function renderProcessList(processes) {
                 html += `  <span class="process-meta-item"><b>Model:</b> ${proc.model || '--'}</span>`;
                 html += `  <span class="process-meta-item"><b>Tasks:</b> ${proc.tasks_completed || 0}</span>`;
                 if (proc.heartbeat_status) {
-                    html += `  <span class="process-meta-item"><b>Status:</b> ${escapeHtml(proc.heartbeat_status)}</span>`;
+                    html += `  <span class="process-meta-item"><b>Status:</b> ${escapeHtml(stripConsoleSequences(proc.heartbeat_status))}</span>`;
                 }
                 if (proc.heartbeat_next_action) {
-                    html += `  <span class="process-meta-item"><b>Next:</b> ${escapeHtml(proc.heartbeat_next_action)}</span>`;
+                    html += `  <span class="process-meta-item"><b>Next:</b> ${escapeHtml(stripConsoleSequences(proc.heartbeat_next_action))}</span>`;
                 }
                 html += `</div>`;
 

--- a/workflows/default/systems/ui/static/modules/utils.js
+++ b/workflows/default/systems/ui/static/modules/utils.js
@@ -34,8 +34,8 @@ function escapeAttr(text) {
 /**
  * Remove ANSI/control-sequence fragments from text before rendering.
  * Handles both real ESC-prefixed sequences and orphaned CSI fragments.
- * The orphaned fallback only removes letter-terminated fragments so text like
- * "[1]" is preserved.
+ * The orphaned fallback requires CSI-like parameter content or the common
+ * parameterless "[m" reset fragment so bracketed words are preserved.
  * @param {string} text - Text to clean
  * @returns {string} Cleaned text
  */
@@ -43,7 +43,7 @@ function stripConsoleSequences(text) {
     if (text == null) return '';
     return String(text)
         .replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, '')
-        .replace(/\[[0-9;?]*[ -/]*[A-Za-z]/g, '')
+        .replace(/\[(?:[0-9?][0-9;?]*[ -/]*[A-Za-z]|m)/g, '')
         .trim();
 }
 

--- a/workflows/default/systems/ui/static/modules/utils.js
+++ b/workflows/default/systems/ui/static/modules/utils.js
@@ -34,6 +34,8 @@ function escapeAttr(text) {
 /**
  * Remove ANSI/control-sequence fragments from text before rendering.
  * Handles both real ESC-prefixed sequences and orphaned CSI fragments.
+ * The orphaned fallback only removes letter-terminated fragments so text like
+ * "[1]" is preserved.
  * @param {string} text - Text to clean
  * @returns {string} Cleaned text
  */
@@ -41,7 +43,7 @@ function stripConsoleSequences(text) {
     if (text == null) return '';
     return String(text)
         .replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, '')
-        .replace(/\[[0-9;?]*[ -/]*[@-~]/g, '')
+        .replace(/\[[0-9;?]*[ -/]*[A-Za-z]/g, '')
         .trim();
 }
 

--- a/workflows/default/systems/ui/static/modules/utils.js
+++ b/workflows/default/systems/ui/static/modules/utils.js
@@ -189,7 +189,7 @@ function getActivityIcon(type) {
  */
 function formatActivityEntry(entry) {
     const type = entry.type || '';
-    const message = entry.message || '';
+    const message = stripConsoleSequences(entry.message || '');
     
     // Handle MCP tool calls: mcp__server__tool_name or mcp_server__tool_name
     if (type.startsWith('mcp__') || type.startsWith('mcp_')) {

--- a/workflows/default/systems/ui/static/modules/utils.js
+++ b/workflows/default/systems/ui/static/modules/utils.js
@@ -32,6 +32,20 @@ function escapeAttr(text) {
 }
 
 /**
+ * Remove ANSI/control-sequence fragments from text before rendering.
+ * Handles both real ESC-prefixed sequences and orphaned CSI fragments.
+ * @param {string} text - Text to clean
+ * @returns {string} Cleaned text
+ */
+function stripConsoleSequences(text) {
+    if (text == null) return '';
+    return String(text)
+        .replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, '')
+        .replace(/\[[0-9;?]*[ -/]*[@-~]/g, '')
+        .trim();
+}
+
+/**
  * Validate that a string matches the expected decision ID pattern (dec-XXXXXXXX).
  * Use before passing IDs into DOM operations or API calls.
  * @param {string} id - Value to validate


### PR DESCRIPTION
## Summary
- sanitize heartbeat status and next-action text before persisting or reading process state so stale process labels stay human-readable
- strip ANSI and orphaned CSI fragments in the Overview and Processes UI as a defense-in-depth fallback
- add regression coverage for ANSI-bearing heartbeat updates and already-corrupted stored values

## Testing
- `pwsh install.ps1`
- `pwsh tests/Run-Tests.ps1`

Fixes #178