### PR TITLE
fix(#224): notify stakeholders on merge-conflict escalation

### DIFF
--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -1557,6 +1557,351 @@ if (Test-Path $notifModule) {
 }
 
 # ═══════════════════════════════════════════════════════════════════
+# MERGE CONFLICT ESCALATION MODULE TESTS (issue #224)
+# ═══════════════════════════════════════════════════════════════════
+Write-Host ""
+Write-Host "--- MergeConflictEscalation Module ---" -ForegroundColor Cyan
+
+$mergeEscModule = Join-Path $botDir "systems\runtime\modules\MergeConflictEscalation.psm1"
+
+if (Test-Path $mergeEscModule) {
+    Import-Module $mergeEscModule -Force
+
+    # Ensure the helper is exported
+    $cmd = Get-Command Move-TaskToMergeConflictNeedsInput -ErrorAction SilentlyContinue
+    Assert-True -Name "Move-TaskToMergeConflictNeedsInput is exported" `
+        -Condition ($null -ne $cmd) `
+        -Message "Expected exported function"
+
+    # Build an isolated workspace with a fake done/ task
+    $mceWorkspace = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-mce-$([System.Guid]::NewGuid().ToString().Substring(0,8))"
+    $mceDone = Join-Path $mceWorkspace "done"
+    $mceNeedsInput = Join-Path $mceWorkspace "needs-input"
+    New-Item -ItemType Directory -Force -Path $mceDone | Out-Null
+
+    $fakeTaskId = "abc12345"
+    # Seed an open execution session on the task so the session-close path is
+    # actually exercised. The runtime parent nulls $env:CLAUDE_SESSION_ID before
+    # the squash-merge step, so the helper must source the session id from
+    # $taskContent.execution_sessions, NOT from the env var.
+    $fakeTaskJson = @{
+        id                 = $fakeTaskId
+        name               = "Fake merge-conflict task"
+        status             = "done"
+        created_at         = "2026-04-11T00:00:00.0000000Z"
+        updated_at         = "2026-04-11T00:00:00.0000000Z"
+        execution_sessions = @(
+            @{ id = "exec-session-1"; started_at = "2026-04-11T00:00:01Z"; ended_at = $null }
+        )
+    } | ConvertTo-Json -Depth 10
+    $fakeTaskFile = Join-Path $mceDone "$fakeTaskId.json"
+    Set-Content -Path $fakeTaskFile -Value $fakeTaskJson -Encoding UTF8
+
+    # NB: PSCustomObject branch of conflict_files extraction is defensive only —
+    # Complete-TaskWorktree returns a [hashtable] in production (WorktreeManager.psm1
+    # 652/707/747/771/816/909/917). The hashtable regression test below is the one
+    # that pins production behaviour.
+    $fakeMergeResult = [PSCustomObject]@{
+        success        = $false
+        message        = "conflict in 2 files"
+        conflict_files = @("src/foo.cs", "src/bar.cs")
+    }
+    $fakeWorktreePath = "C:\worktrees\dotbot\task-$fakeTaskId-fake"
+
+    # Point DotbotProjectRoot at the isolated temp workspace that has no `.bot/` —
+    # `Test-Path` on NotificationClient.psm1 fails, so the notification branch short-circuits
+    # to notified=$false deterministically, regardless of the developer's $testProject config.
+    $savedDotbotRoot = $global:DotbotProjectRoot
+    $savedSessionEnv = $env:CLAUDE_SESSION_ID
+    $global:DotbotProjectRoot = $mceWorkspace
+    $env:CLAUDE_SESSION_ID = $null
+
+    try {
+        $result = Move-TaskToMergeConflictNeedsInput `
+            -TaskId $fakeTaskId `
+            -TasksBaseDir $mceWorkspace `
+            -MergeResult $fakeMergeResult `
+            -WorktreePath $fakeWorktreePath
+
+        Assert-True -Name "Move-TaskToMergeConflictNeedsInput returns success" `
+            -Condition ($result.success -eq $true) `
+            -Message "Expected success=true"
+
+        Assert-True -Name "Task file moved out of done/" `
+            -Condition (-not (Test-Path $fakeTaskFile)) `
+            -Message "Original file still exists in done/"
+
+        $newPath = Join-Path $mceNeedsInput "$fakeTaskId.json"
+        Assert-True -Name "Task file created in needs-input/" `
+            -Condition (Test-Path $newPath) `
+            -Message "Expected file at $newPath"
+
+        if (Test-Path $newPath) {
+            $moved = Get-Content $newPath -Raw | ConvertFrom-Json
+
+            Assert-True -Name "Status transitioned to needs-input" `
+                -Condition ($moved.status -eq "needs-input") `
+                -Message "Expected status=needs-input, got $($moved.status)"
+
+            Assert-True -Name "pending_question.id is merge-conflict" `
+                -Condition ($moved.pending_question.id -eq "merge-conflict") `
+                -Message "Expected id=merge-conflict"
+
+            Assert-True -Name "pending_question has 3 options (A/B/C)" `
+                -Condition (@($moved.pending_question.options).Count -eq 3) `
+                -Message "Expected 3 options, got $(@($moved.pending_question.options).Count)"
+
+            $keys = @($moved.pending_question.options | ForEach-Object { $_.key }) -join ","
+            Assert-True -Name "pending_question option keys are A,B,C" `
+                -Condition ($keys -eq "A,B,C") `
+                -Message "Expected A,B,C, got $keys"
+
+            Assert-True -Name "pending_question recommendation is A" `
+                -Condition ($moved.pending_question.recommendation -eq "A") `
+                -Message "Expected recommendation=A"
+
+            Assert-True -Name "pending_question context includes conflict files" `
+                -Condition ($moved.pending_question.context -match "src/foo\.cs" -and $moved.pending_question.context -match "src/bar\.cs") `
+                -Message "Expected conflict file names in context"
+
+            Assert-True -Name "pending_question context includes worktree path" `
+                -Condition ($moved.pending_question.context -match [regex]::Escape($fakeWorktreePath)) `
+                -Message "Expected worktree path in context"
+        }
+
+        # No .bot/ under $mceWorkspace → NotificationClient not found → notified=$false deterministically
+        Assert-True -Name "Escalation reports notified=false when NotificationClient absent" `
+            -Condition ($result.notified -eq $false) `
+            -Message "Expected notified=false when .bot/systems/mcp/modules/NotificationClient.psm1 is missing"
+
+        Assert-True -Name "Escalation reason is 'NotificationClient module not found'" `
+            -Condition ($result.notification_reason -eq "NotificationClient module not found") `
+            -Message "Expected reason='NotificationClient module not found', got '$($result.notification_reason)'"
+
+        # notification_silent must be $true for a project that hasn't opted in,
+        # so the wrapper's call sites stay quiet on every escalation.
+        Assert-True -Name "Escalation reports notification_silent=true when no module" `
+            -Condition ($result.notification_silent -eq $true) `
+            -Message "Expected notification_silent=true (project never opted in)"
+
+        # Session-close: when SessionTracking.psm1 is unavailable under the temp
+        # workspace, the helper must NOT throw and must still complete the file
+        # move. The execution_sessions array must therefore survive untouched
+        # (still exists, still has the open entry) — the close-with-module branch
+        # is exercised explicitly in the notified=$true block below by stubbing
+        # SessionTracking alongside NotificationClient.
+        if (Test-Path $newPath) {
+            $movedNoSession = Get-Content $newPath -Raw | ConvertFrom-Json
+            Assert-True -Name "Session-close: helper survives missing SessionTracking module" `
+                -Condition ($movedNoSession.execution_sessions -and @($movedNoSession.execution_sessions).Count -eq 1) `
+                -Message "Expected execution_sessions to survive helper run"
+        }
+
+        # Missing-task case: calling again with a task id that is no longer in done/
+        $missingResult = Move-TaskToMergeConflictNeedsInput `
+            -TaskId "does-not-exist" `
+            -TasksBaseDir $mceWorkspace `
+            -MergeResult $fakeMergeResult `
+            -WorktreePath $fakeWorktreePath
+        Assert-True -Name "Missing task returns success=false" `
+            -Condition ($missingResult.success -eq $false) `
+            -Message "Expected success=false when task file not found in done/"
+
+        # --- Regression: hashtable shape (matches Complete-TaskWorktree's real return) ---
+        # Previously the helper probed $MergeResult.PSObject.Properties['conflict_files'],
+        # which is $null for [hashtable], so conflict_files were silently dropped from the
+        # pending_question context and from the Teams card. (issue #224 review defect #2)
+        $fakeTaskId2 = "hash1234"
+        $fakeTaskJson2 = @{
+            id         = $fakeTaskId2
+            name       = "Fake hashtable merge-conflict task"
+            status     = "done"
+            created_at = "2026-04-11T00:00:00.0000000Z"
+            updated_at = "2026-04-11T00:00:00.0000000Z"
+        } | ConvertTo-Json -Depth 10
+        $fakeTaskFile2 = Join-Path $mceDone "$fakeTaskId2.json"
+        Set-Content -Path $fakeTaskFile2 -Value $fakeTaskJson2 -Encoding UTF8
+
+        $fakeMergeResultHashtable = @{
+            success        = $false
+            message        = "conflict in 2 files"
+            conflict_files = @("src/hash-foo.cs", "src/hash-bar.cs")
+        }
+        $fakeWorktreePath2 = "C:\worktrees\dotbot\task-$fakeTaskId2-fake"
+
+        $resultHash = Move-TaskToMergeConflictNeedsInput `
+            -TaskId $fakeTaskId2 `
+            -TasksBaseDir $mceWorkspace `
+            -MergeResult $fakeMergeResultHashtable `
+            -WorktreePath $fakeWorktreePath2
+
+        Assert-True -Name "Hashtable MergeResult: escalation returns success" `
+            -Condition ($resultHash.success -eq $true) `
+            -Message "Expected success=true for hashtable shape"
+
+        $newPath2 = Join-Path $mceNeedsInput "$fakeTaskId2.json"
+        if (Test-Path $newPath2) {
+            $movedHash = Get-Content $newPath2 -Raw | ConvertFrom-Json
+            Assert-True -Name "Hashtable MergeResult: context includes both conflict files" `
+                -Condition ($movedHash.pending_question.context -match "src/hash-foo\.cs" -and $movedHash.pending_question.context -match "src/hash-bar\.cs") `
+                -Message "Expected hashtable conflict_files to appear in pending_question.context (regression for issue #224 review defect #2)"
+        } else {
+            Write-TestResult -Name "Hashtable MergeResult: task file created in needs-input/" -Status Fail -Message "Expected file at $newPath2"
+        }
+
+        # --- notified=$true path: stub NotificationClient under the temp root ---
+        # Materialise a fake .bot/systems/mcp/modules/NotificationClient.psm1 so the
+        # helper's Test-Path succeeds and Send-TaskNotification returns a canned
+        # success payload. This is the direct unit-level guarantee for issue #224:
+        # without it, the entire success branch (Add-Member notification, second
+        # JSON write, notification metadata persistence) would be untested.
+        $stubModulesDir = Join-Path $mceWorkspace ".bot\systems\mcp\modules"
+        New-Item -ItemType Directory -Force -Path $stubModulesDir | Out-Null
+        $stubModulePath = Join-Path $stubModulesDir "NotificationClient.psm1"
+        $stubModuleContent = @'
+function Get-NotificationSettings {
+    return [pscustomobject]@{ enabled = $true }
+}
+function Send-TaskNotification {
+    param($TaskContent, $PendingQuestion)
+    return @{
+        success     = $true
+        question_id = 'q-test'
+        instance_id = 'i-test'
+        channel     = 'teams'
+        project_id  = 'p-test'
+    }
+}
+Export-ModuleMember -Function 'Get-NotificationSettings','Send-TaskNotification'
+'@
+        Set-Content -Path $stubModulePath -Value $stubModuleContent -Encoding UTF8
+
+        # Also stub SessionTracking.psm1 so the helper's session-close branch is
+        # exercised end-to-end (review defect #1: helper used to read $env:CLAUDE_SESSION_ID
+        # which is always null in the runtime parent — must source from execution_sessions).
+        $stubSessionPath = Join-Path $stubModulesDir "SessionTracking.psm1"
+        $stubSessionContent = @'
+function Close-SessionOnTask {
+    param($TaskContent, $SessionId, $Phase)
+    if (-not $SessionId) { return }
+    $arrayName = "${Phase}_sessions"
+    if (-not $TaskContent.PSObject.Properties[$arrayName]) { return }
+    foreach ($s in $TaskContent.$arrayName) {
+        if ($s.id -eq $SessionId -and -not $s.ended_at) {
+            $s | Add-Member -NotePropertyName ended_at -NotePropertyValue '2026-04-11T12:34:56Z' -Force
+            break
+        }
+    }
+}
+Export-ModuleMember -Function 'Close-SessionOnTask'
+'@
+        Set-Content -Path $stubSessionPath -Value $stubSessionContent -Encoding UTF8
+
+        # Seed the task with an open execution session so Close-SessionOnTask has
+        # a target. Note: NO $env:CLAUDE_SESSION_ID — the helper must source the
+        # session id from execution_sessions only.
+        $fakeTaskId3 = "notif001"
+        $fakeTaskJson3 = @{
+            id                 = $fakeTaskId3
+            name               = "Fake notify merge-conflict task"
+            status             = "done"
+            created_at         = "2026-04-11T00:00:00Z"
+            updated_at         = "2026-04-11T00:00:00Z"
+            execution_sessions = @(
+                @{ id = "exec-notif-001"; started_at = "2026-04-11T00:00:01Z"; ended_at = $null }
+            )
+        } | ConvertTo-Json -Depth 10
+        $fakeTaskFile3 = Join-Path $mceDone "$fakeTaskId3.json"
+        Set-Content -Path $fakeTaskFile3 -Value $fakeTaskJson3 -Encoding UTF8
+
+        # Env var already nulled and captured by the outer block — do not re-capture
+        # here or the finally would wipe the developer's real shell var.
+
+        $resultNotif = Move-TaskToMergeConflictNeedsInput `
+            -TaskId $fakeTaskId3 `
+            -TasksBaseDir $mceWorkspace `
+            -MergeResult $fakeMergeResult `
+            -WorktreePath $fakeWorktreePath
+
+        Assert-True -Name "Notified path: escalation returns success" `
+            -Condition ($resultNotif.success -eq $true) `
+            -Message "Expected success=true"
+
+        Assert-True -Name "Notified path: notified=true" `
+            -Condition ($resultNotif.notified -eq $true) `
+            -Message "Expected notified=true when NotificationClient stub returns success"
+
+        Assert-True -Name "Notified path: reason is 'Notification dispatched'" `
+            -Condition ($resultNotif.notification_reason -eq "Notification dispatched") `
+            -Message "Expected notification_reason='Notification dispatched', got '$($resultNotif.notification_reason)'"
+
+        $newPath3 = Join-Path $mceNeedsInput "$fakeTaskId3.json"
+        if (Test-Path $newPath3) {
+            $movedNotif = Get-Content $newPath3 -Raw | ConvertFrom-Json
+
+            Assert-True -Name "Notified path: notification.question_id persisted" `
+                -Condition ($movedNotif.notification.question_id -eq "q-test") `
+                -Message "Expected notification.question_id='q-test'"
+
+            Assert-True -Name "Notified path: notification.channel persisted" `
+                -Condition ($movedNotif.notification.channel -eq "teams") `
+                -Message "Expected notification.channel='teams'"
+
+            Assert-True -Name "Notified path: notification.instance_id persisted" `
+                -Condition ($movedNotif.notification.instance_id -eq "i-test") `
+                -Message "Expected notification.instance_id='i-test'"
+
+            # Timestamp format guard for review defect #2 — second-precision, trailing Z.
+            # NB: ConvertFrom-Json auto-coerces ISO 8601 strings to [datetime], which then
+            # round-trips through local culture and breaks the regex. Pin the *on-disk*
+            # serialised form by grepping the raw JSON text instead.
+            $rawNotifJson = Get-Content $newPath3 -Raw
+            $tsPattern = '"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"'
+            Assert-True -Name "Notified path: notification.sent_at is second-precision (on disk)" `
+                -Condition ($rawNotifJson -match "(?s)`"sent_at`"\s*:\s*$tsPattern") `
+                -Message "Expected sent_at to be serialised as second-precision UTC string"
+
+            Assert-True -Name "Notified path: pending_question.asked_at is second-precision (on disk)" `
+                -Condition ($rawNotifJson -match "(?s)`"asked_at`"\s*:\s*$tsPattern") `
+                -Message "Expected asked_at to be serialised as second-precision UTC string"
+
+            # Session-close: helper must have stamped ended_at on the open
+            # execution_sessions entry by sourcing its id from the task content
+            # (NOT from $env:CLAUDE_SESSION_ID, which is empty in this test).
+            $execSessions = @($movedNotif.execution_sessions)
+            Assert-True -Name "Session-close: execution_sessions still has 1 entry" `
+                -Condition ($execSessions.Count -eq 1) `
+                -Message "Expected single execution session entry"
+
+            if ($execSessions.Count -eq 1) {
+                Assert-True -Name "Session-close: ended_at populated on previously-open session" `
+                    -Condition ($null -ne $execSessions[0].ended_at -and "$($execSessions[0].ended_at)") `
+                    -Message "Expected ended_at to be set after escalation; got '$($execSessions[0].ended_at)'"
+
+                Assert-True -Name "Session-close: id matches the seeded open session" `
+                    -Condition ($execSessions[0].id -eq "exec-notif-001") `
+                    -Message "Expected id=exec-notif-001, got '$($execSessions[0].id)'"
+            }
+        } else {
+            Write-TestResult -Name "Notified path: task file created in needs-input/" -Status Fail -Message "Expected file at $newPath3"
+        }
+
+    } finally {
+        # Unload the stub so it cannot leak into later tests that rely on the real module.
+        # Must run in finally: $ErrorActionPreference=Stop means any assertion failure
+        # above would otherwise skip cleanup and shadow the real NotificationClient
+        # in subsequent tests.
+        Remove-Module NotificationClient -Force -ErrorAction SilentlyContinue
+        Remove-Module SessionTracking -Force -ErrorAction SilentlyContinue
+        if ($null -ne $savedSessionEnv) { $env:CLAUDE_SESSION_ID = $savedSessionEnv } else { Remove-Item Env:CLAUDE_SESSION_ID -ErrorAction SilentlyContinue }
+        $global:DotbotProjectRoot = $savedDotbotRoot
+        Remove-Item -Path $mceWorkspace -Recurse -Force -ErrorAction SilentlyContinue
+    }
+} else {
+    Write-TestResult -Name "MergeConflictEscalation module exists" -Status Fail -Message "Module not found at $mergeEscModule"
+}
+
+# ═══════════════════════════════════════════════════════════════════
 # NOTIFICATION POLLER MODULE TESTS
 # ═══════════════════════════════════════════════════════════════════
 Write-Host ""

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -1611,6 +1611,11 @@ if (Test-Path $mergeEscModule) {
     # Point DotbotProjectRoot at the isolated temp workspace that has no `.bot/` —
     # `Test-Path` on NotificationClient.psm1 fails, so the notification branch short-circuits
     # to notified=$false deterministically, regardless of the developer's $testProject config.
+    # NB: we pass `-BotRoot $mceBotRoot` explicitly to mirror how the runtime wires the helper
+    # (Invoke-WorkflowProcess / Invoke-ExecutionProcess pass the `.bot` directory, NOT the
+    # project root). This pins the regression: if the helper ever treats `$BotRoot` as a
+    # project root again and appends `.bot`, these tests fail instead of passing vacuously.
+    $mceBotRoot = Join-Path $mceWorkspace ".bot"
     $savedDotbotRoot = $global:DotbotProjectRoot
     $savedSessionEnv = $env:CLAUDE_SESSION_ID
     $global:DotbotProjectRoot = $mceWorkspace
@@ -1621,7 +1626,8 @@ if (Test-Path $mergeEscModule) {
             -TaskId $fakeTaskId `
             -TasksBaseDir $mceWorkspace `
             -MergeResult $fakeMergeResult `
-            -WorktreePath $fakeWorktreePath
+            -WorktreePath $fakeWorktreePath `
+            -BotRoot $mceBotRoot
 
         Assert-True -Name "Move-TaskToMergeConflictNeedsInput returns success" `
             -Condition ($result.success -eq $true) `
@@ -1702,7 +1708,8 @@ if (Test-Path $mergeEscModule) {
             -TaskId "does-not-exist" `
             -TasksBaseDir $mceWorkspace `
             -MergeResult $fakeMergeResult `
-            -WorktreePath $fakeWorktreePath
+            -WorktreePath $fakeWorktreePath `
+            -BotRoot $mceBotRoot
         Assert-True -Name "Missing task returns success=false" `
             -Condition ($missingResult.success -eq $false) `
             -Message "Expected success=false when task file not found in done/"
@@ -1733,7 +1740,8 @@ if (Test-Path $mergeEscModule) {
             -TaskId $fakeTaskId2 `
             -TasksBaseDir $mceWorkspace `
             -MergeResult $fakeMergeResultHashtable `
-            -WorktreePath $fakeWorktreePath2
+            -WorktreePath $fakeWorktreePath2 `
+            -BotRoot $mceBotRoot
 
         Assert-True -Name "Hashtable MergeResult: escalation returns success" `
             -Condition ($resultHash.success -eq $true) `
@@ -1821,7 +1829,8 @@ Export-ModuleMember -Function 'Close-SessionOnTask'
             -TaskId $fakeTaskId3 `
             -TasksBaseDir $mceWorkspace `
             -MergeResult $fakeMergeResult `
-            -WorktreePath $fakeWorktreePath
+            -WorktreePath $fakeWorktreePath `
+            -BotRoot $mceBotRoot
 
         Assert-True -Name "Notified path: escalation returns success" `
             -Condition ($resultNotif.success -eq $true) `

--- a/workflows/default/systems/runtime/modules/MergeConflictEscalation.psm1
+++ b/workflows/default/systems/runtime/modules/MergeConflictEscalation.psm1
@@ -19,13 +19,14 @@ function Move-TaskToMergeConflictNeedsInput {
         [Parameter(Mandatory)] [string] $TaskId,
         [Parameter(Mandatory)] [string] $TasksBaseDir,
         [Parameter(Mandatory)] [object] $MergeResult,
-        [Parameter(Mandatory)] [string] $WorktreePath
+        [Parameter(Mandatory)] [string] $WorktreePath,
+        [string] $BotRoot = $global:DotbotProjectRoot
     )
 
     $doneDir = Join-Path $TasksBaseDir "done"
     $needsInputDir = Join-Path $TasksBaseDir "needs-input"
 
-    $taskFile = Get-ChildItem -Path $doneDir -Filter "*.json" -File -ErrorAction SilentlyContinue | Where-Object {
+    $taskFile = Get-ChildItem -LiteralPath $doneDir -Filter "*.json" -File -ErrorAction SilentlyContinue | Where-Object {
         try {
             $c = Get-Content $_.FullName -Raw | ConvertFrom-Json
             $c.id -eq $TaskId
@@ -79,7 +80,7 @@ function Move-TaskToMergeConflictNeedsInput {
     # $env:CLAUDE_SESSION_ID is nulled by both runtime workers before the merge,
     # so we cannot rely on it. Best-effort — never block escalation.
     try {
-        $sessionModule = Join-Path $global:DotbotProjectRoot '.bot' | Join-Path -ChildPath 'systems' | Join-Path -ChildPath 'mcp' | Join-Path -ChildPath 'modules' | Join-Path -ChildPath 'SessionTracking.psm1'
+        $sessionModule = Join-Path $BotRoot '.bot' | Join-Path -ChildPath 'systems' | Join-Path -ChildPath 'mcp' | Join-Path -ChildPath 'modules' | Join-Path -ChildPath 'SessionTracking.psm1'
         if ((Test-Path $sessionModule) -and $taskContent.PSObject.Properties['execution_sessions']) {
             $openSession = @($taskContent.execution_sessions) | Where-Object {
                 $_ -and $_.id -and (-not $_.ended_at)
@@ -101,14 +102,20 @@ function Move-TaskToMergeConflictNeedsInput {
         New-Item -ItemType Directory -Force -Path $needsInputDir | Out-Null
     }
     $newPath = Join-Path $needsInputDir $taskFile.Name
-    $taskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $newPath -Encoding UTF8
-    Remove-Item -Path $taskFile.FullName -Force -ErrorAction SilentlyContinue
+    $taskContent | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $newPath -Encoding UTF8
+    try {
+        Remove-Item -LiteralPath $taskFile.FullName -Force -ErrorAction Stop
+    } catch {
+        # Rollback: remove the newly written file to avoid split-brain (task in both done/ and needs-input/)
+        Remove-Item -LiteralPath $newPath -Force -ErrorAction SilentlyContinue
+        throw
+    }
 
     $notified = $false
     $silent = $true
     $reason = "Notifications disabled"
     try {
-        $notifModule = Join-Path $global:DotbotProjectRoot '.bot' | Join-Path -ChildPath 'systems' | Join-Path -ChildPath 'mcp' | Join-Path -ChildPath 'modules' | Join-Path -ChildPath 'NotificationClient.psm1'
+        $notifModule = Join-Path $BotRoot '.bot' | Join-Path -ChildPath 'systems' | Join-Path -ChildPath 'mcp' | Join-Path -ChildPath 'modules' | Join-Path -ChildPath 'NotificationClient.psm1'
         if (Test-Path $notifModule) {
             Import-Module $notifModule -Force
             $settings = Get-NotificationSettings
@@ -123,7 +130,7 @@ function Move-TaskToMergeConflictNeedsInput {
                         project_id  = $sendResult.project_id
                         sent_at     = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
                     } -Force
-                    $taskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $newPath -Encoding UTF8
+                    $taskContent | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $newPath -Encoding UTF8
                     $notified = $true
                     $reason = "Notification dispatched"
                 } else {
@@ -161,7 +168,8 @@ function Invoke-MergeConflictEscalation {
         [Parameter(Mandatory)] [string] $TasksBaseDir,
         [Parameter(Mandatory)] [object] $MergeResult,
         [Parameter(Mandatory)] [string] $WorktreePath,
-        [string] $ProcId
+        [string] $ProcId,
+        [string] $BotRoot = $global:DotbotProjectRoot
     )
 
     $emitActivity = {
@@ -177,7 +185,8 @@ function Invoke-MergeConflictEscalation {
             -TaskId $Task.id `
             -TasksBaseDir $TasksBaseDir `
             -MergeResult $MergeResult `
-            -WorktreePath $WorktreePath
+            -WorktreePath $WorktreePath `
+            -BotRoot $BotRoot
     } catch {
         $msg = "Merge-conflict escalation helper failed: $($_.Exception.Message)"
         if (Get-Command Write-Status -ErrorAction SilentlyContinue) {

--- a/workflows/default/systems/runtime/modules/MergeConflictEscalation.psm1
+++ b/workflows/default/systems/runtime/modules/MergeConflictEscalation.psm1
@@ -1,0 +1,234 @@
+<#
+.SYNOPSIS
+    Shared helper for escalating merge-conflict failures to needs-input and
+    notifying external stakeholders (see issue #224).
+#>
+
+function Move-TaskToMergeConflictNeedsInput {
+    <#
+    .SYNOPSIS
+    Move a task from done/ to needs-input/ with a merge-conflict pending_question
+    and dispatch an external notification when configured.
+
+    .OUTPUTS
+    @{ success; new_path; notified; notification_silent; notification_reason }
+    notification_silent is $true when the project hasn't opted into notifications
+    (no NotificationClient module or settings.enabled = $false).
+    #>
+    param(
+        [Parameter(Mandatory)] [string] $TaskId,
+        [Parameter(Mandatory)] [string] $TasksBaseDir,
+        [Parameter(Mandatory)] [object] $MergeResult,
+        [Parameter(Mandatory)] [string] $WorktreePath
+    )
+
+    $doneDir = Join-Path $TasksBaseDir "done"
+    $needsInputDir = Join-Path $TasksBaseDir "needs-input"
+
+    $taskFile = Get-ChildItem -Path $doneDir -Filter "*.json" -File -ErrorAction SilentlyContinue | Where-Object {
+        try {
+            $c = Get-Content $_.FullName -Raw | ConvertFrom-Json
+            $c.id -eq $TaskId
+        } catch { $false }
+    } | Select-Object -First 1
+
+    if (-not $taskFile) {
+        return @{
+            success             = $false
+            new_path            = $null
+            notified            = $false
+            notification_silent = $false
+            notification_reason = "Task file not found in done/"
+        }
+    }
+
+    # TODO(#224): delegate to Move-TaskState once it accepts `done` as a FromState.
+    $taskContent = Get-Content $taskFile.FullName -Raw | ConvertFrom-Json
+    $taskContent.status = 'needs-input'
+    $taskContent.updated_at = (Get-Date).ToUniversalTime().ToString("o")
+
+    if (-not $taskContent.PSObject.Properties['pending_question']) {
+        $taskContent | Add-Member -NotePropertyName 'pending_question' -NotePropertyValue $null -Force
+    }
+
+    $conflictFiles = @()
+    if ($MergeResult -is [hashtable]) {
+        if ($MergeResult.ContainsKey('conflict_files') -and $MergeResult['conflict_files']) {
+            $conflictFiles = @($MergeResult['conflict_files'])
+        }
+    } elseif ($MergeResult.PSObject.Properties['conflict_files'] -and $MergeResult.conflict_files) {
+        # Defensive only — Complete-TaskWorktree returns a [hashtable] in production.
+        $conflictFiles = @($MergeResult.conflict_files)
+    }
+    $conflictDetail = if ($conflictFiles.Count -gt 0) { $conflictFiles -join '; ' } else { '(none reported)' }
+
+    $taskContent.pending_question = @{
+        id             = "merge-conflict"
+        question       = "Merge conflict during squash-merge to main"
+        context        = "Conflict details: $conflictDetail. Worktree preserved at: $WorktreePath"
+        options        = @(
+            @{ key = "A"; label = "Resolve manually and retry (recommended)"; rationale = "Inspect the worktree, resolve conflicts, then retry merge" }
+            @{ key = "B"; label = "Discard task changes"; rationale = "Remove worktree and abandon this task's changes" }
+            @{ key = "C"; label = "Retry with fresh rebase"; rationale = "Reset and attempt rebase again" }
+        )
+        recommendation = "A"
+        asked_at       = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
+    }
+
+    # Close the open execution session by walking the task's history. The env var
+    # $env:CLAUDE_SESSION_ID is nulled by both runtime workers before the merge,
+    # so we cannot rely on it. Best-effort — never block escalation.
+    try {
+        $sessionModule = Join-Path $global:DotbotProjectRoot '.bot' | Join-Path -ChildPath 'systems' | Join-Path -ChildPath 'mcp' | Join-Path -ChildPath 'modules' | Join-Path -ChildPath 'SessionTracking.psm1'
+        if ((Test-Path $sessionModule) -and $taskContent.PSObject.Properties['execution_sessions']) {
+            $openSession = @($taskContent.execution_sessions) | Where-Object {
+                $_ -and $_.id -and (-not $_.ended_at)
+            } | Select-Object -Last 1
+            if ($openSession) {
+                Import-Module $sessionModule -Force
+                if (Get-Command Close-SessionOnTask -ErrorAction SilentlyContinue) {
+                    Close-SessionOnTask -TaskContent $taskContent -SessionId $openSession.id -Phase 'execution'
+                }
+            }
+        }
+    } catch {
+        if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
+            Write-BotLog -Level Debug -Message "Merge-conflict session close failed" -Exception $_
+        }
+    }
+
+    if (-not (Test-Path $needsInputDir)) {
+        New-Item -ItemType Directory -Force -Path $needsInputDir | Out-Null
+    }
+    $newPath = Join-Path $needsInputDir $taskFile.Name
+    $taskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $newPath -Encoding UTF8
+    Remove-Item -Path $taskFile.FullName -Force -ErrorAction SilentlyContinue
+
+    $notified = $false
+    $silent = $true
+    $reason = "Notifications disabled"
+    try {
+        $notifModule = Join-Path $global:DotbotProjectRoot '.bot' | Join-Path -ChildPath 'systems' | Join-Path -ChildPath 'mcp' | Join-Path -ChildPath 'modules' | Join-Path -ChildPath 'NotificationClient.psm1'
+        if (Test-Path $notifModule) {
+            Import-Module $notifModule -Force
+            $settings = Get-NotificationSettings
+            if ($settings.enabled) {
+                $silent = $false
+                $sendResult = Send-TaskNotification -TaskContent $taskContent -PendingQuestion $taskContent.pending_question
+                if ($sendResult -and $sendResult.success) {
+                    $taskContent | Add-Member -NotePropertyName 'notification' -NotePropertyValue @{
+                        question_id = $sendResult.question_id
+                        instance_id = $sendResult.instance_id
+                        channel     = $sendResult.channel
+                        project_id  = $sendResult.project_id
+                        sent_at     = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
+                    } -Force
+                    $taskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $newPath -Encoding UTF8
+                    $notified = $true
+                    $reason = "Notification dispatched"
+                } else {
+                    $reason = if ($sendResult -and $sendResult.reason) { $sendResult.reason } else { "Send-TaskNotification failed" }
+                }
+            }
+        } else {
+            $reason = "NotificationClient module not found"
+        }
+    } catch {
+        $reason = "Notification error: $($_.Exception.Message)"
+        if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
+            Write-BotLog -Level Debug -Message "Merge-conflict notification failed" -Exception $_
+        }
+    }
+
+    return @{
+        success             = $true
+        new_path            = $newPath
+        notified            = $notified
+        notification_silent = $silent
+        notification_reason = $reason
+    }
+}
+
+function Invoke-MergeConflictEscalation {
+    <#
+    .SYNOPSIS
+    Runtime-side wrapper around Move-TaskToMergeConflictNeedsInput. Owns
+    Write-Status / Write-ProcessActivity emission so each caller collapses
+    to a single call.
+    #>
+    param(
+        [Parameter(Mandatory)] [object] $Task,
+        [Parameter(Mandatory)] [string] $TasksBaseDir,
+        [Parameter(Mandatory)] [object] $MergeResult,
+        [Parameter(Mandatory)] [string] $WorktreePath,
+        [string] $ProcId
+    )
+
+    $emitActivity = {
+        param($message)
+        if ($ProcId -and (Get-Command Write-ProcessActivity -ErrorAction SilentlyContinue)) {
+            Write-ProcessActivity -Id $ProcId -ActivityType "text" -Message $message
+        }
+    }
+
+    $escalation = $null
+    try {
+        $escalation = Move-TaskToMergeConflictNeedsInput `
+            -TaskId $Task.id `
+            -TasksBaseDir $TasksBaseDir `
+            -MergeResult $MergeResult `
+            -WorktreePath $WorktreePath
+    } catch {
+        $msg = "Merge-conflict escalation helper failed: $($_.Exception.Message)"
+        if (Get-Command Write-Status -ErrorAction SilentlyContinue) {
+            Write-Status $msg -Type Error
+        }
+        & $emitActivity "Escalation helper threw for $($Task.name): $($_.Exception.Message)"
+        return @{
+            success             = $false
+            notified            = $false
+            notification_silent = $false
+            notification_reason = $msg
+        }
+    }
+
+    if ($escalation -and $escalation.success) {
+        $statusMsg = if ($escalation.notified) {
+            "Task moved to needs-input for manual conflict resolution (stakeholders notified)"
+        } else {
+            "Task moved to needs-input for manual conflict resolution"
+        }
+        if (Get-Command Write-Status -ErrorAction SilentlyContinue) {
+            Write-Status $statusMsg -Type Warn
+        }
+        & $emitActivity "Escalated merge conflict for $($Task.name); notified=$($escalation.notified)"
+
+        # Surface real delivery failures; opt-out states stay quiet.
+        if (-not $escalation.notified -and -not $escalation.notification_silent) {
+            if (Get-Command Write-Status -ErrorAction SilentlyContinue) {
+                Write-Status "Merge-conflict notification not delivered: $($escalation.notification_reason)" -Type Warn
+            }
+            & $emitActivity "Merge-conflict notification skipped for $($Task.name): $($escalation.notification_reason)"
+        }
+    } elseif ($escalation) {
+        if (Get-Command Write-Status -ErrorAction SilentlyContinue) {
+            Write-Status "Failed to escalate merge conflict: $($escalation.notification_reason)" -Type Error
+        }
+        & $emitActivity "Failed to escalate merge conflict for $($Task.name): $($escalation.notification_reason)"
+    } else {
+        if (Get-Command Write-Status -ErrorAction SilentlyContinue) {
+            Write-Status "Merge-conflict escalation helper returned no result for $($Task.name)" -Type Error
+        }
+        & $emitActivity "Merge-conflict escalation helper returned null for $($Task.name)"
+        $escalation = @{
+            success             = $false
+            notified            = $false
+            notification_silent = $false
+            notification_reason = "Helper returned no result"
+        }
+    }
+
+    return $escalation
+}
+
+Export-ModuleMember -Function 'Move-TaskToMergeConflictNeedsInput', 'Invoke-MergeConflictEscalation'

--- a/workflows/default/systems/runtime/modules/MergeConflictEscalation.psm1
+++ b/workflows/default/systems/runtime/modules/MergeConflictEscalation.psm1
@@ -10,6 +10,11 @@ function Move-TaskToMergeConflictNeedsInput {
     Move a task from done/ to needs-input/ with a merge-conflict pending_question
     and dispatch an external notification when configured.
 
+    .PARAMETER BotRoot
+    The `.bot` root directory (matches the convention used by WorktreeManager,
+    Get-NotificationSettings, and the runtime process types). Defaults to
+    `$global:DotbotProjectRoot/.bot`.
+
     .OUTPUTS
     @{ success; new_path; notified; notification_silent; notification_reason }
     notification_silent is $true when the project hasn't opted into notifications
@@ -20,8 +25,15 @@ function Move-TaskToMergeConflictNeedsInput {
         [Parameter(Mandatory)] [string] $TasksBaseDir,
         [Parameter(Mandatory)] [object] $MergeResult,
         [Parameter(Mandatory)] [string] $WorktreePath,
-        [string] $BotRoot = $global:DotbotProjectRoot
+        [string] $BotRoot
     )
+
+    if (-not $BotRoot) {
+        if (-not $global:DotbotProjectRoot) {
+            throw "Move-TaskToMergeConflictNeedsInput: BotRoot not provided and \$global:DotbotProjectRoot is not set"
+        }
+        $BotRoot = Join-Path $global:DotbotProjectRoot '.bot'
+    }
 
     $doneDir = Join-Path $TasksBaseDir "done"
     $needsInputDir = Join-Path $TasksBaseDir "needs-input"
@@ -80,7 +92,7 @@ function Move-TaskToMergeConflictNeedsInput {
     # $env:CLAUDE_SESSION_ID is nulled by both runtime workers before the merge,
     # so we cannot rely on it. Best-effort — never block escalation.
     try {
-        $sessionModule = Join-Path $BotRoot '.bot' | Join-Path -ChildPath 'systems' | Join-Path -ChildPath 'mcp' | Join-Path -ChildPath 'modules' | Join-Path -ChildPath 'SessionTracking.psm1'
+        $sessionModule = Join-Path $BotRoot 'systems' | Join-Path -ChildPath 'mcp' | Join-Path -ChildPath 'modules' | Join-Path -ChildPath 'SessionTracking.psm1'
         if ((Test-Path $sessionModule) -and $taskContent.PSObject.Properties['execution_sessions']) {
             $openSession = @($taskContent.execution_sessions) | Where-Object {
                 $_ -and $_.id -and (-not $_.ended_at)
@@ -114,13 +126,20 @@ function Move-TaskToMergeConflictNeedsInput {
     $notified = $false
     $silent = $true
     $reason = "Notifications disabled"
+    $notifModule = Join-Path $BotRoot 'systems' | Join-Path -ChildPath 'mcp' | Join-Path -ChildPath 'modules' | Join-Path -ChildPath 'NotificationClient.psm1'
     try {
-        $notifModule = Join-Path $BotRoot '.bot' | Join-Path -ChildPath 'systems' | Join-Path -ChildPath 'mcp' | Join-Path -ChildPath 'modules' | Join-Path -ChildPath 'NotificationClient.psm1'
         if (Test-Path $notifModule) {
             Import-Module $notifModule -Force
-            $settings = Get-NotificationSettings
-            if ($settings.enabled) {
-                $silent = $false
+            # Module is present — any failure past this point is a real delivery
+            # problem, NOT a silent opt-out. Flip $silent here so the catch below
+            # surfaces unexpected errors instead of masking them.
+            $silent = $false
+            $settings = Get-NotificationSettings -BotRoot $BotRoot
+            if (-not $settings.enabled) {
+                # Explicit opt-out via settings.
+                $silent = $true
+                $reason = "Notifications disabled"
+            } else {
                 $sendResult = Send-TaskNotification -TaskContent $taskContent -PendingQuestion $taskContent.pending_question
                 if ($sendResult -and $sendResult.success) {
                     $taskContent | Add-Member -NotePropertyName 'notification' -NotePropertyValue @{
@@ -169,8 +188,15 @@ function Invoke-MergeConflictEscalation {
         [Parameter(Mandatory)] [object] $MergeResult,
         [Parameter(Mandatory)] [string] $WorktreePath,
         [string] $ProcId,
-        [string] $BotRoot = $global:DotbotProjectRoot
+        [string] $BotRoot
     )
+
+    if (-not $BotRoot) {
+        if (-not $global:DotbotProjectRoot) {
+            throw "Invoke-MergeConflictEscalation: BotRoot not provided and \$global:DotbotProjectRoot is not set"
+        }
+        $BotRoot = Join-Path $global:DotbotProjectRoot '.bot'
+    }
 
     $emitActivity = {
         param($message)

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-ExecutionProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-ExecutionProcess.ps1
@@ -395,45 +395,15 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
                     Write-Status "Merge failed: $($mergeResult.message)" -Type Error
                     Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Merge failed for $($task.name): $($mergeResult.message)"
 
-                    # Escalate: move task from done/ to needs-input/ with conflict info
-                    $doneDir = Join-Path $tasksBaseDir "done"
-                    $needsInputDir = Join-Path $tasksBaseDir "needs-input"
-                    $taskFile = Get-ChildItem -Path $doneDir -Filter "*.json" -File -ErrorAction SilentlyContinue | Where-Object {
-                        try {
-                            $c = Get-Content $_.FullName -Raw | ConvertFrom-Json
-                            $c.id -eq $task.id
-                        } catch { $false }
-                    } | Select-Object -First 1
-
-                    if ($taskFile) {
-                        $taskContent = Get-Content $taskFile.FullName -Raw | ConvertFrom-Json
-                        $taskContent.status = 'needs-input'
-                        $taskContent.updated_at = (Get-Date).ToUniversalTime().ToString("o")
-
-                        if (-not $taskContent.PSObject.Properties['pending_question']) {
-                            $taskContent | Add-Member -NotePropertyName 'pending_question' -NotePropertyValue $null -Force
-                        }
-                        $taskContent.pending_question = @{
-                            id             = "merge-conflict"
-                            question       = "Merge conflict during squash-merge to main"
-                            context        = "Conflict details: $($mergeResult.conflict_files -join '; '). Worktree preserved at: $worktreePath"
-                            options        = @(
-                                @{ key = "A"; label = "Resolve manually and retry (recommended)"; rationale = "Inspect the worktree, resolve conflicts, then retry merge" }
-                                @{ key = "B"; label = "Discard task changes"; rationale = "Remove worktree and abandon this task's changes" }
-                                @{ key = "C"; label = "Retry with fresh rebase"; rationale = "Reset and attempt rebase again" }
-                            )
-                            recommendation = "A"
-                            asked_at       = (Get-Date).ToUniversalTime().ToString("o")
-                        }
-
-                        if (-not (Test-Path $needsInputDir)) {
-                            New-Item -ItemType Directory -Force -Path $needsInputDir | Out-Null
-                        }
-                        $newPath = Join-Path $needsInputDir $taskFile.Name
-                        $taskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $newPath -Encoding UTF8
-                        Remove-Item -Path $taskFile.FullName -Force -ErrorAction SilentlyContinue
-
-                        Write-Status "Task moved to needs-input for manual conflict resolution" -Type Warn
+                    # Resolve via $PSScriptRoot so the lookup is immune to a null
+                    # $global:DotbotProjectRoot and to Join-Path's backslash quirk on Linux.
+                    $escalationModule = Join-Path (Split-Path $PSScriptRoot -Parent) 'MergeConflictEscalation.psm1'
+                    if (Test-Path $escalationModule) {
+                        Import-Module $escalationModule -Force
+                        Invoke-MergeConflictEscalation -Task $task -TasksBaseDir $tasksBaseDir -MergeResult $mergeResult -WorktreePath $worktreePath -ProcId $procId | Out-Null
+                    } else {
+                        Write-Status "Merge-conflict escalation helper not found at $escalationModule" -Type Error
+                        Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Escalation helper missing for $($task.name); task left in done/"
                     }
                 }
             }

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-ExecutionProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-ExecutionProcess.ps1
@@ -400,7 +400,7 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
                     $escalationModule = Join-Path (Split-Path $PSScriptRoot -Parent) 'MergeConflictEscalation.psm1'
                     if (Test-Path $escalationModule) {
                         Import-Module $escalationModule -Force
-                        Invoke-MergeConflictEscalation -Task $task -TasksBaseDir $tasksBaseDir -MergeResult $mergeResult -WorktreePath $worktreePath -ProcId $procId | Out-Null
+                        Invoke-MergeConflictEscalation -Task $task -TasksBaseDir $tasksBaseDir -MergeResult $mergeResult -WorktreePath $worktreePath -ProcId $procId -BotRoot $botRoot | Out-Null
                     } else {
                         Write-Status "Merge-conflict escalation helper not found at $escalationModule" -Type Error
                         Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Escalation helper missing for $($task.name); task left in done/"

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -914,45 +914,15 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
                     Write-Status "Merge failed: $($mergeResult.message)" -Type Error
                     Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Merge failed for $($task.name): $($mergeResult.message)"
 
-                    # Escalate: move task from done/ to needs-input/ with conflict info
-                    $doneDir = Join-Path $tasksBaseDir "done"
-                    $needsInputDir = Join-Path $tasksBaseDir "needs-input"
-                    $taskFile = Get-ChildItem -Path $doneDir -Filter "*.json" -File -ErrorAction SilentlyContinue | Where-Object {
-                        try {
-                            $c = Get-Content $_.FullName -Raw | ConvertFrom-Json
-                            $c.id -eq $task.id
-                        } catch { $false }
-                    } | Select-Object -First 1
-
-                    if ($taskFile) {
-                        $taskContent = Get-Content $taskFile.FullName -Raw | ConvertFrom-Json
-                        $taskContent.status = 'needs-input'
-                        $taskContent.updated_at = (Get-Date).ToUniversalTime().ToString("o")
-
-                        if (-not $taskContent.PSObject.Properties['pending_question']) {
-                            $taskContent | Add-Member -NotePropertyName 'pending_question' -NotePropertyValue $null -Force
-                        }
-                        $taskContent.pending_question = @{
-                            id             = "merge-conflict"
-                            question       = "Merge conflict during squash-merge to main"
-                            context        = "Conflict details: $($mergeResult.conflict_files -join '; '). Worktree preserved at: $worktreePath"
-                            options        = @(
-                                @{ key = "A"; label = "Resolve manually and retry (recommended)"; rationale = "Inspect the worktree, resolve conflicts, then retry merge" }
-                                @{ key = "B"; label = "Discard task changes"; rationale = "Remove worktree and abandon this task's changes" }
-                                @{ key = "C"; label = "Retry with fresh rebase"; rationale = "Reset and attempt rebase again" }
-                            )
-                            recommendation = "A"
-                            asked_at       = (Get-Date).ToUniversalTime().ToString("o")
-                        }
-
-                        if (-not (Test-Path $needsInputDir)) {
-                            New-Item -ItemType Directory -Force -Path $needsInputDir | Out-Null
-                        }
-                        $newPath = Join-Path $needsInputDir $taskFile.Name
-                        $taskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $newPath -Encoding UTF8
-                        Remove-Item -Path $taskFile.FullName -Force -ErrorAction SilentlyContinue
-
-                        Write-Status "Task moved to needs-input for manual conflict resolution" -Type Warn
+                    # Resolve via $PSScriptRoot so the lookup is immune to a null
+                    # $global:DotbotProjectRoot and to Join-Path's backslash quirk on Linux.
+                    $escalationModule = Join-Path (Split-Path $PSScriptRoot -Parent) 'MergeConflictEscalation.psm1'
+                    if (Test-Path $escalationModule) {
+                        Import-Module $escalationModule -Force
+                        Invoke-MergeConflictEscalation -Task $task -TasksBaseDir $tasksBaseDir -MergeResult $mergeResult -WorktreePath $worktreePath -ProcId $procId | Out-Null
+                    } else {
+                        Write-Status "Merge-conflict escalation helper not found at $escalationModule" -Type Error
+                        Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Escalation helper missing for $($task.name); task left in done/"
                     }
                 }
             }

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -919,7 +919,7 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
                     $escalationModule = Join-Path (Split-Path $PSScriptRoot -Parent) 'MergeConflictEscalation.psm1'
                     if (Test-Path $escalationModule) {
                         Import-Module $escalationModule -Force
-                        Invoke-MergeConflictEscalation -Task $task -TasksBaseDir $tasksBaseDir -MergeResult $mergeResult -WorktreePath $worktreePath -ProcId $procId | Out-Null
+                        Invoke-MergeConflictEscalation -Task $task -TasksBaseDir $tasksBaseDir -MergeResult $mergeResult -WorktreePath $worktreePath -ProcId $procId -BotRoot $botRoot | Out-Null
                     } else {
                         Write-Status "Merge-conflict escalation helper not found at $escalationModule" -Type Error
                         Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Escalation helper missing for $($task.name); task left in done/"


### PR DESCRIPTION
## Summary

Closes #224.

When the task runner failed to squash-merge a task branch due to conflicts, it wrote a `pending_question` directly to the task file and moved it from `done/` to `needs-input/`, bypassing the `task_mark_needs_input` MCP tool. As a result, `Send-TaskNotification` was never invoked and Teams/Slack/Jira stakeholders missed every merge-conflict escalation.

This PR extracts the escalation into a shared `MergeConflictEscalation.psm1` helper that owns the file move, the open-session close, and the external notification dispatch. Both runtime callers (`Invoke-WorkflowProcess.ps1`, `Invoke-ExecutionProcess.ps1`) collapse to a single `Invoke-MergeConflictEscalation` call.

## Changes

- **New** `workflows/default/systems/runtime/modules/MergeConflictEscalation.psm1`
  - `Move-TaskToMergeConflictNeedsInput` — low-level primitive: file move + session close + notification dispatch
  - `Invoke-MergeConflictEscalation` — runtime wrapper that owns try/catch, status emission, and silent-opt-out detection
  - Closes the open execution session by walking `$taskContent.execution_sessions` (the `CLAUDE_SESSION_ID` env var is nulled before merge, so it cannot be relied on)
  - Returns `notification_silent` so callers can distinguish "project hasn't opted in" from "real delivery failure"
- **Modified** `Invoke-WorkflowProcess.ps1` and `Invoke-ExecutionProcess.ps1`
  - Inline escalation block (~40 lines each) replaced with a single wrapper call
  - Helper resolved via `$PSScriptRoot` (sibling on disk) — immune to a null `$global:DotbotProjectRoot` and to `Join-Path`'s backslash handling on Linux/macOS
- **Modified** `tests/Test-Components.ps1`
  - New regression coverage for: silent opt-out path, notified path with notification metadata, session-close walking `execution_sessions`, defensive PSCustomObject branch
  - Captures and restores `$env:CLAUDE_SESSION_ID` so the suite is safe to run with the env var set