### PR TITLE
chore: remove or repurpose dead captured test output

### DIFF
--- a/tests/Test-E2E-Claude.ps1
+++ b/tests/Test-E2E-Claude.ps1
@@ -156,7 +156,7 @@ try {
         Write-TestResult -Name "E2E: Kickstart completed within timeout" -Status Fail -Message "Timed out after ${timeoutSeconds}s"
     } else {
         $jobErrors = $job | Receive-Job -ErrorAction SilentlyContinue 2>&1
-        Write-TestResult -Name "E2E: Kickstart completed" -Status Fail -Message "Job state: $($job.State)"
+        Write-TestResult -Name "E2E: Kickstart completed" -Status Fail -Message "Job state: $($job.State)`nErrors: $($jobErrors -join "`n")"
     }
 
     $job | Remove-Job -Force -ErrorAction SilentlyContinue

--- a/tests/Test-E2E-Claude.ps1
+++ b/tests/Test-E2E-Claude.ps1
@@ -155,7 +155,7 @@ try {
         $job | Stop-Job
         Write-TestResult -Name "E2E: Kickstart completed within timeout" -Status Fail -Message "Timed out after ${timeoutSeconds}s"
     } else {
-        $jobErrors = $job | Receive-Job -ErrorAction SilentlyContinue 2>&1
+        $jobErrors = $job | Receive-Job 2>&1
         Write-TestResult -Name "E2E: Kickstart completed" -Status Fail -Message "Job state: $($job.State)`nErrors: $($jobErrors -join "`n")"
     }
 

--- a/tests/Test-MockClaude.ps1
+++ b/tests/Test-MockClaude.ps1
@@ -86,7 +86,7 @@ try {
     # Run mock directly and check output (call mock-claude.ps1 directly for cross-platform reliability;
     # shim resolution is already validated by the PATH tests above)
     $mockScript = Join-Path $testsDir "mock-claude.ps1"
-    $mockOutput = & $mockScript --model test --print --output-format stream-json -- "Hello test" 2>&1
+    & $mockScript --model test --print --output-format stream-json -- "Hello test" 2>&1 | Out-Null
     Assert-PathExists -Name "Mock logs prompt to file" -Path $promptLog
 
     if (Test-Path $promptLog) {

--- a/tests/Test-Structure.ps1
+++ b/tests/Test-Structure.ps1
@@ -131,7 +131,7 @@ try {
     if (Test-Path $cliScript) {
         try {
             $statusOutput = & pwsh -NoProfile -ExecutionPolicy Bypass -File $cliScript status 2>&1
-            Assert-True -Name "dotbot status runs without error" -Condition ($LASTEXITCODE -eq 0 -or $null -eq $LASTEXITCODE) -Message "Exit code: $LASTEXITCODE"
+            Assert-True -Name "dotbot status runs without error" -Condition ($LASTEXITCODE -eq 0 -or $null -eq $LASTEXITCODE) -Message "Exit code: $LASTEXITCODE`nOutput: $($statusOutput -join "`n")"
         } catch {
             Write-TestResult -Name "dotbot status runs without error" -Status Fail -Message $_.Exception.Message
         }
@@ -633,7 +633,7 @@ if (-not $dotbotInstalled) {
                     & '$($hookCopy5 -replace "'","''")'
                 " 2>&1
                 $exitCode1 = $LASTEXITCODE
-                Assert-Equal -Name "Hook: no artifacts -> exit 1" -Expected 1 -Actual $exitCode1
+                Assert-Equal -Name "Hook: no artifacts -> exit 1" -Expected 1 -Actual $exitCode1 -Message "Output: $($result1 -join "`n")"
 
                 # Scenario 2: Only jira-context.md → exit 0 with warnings
                 New-Item -Path $briefingDir5 -ItemType Directory -Force | Out-Null
@@ -644,7 +644,7 @@ if (-not $dotbotInstalled) {
                     & '$($hookCopy5 -replace "'","''")'
                 " 2>&1
                 $exitCode2 = $LASTEXITCODE
-                Assert-Equal -Name "Hook: only jira-context.md -> exit 0" -Expected 0 -Actual $exitCode2
+                Assert-Equal -Name "Hook: only jira-context.md -> exit 0" -Expected 0 -Actual $exitCode2 -Message "Output: $($result2 -join "`n")"
 
                 # Scenario 3: All artifacts present → exit 0, success message
                 "# Interview" | Set-Content (Join-Path $productDir5 "interview-summary.md")


### PR DESCRIPTION
**Summary**
Five variables captured command output but were never read, adding noise
without contributing to test assertions or diagnostics.

**What was changed**

- $statusOutput (Test-Structure.ps1:133): wired into Assert-True failure message so the CLI output is visible when the exit-code check fails
- $result1 (Test-Structure.ps1:631): wired into Assert-Equal failure message to surface hook output when the expected exit code is wrong (mirrors how `$result3` is already used at line 665)
- $result2 (Test-Structure.ps1:642): same as $result1
- $mockOutput (Test-MockClaude.ps1:89): removed entirely — the test already validates behavior through the prompt log file, so the captured output provided no additional value
- $jobErrors (Test-E2E-Claude.ps1:158): wired into Write-TestResult failure message so job errors are visible when the background job ends in an unexpected state

Closes #158 