### PR TITLE
fix: prevent duplicate task cards in WORKING column (#196)

### DIFF
--- a/workflows/default/systems/ui/modules/StateBuilder.psm1
+++ b/workflows/default/systems/ui/modules/StateBuilder.psm1
@@ -435,6 +435,12 @@ function Get-BotState {
             }
     }
 
+    # When in-progress/ is empty, currentTask falls back to analysing/ (line 169).
+    # Exclude that task from analysing list to prevent duplicate cards in UI.
+    if ($currentTask -and $inProgressTasks.Count -eq 0) {
+        $analysingTasksList = @($analysingTasksList | Where-Object { $_.id -ne $currentTask.id })
+    }
+
     # Build per-workflow task counts from all task lists
     $allTaskFiles = @()
     foreach ($statusDir in @('todo', 'analysing', 'needs-input', 'analysed', 'in-progress', 'done', 'skipped')) {

--- a/workflows/default/systems/ui/modules/StateBuilder.psm1
+++ b/workflows/default/systems/ui/modules/StateBuilder.psm1
@@ -435,8 +435,8 @@ function Get-BotState {
             }
     }
 
-    # When in-progress/ is empty, currentTask falls back to analysing/ (line 169).
-    # Exclude that task from analysing list to prevent duplicate cards in UI.
+    # When in-progress/ is empty, currentTask may fall back to a task from analysing/.
+    # Exclude that task from the analysing list to prevent duplicate cards in the UI.
     if ($currentTask -and $inProgressTasks.Count -eq 0) {
         $analysingTasksList = @($analysingTasksList | Where-Object { $_.id -ne $currentTask.id })
     }


### PR DESCRIPTION
## Summary

- When `in-progress/` is empty, `StateBuilder` falls back to picking `currentTask` from `analysing/`, but also included the same task in `analysing_list` — causing the UI to render two cards for one task in the WORKING column
- Added a filter to exclude the fallback `currentTask` from `analysingTasksList` when the fallback is active (`inProgressTasks.Count -eq 0`)

## Root Cause

`StateBuilder.psm1` line 169: when no task is in `in-progress/`, the first task from `analysing/` is promoted to `currentTask`. But `analysingTasksList` (line 290) still included all `analysing/` tasks without excluding it. The frontend merges both into the WORKING column, producing a duplicate.

## What Changed

**`workflows/default/systems/ui/modules/StateBuilder.psm1`**
- After building `$analysingTasksList`, exclude `$currentTask` when the fallback is active

## Test Plan

- [ ] `pwsh tests/Run-Tests.ps1` layers 1-3 pass (no regressions)
- [ ] Create a task and start a workflow — while task is in `analysing/` status, verify only one card appears in WORKING column

Closes #196
