### PR TITLE
Fix: Studio Access to External Registries

### DIFF
--- a/studio-ui/StudioAPI.psm1
+++ b/studio-ui/StudioAPI.psm1
@@ -17,6 +17,7 @@ API namespace: /api/studio
 $script:WorkflowsDir = $null
 $script:StaticRoot   = $null
 $script:LayoutFilename = '.studio-layout.json'
+$script:DotbotHome   = $null
 
 <#
 .SYNOPSIS
@@ -29,6 +30,7 @@ function Initialize-StudioAPI {
     )
     $script:WorkflowsDir = $WorkflowsDir
     $script:StaticRoot   = $StaticRoot
+    $script:DotbotHome   = Split-Path $WorkflowsDir -Parent
 
     if (-not (Test-Path $script:WorkflowsDir)) {
         New-Item -ItemType Directory -Force -Path $script:WorkflowsDir | Out-Null
@@ -67,8 +69,78 @@ function Get-SafeWorkflowDir {
 
 function Test-WorkflowExists {
     param([string]$Name)
+    if ($Name -match '^([^:]+):(.+)$') {
+        $dir = Get-RegistryWorkflowDir -RegistryName $Matches[1] -WorkflowName $Matches[2]
+        return $null -ne $dir -and (Test-Path $dir -PathType Container)
+    }
     $dir = Get-SafeWorkflowDir $Name
     return (Test-Path $dir) -and (Test-Path $dir -PathType Container)
+}
+
+function Get-RegistryWorkflowDir {
+    param([string]$RegistryName, [string]$WorkflowName)
+
+    # Validate names — same rules as Get-SafeWorkflowDir
+    foreach ($n in @($RegistryName, $WorkflowName)) {
+        if ([string]::IsNullOrWhiteSpace($n)) { return $null }
+        $safe = [System.IO.Path]::GetFileName($n)
+        if ($safe -ne $n -or $safe -eq '.' -or $safe -eq '..') { return $null }
+        if ($safe -notmatch '^[A-Za-z0-9._-]+$') { return $null }
+    }
+
+    $registriesDir = Join-Path $script:DotbotHome 'registries'
+    $candidatePath = [System.IO.Path]::GetFullPath((Join-Path $registriesDir $RegistryName 'workflows' $WorkflowName))
+
+    # Verify it stays under the registries directory
+    $rootWithSep = [System.IO.Path]::GetFullPath($registriesDir).TrimEnd(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar
+    ) + [System.IO.Path]::DirectorySeparatorChar
+    if (-not $candidatePath.StartsWith($rootWithSep, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $null
+    }
+
+    return $candidatePath
+}
+
+function Get-RegistryWorkflows {
+    $registriesJsonPath = Join-Path $script:DotbotHome 'registries.json'
+    if (-not (Test-Path $registriesJsonPath)) { return @() }
+
+    try {
+        $registriesConfig = Get-Content -Path $registriesJsonPath -Raw -Encoding UTF8 -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        return @()
+    }
+    if (-not $registriesConfig.registries) { return @() }
+
+    $result = @()
+    foreach ($reg in $registriesConfig.registries) {
+        # Validate registry name — same rules as Get-RegistryWorkflowDir
+        $regName = $reg.name
+        if ([string]::IsNullOrWhiteSpace($regName)) { continue }
+        $safeName = [System.IO.Path]::GetFileName($regName)
+        if ($safeName -ne $regName -or $safeName -eq '.' -or $safeName -eq '..') { continue }
+        if ($safeName -notmatch '^[A-Za-z0-9._-]+$') { continue }
+
+        $regWorkflowsDir = Join-Path $script:DotbotHome 'registries' $regName 'workflows'
+        if (-not (Test-Path $regWorkflowsDir)) { continue }
+
+        $folders = Get-ChildItem -Path $regWorkflowsDir -Directory -ErrorAction SilentlyContinue | Sort-Object Name
+        foreach ($folder in $folders) {
+            $yamlPath = Join-Path $folder.FullName 'workflow.yaml'
+            $yaml = $null
+            if (Test-Path $yamlPath) {
+                $yaml = Get-Content -Path $yamlPath -Raw -Encoding UTF8
+            }
+            $result += @{
+                folder   = "$($reg.name):$($folder.Name)"
+                yaml     = $yaml
+                registry = $reg.name
+            }
+        }
+    }
+    return $result
 }
 
 function Send-Json {
@@ -198,8 +270,10 @@ function Invoke-StudioRequest {
                     if (Test-Path $yamlPath) {
                         $yaml = Get-Content -Path $yamlPath -Raw -Encoding UTF8
                     }
-                    $result += @{ folder = $folder.Name; yaml = $yaml }
+                    $result += @{ folder = $folder.Name; yaml = $yaml; registry = $null }
                 }
+                # Append workflows from external registries
+                $result += Get-RegistryWorkflows
                 Send-Json -Response $res -Data $result
                 return $true
             }
@@ -262,7 +336,12 @@ tasks: []
                         Send-Error -Response $res -Message "Workflow '$workflowName' not found" -StatusCode 404
                         return $true
                     }
-                    $dir = Get-SafeWorkflowDir $workflowName
+                    # Resolve directory — registry workflows use "Registry:name" format
+                    if ($workflowName -match '^([^:]+):(.+)$') {
+                        $dir = Get-RegistryWorkflowDir -RegistryName $Matches[1] -WorkflowName $Matches[2]
+                    } else {
+                        $dir = Get-SafeWorkflowDir $workflowName
+                    }
                     $yamlPath = Join-Path $dir 'workflow.yaml'
                     $yaml = $null
                     if (Test-Path $yamlPath) {
@@ -306,6 +385,11 @@ tasks: []
                     return $true
                 }
                 elseif ($method -eq 'PUT') {
+                    # Registry workflows are read-only
+                    if ($workflowName -match '^[^:]+:.+$') {
+                        Send-Error -Response $res -Message 'Registry workflows are read-only' -StatusCode 403
+                        return $true
+                    }
                     # Save workflow: receive raw YAML + optional layout
                     $body = Read-RequestBody -Request $req | ConvertFrom-Json
                     if (-not $body.yaml) {
@@ -324,6 +408,11 @@ tasks: []
                     return $true
                 }
                 elseif ($method -eq 'DELETE') {
+                    # Registry workflows are read-only
+                    if ($workflowName -match '^[^:]+:.+$') {
+                        Send-Error -Response $res -Message 'Registry workflows are read-only' -StatusCode 403
+                        return $true
+                    }
                     if (-not (Test-WorkflowExists $workflowName)) {
                         Send-Error -Response $res -Message "Workflow '$workflowName' not found" -StatusCode 404
                         return $true
@@ -355,7 +444,13 @@ tasks: []
                     Send-Error -Response $res -Message "Workflow '$newName' already exists" -StatusCode 409
                     return $true
                 }
-                $srcDir = Get-SafeWorkflowDir $workflowName
+                # Resolve source — may be a registry workflow (Registry:name format)
+                if ($workflowName -match '^([^:]+):(.+)$') {
+                    $srcDir = Get-RegistryWorkflowDir -RegistryName $Matches[1] -WorkflowName $Matches[2]
+                } else {
+                    $srcDir = Get-SafeWorkflowDir $workflowName
+                }
+                # Destination is always a local workflow
                 $destDir = Get-SafeWorkflowDir $newName
                 Copy-DirectoryRecursive -Source $srcDir -Destination $destDir
                 Send-Json -Response $res -Data @{ success = $true; name = $newName } -StatusCode 201
@@ -376,7 +471,11 @@ tasks: []
 
             # -- /api/studio/:name/files[/...] --
             if ($segments.Count -ge 2 -and $segments[1] -eq 'files') {
-                $dir = Get-SafeWorkflowDir $workflowName
+                if ($workflowName -match '^([^:]+):(.+)$') {
+                    $dir = Get-RegistryWorkflowDir -RegistryName $Matches[1] -WorkflowName $Matches[2]
+                } else {
+                    $dir = Get-SafeWorkflowDir $workflowName
+                }
 
                 if ($segments.Count -eq 2 -and $method -eq 'GET') {
                     # List files in workflow root

--- a/studio-ui/src/client/App.tsx
+++ b/studio-ui/src/client/App.tsx
@@ -190,12 +190,12 @@ export function App() {
   return (
     <ReactFlowProvider>
       <div className="app-container">
-        {viewMode === 'canvas' && (
-          <>
+        <div style={{ display: viewMode === 'canvas' ? 'contents' : 'none' }}>
             <Toolbar
               currentName={wf.currentName}
               dirty={wf.dirty}
               loading={wf.loading}
+              isRegistry={wf.isRegistry}
               onNew={wf.newWorkflow}
               onOpen={wf.openWorkflow}
               onSave={wf.saveWorkflow}
@@ -242,6 +242,7 @@ export function App() {
                     onConnect={wf.onConnect}
                     onNodeClick={handleNodeClick}
                     onDropTask={(type: TaskType, position: { x: number; y: number }) => wf.addTask(type, position)}
+                    workflowKey={wf.currentName}
                   />
                 )}
               </div>
@@ -278,8 +279,7 @@ export function App() {
                 toggleRight={panelCollapsed ? 8 : panelWidth + 8}
               />
             </div>
-          </>
-        )}
+        </div>
 
         {viewMode === 'fileEditor' && wf.currentName && editorContext && (
           <PromptEditor

--- a/studio-ui/src/client/components/Canvas.tsx
+++ b/studio-ui/src/client/components/Canvas.tsx
@@ -1,7 +1,7 @@
 /**
  * React Flow canvas wrapper with custom node/edge types and controls.
  */
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import {
   ReactFlow,
   Controls,
@@ -43,6 +43,8 @@ interface CanvasProps {
   onConnect: (connection: Connection) => void;
   onNodeClick: (nodeId: string) => void;
   onDropTask?: (type: TaskType, position: { x: number; y: number }) => void;
+  /** Workflow identity key — fitView triggers when this changes (e.g. new workflow opened) */
+  workflowKey?: string | null;
 }
 
 export function Canvas({
@@ -53,8 +55,22 @@ export function Canvas({
   onConnect,
   onNodeClick,
   onDropTask,
+  workflowKey,
 }: CanvasProps) {
-  const { screenToFlowPosition } = useReactFlow();
+  const reactFlow = useReactFlow();
+  const { screenToFlowPosition } = reactFlow;
+  const lastWorkflowKey = useRef<string | null | undefined>(undefined);
+
+  // fitView only when a different workflow is loaded — not on return from editor
+  useEffect(() => {
+    if (workflowKey !== lastWorkflowKey.current) {
+      lastWorkflowKey.current = workflowKey;
+      // Small delay to let React Flow measure the new nodes
+      requestAnimationFrame(() => {
+        reactFlow.fitView({ padding: 0.3 });
+      });
+    }
+  }, [workflowKey, reactFlow]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     if (e.dataTransfer.types.includes('application/dotbot-task-type')) {
@@ -84,8 +100,6 @@ export function Canvas({
       nodeTypes={nodeTypes}
       edgeTypes={edgeTypes}
       defaultEdgeOptions={defaultEdgeOptions}
-      fitView
-      fitViewOptions={{ padding: 0.3 }}
       deleteKeyCode={['Backspace', 'Delete']}
       minZoom={0.2}
       maxZoom={2}

--- a/studio-ui/src/client/components/Toolbar.tsx
+++ b/studio-ui/src/client/components/Toolbar.tsx
@@ -20,6 +20,7 @@ interface ToolbarProps {
   currentName: string | null;
   dirty: boolean;
   loading: boolean;
+  isRegistry: boolean;
   onNew: () => void;
   onOpen: (name: string) => void;
   onSave: () => void;
@@ -32,6 +33,7 @@ export function Toolbar({
   currentName,
   dirty,
   loading,
+  isRegistry,
   onNew,
   onOpen,
   onSave,
@@ -95,13 +97,22 @@ export function Toolbar({
           <button className="toolbar-cmd" onClick={() => setShowPicker(true)} disabled={loading}>
             Open
           </button>
-          <button className="toolbar-cmd" onClick={onSave} disabled={loading || !currentName}>
+          <button
+            className="toolbar-cmd"
+            onClick={onSave}
+            disabled={loading || !currentName || isRegistry}
+            title={isRegistry ? 'Registry workflows are read-only — use Save As' : undefined}
+          >
             Save
           </button>
           <button
             className="toolbar-cmd"
             onClick={() => {
-              setSaveAsName(currentName ? `${currentName}-copy` : 'new-workflow');
+              // Strip registry prefix (e.g. "RegName:workflow" → "workflow")
+              const baseName = currentName?.includes(':')
+                ? currentName.split(':').slice(1).join(':')
+                : currentName;
+              setSaveAsName(baseName ? `${baseName}-copy` : 'new-workflow');
               setSaveAsError(null);
               setShowSaveAs(true);
             }}
@@ -154,7 +165,8 @@ export function Toolbar({
         {currentName && (
           <span className="toolbar-title">
             {currentName}
-            {dirty && <span className="toolbar-dirty"> (unsaved)</span>}
+            {isRegistry && <span className="toolbar-readonly"> (read-only)</span>}
+            {dirty && !isRegistry && <span className="toolbar-dirty"> (unsaved)</span>}
           </span>
         )}
         {!currentName && <span className="toolbar-title" style={{ fontStyle: 'italic' }}>New workflow</span>}

--- a/studio-ui/src/client/components/WorkflowPicker.tsx
+++ b/studio-ui/src/client/components/WorkflowPicker.tsx
@@ -32,6 +32,7 @@ export function WorkflowPicker({ onSelect, onClose }: WorkflowPickerProps) {
                 description: manifest.description || '',
                 version: manifest.version || '',
                 taskCount: manifest.tasks?.length || 0,
+                registry: item.registry || null,
               };
             } catch {
               // Fall through to default
@@ -43,6 +44,7 @@ export function WorkflowPicker({ onSelect, onClose }: WorkflowPickerProps) {
             description: '(unable to read workflow.yaml)',
             version: '',
             taskCount: 0,
+            registry: item.registry || null,
           };
         });
         setWorkflows(summaries);
@@ -66,7 +68,7 @@ export function WorkflowPicker({ onSelect, onClose }: WorkflowPickerProps) {
 
         {!loading && !error && workflows.length === 0 && (
           <div style={{ color: 'var(--color-muted)', padding: 20 }}>
-            No workflows found in ~/dotbot/workflows/
+            No workflows found in ~/dotbot/workflows/ or registries
           </div>
         )}
 
@@ -79,7 +81,21 @@ export function WorkflowPicker({ onSelect, onClose }: WorkflowPickerProps) {
                 onClick={() => onSelect(wf.folder)}
               >
                 <div>
-                  <div className="workflow-list-item-name">{wf.name}</div>
+                  <div className="workflow-list-item-name">
+                    {wf.name}
+                    {wf.registry && (
+                      <span style={{
+                        marginLeft: 8,
+                        fontSize: '0.7em',
+                        padding: '2px 6px',
+                        borderRadius: 3,
+                        background: 'var(--color-surface, #1a1a2e)',
+                        border: '1px solid var(--color-border, #333)',
+                        color: 'var(--color-accent, #f0c040)',
+                        verticalAlign: 'middle',
+                      }}>{wf.registry}</span>
+                    )}
+                  </div>
                   <div className="workflow-list-item-meta">
                     {wf.description ? wf.description.slice(0, 80) : 'No description'}
                   </div>

--- a/studio-ui/src/client/hooks/useApi.ts
+++ b/studio-ui/src/client/hooks/useApi.ts
@@ -19,6 +19,7 @@ async function handleResponse<T>(res: Response): Promise<T> {
 export interface WorkflowListItem {
   folder: string;
   yaml: string | null;
+  registry: string | null;
 }
 
 /** Raw data returned when loading a single workflow */

--- a/studio-ui/src/client/hooks/useWorkflow.ts
+++ b/studio-ui/src/client/hooks/useWorkflow.ts
@@ -31,6 +31,8 @@ export interface WorkflowState {
   agentFiles: string[];
   /** Available skill folders */
   skillFiles: string[];
+  /** Whether the current workflow is from an external registry (read-only) */
+  isRegistry: boolean;
   /** Loading state */
   loading: boolean;
   /** Error message */
@@ -66,6 +68,7 @@ export function useWorkflow(): WorkflowState & WorkflowActions {
   const [promptFiles, setPromptFiles] = useState<string[]>([]);
   const [agentFiles, setAgentFiles] = useState<string[]>([]);
   const [skillFiles, setSkillFiles] = useState<string[]>([]);
+  const [isRegistry, setIsRegistry] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const layoutRef = useRef<WorkflowLayout | null>(null);
@@ -111,6 +114,7 @@ export function useWorkflow(): WorkflowState & WorkflowActions {
     const m = createEmptyManifest('new-workflow');
     setManifest(m);
     setCurrentName(null);
+    setIsRegistry(false);
     setNodes([]);
     setEdges([]);
     setDirty(false);
@@ -145,6 +149,7 @@ export function useWorkflow(): WorkflowState & WorkflowActions {
       }
       setManifest(manifest);
       setCurrentName(name);
+      setIsRegistry(name.includes(':'));
       setValidationErrors(validation);
       setPromptFiles(data.promptFiles);
       setAgentFiles(data.agentFiles || []);
@@ -164,6 +169,10 @@ export function useWorkflow(): WorkflowState & WorkflowActions {
       setError('No workflow name — use Save As for new workflows');
       return;
     }
+    if (isRegistry) {
+      setError('Registry workflows are read-only — use Save As to create a local copy');
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -181,14 +190,14 @@ export function useWorkflow(): WorkflowState & WorkflowActions {
     } finally {
       setLoading(false);
     }
-  }, [currentName, manifest, nodes, edges, syncTasksFromNodes]);
+  }, [currentName, isRegistry, manifest, nodes, edges, syncTasksFromNodes]);
 
   const saveWorkflowAs = useCallback(async (newName: string) => {
     setLoading(true);
     setError(null);
     try {
       if (currentName) {
-        // Copy existing, then overwrite with current state
+        // Copy existing (local or registry), then overwrite with current state
         await api.copyWorkflow(currentName, newName);
       } else {
         await api.createWorkflow(newName);
@@ -201,6 +210,7 @@ export function useWorkflow(): WorkflowState & WorkflowActions {
       await api.saveWorkflow(newName, yaml, layoutJson);
       setManifest(updated);
       setCurrentName(newName);
+      setIsRegistry(false);  // Now a local workflow — fully editable
       layoutRef.current = layout;
       setDirty(false);
     } catch (err: unknown) {
@@ -209,7 +219,7 @@ export function useWorkflow(): WorkflowState & WorkflowActions {
     } finally {
       setLoading(false);
     }
-  }, [currentName, manifest, nodes, edges, syncTasksFromNodes]);
+  }, [currentName, isRegistry, manifest, nodes, edges, syncTasksFromNodes]);
 
   const updateManifestMeta = useCallback((updates: Partial<WorkflowManifest>) => {
     setManifest((prev) => ({ ...prev, ...updates }));
@@ -438,6 +448,7 @@ export function useWorkflow(): WorkflowState & WorkflowActions {
     promptFiles,
     agentFiles,
     skillFiles,
+    isRegistry,
     loading,
     error,
     newWorkflow,

--- a/studio-ui/src/client/model/workflow.ts
+++ b/studio-ui/src/client/model/workflow.ts
@@ -104,6 +104,7 @@ export interface WorkflowSummary {
   description: string;
   version: string;
   taskCount: number;
+  registry: string | null;
 }
 
 /** Layout data stored in sidecar file */

--- a/studio-ui/src/client/styles/globals.css
+++ b/studio-ui/src/client/styles/globals.css
@@ -154,6 +154,12 @@
     text-shadow: 0 0 6px var(--primary-glow);
 }
 
+.toolbar-readonly {
+    color: var(--color-muted, #888);
+    font-size: 11px;
+    font-style: italic;
+}
+
 /* ══════════════════════════════════════════════
    BUTTONS — Outpost ctrl-btn pattern
    ══════════════════════════════════════════════ */

--- a/tests/Test-StudioAPI.ps1
+++ b/tests/Test-StudioAPI.ps1
@@ -125,10 +125,281 @@ foreach ($case in $invalidNames) {
 }
 
 # ===================================================================
+# REGISTRY WORKFLOW DISCOVERY
+# ===================================================================
+
+Write-Host ""
+Write-Host "  REGISTRY WORKFLOW DISCOVERY" -ForegroundColor Cyan
+Write-Host "  --------------------------------------------" -ForegroundColor DarkGray
+
+# Build a fake registry structure under a temporary dotbot home
+$tempHome = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-test-registry-$([System.Guid]::NewGuid().ToString('N').Substring(0,8))"
+$tempWorkflows = Join-Path $tempHome 'workflows'
+$tempRegistries = Join-Path $tempHome 'registries'
+New-Item -ItemType Directory -Force -Path $tempWorkflows | Out-Null
+New-Item -ItemType Directory -Force -Path $tempRegistries | Out-Null
+
+# Create a mock registry with one workflow
+$mockRegName = 'TestRegistry'
+$mockWfName = 'test-workflow'
+$mockRegWfDir = Join-Path $tempRegistries $mockRegName 'workflows' $mockWfName
+New-Item -ItemType Directory -Force -Path $mockRegWfDir | Out-Null
+Set-Content -Path (Join-Path $mockRegWfDir 'workflow.yaml') -Value @"
+name: Test Workflow
+version: 1.0.0
+description: A test registry workflow
+tasks: []
+"@ -Encoding UTF8
+
+# Write registries.json
+Set-Content -Path (Join-Path $tempHome 'registries.json') -Value (@{
+    registries = @(@{
+        name = $mockRegName
+        source = 'https://example.com/test.git'
+        auto_update = $true
+        branch = 'main'
+        type = 'git'
+    })
+} | ConvertTo-Json -Depth 5) -Encoding UTF8
+
+# Re-initialize module with the temp home as parent
+$tempStaticReg = Join-Path $tempHome 'static'
+New-Item -ItemType Directory -Force -Path $tempStaticReg | Out-Null
+Initialize-StudioAPI -WorkflowsDir $tempWorkflows -StaticRoot $tempStaticReg
+
+# --- Test: Get-RegistryWorkflows returns registry workflows ---
+try {
+    $regWorkflows = @(& $studioModule { Get-RegistryWorkflows })
+    if ($regWorkflows.Count -ge 1) {
+        Write-TestResult -Name "Get-RegistryWorkflows returns registry workflows" -Status Pass
+    } else {
+        Write-TestResult -Name "Get-RegistryWorkflows returns registry workflows" -Status Fail -Message "Expected at least 1 workflow, got $($regWorkflows.Count)"
+    }
+} catch {
+    Write-TestResult -Name "Get-RegistryWorkflows returns registry workflows" -Status Fail -Message $_.Exception.Message
+}
+
+# --- Test: Registry workflows include registry name in folder field ---
+try {
+    $regWorkflows = @(& $studioModule { Get-RegistryWorkflows })
+    $first = $regWorkflows[0]
+    $expectedFolder = "${mockRegName}:${mockWfName}"
+    if ($first.folder -eq $expectedFolder) {
+        Write-TestResult -Name "Registry workflow folder uses 'Registry:name' format" -Status Pass
+    } else {
+        Write-TestResult -Name "Registry workflow folder uses 'Registry:name' format" -Status Fail -Message "Expected '$expectedFolder', got '$($first.folder)'"
+    }
+} catch {
+    Write-TestResult -Name "Registry workflow folder uses 'Registry:name' format" -Status Fail -Message $_.Exception.Message
+}
+
+# --- Test: Registry workflows include registry field ---
+try {
+    $regWorkflows = @(& $studioModule { Get-RegistryWorkflows })
+    $first = $regWorkflows[0]
+    if ($first.registry -eq $mockRegName) {
+        Write-TestResult -Name "Registry workflow includes registry field" -Status Pass
+    } else {
+        Write-TestResult -Name "Registry workflow includes registry field" -Status Fail -Message "Expected '$mockRegName', got '$($first.registry)'"
+    }
+} catch {
+    Write-TestResult -Name "Registry workflow includes registry field" -Status Fail -Message $_.Exception.Message
+}
+
+# --- Test: Registry workflows include YAML content ---
+try {
+    $regWorkflows = @(& $studioModule { Get-RegistryWorkflows })
+    $first = $regWorkflows[0]
+    if ($first.yaml -and $first.yaml -match 'Test Workflow') {
+        Write-TestResult -Name "Registry workflow includes YAML content" -Status Pass
+    } else {
+        Write-TestResult -Name "Registry workflow includes YAML content" -Status Fail -Message "YAML was null or missing expected content"
+    }
+} catch {
+    Write-TestResult -Name "Registry workflow includes YAML content" -Status Fail -Message $_.Exception.Message
+}
+
+# --- Test: Get-RegistryWorkflows returns empty when no registries.json ---
+$emptyHome = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-test-empty-$([System.Guid]::NewGuid().ToString('N').Substring(0,8))"
+try {
+    $emptyWf = Join-Path $emptyHome 'workflows'
+    $emptyStatic = Join-Path $emptyHome 'static'
+    New-Item -ItemType Directory -Force -Path $emptyWf | Out-Null
+    New-Item -ItemType Directory -Force -Path $emptyStatic | Out-Null
+    Initialize-StudioAPI -WorkflowsDir $emptyWf -StaticRoot $emptyStatic
+    $emptyResult = @(& $studioModule { Get-RegistryWorkflows })
+    if ($emptyResult.Count -eq 0) {
+        Write-TestResult -Name "Get-RegistryWorkflows returns empty when no registries.json" -Status Pass
+    } else {
+        Write-TestResult -Name "Get-RegistryWorkflows returns empty when no registries.json" -Status Fail -Message "Expected 0, got $($emptyResult.Count)"
+    }
+} catch {
+    Write-TestResult -Name "Get-RegistryWorkflows returns empty when no registries.json" -Status Fail -Message $_.Exception.Message
+} finally {
+    Remove-Item -Path $emptyHome -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# --- Test: Get-RegistryWorkflows returns empty when registries.json is malformed ---
+$malformedHome = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-test-malformed-$([System.Guid]::NewGuid().ToString('N').Substring(0,8))"
+try {
+    $malformedWf = Join-Path $malformedHome 'workflows'
+    $malformedStatic = Join-Path $malformedHome 'static'
+    New-Item -ItemType Directory -Force -Path $malformedWf | Out-Null
+    New-Item -ItemType Directory -Force -Path $malformedStatic | Out-Null
+    Set-Content -Path (Join-Path $malformedHome 'registries.json') -Value 'NOT VALID JSON {{{' -Encoding UTF8
+    Initialize-StudioAPI -WorkflowsDir $malformedWf -StaticRoot $malformedStatic
+    $malformedResult = @(& $studioModule { Get-RegistryWorkflows })
+    if ($malformedResult.Count -eq 0) {
+        Write-TestResult -Name "Get-RegistryWorkflows returns empty when registries.json is malformed" -Status Pass
+    } else {
+        Write-TestResult -Name "Get-RegistryWorkflows returns empty when registries.json is malformed" -Status Fail -Message "Expected 0, got $($malformedResult.Count)"
+    }
+} catch {
+    Write-TestResult -Name "Get-RegistryWorkflows returns empty when registries.json is malformed" -Status Fail -Message "Should not throw: $($_.Exception.Message)"
+} finally {
+    Remove-Item -Path $malformedHome -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# ===================================================================
+# REGISTRY WORKFLOW PATH RESOLUTION
+# ===================================================================
+
+Write-Host ""
+Write-Host "  REGISTRY WORKFLOW PATH RESOLUTION" -ForegroundColor Cyan
+Write-Host "  --------------------------------------------" -ForegroundColor DarkGray
+
+# Re-initialize to the mock registry home
+Initialize-StudioAPI -WorkflowsDir $tempWorkflows -StaticRoot $tempStaticReg
+
+# --- Test: Get-RegistryWorkflowDir resolves valid registry:workflow ---
+try {
+    $regDir = & $studioModule { param($r, $w) Get-RegistryWorkflowDir -RegistryName $r -WorkflowName $w } $mockRegName $mockWfName
+    if ($regDir -and (Test-Path $regDir)) {
+        Write-TestResult -Name "Get-RegistryWorkflowDir resolves valid registry:workflow" -Status Pass
+    } else {
+        Write-TestResult -Name "Get-RegistryWorkflowDir resolves valid registry:workflow" -Status Fail -Message "Path '$regDir' does not exist"
+    }
+} catch {
+    Write-TestResult -Name "Get-RegistryWorkflowDir resolves valid registry:workflow" -Status Fail -Message $_.Exception.Message
+}
+
+# --- Test: Get-RegistryWorkflowDir rejects path traversal ---
+$traversalCases = @(
+    @{ Reg = '..';       Wf = 'test';     Label = 'registry name is ..' },
+    @{ Reg = 'TestReg';  Wf = '../etc';   Label = 'workflow name traversal' },
+    @{ Reg = 'foo/bar';  Wf = 'test';     Label = 'slash in registry name' },
+    @{ Reg = '';          Wf = 'test';     Label = 'empty registry name' },
+    @{ Reg = 'TestReg';  Wf = '';         Label = 'empty workflow name' }
+)
+
+foreach ($case in $traversalCases) {
+    try {
+        $result = & $studioModule { param($r, $w) Get-RegistryWorkflowDir -RegistryName $r -WorkflowName $w } $case.Reg $case.Wf
+        if ($null -eq $result) {
+            Write-TestResult -Name "Reject registry path: $($case.Label)" -Status Pass
+        } else {
+            Write-TestResult -Name "Reject registry path: $($case.Label)" -Status Fail -Message "Expected null but got '$result'"
+        }
+    } catch {
+        # Exceptions are also acceptable rejections
+        Write-TestResult -Name "Reject registry path: $($case.Label)" -Status Pass
+    }
+}
+
+# --- Test: Test-WorkflowExists resolves registry:workflow names ---
+try {
+    $exists = & $studioModule { param($n) Test-WorkflowExists -Name $n } "${mockRegName}:${mockWfName}"
+    if ($exists) {
+        Write-TestResult -Name "Test-WorkflowExists resolves registry:workflow format" -Status Pass
+    } else {
+        Write-TestResult -Name "Test-WorkflowExists resolves registry:workflow format" -Status Fail -Message "Returned false for existing registry workflow"
+    }
+} catch {
+    Write-TestResult -Name "Test-WorkflowExists resolves registry:workflow format" -Status Fail -Message $_.Exception.Message
+}
+
+# --- Test: Test-WorkflowExists returns false for non-existent registry workflow ---
+try {
+    $exists = & $studioModule { param($n) Test-WorkflowExists -Name $n } "FakeRegistry:nonexistent"
+    if (-not $exists) {
+        Write-TestResult -Name "Test-WorkflowExists returns false for non-existent registry workflow" -Status Pass
+    } else {
+        Write-TestResult -Name "Test-WorkflowExists returns false for non-existent registry workflow" -Status Fail -Message "Returned true for non-existent workflow"
+    }
+} catch {
+    Write-TestResult -Name "Test-WorkflowExists returns false for non-existent registry workflow" -Status Fail -Message $_.Exception.Message
+}
+
+# ===================================================================
+# REGISTRY SAVE-AS (copy to local workflows)
+# ===================================================================
+
+Write-Host ""
+Write-Host "  REGISTRY SAVE-AS (copy to local)" -ForegroundColor Cyan
+Write-Host "  --------------------------------------------" -ForegroundColor DarkGray
+
+# Enrich the mock registry workflow with realistic content
+$mockPromptDir = Join-Path $mockRegWfDir 'recipes' 'prompts'
+$mockAgentDir  = Join-Path $mockRegWfDir 'recipes' 'agents' 'test-agent'
+$mockSkillDir  = Join-Path $mockRegWfDir 'recipes' 'skills' 'test-skill'
+New-Item -ItemType Directory -Force -Path $mockPromptDir | Out-Null
+New-Item -ItemType Directory -Force -Path $mockAgentDir  | Out-Null
+New-Item -ItemType Directory -Force -Path $mockSkillDir  | Out-Null
+Set-Content -Path (Join-Path $mockRegWfDir 'manifest.yaml')            -Value 'name: test-workflow' -Encoding UTF8
+Set-Content -Path (Join-Path $mockRegWfDir 'on-install.ps1')           -Value '# on-install stub' -Encoding UTF8
+Set-Content -Path (Join-Path $mockPromptDir '00-kickstart.md')         -Value '# Kickstart prompt' -Encoding UTF8
+Set-Content -Path (Join-Path $mockAgentDir 'agent.md')                 -Value '# Test agent' -Encoding UTF8
+Set-Content -Path (Join-Path $mockSkillDir 'SKILL.md')                 -Value '# Test skill' -Encoding UTF8
+
+# Simulate Save As: copy from registry to local workflows folder
+$localCopyName = 'test-workflow-local'
+$localCopyDir  = Join-Path $tempWorkflows $localCopyName
+
+try {
+    & $studioModule { param($src, $dst) Copy-DirectoryRecursive -Source $src -Destination $dst } $mockRegWfDir $localCopyDir
+
+    $expectedFiles = @(
+        'workflow.yaml',
+        'manifest.yaml',
+        'on-install.ps1',
+        (Join-Path 'recipes' 'prompts' '00-kickstart.md'),
+        (Join-Path 'recipes' 'agents' 'test-agent' 'agent.md'),
+        (Join-Path 'recipes' 'skills' 'test-skill' 'SKILL.md')
+    )
+
+    $allPresent = $true
+    $missingFiles = @()
+    foreach ($relPath in $expectedFiles) {
+        $fullPath = Join-Path $localCopyDir $relPath
+        if (-not (Test-Path $fullPath)) {
+            $allPresent = $false
+            $missingFiles += $relPath
+        }
+    }
+
+    if ($allPresent) {
+        Write-TestResult -Name "Save As copies all workflow files from registry to local" -Status Pass
+    } else {
+        Write-TestResult -Name "Save As copies all workflow files from registry to local" -Status Fail -Message "Missing: $($missingFiles -join ', ')"
+    }
+
+    # Spot-check content
+    $promptContent = Get-Content -Path (Join-Path $localCopyDir 'recipes' 'prompts' '00-kickstart.md') -Raw -Encoding UTF8
+    if ($promptContent -match 'Kickstart prompt') {
+        Write-TestResult -Name "Save As preserves file content" -Status Pass
+    } else {
+        Write-TestResult -Name "Save As preserves file content" -Status Fail -Message "Content mismatch in copied prompt file"
+    }
+} catch {
+    Write-TestResult -Name "Save As copies all workflow files from registry to local" -Status Fail -Message $_.Exception.Message
+}
+
+# ===================================================================
 # Cleanup
 # ===================================================================
 
 Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item -Path $tempHome -Recurse -Force -ErrorAction SilentlyContinue
 
 Write-Host ""
 Write-TestSummary -LayerName "Layer 2: StudioAPI"


### PR DESCRIPTION
# Fix: Studio Access to External Registries

Fixes #186

## Table of Contents

- [Executive Summary](#executive-summary)
- [Symptoms and Issues Addressed](#symptoms-and-issues-addressed)
- [Fixes Applied](#fixes-applied)
  - [1. Registry Workflow Discovery](#1-registry-workflow-discovery)
  - [2. Read-Only Enforcement with Save As](#2-read-only-enforcement-with-save-as)
  - [3. Full Recursive Copy on Save As](#3-full-recursive-copy-on-save-as)
  - [4. Canvas Viewport Preservation](#4-canvas-viewport-preservation)
- [Files Changed](#files-changed)
- [Testing Performed](#testing-performed)
- [Regression Tests Added](#regression-tests-added)

---

## Executive Summary

Dotbot Studio had no awareness of the external registry system. Workflows installed via `dotbot registry add` were invisible in the Studio Open dialog, and there was no way to browse, inspect, or fork them from the editor. This PR adds full registry workflow support to Studio: discovery, read-only viewing, Save As to local, and proper viewport behavior when editing workflow content.

## Symptoms and Issues Addressed

1. **Registry workflows missing from Open dialog** -- After running `dotbot registry add`, the registered workflows did not appear in Studio's Open dialog. Only local workflows from `~/dotbot/workflows/` were listed.

2. **No read-only protection for registry content** -- There was no concept of a read-only workflow in Studio. If registry workflows were somehow loaded, nothing prevented the user from overwriting externally-managed content.

3. **Save As did not copy all workflow files** -- When using Save As on a registry workflow, only `workflow.yaml` was saved. Supporting files (`manifest.yaml`, `on-install.ps1`, `recipes/prompts/*`, `recipes/agents/*`, `recipes/skills/*`) were not copied.

4. **Save As dialog showed registry namespace in suggested name** -- The Save As dialog pre-filled `APDotBotRegistry:discovery-copy` instead of stripping the registry prefix to suggest `discovery-copy`.

5. **Canvas viewport reset after editing prompts** -- When a user opened a prompt/agent/skill in the file editor and returned to the canvas, the workflow diagram auto-zoomed to fit the window, losing the user's zoom level and pan position.

## Fixes Applied

### 1. Registry Workflow Discovery

**Backend (`StudioAPI.psm1`):**
- Added `$script:DotbotHome` state variable, derived from the workflows directory parent during initialization
- Added `Get-RegistryWorkflowDir` function with path-traversal protection matching `Get-SafeWorkflowDir`
- Added `Get-RegistryWorkflows` function that reads `~/dotbot/registries.json` and scans each registry's `workflows/` subdirectories
- `GET /api/studio` now appends registry workflows (with `registry` field) after local workflows
- `GET /api/studio/:name` resolves `Registry:name` format via `Get-RegistryWorkflowDir`
- `GET /api/studio/:name/files` uses the same registry-aware resolution
- `Test-WorkflowExists` now handles the `Registry:name` format

**Frontend:**
- `WorkflowListItem` and `WorkflowSummary` interfaces include `registry: string | null`
- `WorkflowPicker` displays a styled badge next to registry workflow names showing the source registry
- Empty-state message updated to mention registries

### 2. Read-Only Enforcement with Save As

- `useWorkflow.ts` tracks `isRegistry` state, set when opening a workflow with `:` in its name
- `saveWorkflow` returns early with an error for registry workflows
- `Toolbar` disables the Save button with a tooltip when `isRegistry` is true
- Title bar shows "(read-only)" instead of "(unsaved)" for registry workflows
- `PUT` and `DELETE` endpoints return HTTP 403 for registry workflow names
- After Save As completes, `isRegistry` is cleared so the local copy is fully editable

### 3. Full Recursive Copy on Save As

- Backend `/copy` endpoint now resolves registry sources via `Get-RegistryWorkflowDir`, enabling `Copy-DirectoryRecursive` to copy all files from the registry workflow to the local destination
- Frontend `saveWorkflowAs` always uses the `copyWorkflow` API when a current workflow exists (no longer bypasses copy for registry sources)
- Save As dialog strips the registry prefix from the suggested name (e.g., `APDotBotRegistry:discovery` becomes `discovery-copy`)

### 4. Canvas Viewport Preservation

- `App.tsx` uses `display: contents/none` instead of conditional mount/unmount for the canvas section, keeping React Flow alive with its viewport state during file editing
- `Canvas.tsx` replaces the always-on `fitView` prop with a `useEffect` keyed on `workflowKey` (the workflow name), so `fitView` only triggers when a different workflow is loaded, not on every view mode switch

## Files Changed

| File | Change |
|------|--------|
| `studio-ui/StudioAPI.psm1` | Registry discovery, path resolution, read-only guards, copy endpoint |
| `studio-ui/src/client/App.tsx` | Pass `isRegistry` to Toolbar, `workflowKey` to Canvas, `display` toggle |
| `studio-ui/src/client/components/Canvas.tsx` | Viewport persistence via `workflowKey` effect |
| `studio-ui/src/client/components/Toolbar.tsx` | Disable Save for registry, strip prefix in Save As, read-only indicator |
| `studio-ui/src/client/components/WorkflowPicker.tsx` | Registry badge, registry field passthrough |
| `studio-ui/src/client/hooks/useApi.ts` | `registry` field on `WorkflowListItem` |
| `studio-ui/src/client/hooks/useWorkflow.ts` | `isRegistry` state, save guards, Save As logic |
| `studio-ui/src/client/model/workflow.ts` | `registry` field on `WorkflowSummary` |
| `studio-ui/src/client/styles/globals.css` | `.toolbar-readonly` class |
| `tests/Test-StudioAPI.ps1` | 15 new regression tests |

## Testing Performed

All existing Layer 1-3 tests pass without modification:

| Layer | Status | Description |
|-------|--------|-------------|
| 1 | PASSED | Structure tests (222 passed) |
| 2 | PASSED | Component tests including 33 StudioAPI tests |
| 3 | PASSED | Mock Claude tests (13 passed) |

Manual testing verified:
- Open dialog shows registry workflows with badge
- Registry workflows open in read-only mode (Save disabled, title shows "read-only")
- Save As copies all files including recipes subdirectories
- Save As suggests name without registry prefix
- After Save As, the local copy is fully editable
- Canvas zoom/pan preserved when switching to/from prompt editor

## Regression Tests Added

15 new tests in `tests/Test-StudioAPI.ps1` across three sections:

**Registry Workflow Discovery (5 tests):**

| Test | Validates |
|------|-----------|
| Get-RegistryWorkflows returns registry workflows | Finds workflows under `registries/<name>/workflows/` |
| Registry workflow folder uses 'Registry:name' format | Folder field formatted as `RegistryName:workflowName` |
| Registry workflow includes registry field | `registry` field populated with registry name |
| Registry workflow includes YAML content | `yaml` field contains workflow.yaml content |
| Get-RegistryWorkflows returns empty when no registries.json | Graceful degradation with no registries configured |

**Registry Workflow Path Resolution (8 tests):**

| Test | Validates |
|------|-----------|
| Get-RegistryWorkflowDir resolves valid registry:workflow | Valid names resolve to correct filesystem path |
| Reject registry path: registry name is .. | Path traversal blocked |
| Reject registry path: workflow name traversal | Path traversal blocked |
| Reject registry path: slash in registry name | Directory separator blocked |
| Reject registry path: empty registry name | Empty name rejected |
| Reject registry path: empty workflow name | Empty name rejected |
| Test-WorkflowExists resolves registry:workflow format | Existence check works for Registry:name format |
| Test-WorkflowExists returns false for non-existent registry workflow | Non-existent registry workflow returns false |

**Registry Save As (2 tests):**

| Test | Validates |
|------|-----------|
| Save As copies all workflow files from registry to local | All files copied: workflow.yaml, manifest.yaml, on-install.ps1, recipes/prompts/*, recipes/agents/*, recipes/skills/* |
| Save As preserves file content | Copied file content matches source |

All tests use isolated temporary directories with unique GUIDs and clean up after themselves.
