### PR TITLE
fix(#222): honour post_script field in task-runner engine

### DIFF
--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -453,6 +453,38 @@ try {
         Assert-Equal -Name "Script task workflow" -Expected "default" -Actual $scriptJson.workflow
     }
 
+    # Task with post_script — regression for andresharpe/dotbot#222
+    $postScriptDef = @{
+        name = "Task With Post Hook"
+        type = "script"
+        script = "do-work.ps1"
+        post_script = "post-phase-task-groups.ps1"
+        priority = 5
+    }
+
+    $postResult = New-WorkflowTask -ProjectBotDir $taskBotDir -WorkflowName "default" -TaskDef $postScriptDef
+    $postFile = Join-Path $taskBotDir "workspace\tasks\todo" $postResult.file
+    if (Test-Path $postFile) {
+        $postJson = Get-Content $postFile -Raw | ConvertFrom-Json
+        Assert-Equal -Name "post_script field preserved in task JSON" `
+            -Expected "post-phase-task-groups.ps1" -Actual $postJson.post_script
+    }
+
+    # Task without post_script — ensure field is absent (keeps task JSON clean)
+    $noPostDef = @{
+        name = "Task Without Post Hook"
+        type = "script"
+        script = "do-work.ps1"
+        priority = 5
+    }
+    $noPostResult = New-WorkflowTask -ProjectBotDir $taskBotDir -WorkflowName "default" -TaskDef $noPostDef
+    $noPostFile = Join-Path $taskBotDir "workspace\tasks\todo" $noPostResult.file
+    if (Test-Path $noPostFile) {
+        $noPostJson = Get-Content $noPostFile -Raw | ConvertFrom-Json
+        Assert-True -Name "post_script absent when not declared" `
+            -Condition ($null -eq $noPostJson.post_script)
+    }
+
 } finally {
     Remove-Item -Path $taskRoot -Recurse -Force -ErrorAction SilentlyContinue
 }
@@ -658,6 +690,322 @@ if (-not $hasYaml) {
         }
     }
 }
+
+Write-Host ""
+
+# ═══════════════════════════════════════════════════════════════════
+# INVOKE-POSTSCRIPT (regression for andresharpe/dotbot#222)
+# ═══════════════════════════════════════════════════════════════════
+
+Write-Host "  INVOKE-POSTSCRIPT" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+# Provide no-op implementations of the theme/activity helpers that the
+# post-script-runner calls. These normally come from DotBotTheme.psm1 and the
+# runtime, but we only care about Invoke-PostScript's own behaviour here.
+function Write-Status { param($Message, $Type) }
+function Write-ProcessActivity { param($Id, $ActivityType, $Message) }
+
+. (Join-Path $repoRoot "workflows\default\systems\runtime\modules\post-script-runner.ps1")
+
+$postRoot = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-post-$([System.Guid]::NewGuid().ToString().Substring(0,8))"
+New-Item -ItemType Directory -Path (Join-Path $postRoot "systems\runtime") -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $postRoot "scripts") -Force | Out-Null
+
+try {
+    # A post-script that writes a sentinel file and echoes its received parameters
+    $sentinelDir = Join-Path $postRoot "sentinel"
+    New-Item -ItemType Directory -Path $sentinelDir -Force | Out-Null
+
+    $okScript = @'
+param([string]$BotRoot, [string]$ProductDir, $Settings, [string]$Model, [string]$ProcessId)
+$sentinel = Join-Path $BotRoot "sentinel\ran.txt"
+"BotRoot=$BotRoot`nProductDir=$ProductDir`nModel=$Model`nProcessId=$ProcessId`nSetting=$($Settings.foo)" |
+    Set-Content $sentinel
+exit 0
+'@
+    $okScript | Set-Content (Join-Path $postRoot "systems\runtime\ok-post.ps1")
+
+    $failScript = @'
+param([string]$BotRoot, [string]$ProductDir, $Settings, [string]$Model, [string]$ProcessId)
+exit 7
+'@
+    $failScript | Set-Content (Join-Path $postRoot "systems\runtime\fail-post.ps1")
+
+    $scriptsDirScript = @'
+param([string]$BotRoot, [string]$ProductDir, $Settings, [string]$Model, [string]$ProcessId)
+Set-Content (Join-Path $BotRoot "sentinel\scripts-ran.txt") "ok"
+exit 0
+'@
+    $scriptsDirScript | Set-Content (Join-Path $postRoot "scripts\scripts-post.ps1")
+
+    $settings = @{ foo = "bar" }
+    $productDir = Join-Path $postRoot "workspace\product"
+
+    # Happy path: default path resolution (systems/runtime/<name>)
+    $threw = $false
+    try {
+        Invoke-PostScript -BotRoot $postRoot -ProductDir $productDir `
+            -Settings $settings -Model "Sonnet" -ProcessId "proc-123" `
+            -RawPostScript "ok-post.ps1"
+    } catch { $threw = $true }
+    Assert-True -Name "Invoke-PostScript: happy path does not throw" -Condition (-not $threw)
+    Assert-PathExists -Name "Invoke-PostScript: sentinel file created" `
+        -Path (Join-Path $postRoot "sentinel\ran.txt")
+    if (Test-Path (Join-Path $postRoot "sentinel\ran.txt")) {
+        $sentinelContent = Get-Content (Join-Path $postRoot "sentinel\ran.txt") -Raw
+        Assert-True -Name "Invoke-PostScript: passes BotRoot" `
+            -Condition ($sentinelContent -match [regex]::Escape("BotRoot=$postRoot"))
+        Assert-True -Name "Invoke-PostScript: passes ProductDir" `
+            -Condition ($sentinelContent -match [regex]::Escape("ProductDir=$productDir"))
+        Assert-True -Name "Invoke-PostScript: passes Model" `
+            -Condition ($sentinelContent -match "Model=Sonnet")
+        Assert-True -Name "Invoke-PostScript: passes ProcessId" `
+            -Condition ($sentinelContent -match "ProcessId=proc-123")
+        Assert-True -Name "Invoke-PostScript: passes Settings hashtable" `
+            -Condition ($sentinelContent -match "Setting=bar")
+    }
+
+    # Scripts/ prefix path resolution
+    $threw = $false
+    try {
+        Invoke-PostScript -BotRoot $postRoot -ProductDir $productDir `
+            -Settings $settings -Model "Sonnet" -ProcessId "proc-123" `
+            -RawPostScript "scripts/scripts-post.ps1"
+    } catch { $threw = $true }
+    Assert-True -Name "Invoke-PostScript: scripts/ prefix resolves under BotRoot/scripts" `
+        -Condition (-not $threw)
+    Assert-PathExists -Name "Invoke-PostScript: scripts/ sentinel created" `
+        -Path (Join-Path $postRoot "sentinel\scripts-ran.txt")
+
+    # Backslash separator normalisation (Unix safety)
+    Remove-Item (Join-Path $postRoot "sentinel\scripts-ran.txt") -Force -ErrorAction SilentlyContinue
+    $threw = $false
+    try {
+        Invoke-PostScript -BotRoot $postRoot -ProductDir $productDir `
+            -Settings $settings -Model "Sonnet" -ProcessId "proc-123" `
+            -RawPostScript "scripts\scripts-post.ps1"
+    } catch { $threw = $true }
+    Assert-True -Name "Invoke-PostScript: backslash separator is normalised" `
+        -Condition (-not $threw)
+
+    # Failing exit code is surfaced as a throw
+    $threw = $false
+    $errMsg = $null
+    try {
+        Invoke-PostScript -BotRoot $postRoot -ProductDir $productDir `
+            -Settings $settings -Model "Sonnet" -ProcessId "proc-123" `
+            -RawPostScript "fail-post.ps1"
+    } catch { $threw = $true; $errMsg = $_.Exception.Message }
+    Assert-True -Name "Invoke-PostScript: non-zero exit code throws" -Condition $threw
+    Assert-True -Name "Invoke-PostScript: exit code 7 surfaced in error" `
+        -Condition ($errMsg -match "7")
+
+    # Missing script file is surfaced as a throw before any invocation
+    $threw = $false
+    try {
+        Invoke-PostScript -BotRoot $postRoot -ProductDir $productDir `
+            -Settings $settings -Model "Sonnet" -ProcessId "proc-123" `
+            -RawPostScript "does-not-exist.ps1"
+    } catch { $threw = $true }
+    Assert-True -Name "Invoke-PostScript: missing script throws" -Condition $threw
+
+} finally {
+    Remove-Item -Path $postRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+
+# ═══════════════════════════════════════════════════════════════════
+# INVOKE-TASKPOSTSCRIPTIFPRESENT (wrapper used by task-runner branches)
+# ═══════════════════════════════════════════════════════════════════
+
+Write-Host "  INVOKE-TASKPOSTSCRIPTIFPRESENT" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$wrapRoot = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-wrap-$([System.Guid]::NewGuid().ToString().Substring(0,8))"
+New-Item -ItemType Directory -Path (Join-Path $wrapRoot "systems\runtime") -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $wrapRoot "sentinel") -Force | Out-Null
+
+try {
+    # Reusable scripts from the previous section aren't available — create fresh
+    $okScript = @'
+param([string]$BotRoot, [string]$ProductDir, $Settings, [string]$Model, [string]$ProcessId)
+Set-Content (Join-Path $BotRoot "sentinel\wrap-ok.txt") "ran"
+exit 0
+'@
+    $okScript | Set-Content (Join-Path $wrapRoot "systems\runtime\wrap-ok.ps1")
+
+    $failScript = @'
+param([string]$BotRoot, [string]$ProductDir, $Settings, [string]$Model, [string]$ProcessId)
+exit 3
+'@
+    $failScript | Set-Content (Join-Path $wrapRoot "systems\runtime\wrap-fail.ps1")
+
+    $settings = @{}
+    $productDir = Join-Path $wrapRoot "workspace\product"
+
+    # No post_script declared → returns $null, no-op
+    $taskNoHook = [pscustomobject]@{ name = "No hook"; post_script = $null }
+    $result = Invoke-TaskPostScriptIfPresent -Task $taskNoHook -BotRoot $wrapRoot `
+        -ProductDir $productDir -Settings $settings -Model "Sonnet" -ProcessId "p1"
+    Assert-True -Name "Wrapper: no post_script returns null" -Condition ($null -eq $result)
+
+    # Happy path → returns $null, sentinel exists
+    $taskOk = [pscustomobject]@{ name = "Ok hook"; post_script = "wrap-ok.ps1" }
+    $result = Invoke-TaskPostScriptIfPresent -Task $taskOk -BotRoot $wrapRoot `
+        -ProductDir $productDir -Settings $settings -Model "Sonnet" -ProcessId "p1"
+    Assert-True -Name "Wrapper: success returns null" -Condition ($null -eq $result)
+    Assert-PathExists -Name "Wrapper: success ran the script" `
+        -Path (Join-Path $wrapRoot "sentinel\wrap-ok.txt")
+
+    # Failure → returns error string, does not throw
+    $taskFail = [pscustomobject]@{ name = "Fail hook"; post_script = "wrap-fail.ps1" }
+    $threw = $false
+    $result = $null
+    try {
+        $result = Invoke-TaskPostScriptIfPresent -Task $taskFail -BotRoot $wrapRoot `
+            -ProductDir $productDir -Settings $settings -Model "Sonnet" -ProcessId "p1"
+    } catch { $threw = $true }
+    Assert-True -Name "Wrapper: failure does not throw" -Condition (-not $threw)
+    Assert-True -Name "Wrapper: failure returns non-null string" -Condition ($null -ne $result -and $result -is [string])
+    Assert-True -Name "Wrapper: failure message mentions post_script" `
+        -Condition ($result -match "post_script failed")
+
+} finally {
+    Remove-Item -Path $wrapRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+
+# ═══════════════════════════════════════════════════════════════════
+# INVOKE-POSTSCRIPTFAILUREESCALATION
+# ═══════════════════════════════════════════════════════════════════
+# When a Claude-executed task's post_script fails AFTER task_mark_done has
+# moved the task JSON to done/, we escalate to needs-input/ with a
+# pending_question rather than destroying the worktree. This regression guards
+# that behaviour — see review item 2 / the "Path B broken" trace.
+
+Write-Host "  INVOKE-POSTSCRIPTFAILUREESCALATION" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$escRoot = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-esc-$([System.Guid]::NewGuid().ToString().Substring(0,8))"
+$escTasksDir = Join-Path $escRoot "workspace\tasks"
+New-Item -ItemType Directory -Path (Join-Path $escTasksDir "done") -Force | Out-Null
+
+try {
+    # Seed a task file in done/ (simulating the state after task_mark_done has run)
+    $taskId = "abcdef1234567890"
+    $taskJson = @{
+        id = $taskId
+        name = "Esc test task"
+        status = "done"
+        completed_at = "2026-04-11T00:00:00Z"
+    } | ConvertTo-Json -Depth 10
+    $taskFilePath = Join-Path $escTasksDir "done\$taskId.json"
+    $taskJson | Set-Content -Path $taskFilePath -Encoding UTF8
+
+    $taskObj = [pscustomobject]@{ id = $taskId; name = "Esc test task" }
+    $worktreePath = "C:\fake\worktree\path"
+
+    $moved = Invoke-PostScriptFailureEscalation -Task $taskObj -TasksBaseDir $escTasksDir `
+        -PostScriptError "post_script failed: exit 5" -WorktreePath $worktreePath
+
+    Assert-True -Name "Escalation: returns true when task found in done/" -Condition $moved
+    Assert-True -Name "Escalation: task removed from done/" -Condition (-not (Test-Path $taskFilePath))
+
+    $needsInputFile = Join-Path $escTasksDir "needs-input\$taskId.json"
+    Assert-PathExists -Name "Escalation: task now in needs-input/" -Path $needsInputFile
+
+    if (Test-Path $needsInputFile) {
+        $movedContent = Get-Content $needsInputFile -Raw | ConvertFrom-Json
+        Assert-Equal -Name "Escalation: status is needs-input" -Expected "needs-input" -Actual $movedContent.status
+        Assert-True -Name "Escalation: pending_question present" `
+            -Condition ($null -ne $movedContent.pending_question)
+        Assert-Equal -Name "Escalation: pending_question.id" `
+            -Expected "post-script-failure" -Actual $movedContent.pending_question.id
+        Assert-True -Name "Escalation: context includes error message" `
+            -Condition ($movedContent.pending_question.context -match "exit 5")
+        Assert-True -Name "Escalation: context includes worktree path" `
+            -Condition ($movedContent.pending_question.context -match [regex]::Escape($worktreePath))
+        Assert-True -Name "Escalation: options present" `
+            -Condition ($movedContent.pending_question.options.Count -ge 2)
+    }
+
+    # Task not in done/ → returns $false without throwing
+    $missingTask = [pscustomobject]@{ id = "nonexistent-id"; name = "Missing" }
+    $threw = $false
+    $result = $null
+    try {
+        $result = Invoke-PostScriptFailureEscalation -Task $missingTask -TasksBaseDir $escTasksDir `
+            -PostScriptError "whatever" -WorktreePath ""
+    } catch { $threw = $true }
+    Assert-True -Name "Escalation: missing task does not throw" -Condition (-not $threw)
+    Assert-True -Name "Escalation: missing task returns false" -Condition ($result -eq $false)
+
+    # Empty worktree path is accepted (e.g. if we ever call this from a non-worktree path)
+    $taskId2 = "fedcba0987654321"
+    @{ id = $taskId2; name = "No worktree"; status = "done" } | ConvertTo-Json -Depth 10 |
+        Set-Content -Path (Join-Path $escTasksDir "done\$taskId2.json") -Encoding UTF8
+    $taskObj2 = [pscustomobject]@{ id = $taskId2; name = "No worktree" }
+    $moved2 = Invoke-PostScriptFailureEscalation -Task $taskObj2 -TasksBaseDir $escTasksDir `
+        -PostScriptError "boom" -WorktreePath ""
+    Assert-True -Name "Escalation: empty worktree path works" -Condition $moved2
+    $niFile2 = Join-Path $escTasksDir "needs-input\$taskId2.json"
+    if (Test-Path $niFile2) {
+        $c2 = Get-Content $niFile2 -Raw | ConvertFrom-Json
+        Assert-True -Name "Escalation: empty worktree path omits 'Worktree preserved'" `
+            -Condition (-not ($c2.pending_question.context -match "Worktree preserved"))
+    }
+
+} finally {
+    Remove-Item -Path $escRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+
+# ═══════════════════════════════════════════════════════════════════
+# POST_SCRIPT WIRING (regression for andresharpe/dotbot#222)
+# ═══════════════════════════════════════════════════════════════════
+# Static check that both engines actually call into the shared helper.
+# If anyone re-removes the wiring the task-runner would once again silently
+# ignore post_script — these tests guard against that regression.
+
+Write-Host "  POST_SCRIPT WIRING" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$workflowProcessPath = Join-Path $repoRoot "workflows\default\systems\runtime\modules\ProcessTypes\Invoke-WorkflowProcess.ps1"
+$kickstartProcessPath = Join-Path $repoRoot "workflows\default\systems\runtime\modules\ProcessTypes\Invoke-KickstartProcess.ps1"
+
+Assert-PathExists -Name "Invoke-WorkflowProcess.ps1 exists" -Path $workflowProcessPath
+Assert-PathExists -Name "Invoke-KickstartProcess.ps1 exists" -Path $kickstartProcessPath
+
+$workflowSrc = Get-Content $workflowProcessPath -Raw
+$kickstartSrc = Get-Content $kickstartProcessPath -Raw
+
+Assert-True -Name "Invoke-WorkflowProcess dot-sources post-script-runner" `
+    -Condition ($workflowSrc -match 'post-script-runner\.ps1')
+
+$wrapperCallCount = ([regex]::Matches($workflowSrc, 'Invoke-TaskPostScriptIfPresent')).Count
+Assert-True -Name "Invoke-WorkflowProcess calls wrapper in both branches (>=2 call sites)" `
+    -Condition ($wrapperCallCount -ge 2)
+
+# Ensure the Claude-branch post_script failure escalates to needs-input/ rather
+# than falling into generic failure cleanup (worktree destruction, failure-counter
+# bump). Regression guard for the Path B bug traced during review.
+Assert-True -Name "Invoke-WorkflowProcess tracks postScriptFailed flag" `
+    -Condition ($workflowSrc -match '\$postScriptFailed\s*=\s*\$true')
+Assert-True -Name "Invoke-WorkflowProcess has elseif (postScriptFailed) branch" `
+    -Condition ($workflowSrc -match 'elseif\s*\(\s*\$postScriptFailed\s*\)')
+Assert-True -Name "Invoke-WorkflowProcess calls Invoke-PostScriptFailureEscalation" `
+    -Condition ($workflowSrc -match 'Invoke-PostScriptFailureEscalation')
+
+Assert-True -Name "Invoke-KickstartProcess dot-sources post-script-runner" `
+    -Condition ($kickstartSrc -match 'post-script-runner\.ps1')
+Assert-True -Name "Invoke-KickstartProcess calls Invoke-PostScript" `
+    -Condition ($kickstartSrc -match 'Invoke-PostScript\b')
+Assert-True -Name "Invoke-KickstartProcess no longer has inline post_script path resolution" `
+    -Condition (-not ($kickstartSrc -match 'systems\\runtime\\\$rawPostScript'))
 
 Write-Host ""
 

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -482,7 +482,7 @@ try {
     if (Test-Path $noPostFile) {
         $noPostJson = Get-Content $noPostFile -Raw | ConvertFrom-Json
         Assert-True -Name "post_script absent when not declared" `
-            -Condition ($null -eq $noPostJson.post_script)
+            -Condition ($null -eq $noPostJson.PSObject.Properties['post_script'])
     }
 
 } finally {

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-KickstartProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-KickstartProcess.ps1
@@ -55,6 +55,8 @@ try {
     # ===== Kickstart task pipeline (manifest-driven) =====
     # Load manifest helpers
     . (Join-Path $botRoot "systems\runtime\modules\workflow-manifest.ps1")
+    # Load post-script runner (shared with Invoke-WorkflowProcess)
+    . (Join-Path $botRoot "systems\runtime\modules\post-script-runner.ps1")
 
     $kickstartPhases = @()
     $activeWorkflowDir = $null
@@ -623,14 +625,11 @@ Instructions:
         }
 
         # --- Post-script ---
+        # Delegated to shared helper; raises on non-zero exit so a failing
+        # post-script now fails the phase instead of being silently ignored.
         if ($phase.post_script) {
-            $rawPostScript = $phase.post_script
-            $postPath = if ($rawPostScript -match '^scripts[/\\]') {
-                Join-Path $botRoot $rawPostScript
-            } else {
-                Join-Path $botRoot "systems\runtime\$rawPostScript"
-            }
-            & $postPath -BotRoot $botRoot -ProductDir $productDir -Settings $settings -Model $claudeModelName -ProcessId $procId
+            Invoke-PostScript -BotRoot $botRoot -ProductDir $productDir -Settings $settings `
+                -Model $claudeModelName -ProcessId $procId -RawPostScript $phase.post_script
         }
 
         # --- Git checkpoint (supports manifest-style commit object and legacy commit_paths/commit_message) ---

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -64,6 +64,8 @@ $entityModel = if (Test-Path (Join-Path $productDir "entity-model.md")) { "Read 
 
 # Task reset
 . (Join-Path $botRoot "systems\runtime\modules\task-reset.ps1")
+# Post-script runner (shared helper)
+. (Join-Path $botRoot "systems\runtime\modules\post-script-runner.ps1")
 $tasksBaseDir = Join-Path $botRoot "workspace\tasks"
 
 # Recover orphaned tasks
@@ -359,6 +361,20 @@ try {
                 $typeError = $_.Exception.Message
                 Write-Status "Task type execution failed: $typeError" -Type Error
                 Write-ProcessActivity -Id $procId -ActivityType "error" -Message "$($task.name): $typeError"
+            }
+
+            # Post-script hook: run after successful task execution, before the
+            # move to done/. There is no task_mark_done call on this path (script/
+            # mcp/task_gen tasks skip verification hooks), so the post-script is
+            # the last thing to run before the task is considered complete. On
+            # failure, $typeSuccess is flipped so the task is marked skipped below.
+            if ($typeSuccess) {
+                $psErr = Invoke-TaskPostScriptIfPresent -Task $task -BotRoot $botRoot `
+                    -ProductDir $productDir -Settings $settings -Model $claudeModelName -ProcessId $procId
+                if ($psErr) {
+                    $typeSuccess = $false
+                    $typeError = $psErr
+                }
             }
 
             if ($typeSuccess) {
@@ -739,6 +755,8 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
         Write-ProcessFile -Id $procId -Data $processData
 
         $taskSuccess = $false
+        $postScriptFailed = $false
+        $postScriptError = $null
         $attemptNumber = 0
 
         if ($worktreePath) { Push-Location $worktreePath }
@@ -856,6 +874,25 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
                 break
             }
         }
+
+        # Post-script hook: run inside the worktree (CWD is still the worktree
+        # here — Pop-Location happens in the finally below) so the script can
+        # operate on the task's artefacts before the squash-merge.
+        #
+        # At this point task_mark_done has already moved the task JSON to done/,
+        # so a failure here is NOT a generic task failure — we must NOT destroy
+        # the worktree or increment consecutive_failures. Instead we set
+        # $postScriptFailed and escalate to needs-input/ below, mirroring the
+        # merge-conflict escalation pattern.
+        if ($taskSuccess) {
+            $psErr = Invoke-TaskPostScriptIfPresent -Task $task -BotRoot $botRoot `
+                -ProductDir $productDir -Settings $settings -Model $claudeModelName -ProcessId $procId
+            if ($psErr) {
+                $taskSuccess = $false
+                $postScriptFailed = $true
+                $postScriptError = $psErr
+            }
+        }
         } finally {
             # Final safety-net cleanup: kill any remaining worktree processes
             if ($worktreePath) {
@@ -963,6 +1000,29 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
             $processData.heartbeat_status = "Completed: $($task.name)"
             Write-ProcessFile -Id $procId -Data $processData
             Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task completed (analyse+execute): $($task.name)"
+        } elseif ($postScriptFailed) {
+            # post_script failed AFTER task_mark_done moved the task JSON to done/.
+            # Preserve the worktree (so the operator can inspect artefacts and re-run
+            # the post_script manually) and move the task to needs-input/ with a
+            # pending_question. Deliberately skip worktree destruction and the
+            # consecutive_failures bump — this is operator-recoverable, not an agent
+            # failure.
+            Write-Status "post_script failed for $($task.name) — escalating to needs-input" -Type Warn
+            Write-ProcessActivity -Id $procId -ActivityType "error" -Message "post_script failed for $($task.name): $postScriptError — worktree preserved at $worktreePath"
+
+            try {
+                $moved = Invoke-PostScriptFailureEscalation -Task $task -TasksBaseDir $tasksBaseDir `
+                    -PostScriptError $postScriptError -WorktreePath $worktreePath
+                if ($moved) {
+                    Write-Status "Task moved to needs-input for manual post_script resolution" -Type Warn
+                } else {
+                    Write-Status "Could not locate task in done/ during post_script escalation — state may be inconsistent" -Type Error
+                    Write-ProcessActivity -Id $procId -ActivityType "error" -Message "Post-script escalation could not find $($task.name) in done/"
+                }
+            } catch {
+                Write-Status "Post-script escalation failed: $($_.Exception.Message)" -Type Error
+                Write-ProcessActivity -Id $procId -ActivityType "error" -Message "Post-script escalation failed for $($task.name): $($_.Exception.Message)"
+            }
         } else {
             Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task failed: $($task.name)"
 

--- a/workflows/default/systems/runtime/modules/post-script-runner.ps1
+++ b/workflows/default/systems/runtime/modules/post-script-runner.ps1
@@ -27,6 +27,7 @@ function Invoke-PostScript {
         [Parameter(Mandatory)][string]$RawPostScript
     )
 
+    # NOTE: post_script is trusted manifest input (developer-authored, checked in).
     # Normalise backslashes to forward slashes so Join-Path produces a valid
     # path on both Windows and Unix (Windows accepts either separator).
     $normalized = $RawPostScript -replace '\\', '/'
@@ -51,16 +52,6 @@ function Invoke-PostScript {
     }
 }
 
-<#
-.SYNOPSIS
-Task-runner wrapper that invokes a task's post_script (if any) and reports failure.
-
-.DESCRIPTION
-Used by both task-runner code paths in Invoke-WorkflowProcess.ps1 to avoid
-duplicating the guard + try/catch + logging block. Returns $null on success or
-when the task has no post_script; returns a string error message on failure,
-leaving it to the caller to flip any success flag.
-#>
 <#
 .SYNOPSIS
 Escalate a post_script failure by moving a task from done/ → needs-input/.
@@ -139,6 +130,16 @@ function Invoke-PostScriptFailureEscalation {
     return $true
 }
 
+<#
+.SYNOPSIS
+Task-runner wrapper that invokes a task's post_script (if any) and reports failure.
+
+.DESCRIPTION
+Used by both task-runner code paths in Invoke-WorkflowProcess.ps1 to avoid
+duplicating the guard + try/catch + logging block. Returns $null on success or
+when the task has no post_script; returns a string error message on failure,
+leaving it to the caller to flip any success flag.
+#>
 function Invoke-TaskPostScriptIfPresent {
     [CmdletBinding()]
     param(

--- a/workflows/default/systems/runtime/modules/post-script-runner.ps1
+++ b/workflows/default/systems/runtime/modules/post-script-runner.ps1
@@ -1,0 +1,165 @@
+<#
+.SYNOPSIS
+Post-script execution helper shared between the task-runner and kickstart engines.
+
+.DESCRIPTION
+Resolves a `post_script` path (relative to the bot root) and invokes it with the
+standard parameter set used by both the task-runner (Invoke-WorkflowProcess) and
+the kickstart engine (Invoke-KickstartProcess). Raises on non-zero exit code so
+callers can decide how to handle failure.
+
+Path resolution rules:
+  - "scripts/..."         -> resolved relative to $BotRoot
+  - anything else         -> resolved relative to $BotRoot/systems/runtime/
+
+Forward- or back-slashes in the raw path are normalised so the resolved path is
+valid on both Windows and Unix.
+#>
+
+function Invoke-PostScript {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$BotRoot,
+        [Parameter(Mandatory)][string]$ProductDir,
+        [Parameter(Mandatory)]$Settings,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Model,
+        [Parameter(Mandatory)][string]$ProcessId,
+        [Parameter(Mandatory)][string]$RawPostScript
+    )
+
+    # Normalise backslashes to forward slashes so Join-Path produces a valid
+    # path on both Windows and Unix (Windows accepts either separator).
+    $normalized = $RawPostScript -replace '\\', '/'
+
+    $postPath = if ($normalized -match '^scripts/') {
+        Join-Path $BotRoot $normalized
+    } else {
+        Join-Path $BotRoot "systems/runtime/$normalized"
+    }
+
+    if (-not (Test-Path $postPath)) {
+        throw "post_script not found: $postPath"
+    }
+
+    Write-Status "Running post-script: $RawPostScript" -Type Process
+    Write-ProcessActivity -Id $ProcessId -ActivityType "text" -Message "Executing post_script: $RawPostScript"
+
+    $global:LASTEXITCODE = 0
+    & $postPath -BotRoot $BotRoot -ProductDir $ProductDir -Settings $Settings -Model $Model -ProcessId $ProcessId
+    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+        throw "post_script exited with code $LASTEXITCODE"
+    }
+}
+
+<#
+.SYNOPSIS
+Task-runner wrapper that invokes a task's post_script (if any) and reports failure.
+
+.DESCRIPTION
+Used by both task-runner code paths in Invoke-WorkflowProcess.ps1 to avoid
+duplicating the guard + try/catch + logging block. Returns $null on success or
+when the task has no post_script; returns a string error message on failure,
+leaving it to the caller to flip any success flag.
+#>
+<#
+.SYNOPSIS
+Escalate a post_script failure by moving a task from done/ → needs-input/.
+
+.DESCRIPTION
+Used by the Claude-executed branch in Invoke-WorkflowProcess.ps1 when a
+post_script fails after `task_mark_done` has already moved the task JSON into
+`workspace\tasks\done\`. Rather than destroy the worktree and increment failure
+counters, we move the task to `workspace\tasks\needs-input\` with a
+`pending_question` so the operator can inspect the worktree, fix the post_script
+(or the artefacts it consumes), and retry manually.
+
+Mirrors the merge-conflict escalation pattern already used when the squash-merge
+step fails. Returns $true if the task was moved, $false otherwise (e.g. the task
+JSON was not found in done/).
+#>
+function Invoke-PostScriptFailureEscalation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]$Task,
+        [Parameter(Mandatory)][string]$TasksBaseDir,
+        [Parameter(Mandatory)][string]$PostScriptError,
+        [AllowEmptyString()][string]$WorktreePath = ""
+    )
+
+    $doneDir = Join-Path $TasksBaseDir "done"
+    $needsInputDir = Join-Path $TasksBaseDir "needs-input"
+
+    if (-not (Test-Path $needsInputDir)) {
+        New-Item -ItemType Directory -Force -Path $needsInputDir | Out-Null
+    }
+
+    $taskFile = Get-ChildItem -Path $doneDir -Filter "*.json" -File -ErrorAction SilentlyContinue | Where-Object {
+        try {
+            $c = Get-Content $_.FullName -Raw | ConvertFrom-Json
+            $c.id -eq $Task.id
+        } catch { $false }
+    } | Select-Object -First 1
+
+    if (-not $taskFile) { return $false }
+
+    $taskContent = Get-Content $taskFile.FullName -Raw | ConvertFrom-Json
+    $nowIso = (Get-Date).ToUniversalTime().ToString("o")
+
+    # Use Add-Member -Force so the helper works on task JSON that may or may not
+    # already have status / updated_at / pending_question properties.
+    $taskContent | Add-Member -NotePropertyName 'status' -NotePropertyValue 'needs-input' -Force
+    $taskContent | Add-Member -NotePropertyName 'updated_at' -NotePropertyValue $nowIso -Force
+
+    if (-not $taskContent.PSObject.Properties['pending_question']) {
+        $taskContent | Add-Member -NotePropertyName 'pending_question' -NotePropertyValue $null -Force
+    }
+
+    $contextText = if ($WorktreePath) {
+        "Error: $PostScriptError. Worktree preserved at: $WorktreePath"
+    } else {
+        "Error: $PostScriptError"
+    }
+
+    $taskContent.pending_question = @{
+        id             = "post-script-failure"
+        question       = "post_script failed during task completion"
+        context        = $contextText
+        options        = @(
+            @{ key = "A"; label = "Fix the post_script and retry manually"; rationale = "Inspect the worktree, repair the post_script, then retry the task" }
+            @{ key = "B"; label = "Discard task changes"; rationale = "Remove worktree and abandon this task's changes" }
+        )
+        recommendation = "A"
+        asked_at       = (Get-Date).ToUniversalTime().ToString("o")
+    }
+
+    $newPath = Join-Path $needsInputDir $taskFile.Name
+    $taskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $newPath -Encoding UTF8
+    Remove-Item -Path $taskFile.FullName -Force -ErrorAction SilentlyContinue
+
+    return $true
+}
+
+function Invoke-TaskPostScriptIfPresent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]$Task,
+        [Parameter(Mandatory)][string]$BotRoot,
+        [Parameter(Mandatory)][string]$ProductDir,
+        [Parameter(Mandatory)]$Settings,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Model,
+        [Parameter(Mandatory)][string]$ProcessId
+    )
+
+    if (-not $Task.post_script) { return $null }
+
+    try {
+        Invoke-PostScript -BotRoot $BotRoot -ProductDir $ProductDir -Settings $Settings `
+            -Model $Model -ProcessId $ProcessId -RawPostScript $Task.post_script
+        return $null
+    } catch {
+        $msg = "post_script failed: $($_.Exception.Message)"
+        Write-Status $msg -Type Error
+        Write-ProcessActivity -Id $ProcessId -ActivityType "error" -Message "$($Task.name): $msg"
+        return $msg
+    }
+}

--- a/workflows/default/systems/runtime/modules/workflow-manifest.ps1
+++ b/workflows/default/systems/runtime/modules/workflow-manifest.ps1
@@ -371,6 +371,7 @@ function New-WorkflowTask {
     if ($TaskDef['condition'])                 { $task["condition"] = $TaskDef['condition'] }
     if ($TaskDef['outputs'])                   { $task["outputs"] = @($TaskDef['outputs']) }
     if ($TaskDef['env'])                       { $task["env"] = $TaskDef['env'] }
+    if ($TaskDef['post_script'])               { $task["post_script"] = $TaskDef['post_script'] }
 
     $slug = ($name -replace '[^\w\s-]', '' -replace '\s+', '-').ToLower()
     if ($slug.Length -gt 50) { $slug = $slug.Substring(0, 50) }


### PR DESCRIPTION
Closes #222.

## Summary

The task-runner (`Invoke-WorkflowProcess.ps1`) had zero references to `post_script`, so any manifest declaring a `post_script` on a task was silently ignored under the task-runner path. Workflows like `kickstart-from-scratch` rely on post-phase bookkeeping (`post-phase-task-groups.ps1`) that cannot live inside an LLM prompt, so this was blocking real usage.

This PR wires `post_script` through both task-runner code paths (script/mcp/task_gen and Claude-executed) via a new shared `post-script-runner.ps1` helper, refactors `Invoke-KickstartProcess.ps1` to use the same helper, and preserves the field through `New-WorkflowTask` so it survives manifest → task JSON round-trips.

## Changes

- **New**: `workflows/default/systems/runtime/modules/post-script-runner.ps1` — shared helper exposing:
  - `Invoke-PostScript` — resolves a `post_script` path (`scripts/...` under `$BotRoot`, otherwise under `$BotRoot/systems/runtime/`), normalises backslashes for Unix safety, invokes the script with the standard parameter set (`-BotRoot`, `-ProductDir`, `-Settings`, `-Model`, `-ProcessId`), and throws on non-zero exit.
  - `Invoke-TaskPostScriptIfPresent` — thin wrapper used by both task-runner branches; returns `$null` on success/no-op, or an error string on failure. Eliminates duplicated try/catch/logging blocks at the call sites.
  - `Invoke-PostScriptFailureEscalation` — moves a task from `done/` → `needs-input/` with a `pending_question` when a Claude-executed task's post-script fails.
- **Wired**: `Invoke-WorkflowProcess.ps1` — both branches now invoke the wrapper; the Claude-executed branch also records a new `$postScriptFailed` flag so the per-task result block can dispatch to the correct failure path.
- **Refactored**: `Invoke-KickstartProcess.ps1` — phase-level post-script block replaced by `Invoke-PostScript`. As a side-effect this fixes a latent bug where a failing kickstart post-script was silently ignored (the previous inline code never checked `$LASTEXITCODE`); it now propagates out and marks the phase failed.
- **Preserved**: `workflow-manifest.ps1` — `New-WorkflowTask` now copies the `post_script` field into the generated task JSON.

## Failure handling by path

| Path | State at post-script time | On failure |
|---|---|---|
| **`script` / `mcp` / `task_gen`** | Task JSON in `in-progress/` | `$typeSuccess = $false` → `Invoke-TaskMarkSkipped` with `skip_reason = "<type> execution failed: post_script failed: <msg>"`. Task ends up in `skipped/`. |
| **Kickstart phase** | Phase body finished, before the phase `git commit` | `Invoke-PostScript` throws → caught by the existing outer phase `catch` → `phases[i].status = 'failed'`, phase commit is skipped, pipeline halts. |
| **Claude-executed (worktree)** | Task JSON already in `done/` (because `task_mark_done` ran inside the MCP call) | See below — this is the delicate case. |

### Claude-executed: the `done/` → `needs-input/` escalation

At this point `task_mark_done` has already moved the task JSON to `done/`, so a post-script failure must **not** trigger the generic failure cleanup — that would destroy the worktree, delete the task branch (losing the agent's work entirely), and bump `consecutive_failures`, even though the failure is operator-recoverable.

Instead, **this path mimics the existing merge-conflict escalation pattern** already used at `Invoke-WorkflowProcess.ps1` lines 942–981 when the squash-merge step fails. The new `Invoke-PostScriptFailureEscalation` helper:

- Moves the task JSON from `done/` → `needs-input/`.
- Attaches a `pending_question` (id: `post-script-failure`) describing the error and the preserved worktree path, with operator options (fix & retry manually, or discard).
- **Preserves the worktree** so the operator can inspect artefacts and re-run the post-script by hand.
- **Does not** delete the task branch, remove the worktree, or increment `consecutive_failures`.

A new `elseif ($postScriptFailed)` branch in the per-task result block routes to this helper instead of falling through to the generic failure cleanup.