### PR TITLE
Remove stale .playwright-mcp/ path references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,6 @@ Thumbs.db
 !.claude/skills/dotbot-code-review/
 !.claude/skills/design-system/
 
-# MCP tools
-.playwright-mcp/
-
 # Playwright MCP screenshots (should use --output-dir)
 page-*.png
 page-*.jpeg

--- a/workflows/default/systems/runtime/modules/WorktreeManager.psm1
+++ b/workflows/default/systems/runtime/modules/WorktreeManager.psm1
@@ -32,7 +32,7 @@ $script:NoiseDirectories = @(
     'Debug', 'Release', 'x64', 'x86',
     '.vs', '.idea', '.vscode',
     '__pycache__', '.mypy_cache',
-    '.git', '.control', '.playwright-mcp', '.serena',
+    '.git', '.control', '.serena',
     'TestResults', 'test-results', 'playwright-report',
     'sessions'
 )


### PR DESCRIPTION
### Summary
- Remove obsolete `.playwright-mcp/` entry from `.gitignore`
- Remove `.playwright-mcp` from worktree noise directory filter in `WorktreeManager.psm1`

### Why
The legacy `.playwright-mcp/` artifact path has no producer in the codebase. The current Playwright integration writes output to `.bot/.control/playwright-output`, making these references dead code that adds confusion.

### What's unchanged
- Current Playwright MCP server configuration in `init-project.ps1`
- Playwright output path (`.bot/.control/playwright-output`)
- `playwright-report/` gitignore entry

Closes #148