### PR TITLE
Fix stale -Profile flag in registry-add success message (#227)

### DIFF
--- a/scripts/registry-add.ps1
+++ b/scripts/registry-add.ps1
@@ -270,5 +270,6 @@ foreach ($type in $contentMap.Keys) {
 }
 
 Write-BlankLine
-Write-DotbotCommand "Use with: dotbot init -Profile ${Name}:<workflow>"
+Write-DotbotCommand "Use in a new project:      dotbot init -Workflow ${Name}:<workflow>"
+Write-DotbotCommand "Add to existing project:   dotbot workflow add ${Name}:<workflow>"
 Write-BlankLine


### PR DESCRIPTION
## Summary

Fixes andresharpe/dotbot#227 — the success message printed after `dotbot registry add <name> <url>` referenced the retired `-Profile` flag, so users copying the printed command hit a `parameter not found` error with no obvious recovery path.

The `-Profile` parameter was removed in #79 and replaced with `-Workflow <namespace>:<workflow>`. This PR updates the printed guidance to reflect the current CLI surface.

## Change

`scripts/registry-add.ps1:273`

**Before**

```powershell
Write-DotbotCommand "Use with: dotbot init -Profile ${Name}:<workflow>"
```

**After**

```powershell
Write-DotbotCommand "Use in a new project:      dotbot init -Workflow ${Name}:<workflow>"
Write-DotbotCommand "Add to existing project:   dotbot workflow add ${Name}:<workflow>"
```

Both forms are surfaced so users know how to consume the registry regardless of whether they're bootstrapping a new project or adding a workflow to an existing one. Theme helper (`Write-DotbotCommand`) preserved for output hygiene compliance (CLAUDE.md §Terminal Output).

## Test plan

- [ ] `dotbot registry add test-registry <url>` prints the two new `-Workflow` / `workflow add` lines, not the old `-Profile` line
- [ ] `dotbot init -Workflow test-registry:<workflow>` runs without a "parameter not found" error
- [ ] `dotbot workflow add test-registry:<workflow>` runs without error
- [ ] CI layers 1–3 green

Closes #227
