### PR TITLE
fix: evaluate task condition fields at runtime, not creation time (#226)

### DIFF
--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -621,6 +621,287 @@ finally {
     }
 }
 
+# ─── task-get-next runtime condition evaluation (issue #226) ────────────────
+
+$testProject = $null
+$savedDotbotProjectRoot = $global:DotbotProjectRoot
+try {
+    $testProject = New-SourceBackedTestProject -RepoRoot $repoRoot
+    $botDir       = Join-Path $testProject ".bot"
+    $tasksBaseDir = Join-Path $botDir "workspace\tasks"
+    $todoDir      = Join-Path $tasksBaseDir "todo"
+    $analysedDir  = Join-Path $tasksBaseDir "analysed"
+    $skippedDir   = Join-Path $tasksBaseDir "skipped"
+
+    $global:DotbotProjectRoot = $testProject
+
+    # task-get-next/script.ps1 calls Write-BotLog, which the MCP server provides by
+    # importing DotBotLog at startup. Outside the server we have to load it ourselves
+    # before dot-sourcing the tool script.
+    $dotBotLogModule = Join-Path $botDir "systems\runtime\modules\DotBotLog.psm1"
+    if (Test-Path $dotBotLogModule) {
+        Import-Module $dotBotLogModule -Force -DisableNameChecking | Out-Null
+        $tglLogsDir = Join-Path $botDir ".control\logs"
+        $tglControlDir = Join-Path $botDir ".control"
+        if (-not (Test-Path $tglLogsDir)) { New-Item -ItemType Directory -Path $tglLogsDir -Force | Out-Null }
+        if (-not (Test-Path $tglControlDir)) { New-Item -ItemType Directory -Path $tglControlDir -Force | Out-Null }
+        if (Get-Command Initialize-DotBotLog -ErrorAction SilentlyContinue) {
+            Initialize-DotBotLog -LogDir $tglLogsDir -ControlDir $tglControlDir -ProjectRoot $testProject -ConsoleEnabled $false | Out-Null
+        }
+    }
+
+    # task-get-next's script.ps1 is not a module; we dot-source it so the test
+    # can call Invoke-TaskGetNext directly against the test project's .bot.
+    $taskGetNextScript = Join-Path $botDir "systems\mcp\tools\task-get-next\script.ps1"
+    Assert-PathExists -Name "task-get-next script exists in test project" -Path $taskGetNextScript
+    . $taskGetNextScript
+
+    Assert-True -Name "task-get-next dot-source exposes Invoke-TaskGetNext" `
+        -Condition ($null -ne (Get-Command Invoke-TaskGetNext -ErrorAction SilentlyContinue)) `
+        -Message "Expected Invoke-TaskGetNext to be defined after dot-sourcing task-get-next script"
+    Assert-True -Name "task-get-next loads Test-ManifestCondition" `
+        -Condition ($null -ne (Get-Command Test-ManifestCondition -ErrorAction SilentlyContinue)) `
+        -Message "Expected Test-ManifestCondition to be imported from workflow-manifest.ps1"
+
+    # ── Scenario A: condition references a nonexistent file → task is skipped ──
+    $missingCondPath = Join-Path $todoDir "cond-missing.json"
+    [ordered]@{
+        id = "cond-missing"
+        name = "Task with unmet condition"
+        description = "Should be skipped at runtime"
+        category = "feature"
+        priority = 10
+        effort = "S"
+        status = "todo"
+        dependencies = @()
+        condition = ".bot/workspace/product/nonexistent.md"
+        acceptance_criteria = @()
+        steps = @()
+        applicable_standards = @()
+        applicable_agents = @()
+        created_at = "2026-03-06T12:00:00Z"
+        updated_at = "2026-03-06T12:00:00Z"
+        completed_at = $null
+    } | ConvertTo-Json -Depth 10 | Set-Content -Path $missingCondPath -Encoding UTF8
+
+    Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
+    Update-TaskIndex
+
+    $resultA = Invoke-TaskGetNext -Arguments @{ prefer_analysed = $false }
+    Assert-True -Name "Invoke-TaskGetNext returns success when condition unmet" `
+        -Condition ($resultA.success -eq $true) `
+        -Message "Expected success=true, got: $($resultA | ConvertTo-Json -Depth 3)"
+    Assert-True -Name "Invoke-TaskGetNext returns no task when only candidate has unmet condition" `
+        -Condition ($null -eq $resultA.task) `
+        -Message "Expected task=null, got: $($resultA.task | ConvertTo-Json -Depth 3)"
+
+    $skippedFile = Join-Path $skippedDir "cond-missing.json"
+    Assert-PathExists -Name "Task with unmet condition is moved to skipped/" -Path $skippedFile
+    $skippedContent = Get-Content $skippedFile -Raw | ConvertFrom-Json
+    Assert-Equal -Name "Skipped task has skip_reason=condition-not-met" `
+        -Expected "condition-not-met" `
+        -Actual $skippedContent.skip_reason
+    Assert-Equal -Name "Skipped task has status=skipped" `
+        -Expected "skipped" `
+        -Actual $skippedContent.status
+
+    $missingTodoGone = -not (Test-Path $missingCondPath)
+    Assert-True -Name "Skipped task is removed from todo/" `
+        -Condition $missingTodoGone `
+        -Message "Expected todo file to be gone after skip"
+
+    # ── Scenario B: condition references an existing file → task is returned ──
+    $productDir = Join-Path $botDir "workspace\product"
+    if (-not (Test-Path $productDir)) {
+        New-Item -ItemType Directory -Path $productDir -Force | Out-Null
+    }
+    Set-Content -Path (Join-Path $productDir "mission.md") -Value "test mission" -Encoding UTF8
+
+    $metCondPath = Join-Path $todoDir "cond-met.json"
+    [ordered]@{
+        id = "cond-met"
+        name = "Task with satisfied condition"
+        description = "Should be returned at runtime"
+        category = "feature"
+        priority = 20
+        effort = "S"
+        status = "todo"
+        dependencies = @()
+        condition = ".bot/workspace/product/mission.md"
+        acceptance_criteria = @()
+        steps = @()
+        applicable_standards = @()
+        applicable_agents = @()
+        created_at = "2026-03-06T12:00:00Z"
+        updated_at = "2026-03-06T12:00:00Z"
+        completed_at = $null
+    } | ConvertTo-Json -Depth 10 | Set-Content -Path $metCondPath -Encoding UTF8
+
+    Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
+    Update-TaskIndex
+
+    $resultB = Invoke-TaskGetNext -Arguments @{ prefer_analysed = $false }
+    Assert-True -Name "Invoke-TaskGetNext returns task when condition is met" `
+        -Condition ($null -ne $resultB.task) `
+        -Message "Expected task to be returned, got null. Message: $($resultB.message)"
+    if ($resultB.task) {
+        Assert-Equal -Name "Returned task is the one with satisfied condition" `
+            -Expected "cond-met" `
+            -Actual $resultB.task.id
+    }
+    Assert-PathExists -Name "Task with satisfied condition stays in todo/" -Path $metCondPath
+
+    # Clean slate before scenarios C and D so leftover todo/skipped files
+    # don't interfere with selection.
+    Get-ChildItem -Path $todoDir -Filter "*.json" -ErrorAction SilentlyContinue | Remove-Item -Force
+    Get-ChildItem -Path $skippedDir -Filter "*.json" -ErrorAction SilentlyContinue | Remove-Item -Force
+
+    # Scenario C sets up its own product-file state explicitly rather than inheriting
+    # from scenario B, so the block stays valid if B is ever reordered or removed.
+    if (-not (Test-Path $productDir)) {
+        New-Item -ItemType Directory -Path $productDir -Force | Out-Null
+    }
+    Set-Content -Path (Join-Path $productDir "mission.md") -Value "test mission for scenario C" -Encoding UTF8
+    if (Test-Path (Join-Path $productDir "nope.md")) {
+        Remove-Item (Join-Path $productDir "nope.md") -Force
+    }
+
+    # ── Scenario C: array-form condition (AND semantics) ──
+    # mission.md must exist AND nope.md must NOT exist → both rules pass, task is returned.
+    $arrayCondPath = Join-Path $todoDir "cond-array.json"
+    [ordered]@{
+        id = "cond-array"
+        name = "Task with array condition"
+        description = "AND of two rules"
+        category = "feature"
+        priority = 30
+        effort = "S"
+        status = "todo"
+        dependencies = @()
+        condition = @(
+            ".bot/workspace/product/mission.md",
+            "!.bot/workspace/product/nope.md"
+        )
+        acceptance_criteria = @()
+        steps = @()
+        applicable_standards = @()
+        applicable_agents = @()
+        created_at = "2026-03-06T12:00:00Z"
+        updated_at = "2026-03-06T12:00:00Z"
+        completed_at = $null
+    } | ConvertTo-Json -Depth 10 | Set-Content -Path $arrayCondPath -Encoding UTF8
+
+    Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
+    Update-TaskIndex
+
+    $resultC1 = Invoke-TaskGetNext -Arguments @{ prefer_analysed = $false }
+    Assert-True -Name "Array condition (all rules true) returns the task" `
+        -Condition ($null -ne $resultC1.task -and $resultC1.task.id -eq 'cond-array') `
+        -Message "Expected cond-array task to be returned. Got: $($resultC1.task.id)"
+    Assert-PathExists -Name "Array-condition task stays in todo/ when all rules pass" -Path $arrayCondPath
+
+    # Now break one rule by creating the file the negated rule says must not exist.
+    Set-Content -Path (Join-Path $productDir "nope.md") -Value "boom" -Encoding UTF8
+    Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
+    Update-TaskIndex
+
+    $resultC2 = Invoke-TaskGetNext -Arguments @{ prefer_analysed = $false }
+    Assert-True -Name "Array condition (one rule false) returns no task" `
+        -Condition ($null -eq $resultC2.task) `
+        -Message "Expected no task; got: $($resultC2.task | ConvertTo-Json -Depth 3)"
+    Assert-PathExists -Name "Array-condition task moved to skipped/ when a rule fails" `
+        -Path (Join-Path $skippedDir "cond-array.json")
+    $arraySkipped = Get-Content (Join-Path $skippedDir "cond-array.json") -Raw | ConvertFrom-Json
+    Assert-Equal -Name "Array-condition skipped task records skip_reason=condition-not-met" `
+        -Expected "condition-not-met" `
+        -Actual $arraySkipped.skip_reason
+
+    # Clean up the offending file before scenario D.
+    Remove-Item (Join-Path $productDir "nope.md") -Force
+
+    # ── Scenario D: prefer_analysed=true → analysed task with unmet condition ──
+    # This is the path the issue cares about most: a task that has already passed
+    # the analysis phase (lives in analysed/) gets its condition re-evaluated at
+    # execution selection time, and is moved analysed → skipped via Move-TaskState
+    # -FromStates @('analysed').
+    if (-not (Test-Path $analysedDir)) {
+        New-Item -ItemType Directory -Path $analysedDir -Force | Out-Null
+    }
+    Get-ChildItem -Path $todoDir -Filter "*.json" -ErrorAction SilentlyContinue | Remove-Item -Force
+    Get-ChildItem -Path $analysedDir -Filter "*.json" -ErrorAction SilentlyContinue | Remove-Item -Force
+    Get-ChildItem -Path $skippedDir -Filter "*.json" -ErrorAction SilentlyContinue | Remove-Item -Force
+
+    $analysedSkipPath = Join-Path $analysedDir "cond-analysed-skip.json"
+    [ordered]@{
+        id = "cond-analysed-skip"
+        name = "Analysed task with unmet condition"
+        description = "Should be moved analysed -> skipped at selection time"
+        category = "feature"
+        priority = 10
+        effort = "S"
+        status = "analysed"
+        dependencies = @()
+        condition = ".bot/workspace/product/never-created.md"
+        acceptance_criteria = @()
+        steps = @()
+        applicable_standards = @()
+        applicable_agents = @()
+        created_at = "2026-03-06T12:00:00Z"
+        updated_at = "2026-03-06T12:00:00Z"
+        completed_at = $null
+    } | ConvertTo-Json -Depth 10 | Set-Content -Path $analysedSkipPath -Encoding UTF8
+
+    $analysedKeepPath = Join-Path $analysedDir "cond-analysed-keep.json"
+    [ordered]@{
+        id = "cond-analysed-keep"
+        name = "Analysed task with met condition"
+        description = "Should be returned"
+        category = "feature"
+        priority = 20
+        effort = "S"
+        status = "analysed"
+        dependencies = @()
+        condition = ".bot/workspace/product/mission.md"
+        acceptance_criteria = @()
+        steps = @()
+        applicable_standards = @()
+        applicable_agents = @()
+        created_at = "2026-03-06T12:00:00Z"
+        updated_at = "2026-03-06T12:00:00Z"
+        completed_at = $null
+    } | ConvertTo-Json -Depth 10 | Set-Content -Path $analysedKeepPath -Encoding UTF8
+
+    Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
+    Update-TaskIndex
+
+    # Default prefer_analysed=true. The runner picks the highest-priority analysed
+    # task first (cond-analysed-skip), discovers its condition is unmet, moves it
+    # to skipped, then re-picks and returns cond-analysed-keep.
+    $resultD = Invoke-TaskGetNext -Arguments @{}
+    Assert-True -Name "Analysed task with unmet condition is skipped, next analysed task is returned" `
+        -Condition ($null -ne $resultD.task -and $resultD.task.id -eq 'cond-analysed-keep') `
+        -Message "Expected cond-analysed-keep to be returned. Got: $($resultD.task.id); message: $($resultD.message)"
+    Assert-Equal -Name "Returned analysed task carries status=analysed" `
+        -Expected "analysed" `
+        -Actual $resultD.task.status
+
+    $analysedSkipDest = Join-Path $skippedDir "cond-analysed-skip.json"
+    Assert-PathExists -Name "Analysed task with unmet condition moved to skipped/" -Path $analysedSkipDest
+    Assert-True -Name "Analysed-skip task no longer in analysed/" `
+        -Condition (-not (Test-Path $analysedSkipPath)) `
+        -Message "Expected analysed/ source file to be removed after Move-TaskState"
+    $analysedSkipped = Get-Content $analysedSkipDest -Raw | ConvertFrom-Json
+    Assert-Equal -Name "Analysed→skipped task records skip_reason=condition-not-met" `
+        -Expected "condition-not-met" `
+        -Actual $analysedSkipped.skip_reason
+}
+finally {
+    if ($testProject) {
+        Remove-TestProject -Path $testProject
+    }
+    $global:DotbotProjectRoot = $savedDotbotProjectRoot
+}
+
 $allPassed = Write-TestSummary -LayerName "Task Action Source Tests"
 
 if (-not $allPassed) {

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -635,9 +635,7 @@ try {
 
     $global:DotbotProjectRoot = $testProject
 
-    # task-get-next/script.ps1 calls Write-BotLog, which the MCP server provides by
-    # importing DotBotLog at startup. Outside the server we have to load it ourselves
-    # before dot-sourcing the tool script.
+    # Load DotBotLog (normally provided by the MCP server) before dot-sourcing the tool.
     $dotBotLogModule = Join-Path $botDir "systems\runtime\modules\DotBotLog.psm1"
     if (Test-Path $dotBotLogModule) {
         Import-Module $dotBotLogModule -Force -DisableNameChecking | Out-Null
@@ -650,8 +648,7 @@ try {
         }
     }
 
-    # task-get-next's script.ps1 is not a module; we dot-source it so the test
-    # can call Invoke-TaskGetNext directly against the test project's .bot.
+    # Dot-source the tool script (not a module) so we can call Invoke-TaskGetNext directly.
     $taskGetNextScript = Join-Path $botDir "systems\mcp\tools\task-get-next\script.ps1"
     Assert-PathExists -Name "task-get-next script exists in test project" -Path $taskGetNextScript
     . $taskGetNextScript
@@ -663,7 +660,7 @@ try {
         -Condition ($null -ne (Get-Command Test-ManifestCondition -ErrorAction SilentlyContinue)) `
         -Message "Expected Test-ManifestCondition to be imported from workflow-manifest.ps1"
 
-    # ── Scenario A: condition references a nonexistent file → task is skipped ──
+    # ── Scenario A: unmet condition → task is auto-skipped ──
     $missingCondPath = Join-Path $todoDir "cond-missing.json"
     [ordered]@{
         id = "cond-missing"
@@ -710,7 +707,7 @@ try {
         -Condition $missingTodoGone `
         -Message "Expected todo file to be gone after skip"
 
-    # ── Scenario B: condition references an existing file → task is returned ──
+    # ── Scenario B: condition met → task returned ──
     $productDir = Join-Path $botDir "workspace\product"
     if (-not (Test-Path $productDir)) {
         New-Item -ItemType Directory -Path $productDir -Force | Out-Null
@@ -751,13 +748,10 @@ try {
     }
     Assert-PathExists -Name "Task with satisfied condition stays in todo/" -Path $metCondPath
 
-    # Clean slate before scenarios C and D so leftover todo/skipped files
-    # don't interfere with selection.
+    # Reset state for scenarios C and D.
     Get-ChildItem -Path $todoDir -Filter "*.json" -ErrorAction SilentlyContinue | Remove-Item -Force
     Get-ChildItem -Path $skippedDir -Filter "*.json" -ErrorAction SilentlyContinue | Remove-Item -Force
 
-    # Scenario C sets up its own product-file state explicitly rather than inheriting
-    # from scenario B, so the block stays valid if B is ever reordered or removed.
     if (-not (Test-Path $productDir)) {
         New-Item -ItemType Directory -Path $productDir -Force | Out-Null
     }
@@ -766,8 +760,7 @@ try {
         Remove-Item (Join-Path $productDir "nope.md") -Force
     }
 
-    # ── Scenario C: array-form condition (AND semantics) ──
-    # mission.md must exist AND nope.md must NOT exist → both rules pass, task is returned.
+    # ── Scenario C: array condition (AND of rules) ──
     $arrayCondPath = Join-Path $todoDir "cond-array.json"
     [ordered]@{
         id = "cond-array"
@@ -800,7 +793,7 @@ try {
         -Message "Expected cond-array task to be returned. Got: $($resultC1.task.id)"
     Assert-PathExists -Name "Array-condition task stays in todo/ when all rules pass" -Path $arrayCondPath
 
-    # Now break one rule by creating the file the negated rule says must not exist.
+    # Break the negated rule.
     Set-Content -Path (Join-Path $productDir "nope.md") -Value "boom" -Encoding UTF8
     Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
     Update-TaskIndex
@@ -816,14 +809,10 @@ try {
         -Expected "condition-not-met" `
         -Actual $arraySkipped.skip_reason
 
-    # Clean up the offending file before scenario D.
     Remove-Item (Join-Path $productDir "nope.md") -Force
 
-    # ── Scenario D: prefer_analysed=true → analysed task with unmet condition ──
-    # This is the path the issue cares about most: a task that has already passed
-    # the analysis phase (lives in analysed/) gets its condition re-evaluated at
-    # execution selection time, and is moved analysed → skipped via Move-TaskState
-    # -FromStates @('analysed').
+    # ── Scenario D: analysed task with unmet condition (prefer_analysed=true) ──
+    # The core issue path: re-evaluate condition at execution selection and move analysed → skipped.
     if (-not (Test-Path $analysedDir)) {
         New-Item -ItemType Directory -Path $analysedDir -Force | Out-Null
     }
@@ -874,9 +863,7 @@ try {
     Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
     Update-TaskIndex
 
-    # Default prefer_analysed=true. The runner picks the highest-priority analysed
-    # task first (cond-analysed-skip), discovers its condition is unmet, moves it
-    # to skipped, then re-picks and returns cond-analysed-keep.
+    # Default prefer_analysed=true: skip cond-analysed-skip, return cond-analysed-keep.
     $resultD = Invoke-TaskGetNext -Arguments @{}
     Assert-True -Name "Analysed task with unmet condition is skipped, next analysed task is returned" `
         -Condition ($null -ne $resultD.task -and $resultD.task.id -eq 'cond-analysed-keep') `

--- a/workflows/default/systems/mcp/modules/TaskIndexCache.psm1
+++ b/workflows/default/systems/mcp/modules/TaskIndexCache.psm1
@@ -433,6 +433,7 @@ function Update-TaskIndex {
                     skip_analysis = $content.skip_analysis
                     skip_worktree = $content.skip_worktree
                     workflow = $content.workflow
+                    condition = $content.condition
                 }
 
                 switch ($status) {

--- a/workflows/default/systems/mcp/tools/task-get-next/script.ps1
+++ b/workflows/default/systems/mcp/tools/task-get-next/script.ps1
@@ -50,8 +50,19 @@ function Invoke-TaskGetNext {
 
     # Re-evaluate `condition` per candidate (issue #226). Loop so we can skip
     # condition-unmet tasks and pick the next eligible one. Priority: analysed → todo.
-    $maxIterations = 50
-    for ($iter = 0; $iter -lt $maxIterations; $iter++) {
+    # Bound = current candidate pool size (+ small buffer) so we can't return
+    # "no task" while eligible candidates remain behind skipped ones.
+    $initialIndex = Get-TaskIndex
+    $candidatePoolSize = $initialIndex.Todo.Count + $initialIndex.Analysed.Count
+    $maxIterations = [Math]::Max(50, $candidatePoolSize + 10)
+
+    # Track IDs we've already considered in this invocation. Acts as a safety net
+    # against re-picking a task whose Move-TaskState failed (so the index still
+    # lists it as todo/analysed on subsequent Update-TaskIndex calls).
+    $seenIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+    $iter = 0
+    for (; $iter -lt $maxIterations; $iter++) {
         $candidate = $null
         $candidateStatus = 'todo'
 
@@ -61,7 +72,7 @@ function Invoke-TaskGetNext {
             if ($analysedResult.BlockedCount -gt $blockedCount) {
                 $blockedCount = $analysedResult.BlockedCount
             }
-            if ($analysedResult.Task) {
+            if ($analysedResult.Task -and -not $seenIds.Contains($analysedResult.Task.id)) {
                 $candidate = $analysedResult.Task
                 $candidateStatus = 'analysed'
                 Write-BotLog -Level Debug -Message "[task-get-next] Found analysed task: $($candidate.id) ($($analysedResult.BlockedCount) blocked by dependencies)"
@@ -73,13 +84,15 @@ function Invoke-TaskGetNext {
         # Fallback to todo (or todo-only when prefer_analysed=false, used by analysis phase)
         if (-not $candidate) {
             $todoCandidate = Get-NextTask -WorkflowFilter $workflowFilter
-            if ($todoCandidate) {
+            if ($todoCandidate -and -not $seenIds.Contains($todoCandidate.id)) {
                 $candidate = $todoCandidate
                 $candidateStatus = 'todo'
             }
         }
 
         if (-not $candidate) { break }
+
+        [void]$seenIds.Add($candidate.id)
 
         # If Test-ManifestCondition is missing here we deliberately let PS raise (see load-time check).
         if ($candidate.condition) {
@@ -95,15 +108,15 @@ function Invoke-TaskGetNext {
                             skip_reason = 'condition-not-met'
                             skip_detail = "Condition not met at runtime: $conditionText"
                         } | Out-Null
+                    $conditionSkipCount++
+                    # TODO: incrementalise — full rescan per skip is O(N·skips).
+                    Update-TaskIndex
                 } catch {
-                    Write-BotLog -Level Warn -Message "[task-get-next] Failed to move task $($candidate.id) to skipped" -Exception $_
-                    # Surface in status message and break to avoid re-picking the same task.
+                    # Surface the failure but keep looking — one bad task shouldn't stall
+                    # the whole pipeline. $seenIds prevents re-picking this candidate.
+                    Write-BotLog -Level Warn -Message "[task-get-next] Failed to move task $($candidate.id) to skipped; continuing with other candidates" -Exception $_
                     $moveFailures += "$($candidate.id) ($($candidate.name))"
-                    break
                 }
-                $conditionSkipCount++
-                # TODO: incrementalise — full rescan per skip is O(N·skips).
-                Update-TaskIndex
                 continue
             }
         }

--- a/workflows/default/systems/mcp/tools/task-get-next/script.ps1
+++ b/workflows/default/systems/mcp/tools/task-get-next/script.ps1
@@ -4,6 +4,32 @@ if (-not (Get-Module TaskIndexCache)) {
     Import-Module $indexModule -Force
 }
 
+# Import task store (for Move-TaskState, used when skipping tasks whose condition is unmet)
+$taskStoreModule = Join-Path $global:DotbotProjectRoot ".bot\systems\mcp\modules\TaskStore.psm1"
+if (-not (Get-Module TaskStore)) {
+    Import-Module $taskStoreModule -Force
+}
+
+# Dot-source workflow-manifest.ps1 to get Test-ManifestCondition.
+# NOTE: matches the existing project convention (also used by Invoke-KickstartProcess.ps1,
+# ProductAPI.psm1, and ui/server.ps1). Pulls every function from workflow-manifest.ps1 into
+# scope, not just Test-ManifestCondition. TODO: extract Test-ManifestCondition into its own
+# .psm1 with Export-ModuleMember to shrink the imported surface area.
+$runtimeManifest = Join-Path $global:DotbotProjectRoot ".bot\systems\runtime\modules\workflow-manifest.ps1"
+if ((Test-Path $runtimeManifest) -and -not (Get-Command Test-ManifestCondition -ErrorAction SilentlyContinue)) {
+    . $runtimeManifest
+}
+
+# Fail loudly if Test-ManifestCondition is still unavailable. A silent fallback here would
+# reintroduce issue #226 (frozen-at-creation conditions) without any visible signal.
+# We use [Console]::Error.WriteLine (matching dotbot-mcp.ps1:103) rather than Write-BotLog
+# because this script is dot-sourced during MCP tool discovery; if DotBotLog initialization
+# was skipped (missing module / failed import), calling Write-BotLog here would throw and
+# prevent task-get-next from registering at all.
+if (-not (Get-Command Test-ManifestCondition -ErrorAction SilentlyContinue)) {
+    [Console]::Error.WriteLine("WARN: [task-get-next] Test-ManifestCondition not available after dot-sourcing '$runtimeManifest' - runtime condition checks DISABLED. Tasks with conditions will not be re-evaluated. This typically means workflow-manifest.ps1 is missing or out of date - re-run 'pwsh install.ps1' or 'dotbot init'.")
+}
+
 # Initialize index on first use
 $tasksBaseDir = Join-Path $global:DotbotProjectRoot ".bot\workspace\tasks"
 Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
@@ -24,38 +50,100 @@ function Invoke-TaskGetNext {
 
     Write-BotLog -Level Debug -Message "[task-get-next] Using cached task index (prefer_analysed: $preferAnalysed)"
 
-    $index = Get-TaskIndex
     $nextTask = $null
     $taskStatus = 'todo'
-    
+    $blockedCount = 0
+    $conditionSkipCount = 0
+    $moveFailures = @()
+
     # Priority order:
     # 1. Analysed tasks (ready for implementation, already pre-processed)
     # 2. Todo tasks (need analysis first, or legacy mode)
-    
-    $blockedCount = 0
+    #
+    # Task `condition` fields are re-evaluated here (at selection time) rather than
+    # when the task was created. Dependencies guarantee ordering, so by the time we
+    # consider a task its prerequisites have already run; if its condition is still
+    # unmet we permanently skip it and look for the next eligible task.
+    $maxIterations = 50
+    for ($iter = 0; $iter -lt $maxIterations; $iter++) {
+        $candidate = $null
+        $candidateStatus = 'todo'
 
-    if ($preferAnalysed) {
-        # Check for analysed tasks first (dependency-aware)
-        $analysedResult = Get-NextAnalysedTask -WorkflowFilter $workflowFilter
-        if ($analysedResult.Task) {
-            $nextTask = $analysedResult.Task
-            $taskStatus = 'analysed'
-            $blockedCount = $analysedResult.BlockedCount
-            Write-BotLog -Level Debug -Message "[task-get-next] Found analysed task: $($nextTask.id) ($blockedCount blocked by dependencies)"
-        } elseif ($analysedResult.BlockedCount -gt 0) {
-            Write-BotLog -Level Debug -Message "[task-get-next] All $($analysedResult.BlockedCount) analysed task(s) blocked by unmet dependencies"
+        if ($preferAnalysed) {
+            $analysedResult = Get-NextAnalysedTask -WorkflowFilter $workflowFilter
+            # Track the highest blocked count seen across iterations so that after
+            # we skip condition-unmet tasks the "no tasks available" message still
+            # reports the true number of analysed tasks blocked by dependencies.
+            if ($analysedResult.BlockedCount -gt $blockedCount) {
+                $blockedCount = $analysedResult.BlockedCount
+            }
+            if ($analysedResult.Task) {
+                $candidate = $analysedResult.Task
+                $candidateStatus = 'analysed'
+                Write-BotLog -Level Debug -Message "[task-get-next] Found analysed task: $($candidate.id) ($($analysedResult.BlockedCount) blocked by dependencies)"
+            } elseif ($analysedResult.BlockedCount -gt 0) {
+                Write-BotLog -Level Debug -Message "[task-get-next] All $($analysedResult.BlockedCount) analysed task(s) blocked by unmet dependencies"
+            }
         }
+
+        # Fallback:
+        # - prefer_analysed = true  -> try analysed first, then todo
+        # - prefer_analysed = false -> todo only (used by analysis phase)
+        if (-not $candidate) {
+            $todoCandidate = Get-NextTask -WorkflowFilter $workflowFilter
+            if ($todoCandidate) {
+                $candidate = $todoCandidate
+                $candidateStatus = 'todo'
+            }
+        }
+
+        if (-not $candidate) { break }
+
+        # Runtime condition check — re-evaluate against current filesystem state.
+        # Test-ManifestCondition availability is asserted at script load above; if it's
+        # missing here we deliberately let PowerShell raise rather than silently skipping
+        # the check (which would resurrect issue #226).
+        if ($candidate.condition) {
+            $conditionMet = Test-ManifestCondition -ProjectRoot $global:DotbotProjectRoot -Condition $candidate.condition
+            if (-not $conditionMet) {
+                $conditionText = if ($candidate.condition -is [array]) { ($candidate.condition -join ', ') } else { "$($candidate.condition)" }
+                Write-BotLog -Level Info -Message "[task-get-next] Skipped task '$($candidate.name)' ($($candidate.id)): condition not met ($conditionText)"
+                try {
+                    Move-TaskState -TaskId $candidate.id `
+                        -FromStates @($candidateStatus) `
+                        -ToState 'skipped' `
+                        -Updates @{
+                            skip_reason = 'condition-not-met'
+                            skip_detail = "Condition not met at runtime: $conditionText"
+                        } | Out-Null
+                } catch {
+                    Write-BotLog -Level Warn -Message "[task-get-next] Failed to move task $($candidate.id) to skipped" -Exception $_
+                    # Record for the caller so a stuck task doesn't masquerade as an
+                    # empty queue — the returned status message will flag it.
+                    $moveFailures += "$($candidate.id) ($($candidate.name))"
+                    # Avoid infinite loop if the move fails — return no task rather than re-picking the same one.
+                    break
+                }
+                $conditionSkipCount++
+                # TODO: incrementalise. Update-TaskIndex rescans the entire tasks tree
+                # on every skip (O(N·skips)). Acceptable under the 50-iteration cap and
+                # typical queue sizes, but a targeted remove/move helper on the index
+                # would be cheaper. Tracked alongside the TaskIndexCache refactor.
+                Update-TaskIndex
+                continue
+            }
+        }
+
+        $nextTask = $candidate
+        $taskStatus = $candidateStatus
+        break
     }
 
-    # Fallback behavior:
-    # - prefer_analysed = true  -> try analysed first, then todo
-    # - prefer_analysed = false -> todo only (used by analysis phase)
-    if (-not $nextTask) {
-        $nextTask = Get-NextTask -WorkflowFilter $workflowFilter
-        if ($nextTask) {
-            $taskStatus = 'todo'
-        }
+    if ($iter -ge $maxIterations) {
+        Write-BotLog -Level Warn -Message "[task-get-next] Hit maxIterations cap ($maxIterations) while skipping tasks with unmet conditions; aborting selection. This usually indicates a stuck task in the queue or a Move-TaskState failure — inspect .bot/workspace/tasks/ for orphans."
     }
+
+    $index = Get-TaskIndex
 
     if (-not $nextTask) {
         # Check if there are tasks in other states that might explain why nothing is available
@@ -72,6 +160,12 @@ function Invoke-TaskGetNext {
         if ($needsInputCount -gt 0) {
             $statusMessage += " $needsInputCount task(s) waiting for input."
         }
+        if ($conditionSkipCount -gt 0) {
+            $statusMessage += " $conditionSkipCount task(s) skipped (condition not met)."
+        }
+        if ($moveFailures.Count -gt 0) {
+            $statusMessage += " WARNING: $($moveFailures.Count) task(s) stuck (Move-TaskState failed): $($moveFailures -join ', '). Inspect logs and .bot/workspace/tasks/."
+        }
 
         Write-BotLog -Level Debug -Message "[task-get-next] No eligible tasks found"
         return @{
@@ -81,6 +175,8 @@ function Invoke-TaskGetNext {
             analysing_count = $analysingCount
             needs_input_count = $needsInputCount
             blocked_count = $blockedCount
+            condition_skip_count = $conditionSkipCount
+            move_failures = $moveFailures
         }
     }
 

--- a/workflows/default/systems/mcp/tools/task-get-next/script.ps1
+++ b/workflows/default/systems/mcp/tools/task-get-next/script.ps1
@@ -10,11 +10,10 @@ if (-not (Get-Module TaskStore)) {
     Import-Module $taskStoreModule -Force
 }
 
-# Dot-source workflow-manifest.ps1 for Test-ManifestCondition.
-# TODO: extract Test-ManifestCondition into its own .psm1 — dot-source pulls every function.
-$runtimeManifest = Join-Path $global:DotbotProjectRoot ".bot\systems\runtime\modules\workflow-manifest.ps1"
-if ((Test-Path $runtimeManifest) -and -not (Get-Command Test-ManifestCondition -ErrorAction SilentlyContinue)) {
-    . $runtimeManifest
+# Import ManifestCondition module for Test-ManifestCondition
+$manifestConditionModule = Join-Path $global:DotbotProjectRoot ".bot\systems\runtime\modules\ManifestCondition.psm1"
+if (-not (Get-Module ManifestCondition)) {
+    Import-Module $manifestConditionModule -Force
 }
 
 # Fail loud if still missing — silent fallback would resurrect #226. Stderr (not Write-BotLog)

--- a/workflows/default/systems/mcp/tools/task-get-next/script.ps1
+++ b/workflows/default/systems/mcp/tools/task-get-next/script.ps1
@@ -4,30 +4,23 @@ if (-not (Get-Module TaskIndexCache)) {
     Import-Module $indexModule -Force
 }
 
-# Import task store (for Move-TaskState, used when skipping tasks whose condition is unmet)
+# Import task store (for Move-TaskState when skipping condition-unmet tasks)
 $taskStoreModule = Join-Path $global:DotbotProjectRoot ".bot\systems\mcp\modules\TaskStore.psm1"
 if (-not (Get-Module TaskStore)) {
     Import-Module $taskStoreModule -Force
 }
 
-# Dot-source workflow-manifest.ps1 to get Test-ManifestCondition.
-# NOTE: matches the existing project convention (also used by Invoke-KickstartProcess.ps1,
-# ProductAPI.psm1, and ui/server.ps1). Pulls every function from workflow-manifest.ps1 into
-# scope, not just Test-ManifestCondition. TODO: extract Test-ManifestCondition into its own
-# .psm1 with Export-ModuleMember to shrink the imported surface area.
+# Dot-source workflow-manifest.ps1 for Test-ManifestCondition.
+# TODO: extract Test-ManifestCondition into its own .psm1 — dot-source pulls every function.
 $runtimeManifest = Join-Path $global:DotbotProjectRoot ".bot\systems\runtime\modules\workflow-manifest.ps1"
 if ((Test-Path $runtimeManifest) -and -not (Get-Command Test-ManifestCondition -ErrorAction SilentlyContinue)) {
     . $runtimeManifest
 }
 
-# Fail loudly if Test-ManifestCondition is still unavailable. A silent fallback here would
-# reintroduce issue #226 (frozen-at-creation conditions) without any visible signal.
-# We use [Console]::Error.WriteLine (matching dotbot-mcp.ps1:103) rather than Write-BotLog
-# because this script is dot-sourced during MCP tool discovery; if DotBotLog initialization
-# was skipped (missing module / failed import), calling Write-BotLog here would throw and
-# prevent task-get-next from registering at all.
+# Fail loud if still missing — silent fallback would resurrect #226. Stderr (not Write-BotLog)
+# because tool discovery may run before DotBotLog is initialized.
 if (-not (Get-Command Test-ManifestCondition -ErrorAction SilentlyContinue)) {
-    [Console]::Error.WriteLine("WARN: [task-get-next] Test-ManifestCondition not available after dot-sourcing '$runtimeManifest' - runtime condition checks DISABLED. Tasks with conditions will not be re-evaluated. This typically means workflow-manifest.ps1 is missing or out of date - re-run 'pwsh install.ps1' or 'dotbot init'.")
+    [Console]::Error.WriteLine("WARN: [task-get-next] Test-ManifestCondition unavailable - runtime condition checks DISABLED. Re-run 'pwsh install.ps1' or 'dotbot init'.")
 }
 
 # Initialize index on first use
@@ -56,14 +49,8 @@ function Invoke-TaskGetNext {
     $conditionSkipCount = 0
     $moveFailures = @()
 
-    # Priority order:
-    # 1. Analysed tasks (ready for implementation, already pre-processed)
-    # 2. Todo tasks (need analysis first, or legacy mode)
-    #
-    # Task `condition` fields are re-evaluated here (at selection time) rather than
-    # when the task was created. Dependencies guarantee ordering, so by the time we
-    # consider a task its prerequisites have already run; if its condition is still
-    # unmet we permanently skip it and look for the next eligible task.
+    # Re-evaluate `condition` per candidate (issue #226). Loop so we can skip
+    # condition-unmet tasks and pick the next eligible one. Priority: analysed → todo.
     $maxIterations = 50
     for ($iter = 0; $iter -lt $maxIterations; $iter++) {
         $candidate = $null
@@ -71,9 +58,7 @@ function Invoke-TaskGetNext {
 
         if ($preferAnalysed) {
             $analysedResult = Get-NextAnalysedTask -WorkflowFilter $workflowFilter
-            # Track the highest blocked count seen across iterations so that after
-            # we skip condition-unmet tasks the "no tasks available" message still
-            # reports the true number of analysed tasks blocked by dependencies.
+            # Track max so the "no tasks available" message stays accurate after skips.
             if ($analysedResult.BlockedCount -gt $blockedCount) {
                 $blockedCount = $analysedResult.BlockedCount
             }
@@ -86,9 +71,7 @@ function Invoke-TaskGetNext {
             }
         }
 
-        # Fallback:
-        # - prefer_analysed = true  -> try analysed first, then todo
-        # - prefer_analysed = false -> todo only (used by analysis phase)
+        # Fallback to todo (or todo-only when prefer_analysed=false, used by analysis phase)
         if (-not $candidate) {
             $todoCandidate = Get-NextTask -WorkflowFilter $workflowFilter
             if ($todoCandidate) {
@@ -99,10 +82,7 @@ function Invoke-TaskGetNext {
 
         if (-not $candidate) { break }
 
-        # Runtime condition check — re-evaluate against current filesystem state.
-        # Test-ManifestCondition availability is asserted at script load above; if it's
-        # missing here we deliberately let PowerShell raise rather than silently skipping
-        # the check (which would resurrect issue #226).
+        # If Test-ManifestCondition is missing here we deliberately let PS raise (see load-time check).
         if ($candidate.condition) {
             $conditionMet = Test-ManifestCondition -ProjectRoot $global:DotbotProjectRoot -Condition $candidate.condition
             if (-not $conditionMet) {
@@ -118,17 +98,12 @@ function Invoke-TaskGetNext {
                         } | Out-Null
                 } catch {
                     Write-BotLog -Level Warn -Message "[task-get-next] Failed to move task $($candidate.id) to skipped" -Exception $_
-                    # Record for the caller so a stuck task doesn't masquerade as an
-                    # empty queue — the returned status message will flag it.
+                    # Surface in status message and break to avoid re-picking the same task.
                     $moveFailures += "$($candidate.id) ($($candidate.name))"
-                    # Avoid infinite loop if the move fails — return no task rather than re-picking the same one.
                     break
                 }
                 $conditionSkipCount++
-                # TODO: incrementalise. Update-TaskIndex rescans the entire tasks tree
-                # on every skip (O(N·skips)). Acceptable under the 50-iteration cap and
-                # typical queue sizes, but a targeted remove/move helper on the index
-                # would be cheaper. Tracked alongside the TaskIndexCache refactor.
+                # TODO: incrementalise — full rescan per skip is O(N·skips).
                 Update-TaskIndex
                 continue
             }
@@ -140,7 +115,7 @@ function Invoke-TaskGetNext {
     }
 
     if ($iter -ge $maxIterations) {
-        Write-BotLog -Level Warn -Message "[task-get-next] Hit maxIterations cap ($maxIterations) while skipping tasks with unmet conditions; aborting selection. This usually indicates a stuck task in the queue or a Move-TaskState failure — inspect .bot/workspace/tasks/ for orphans."
+        Write-BotLog -Level Warn -Message "[task-get-next] Hit maxIterations cap ($maxIterations) — possible stuck task; inspect .bot/workspace/tasks/ for orphans."
     }
 
     $index = Get-TaskIndex

--- a/workflows/default/systems/runtime/modules/ManifestCondition.psm1
+++ b/workflows/default/systems/runtime/modules/ManifestCondition.psm1
@@ -26,7 +26,10 @@ function Test-ManifestCondition {
              elseif ($Condition -is [string]) { @($Condition) }
              else { return $true }
 
-    $resolvedRoot = [System.IO.Path]::GetFullPath($ProjectRoot)
+    $resolvedRoot = [System.IO.Path]::GetFullPath($ProjectRoot).TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+    $rootWithSep = $resolvedRoot + [System.IO.Path]::DirectorySeparatorChar
+    # Windows/macOS are case-insensitive on paths; Linux is case-sensitive.
+    $pathComparison = if ($IsLinux) { [System.StringComparison]::Ordinal } else { [System.StringComparison]::OrdinalIgnoreCase }
 
     foreach ($rule in $rules) {
         $rule = "$rule".Trim()
@@ -43,8 +46,12 @@ function Test-ManifestCondition {
         $fullPath = Join-Path $ProjectRoot $rule
 
         # Path traversal guard: resolved path must stay within project root.
+        # Use boundary-safe comparison (root + separator) with OS-appropriate casing
+        # so sibling paths like "C:\projX" can't bypass a "C:\proj" root.
         $resolvedFull = [System.IO.Path]::GetFullPath($fullPath)
-        if (-not $resolvedFull.StartsWith($resolvedRoot)) {
+        $insideRoot = $resolvedFull.Equals($resolvedRoot, $pathComparison) -or `
+                      $resolvedFull.StartsWith($rootWithSep, $pathComparison)
+        if (-not $insideRoot) {
             if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
                 Write-BotLog -Level Warn -Message "[ManifestCondition] Path traversal blocked: '$rule' resolves outside project root."
             }

--- a/workflows/default/systems/runtime/modules/ManifestCondition.psm1
+++ b/workflows/default/systems/runtime/modules/ManifestCondition.psm1
@@ -1,0 +1,64 @@
+function Test-ManifestCondition {
+    <#
+    .SYNOPSIS
+    Evaluate a gitignore-style path condition against the project root.
+
+    .DESCRIPTION
+    Conditions are path patterns resolved from the project root (parent of .bot/).
+    - Path present = must exist: ".bot/workspace/product/mission.md"
+    - ! prefix = must NOT exist: "!.bot/workspace/product/mission.md"
+    - Glob * = directory has matching files: ".git/refs/heads/*"
+    - Single string = one condition. Array = AND (all must match).
+    - Legacy file_exists: prefix = backward-compat alias (resolves under .bot/).
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ProjectRoot,
+
+        [Parameter()]
+        [object]$Condition
+    )
+
+    if (-not $Condition) { return $true }
+
+    # Normalize to array
+    $rules = if ($Condition -is [array]) { $Condition }
+             elseif ($Condition -is [string]) { @($Condition) }
+             else { return $true }
+
+    $resolvedRoot = [System.IO.Path]::GetFullPath($ProjectRoot)
+
+    foreach ($rule in $rules) {
+        $rule = "$rule".Trim()
+        if (-not $rule) { continue }
+
+        # Legacy compat: strip file_exists: prefix -> resolve under .bot/
+        if ($rule -match '^file_exists:(.+)$') {
+            $rule = ".bot/$($Matches[1])"
+        }
+
+        $negate = $rule.StartsWith('!')
+        if ($negate) { $rule = $rule.Substring(1) }
+
+        $fullPath = Join-Path $ProjectRoot $rule
+
+        # Path traversal guard: resolved path must stay within project root.
+        $resolvedFull = [System.IO.Path]::GetFullPath($fullPath)
+        if (-not $resolvedFull.StartsWith($resolvedRoot)) {
+            Write-Warning "[ManifestCondition] Path traversal blocked: '$rule' resolves outside project root."
+            return $false
+        }
+
+        $exists = if ($rule -match '\*') {
+            @(Resolve-Path $fullPath -ErrorAction SilentlyContinue).Count -gt 0
+        } else {
+            Test-Path $fullPath
+        }
+
+        if ($negate -eq $exists) { return $false }
+    }
+
+    return $true
+}
+
+Export-ModuleMember -Function 'Test-ManifestCondition'

--- a/workflows/default/systems/runtime/modules/ManifestCondition.psm1
+++ b/workflows/default/systems/runtime/modules/ManifestCondition.psm1
@@ -45,7 +45,9 @@ function Test-ManifestCondition {
         # Path traversal guard: resolved path must stay within project root.
         $resolvedFull = [System.IO.Path]::GetFullPath($fullPath)
         if (-not $resolvedFull.StartsWith($resolvedRoot)) {
-            Write-Warning "[ManifestCondition] Path traversal blocked: '$rule' resolves outside project root."
+            if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
+                Write-BotLog -Level Warn -Message "[ManifestCondition] Path traversal blocked: '$rule' resolves outside project root."
+            }
             return $false
         }
 

--- a/workflows/default/systems/runtime/modules/workflow-manifest.ps1
+++ b/workflows/default/systems/runtime/modules/workflow-manifest.ps1
@@ -171,58 +171,8 @@ function Convert-ManifestRequiresToPreflightChecks {
     return $checks
 }
 
-function Test-ManifestCondition {
-    <#
-    .SYNOPSIS
-    Evaluate a gitignore-style path condition against the project root.
-
-    .DESCRIPTION
-    Conditions are path patterns resolved from the project root (parent of .bot/).
-    - Path present = must exist: ".bot/workspace/product/mission.md"
-    - ! prefix = must NOT exist: "!.bot/workspace/product/mission.md"
-    - Glob * = directory has matching files: ".git/refs/heads/*"
-    - Single string = one condition. Array = AND (all must match).
-    - Legacy file_exists: prefix = backward-compat alias (resolves under .bot/).
-    #>
-    param(
-        [Parameter(Mandatory)]
-        [string]$ProjectRoot,
-
-        [Parameter()]
-        [object]$Condition
-    )
-
-    if (-not $Condition) { return $true }
-
-    # Normalize to array
-    $rules = if ($Condition -is [array]) { $Condition }
-             elseif ($Condition -is [string]) { @($Condition) }
-             else { return $true }
-
-    foreach ($rule in $rules) {
-        $rule = "$rule".Trim()
-        if (-not $rule) { continue }
-
-        # Legacy compat: strip file_exists: prefix → resolve under .bot/
-        if ($rule -match '^file_exists:(.+)$') {
-            $rule = ".bot/$($Matches[1])"
-        }
-
-        $negate = $rule.StartsWith('!')
-        if ($negate) { $rule = $rule.Substring(1) }
-
-        $fullPath = Join-Path $ProjectRoot $rule
-        $exists = if ($rule -match '\*') {
-            @(Resolve-Path $fullPath -ErrorAction SilentlyContinue).Count -gt 0
-        } else {
-            Test-Path $fullPath
-        }
-
-        if ($negate -eq $exists) { return $false }
-    }
-
-    return $true
-}
+# Test-ManifestCondition lives in its own module for controlled exports.
+Import-Module (Join-Path $PSScriptRoot "ManifestCondition.psm1") -Force -DisableNameChecking
 
 function Ensure-ManifestTaskIds {
     <#


### PR DESCRIPTION
## Summary

Fixes andresharpe/dotbot#226. Task `condition` fields were stored on the task JSON at creation time but never re-evaluated by the selector, so a task whose condition depended on state produced by an earlier task (e.g. `condition: .bot/workspace/product/mission.md` produced by an upstream task) would incorrectly skip or stall.

`Invoke-TaskGetNext` now re-evaluates each candidate's `condition` via `Test-ManifestCondition` at selection time. If unmet, the task is atomically moved to `skipped` with `skip_reason = condition-not-met` and a `skip_detail` line, then the loop picks the next eligible candidate. The behaviour matches what kickstart already does for phases (`Invoke-KickstartProcess.ps1:187`).

## Changes

- **`task-get-next/script.ps1`** — Bounded loop (max 50 iterations) re-evaluates `condition` per candidate, skips via `Move-TaskState`, logs via `Write-BotLog`, and surfaces `condition_skip_count` / `move_failures` in the no-tasks status. Loud `[Console]::Error` warning at load time if `Test-ManifestCondition` is unavailable (silent fallback would resurrect the bug).
- **`TaskIndexCache.psm1`** — Cache `condition` on indexed entries so the selector reads from memory.
- **`tests/Test-TaskActions.ps1`** — 4 new scenarios (todo unmet→skipped, todo met→returned, array AND condition, analysed→skipped via `prefer_analysed=true`), 100 assertions.