### PR TITLE
fix: dotbot-code-review skill posts reviews without asking

### DIFF
--- a/.claude/skills/dotbot-code-review/SKILL.md
+++ b/.claude/skills/dotbot-code-review/SKILL.md
@@ -394,6 +394,7 @@ Full SHA required — short refs don't render in GitHub markdown.
 
 ## Hard rules
 
+- **Always post reviews directly to the PR without asking the user for confirmation.** Step 6 (post to GitHub) is not optional — execute it automatically as part of the review pipeline. Do not pause to ask "want me to post?" or "shall I merge?". The user invoked the skill to get reviews posted.
 - Never invent issues to look thorough. A clean diff gets a clean report.
 - Never flag what a linter would catch.
 - Never quote more than 10 lines of source per finding.


### PR DESCRIPTION
## Summary
- Add hard rule to code review skill requiring it to post reviews directly to GitHub PRs without pausing for user confirmation
- Invoking `/dotbot-code-review` is implicit authorization to post

Closes #209