### PR TITLE
feat: send split proposals via Teams connector (#223)

### DIFF
--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -1645,6 +1645,10 @@ if (Test-Path $notifModule) {
         Assert-True -Name "Split template has questionId (deterministic GUID)" `
             -Condition ($null -ne $templateCapture.questionId -and $templateCapture.questionId.Length -eq 36) `
             -Message "Expected 36-char GUID questionId, got: $($templateCapture.questionId)"
+
+        Assert-True -Name "Split template disables free-text (Approve/Reject binary)" `
+            -Condition ($templateCapture.responseSettings.allowFreeText -eq $false) `
+            -Message "Expected allowFreeText=false for split proposal, got: $($templateCapture.responseSettings.allowFreeText)"
     }
 } else {
     Write-TestResult -Name "NotificationClient module exists" -Status Fail -Message "Module not found at $notifModule"
@@ -1773,6 +1777,16 @@ if (Test-Path $pollerModule) {
         -Message "Invalid key should not throw"
 
     Assert-PathExists -Name "Invalid key: task stays in needs-input" -Path $invalidFile
+
+    if (Test-Path $invalidFile) {
+        $invalidContent = Get-Content -Path $invalidFile -Raw | ConvertFrom-Json
+        Assert-True -Name "Invalid key: notification metadata cleared (prevents poll loop)" `
+            -Condition ($null -eq $invalidContent.notification) `
+            -Message "Expected notification=null after invalid-key ignore"
+        Assert-True -Name "Invalid key: split_proposal preserved" `
+            -Condition ($null -ne $invalidContent.split_proposal -and $invalidContent.split_proposal.reason -eq 'Reason') `
+            -Message "Expected split_proposal preserved"
+    }
     # Cleanup
     Remove-Item -Path $invalidFile -Force -ErrorAction SilentlyContinue
 } else {

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -1599,20 +1599,23 @@ if (Test-Path $notifModule) {
         project_name = "test-proj"; project_description = "desc"; instance_id = ""
     }
     $templateCapture = $null
-    $splitTemplateResult = & {
-        function Invoke-RestMethod {
-            param([string]$Method = 'Get', [string]$Uri, [string]$Body, $Headers, $ContentType, $TimeoutSec)
-            if ($Uri -match '/api/templates$') {
-                $script:templateCapture = $Body | ConvertFrom-Json
-                return @{}
-            }
-            if ($Uri -match '/api/instances$') {
-                return @{}
-            }
-            throw "Unexpected URI: $Uri"
+    function global:Invoke-RestMethod {
+        param([string]$Method = 'Get', [string]$Uri, [string]$Body, $Headers, $ContentType, $TimeoutSec)
+        if ($Uri -match '/api/templates$') {
+            $global:templateCapture = $Body | ConvertFrom-Json
+            return @{}
         }
-        Send-SplitProposalNotification -TaskContent $mockSplitTask -SplitProposal $mockSplitProposal -Settings $enabledSettings
+        if ($Uri -match '/api/instances$') {
+            return @{}
+        }
+        throw "Unexpected URI: $Uri"
     }
+    $splitTemplateResult = try {
+        Send-SplitProposalNotification -TaskContent $mockSplitTask -SplitProposal $mockSplitProposal -Settings $enabledSettings
+    } finally {
+        Remove-Item -Path 'function:global:Invoke-RestMethod' -ErrorAction SilentlyContinue
+    }
+    $templateCapture = $global:templateCapture
     Assert-True -Name "Send-SplitProposalNotification returns success with mock server" `
         -Condition ($splitTemplateResult.success -eq $true) `
         -Message "Expected success=true, got: $($splitTemplateResult | ConvertTo-Json -Depth 5)"

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -1552,6 +1552,97 @@ if (Test-Path $notifModule) {
     Assert-True -Name "Get-TaskNotificationResponse returns null when disabled" `
         -Condition ($null -eq $pollResult) `
         -Message "Expected null"
+
+    # ── Send-SplitProposalNotification tests ─────────────────────────
+    $mockSplitTask = [PSCustomObject]@{ id = "split-test-1"; name = "Refactor auth" }
+    $mockSplitProposal = [PSCustomObject]@{
+        reason = "Task is too large"
+        proposed_at = "2026-01-15T10:00:00Z"
+        sub_tasks = @(
+            [PSCustomObject]@{ name = "Extract middleware"; effort = "S"; description = "Pull out auth middleware" },
+            [PSCustomObject]@{ name = "Add token rotation"; effort = "M"; description = "Implement refresh tokens" }
+        )
+    }
+
+    $splitResult = Send-SplitProposalNotification -TaskContent $mockSplitTask -SplitProposal $mockSplitProposal -Settings $settings
+    Assert-True -Name "Send-SplitProposalNotification returns not-configured when disabled" `
+        -Condition ($splitResult.success -eq $false) `
+        -Message "Expected success=false, got $($splitResult.success)"
+
+    # Test empty sub_tasks guard
+    $emptySplitProposal = [PSCustomObject]@{
+        reason = "Should fail"
+        proposed_at = "2026-01-15T10:00:00Z"
+        sub_tasks = @()
+    }
+    $emptyResult = Send-SplitProposalNotification -TaskContent $mockSplitTask -SplitProposal $emptySplitProposal -Settings $settings
+    Assert-True -Name "Send-SplitProposalNotification rejects empty sub_tasks" `
+        -Condition ($emptyResult.success -eq $false -and $emptyResult.reason -match "no sub-tasks") `
+        -Message "Expected failure with 'no sub-tasks' reason, got: $($emptyResult.reason)"
+
+    # Test missing proposed_at guard
+    $noPropAtProposal = [PSCustomObject]@{
+        reason = "Should fail"
+        sub_tasks = @(
+            [PSCustomObject]@{ name = "Some task"; effort = "S" }
+        )
+    }
+    $noPropAtResult = Send-SplitProposalNotification -TaskContent $mockSplitTask -SplitProposal $noPropAtProposal -Settings $settings
+    Assert-True -Name "Send-SplitProposalNotification rejects missing proposed_at" `
+        -Condition ($noPropAtResult.success -eq $false -and $noPropAtResult.reason -match "proposed_at") `
+        -Message "Expected failure with 'proposed_at' reason, got: $($noPropAtResult.reason)"
+
+    # Test template structure with enabled settings (mock REST to verify shape)
+    $enabledSettings = [PSCustomObject]@{
+        enabled = $true; server_url = "http://localhost:9999"; api_key = "test-key"
+        channel = "teams"; recipients = @("user@example.com")
+        project_name = "test-proj"; project_description = "desc"; instance_id = ""
+    }
+    $templateCapture = $null
+    $splitTemplateResult = & {
+        function Invoke-RestMethod {
+            param([string]$Method = 'Get', [string]$Uri, [string]$Body, $Headers, $ContentType, $TimeoutSec)
+            if ($Uri -match '/api/templates$') {
+                $script:templateCapture = $Body | ConvertFrom-Json
+                return @{}
+            }
+            if ($Uri -match '/api/instances$') {
+                return @{}
+            }
+            throw "Unexpected URI: $Uri"
+        }
+        Send-SplitProposalNotification -TaskContent $mockSplitTask -SplitProposal $mockSplitProposal -Settings $enabledSettings
+    }
+    Assert-True -Name "Send-SplitProposalNotification returns success with mock server" `
+        -Condition ($splitTemplateResult.success -eq $true) `
+        -Message "Expected success=true, got: $($splitTemplateResult | ConvertTo-Json -Depth 5)"
+
+    if ($templateCapture) {
+        Assert-True -Name "Split template title contains task name" `
+            -Condition ($templateCapture.title -match "Refactor auth") `
+            -Message "Expected title to contain task name, got: $($templateCapture.title)"
+
+        Assert-True -Name "Split template has 2 options (Approve/Reject)" `
+            -Condition ($templateCapture.options.Count -eq 2) `
+            -Message "Expected 2 options, got $($templateCapture.options.Count)"
+
+        $optionKeys = @($templateCapture.options | ForEach-Object { $_.key })
+        Assert-True -Name "Split template options are 'approve' and 'reject'" `
+            -Condition ($optionKeys -contains 'approve' -and $optionKeys -contains 'reject') `
+            -Message "Expected approve/reject keys, got: $($optionKeys -join ', ')"
+
+        Assert-True -Name "Split template context contains reason" `
+            -Condition ($templateCapture.context -match "too large") `
+            -Message "Expected context to contain reason"
+
+        Assert-True -Name "Split template context contains sub-task names" `
+            -Condition ($templateCapture.context -match "Extract middleware" -and $templateCapture.context -match "Add token rotation") `
+            -Message "Expected context to list sub-tasks"
+
+        Assert-True -Name "Split template has questionId (deterministic GUID)" `
+            -Condition ($null -ne $templateCapture.questionId -and $templateCapture.questionId.Length -eq 36) `
+            -Message "Expected 36-char GUID questionId, got: $($templateCapture.questionId)"
+    }
 } else {
     Write-TestResult -Name "NotificationClient module exists" -Status Fail -Message "Module not found at $notifModule"
 }
@@ -1588,6 +1679,99 @@ if (Test-Path $pollerModule) {
     Assert-True -Name "Invoke-NotificationPollTick no-op when no tasks" `
         -Condition (-not $pollTickError) `
         -Message "Should not throw with empty needs-input"
+
+    # ── Invoke-SplitTransitionFromNotification tests ─────────────────
+    $needsInputDir = Join-Path $botDir "workspace" "tasks" "needs-input"
+    $analysingDir  = Join-Path $botDir "workspace" "tasks" "analysing"
+    if (-not (Test-Path $needsInputDir)) {
+        New-Item -ItemType Directory -Force -Path $needsInputDir | Out-Null
+    }
+
+    # --- Reject path test ---
+    $rejectTask = [PSCustomObject]@{
+        id = "split-reject-test"
+        name = "Task to reject"
+        status = "needs-input"
+        split_proposal = [PSCustomObject]@{
+            reason = "Too big"
+            sub_tasks = @([PSCustomObject]@{ name = "Sub A" })
+            proposed_at = "2026-01-15T10:00:00Z"
+        }
+        notification = [PSCustomObject]@{
+            question_id = "q-reject"; instance_id = "i-reject"; channel = "teams"; project_id = "proj1"
+        }
+        updated_at = "2026-01-15T10:00:00Z"
+    }
+    $rejectFile = Join-Path $needsInputDir "split-reject-test.json"
+    $rejectTask | ConvertTo-Json -Depth 20 | Set-Content -Path $rejectFile -Encoding UTF8
+    $rejectFileInfo = Get-Item $rejectFile
+
+    $rejectError = $false
+    try {
+        Invoke-SplitTransitionFromNotification -TaskFile $rejectFileInfo -TaskContent $rejectTask `
+            -AnswerKey 'reject' -BotRoot $botDir
+    } catch {
+        $rejectError = $true
+    }
+    Assert-True -Name "Invoke-SplitTransitionFromNotification reject does not throw" `
+        -Condition (-not $rejectError) `
+        -Message "Reject path threw an error"
+
+    Assert-PathNotExists -Name "Reject: task removed from needs-input" -Path $rejectFile
+
+    $rejectedFile = Join-Path $analysingDir "split-reject-test.json"
+    Assert-PathExists -Name "Reject: task moved to analysing" -Path $rejectedFile
+
+    if (Test-Path $rejectedFile) {
+        $rejectedContent = Get-Content -Path $rejectedFile -Raw | ConvertFrom-Json
+        Assert-True -Name "Reject: split_proposal.status is 'rejected'" `
+            -Condition ($rejectedContent.split_proposal.status -eq 'rejected') `
+            -Message "Expected 'rejected', got '$($rejectedContent.split_proposal.status)'"
+        Assert-True -Name "Reject: split_proposal.answered_via is 'notification'" `
+            -Condition ($rejectedContent.split_proposal.answered_via -eq 'notification') `
+            -Message "Expected 'notification', got '$($rejectedContent.split_proposal.answered_via)'"
+        Assert-True -Name "Reject: notification metadata cleared" `
+            -Condition ($null -eq $rejectedContent.notification) `
+            -Message "Expected notification=null"
+        Assert-True -Name "Reject: task status is 'analysing'" `
+            -Condition ($rejectedContent.status -eq 'analysing') `
+            -Message "Expected 'analysing', got '$($rejectedContent.status)'"
+        # Cleanup
+        Remove-Item -Path $rejectedFile -Force -ErrorAction SilentlyContinue
+    }
+
+    # --- Invalid key test (no-op) ---
+    $invalidKeyTask = [PSCustomObject]@{
+        id = "split-invalid-test"
+        name = "Task with bad key"
+        status = "needs-input"
+        split_proposal = [PSCustomObject]@{
+            reason = "Reason"; sub_tasks = @([PSCustomObject]@{ name = "Sub" })
+            proposed_at = "2026-01-15T10:00:00Z"
+        }
+        notification = [PSCustomObject]@{
+            question_id = "q-inv"; instance_id = "i-inv"; channel = "teams"; project_id = "proj1"
+        }
+        updated_at = "2026-01-15T10:00:00Z"
+    }
+    $invalidFile = Join-Path $needsInputDir "split-invalid-test.json"
+    $invalidKeyTask | ConvertTo-Json -Depth 20 | Set-Content -Path $invalidFile -Encoding UTF8
+    $invalidFileInfo = Get-Item $invalidFile
+
+    $invalidError = $false
+    try {
+        Invoke-SplitTransitionFromNotification -TaskFile $invalidFileInfo -TaskContent $invalidKeyTask `
+            -AnswerKey 'maybe' -BotRoot $botDir
+    } catch {
+        $invalidError = $true
+    }
+    Assert-True -Name "Invoke-SplitTransitionFromNotification ignores invalid key" `
+        -Condition (-not $invalidError) `
+        -Message "Invalid key should not throw"
+
+    Assert-PathExists -Name "Invalid key: task stays in needs-input" -Path $invalidFile
+    # Cleanup
+    Remove-Item -Path $invalidFile -Force -ErrorAction SilentlyContinue
 } else {
     Write-TestResult -Name "NotificationPoller module exists" -Status Fail -Message "Module not found at $pollerModule"
 }

--- a/workflows/default/systems/mcp/modules/NotificationClient.psm1
+++ b/workflows/default/systems/mcp/modules/NotificationClient.psm1
@@ -289,8 +289,8 @@ function Send-TaskNotification {
     Optional notification settings. If not provided, reads from config.
 
     .OUTPUTS
-    Hashtable: @{ success; question_id; instance_id; channel; project_id }
-    Returns @{ success = $false } on any failure.
+    Hashtable. On success: @{ success = $true; question_id; instance_id; channel; project_id }.
+    On failure: @{ success = $false; reason = "..." } (reason is supplied by Send-ServerNotification).
     #>
     param(
         [Parameter(Mandatory)]
@@ -341,8 +341,8 @@ function Send-SplitProposalNotification {
     Optional notification settings. If not provided, reads from config.
 
     .OUTPUTS
-    Hashtable: @{ success; question_id; instance_id; channel; project_id }
-    Returns @{ success = $false } on any failure.
+    Hashtable. On success: @{ success = $true; question_id; instance_id; channel; project_id }.
+    On failure: @{ success = $false; reason = "..." }.
     #>
     param(
         [Parameter(Mandatory)]
@@ -397,7 +397,10 @@ function Send-SplitProposalNotification {
                 isRecommended = $false
             }
         )
-        responseSettings = @{ allowFreeText = $true }
+        # Split proposal is an explicit Approve/Reject binary choice — free-text
+        # replies have no mapping in the poller and would leave the task stuck
+        # in needs-input with the poller repeatedly re-fetching the same response.
+        responseSettings = @{ allowFreeText = $false }
     }
 
     return Send-ServerNotification -CompositeKey $compositeKey -Template $template -Settings $Settings

--- a/workflows/default/systems/mcp/modules/NotificationClient.psm1
+++ b/workflows/default/systems/mcp/modules/NotificationClient.psm1
@@ -126,35 +126,47 @@ function Test-NotificationServer {
     }
 }
 
-function Send-TaskNotification {
+function Send-ServerNotification {
     <#
     .SYNOPSIS
-    Sends a task's pending_question to DotbotServer via the two-step API
-    (POST /api/templates + POST /api/instances).
+    Shared plumbing for sending notifications to DotbotServer via the two-step
+    API (POST /api/templates + POST /api/instances).
 
-    .PARAMETER TaskContent
-    The task PSCustomObject containing id, name, pending_question, etc.
+    .DESCRIPTION
+    Private helper — not exported. Handles settings validation, project ID
+    resolution, deterministic GUID generation, template publishing, and
+    instance creation.  Callers supply the composite key (for idempotency)
+    and a pre-built template body.
 
-    .PARAMETER PendingQuestion
-    The pending_question object from the task. Contains id, question, context,
-    options (key/label/rationale), recommendation.
+    .PARAMETER CompositeKey
+    A string used to derive a deterministic UUIDv5-style question ID
+    (e.g. "<task-id>-<question-id>" or "<task-id>-split").
+
+    .PARAMETER Template
+    Hashtable with the card-specific fields: title, context, options,
+    responseSettings.  This function adds questionId, version, and project.
 
     .PARAMETER Settings
     Optional notification settings. If not provided, reads from config.
 
     .OUTPUTS
-    Hashtable: @{ success; question_id; instance_id; channel }
-    Returns @{ success = $false } on any failure.
+    Hashtable: @{ success; question_id; instance_id; channel; project_id }
+    Returns @{ success = $false; reason = "..." } on any failure.
     #>
     param(
         [Parameter(Mandatory)]
-        [object]$TaskContent,
+        [string]$CompositeKey,
 
         [Parameter(Mandatory)]
-        [object]$PendingQuestion,
+        [hashtable]$Template,
 
         [object]$Settings
     )
+
+    # Shallow clone to avoid mutating the caller's hashtable (reference type).
+    # Only top-level keys (questionId, version, project) are added below, so
+    # shallow is sufficient — nested values (options, responseSettings) are not mutated.
+    $Template = $Template.Clone()
 
     if (-not $Settings) {
         $Settings = Get-NotificationSettings
@@ -186,10 +198,8 @@ function Send-TaskNotification {
         $projectId = ($projectName.ToLower() -replace '[^a-z0-9]+', '-').Trim('-')
     }
 
-    # Use stable question ID derived as a deterministic GUID from task-id + question-id
-    # This behaves like a UUIDv5-style name-based GUID, ensuring stability across retries.
-    $compositeQuestionKey = "$($TaskContent.id)-$($PendingQuestion.id)"
-    $bytes = [System.Text.Encoding]::UTF8.GetBytes($compositeQuestionKey)
+    # Deterministic UUIDv5-style GUID from composite key for idempotent retries
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($CompositeKey)
     $sha1  = [System.Security.Cryptography.SHA1]::Create()
     try {
         $hash = $sha1.ComputeHash($bytes)
@@ -198,39 +208,21 @@ function Send-TaskNotification {
     }
     $guidBytes = New-Object 'System.Byte[]' 16
     [Array]::Copy($hash, $guidBytes, 16)
-    # Set version 5 (0101) in the high 4 bits of byte 6
-    $guidBytes[6] = ($guidBytes[6] -band 0x0F) -bor 0x50
-    # Set RFC 4122 variant (10xx) in the high bits of byte 8
-    $guidBytes[8] = ($guidBytes[8] -band 0x3F) -bor 0x80
+    $guidBytes[6] = ($guidBytes[6] -band 0x0F) -bor 0x50   # version 5
+    $guidBytes[8] = ($guidBytes[8] -band 0x3F) -bor 0x80   # RFC 4122 variant
     $questionId = ([System.Guid]::new([byte[]]$guidBytes)).ToString()
 
     # ── Step 1: Publish template ──────────────────────────────────────────
-    $templateOptions = @(foreach ($opt in $PendingQuestion.options) {
-        @{
-            optionId      = [guid]::NewGuid().ToString()
-            key           = "$($opt.key)"
-            title         = "$($opt.label)"
-            summary       = if ($opt.rationale) { "$($opt.rationale)" } else { $null }
-            isRecommended = ("$($opt.key)" -eq $PendingQuestion.recommendation)
-        }
-    })
-
-    $template = @{
-        questionId       = $questionId
-        version          = 1
-        title            = $PendingQuestion.question
-        context          = if ($PendingQuestion.context) { $PendingQuestion.context } else { $null }
-        options          = $templateOptions
-        responseSettings = @{ allowFreeText = $true }
-        project          = @{
-            projectId   = $projectId
-            name        = $projectName
-            description = $projectDesc
-        }
+    $Template['questionId'] = $questionId
+    $Template['version']    = 1
+    $Template['project']    = @{
+        projectId   = $projectId
+        name        = $projectName
+        description = $projectDesc
     }
 
     try {
-        $templateJson = $template | ConvertTo-Json -Depth 5
+        $templateJson = $Template | ConvertTo-Json -Depth 20
         $null = Invoke-RestMethod -Uri "$baseUrl/api/templates" -Method Post `
             -Body $templateJson -ContentType 'application/json' -Headers $headers -TimeoutSec 15
     } catch {
@@ -265,7 +257,7 @@ function Send-TaskNotification {
     }
 
     try {
-        $instanceJson = $instanceReq | ConvertTo-Json -Depth 5
+        $instanceJson = $instanceReq | ConvertTo-Json -Depth 20
         $null = Invoke-RestMethod -Uri "$baseUrl/api/instances" -Method Post `
             -Body $instanceJson -ContentType 'application/json' -Headers $headers -TimeoutSec 15
     } catch {
@@ -279,6 +271,136 @@ function Send-TaskNotification {
         channel     = $channel
         project_id  = $projectId
     }
+}
+
+function Send-TaskNotification {
+    <#
+    .SYNOPSIS
+    Sends a task's pending_question to DotbotServer as an Adaptive Card.
+
+    .PARAMETER TaskContent
+    The task PSCustomObject containing id, name, pending_question, etc.
+
+    .PARAMETER PendingQuestion
+    The pending_question object from the task. Contains id, question, context,
+    options (key/label/rationale), recommendation.
+
+    .PARAMETER Settings
+    Optional notification settings. If not provided, reads from config.
+
+    .OUTPUTS
+    Hashtable: @{ success; question_id; instance_id; channel; project_id }
+    Returns @{ success = $false } on any failure.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [object]$TaskContent,
+
+        [Parameter(Mandatory)]
+        [object]$PendingQuestion,
+
+        [object]$Settings
+    )
+
+    $compositeKey = "$($TaskContent.id)-$($PendingQuestion.id)"
+
+    $templateOptions = @(foreach ($opt in $PendingQuestion.options) {
+        @{
+            optionId      = [guid]::NewGuid().ToString()
+            key           = "$($opt.key)"
+            title         = "$($opt.label)"
+            summary       = if ($opt.rationale) { "$($opt.rationale)" } else { $null }
+            isRecommended = ("$($opt.key)" -eq $PendingQuestion.recommendation)
+        }
+    })
+
+    $template = @{
+        title            = $PendingQuestion.question
+        context          = if ($PendingQuestion.context) { $PendingQuestion.context } else { $null }
+        options          = $templateOptions
+        responseSettings = @{ allowFreeText = $true }
+    }
+
+    return Send-ServerNotification -CompositeKey $compositeKey -Template $template -Settings $Settings
+}
+
+function Send-SplitProposalNotification {
+    <#
+    .SYNOPSIS
+    Sends a task's split_proposal to DotbotServer as an Adaptive Card with
+    Approve / Reject options and sub-task details.
+
+    .PARAMETER TaskContent
+    The task PSCustomObject containing id, name, split_proposal, etc.
+
+    .PARAMETER SplitProposal
+    The split_proposal object from the task. Contains reason, sub_tasks
+    (each with name, description, effort), proposed_at.
+
+    .PARAMETER Settings
+    Optional notification settings. If not provided, reads from config.
+
+    .OUTPUTS
+    Hashtable: @{ success; question_id; instance_id; channel; project_id }
+    Returns @{ success = $false } on any failure.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [object]$TaskContent,
+
+        [Parameter(Mandatory)]
+        [object]$SplitProposal,
+
+        [object]$Settings
+    )
+
+    if (-not $SplitProposal.proposed_at) {
+        return @{ success = $false; reason = "Split proposal missing proposed_at" }
+    }
+
+    # Use proposed_at in the composite key: it's stable for the lifetime of a
+    # proposal (set once at creation, reused on notification retries), and new
+    # proposals after rejection get a fresh timestamp — producing a new GUID.
+    $compositeKey = "$($TaskContent.id)-split-$($SplitProposal.proposed_at)"
+
+    if (-not $SplitProposal.sub_tasks -or @($SplitProposal.sub_tasks).Count -eq 0) {
+        return @{ success = $false; reason = "Split proposal has no sub-tasks" }
+    }
+
+    # Build context body: reason + numbered sub-task list
+    $subTaskLines = @()
+    $index = 1
+    foreach ($st in $SplitProposal.sub_tasks) {
+        $effort = if ($st.effort) { " [$($st.effort)]" } else { "" }
+        $desc   = if ($st.description) { " — $($st.description)" } else { "" }
+        $subTaskLines += "$index. $($st.name)$effort$desc"
+        $index++
+    }
+    $contextBody = "Reason: $($SplitProposal.reason)`n`nProposed sub-tasks:`n$($subTaskLines -join "`n")"
+
+    $template = @{
+        title            = "Split proposal for task: $($TaskContent.name)"
+        context          = $contextBody
+        options          = @(
+            @{
+                optionId      = [guid]::NewGuid().ToString()
+                key           = "approve"
+                title         = "Approve"
+                summary       = "Accept the split and create the proposed sub-tasks"
+                isRecommended = $true
+            },
+            @{
+                optionId      = [guid]::NewGuid().ToString()
+                key           = "reject"
+                title         = "Reject"
+                summary       = "Reject the split and return the task to analysis"
+                isRecommended = $false
+            }
+        )
+        responseSettings = @{ allowFreeText = $true }
+    }
+
+    return Send-ServerNotification -CompositeKey $compositeKey -Template $template -Settings $Settings
 }
 
 function Get-TaskNotificationResponse {
@@ -422,6 +544,7 @@ Export-ModuleMember -Function @(
     'Get-NotificationSettings'
     'Test-NotificationServer'
     'Send-TaskNotification'
+    'Send-SplitProposalNotification'
     'Get-TaskNotificationResponse'
     'Resolve-NotificationAnswer'
 )

--- a/workflows/default/systems/mcp/tools/task-mark-needs-input/script.ps1
+++ b/workflows/default/systems/mcp/tools/task-mark-needs-input/script.ps1
@@ -81,8 +81,12 @@ function Invoke-TaskMarkNeedsInput {
         if (Test-Path $notifModule) {
             Import-Module $notifModule -Force
             $settings = Get-NotificationSettings
-            if ($settings.enabled -and $question) {
-                $sendResult = Send-TaskNotification -TaskContent $taskContent -PendingQuestion $taskContent.pending_question
+            if ($settings.enabled -and ($question -or $splitProposal)) {
+                $sendResult = if ($question) {
+                    Send-TaskNotification -TaskContent $taskContent -PendingQuestion $taskContent.pending_question -Settings $settings
+                } else {
+                    Send-SplitProposalNotification -TaskContent $taskContent -SplitProposal $taskContent.split_proposal -Settings $settings
+                }
                 if ($sendResult.success) {
                     $taskContent | Add-Member -NotePropertyName 'notification' -NotePropertyValue @{
                         question_id = $sendResult.question_id

--- a/workflows/default/systems/ui/modules/NotificationPoller.psm1
+++ b/workflows/default/systems/ui/modules/NotificationPoller.psm1
@@ -128,6 +128,13 @@ function Invoke-NotificationPollTick {
                     if ($answerKey) {
                         Invoke-SplitTransitionFromNotification -TaskFile $taskFile -TaskContent $taskContent `
                             -AnswerKey $answerKey -BotRoot $botRoot
+                    } else {
+                        # Unsupported response (e.g. free-text reply). The template
+                        # disables free-text, but if a response without selectedKey
+                        # still reaches us we must consume it — otherwise the same
+                        # response is re-fetched on every poll tick indefinitely.
+                        $taskContent.notification = $null
+                        $taskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $taskFile.FullName -Encoding UTF8
                     }
                 } else {
                     # Question response: resolve answer and transition
@@ -275,6 +282,12 @@ function Invoke-SplitTransitionFromNotification {
     $validKeys = @('approve', 'reject')
     if ($AnswerKey -notin $validKeys) {
         Write-BotLog -Level Warn -Message "Unexpected split proposal answer key '$AnswerKey' for task $($TaskContent.id) — ignoring"
+        # Clear notification metadata so the same invalid response is not
+        # re-fetched and re-logged on every subsequent poll tick.
+        if (Test-Path $TaskFile.FullName) {
+            $TaskContent.notification = $null
+            $TaskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $TaskFile.FullName -Encoding UTF8
+        }
         return
     }
 

--- a/workflows/default/systems/ui/modules/NotificationPoller.psm1
+++ b/workflows/default/systems/ui/modules/NotificationPoller.psm1
@@ -342,4 +342,6 @@ function Invoke-SplitTransitionFromNotification {
 Export-ModuleMember -Function @(
     'Initialize-NotificationPoller'
     'Invoke-NotificationPollTick'
+    'Invoke-SplitTransitionFromNotification'
+    'Invoke-TaskTransitionFromNotification'
 )

--- a/workflows/default/systems/ui/modules/NotificationPoller.psm1
+++ b/workflows/default/systems/ui/modules/NotificationPoller.psm1
@@ -57,6 +57,7 @@ function Initialize-NotificationPoller {
         Import-Module '$($pollerModule -replace "'","''")' -Force
         Import-Module '$($notifModule -replace "'","''")' -Force
         `$script:pollerBotRoot = '$($BotRoot -replace "'","''")'
+        `$global:DotbotProjectRoot = '$((Split-Path $BotRoot -Parent) -replace "'","''")'
 
         while (`$true) {
             Start-Sleep -Seconds $intervalSeconds
@@ -105,8 +106,12 @@ function Invoke-NotificationPollTick {
                 continue
             }
 
-            # Skip tasks without a pending question (already answered)
-            if (-not $taskContent.pending_question) {
+            # Determine notification type: question or split proposal
+            $isQuestion = [bool]$taskContent.pending_question
+            $isSplit    = [bool]$taskContent.split_proposal
+
+            # Skip tasks that have neither (already answered/resolved)
+            if (-not $isQuestion -and -not $isSplit) {
                 continue
             }
 
@@ -114,15 +119,24 @@ function Invoke-NotificationPollTick {
             $response = Get-TaskNotificationResponse -Notification $notification -Settings $settings
 
             if ($response) {
-                # Resolve the answer and download any attachments
-                $taskId    = $taskContent.id
-                $questionId = $taskContent.pending_question.id
-                $attachDir = Join-Path $botRoot "workspace\attachments\$taskId\$questionId"
-                $resolved  = Resolve-NotificationAnswer -Response $response -Settings $settings -AttachDir $attachDir
+                # Re-check that the task is still in needs-input (first-write-wins)
+                if (-not (Test-Path $taskFile.FullName)) { continue }
 
-                if ($resolved) {
-                    # Re-check that the task is still in needs-input (first-write-wins)
-                    if (Test-Path $taskFile.FullName) {
+                if ($isSplit) {
+                    # Split proposal response: "approve" or "reject" key
+                    $answerKey = if ($response.selectedKey) { $response.selectedKey } else { $null }
+                    if ($answerKey) {
+                        Invoke-SplitTransitionFromNotification -TaskFile $taskFile -TaskContent $taskContent `
+                            -AnswerKey $answerKey -BotRoot $botRoot
+                    }
+                } else {
+                    # Question response: resolve answer and transition
+                    $taskId    = $taskContent.id
+                    $questionId = $taskContent.pending_question.id
+                    $attachDir = Join-Path $botRoot "workspace\attachments\$taskId\$questionId"
+                    $resolved  = Resolve-NotificationAnswer -Response $response -Settings $settings -AttachDir $attachDir
+
+                    if ($resolved) {
                         Invoke-TaskTransitionFromNotification -TaskFile $taskFile -TaskContent $taskContent `
                             -Answer $resolved.answer -Attachments $resolved.attachments -BotRoot $botRoot
                     }
@@ -235,6 +249,94 @@ function Invoke-TaskTransitionFromNotification {
     # Save updated task to new location and remove from needs-input
     $TaskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $newFilePath -Encoding UTF8
     Remove-Item -Path $TaskFile.FullName -Force
+}
+
+function Invoke-SplitTransitionFromNotification {
+    <#
+    .SYNOPSIS
+    Transitions a needs-input task based on a split-proposal response from Teams.
+    Maps "approve"/"reject" answer keys to the corresponding task-approve-split logic.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [System.IO.FileInfo]$TaskFile,
+
+        [Parameter(Mandatory)]
+        [object]$TaskContent,
+
+        [Parameter(Mandatory)]
+        [string]$AnswerKey,
+
+        [Parameter(Mandatory)]
+        [string]$BotRoot
+    )
+
+    # Validate answer key — only "approve" and "reject" are expected
+    $validKeys = @('approve', 'reject')
+    if ($AnswerKey -notin $validKeys) {
+        Write-BotLog -Level Warn -Message "Unexpected split proposal answer key '$AnswerKey' for task $($TaskContent.id) — ignoring"
+        return
+    }
+
+    $approved = $AnswerKey -eq 'approve'
+
+    if (-not $approved) {
+        # ── Reject path: mark rejected, move back to analysing ────────────
+        $tasksBaseDir = Join-Path $BotRoot "workspace" "tasks"
+        $analysingDir = Join-Path $tasksBaseDir "analysing"
+
+        $TaskContent.status = 'analysing'
+        $TaskContent.updated_at = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
+
+        $TaskContent.split_proposal | Add-Member -NotePropertyName 'rejected_at' `
+            -NotePropertyValue (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'") -Force
+        $TaskContent.split_proposal | Add-Member -NotePropertyName 'status' -NotePropertyValue 'rejected' -Force
+        $TaskContent.split_proposal | Add-Member -NotePropertyName 'answered_via' -NotePropertyValue 'notification' -Force
+
+        # Clear stale notification metadata so it doesn't carry over if the task
+        # cycles back to needs-input with a new question or proposal
+        $TaskContent.notification = $null
+
+        if (-not (Test-Path $analysingDir)) {
+            New-Item -ItemType Directory -Force -Path $analysingDir | Out-Null
+        }
+
+        $newFilePath = Join-Path $analysingDir $TaskFile.Name
+        $TaskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $newFilePath -Encoding UTF8
+        Remove-Item -Path $TaskFile.FullName -Force
+    } else {
+        # ── Approve path: delegate to Invoke-TaskApproveSplit ─────────────
+        # $global:DotbotProjectRoot is set in the runspace init block
+        # (Initialize-NotificationPoller) so it's available here.
+        $approveScript = Join-Path $BotRoot "systems" "mcp" "tools" "task-approve-split" "script.ps1"
+        if (-not (Get-Command Invoke-TaskApproveSplit -ErrorAction SilentlyContinue)) {
+            . $approveScript
+        }
+
+        try {
+            $approveResult = Invoke-TaskApproveSplit -Arguments @{
+                task_id  = $TaskContent.id
+                approved = $true
+            }
+
+            # Record that the approval came via Teams notification (for audit trail)
+            if ($approveResult.file_path -and (Test-Path $approveResult.file_path)) {
+                $approvedTask = Get-Content -Path $approveResult.file_path -Raw | ConvertFrom-Json
+                $approvedTask.split_proposal | Add-Member -NotePropertyName 'answered_via' -NotePropertyValue 'notification' -Force
+                $approvedTask.notification = $null
+                $approvedTask | ConvertTo-Json -Depth 20 | Set-Content -Path $approveResult.file_path -Encoding UTF8
+            }
+        } catch {
+            # Clear notification metadata to prevent infinite retry loops on
+            # persistent failures (e.g., task already moved, sub-task creation broken)
+            Write-BotLog -Level Warn -Message "Split approval failed for task $($TaskContent.id): $($_.Exception.Message)" -Exception $_
+            if (Test-Path $TaskFile.FullName) {
+                $TaskContent.notification = $null
+                $TaskContent.updated_at = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
+                $TaskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $TaskFile.FullName -Encoding UTF8
+            }
+        }
+    }
 }
 
 Export-ModuleMember -Function @(


### PR DESCRIPTION
## Summary

- Refactors `Send-TaskNotification` to extract shared notification plumbing into a private `Send-ServerNotification` helper
- Adds `Send-SplitProposalNotification` to deliver split proposals as Adaptive Cards with Approve/Reject options
- Updates `task-mark-needs-input` to route split proposals through the new notification path
- Adds `Invoke-SplitTransitionFromNotification` to the notification poller to handle approve/reject responses from Teams

## Changes

**`NotificationClient.psm1`**
- Extracted common HTTP/template/instance logic into `Send-ServerNotification` (private)
- `Send-TaskNotification` now delegates to `Send-ServerNotification`
- New `Send-SplitProposalNotification` builds a card with reason, numbered sub-task list, and Approve/Reject options; uses `proposed_at` in the composite key for stable idempotency across retries

**`task-mark-needs-input/script.ps1`**
- Notification gate now triggers on `$question -or $splitProposal`, routing each to the appropriate sender

**`NotificationPoller.psm1`**
- Poll tick now distinguishes question vs split-proposal tasks and dispatches accordingly
- New `Invoke-SplitTransitionFromNotification`: reject moves the task back to `analysing` with audit metadata; approve delegates to `Invoke-TaskApproveSplit` and annotates the result with `answered_via=notification`
- Sets `$global:DotbotProjectRoot` in the runspace init block so approve-path tool scripts have the project root available

**`tests/Test-Components.ps1`**
- `Send-SplitProposalNotification`: guard validations (empty sub-tasks, missing `proposed_at`), template structure via mocked REST (title, option keys, context body, deterministic GUID)
- `Invoke-SplitTransitionFromNotification`: reject path (file movement, status, metadata), invalid key no-op

Closes #223 
