### PR TITLE
fix:Kickstart modal shows wrong workflow's form when multiple workflo…

### DIFF
--- a/tests/Test-ServerStartup.ps1
+++ b/tests/Test-ServerStartup.ps1
@@ -315,6 +315,7 @@ form:
   show_prompt: true
   show_files: false
   show_interview: true
+  show_auto_workflow: false
 tasks:
   - name: "Bravo Phase 1"
     type: prompt
@@ -381,6 +382,12 @@ tasks:
             Assert-Equal -Name "bravo form.show_files respects bravo manifest" `
                 -Expected $false `
                 -Actual ([bool]$bravoResp.dialog.show_files)
+            Assert-Equal -Name "bravo form.show_auto_workflow respects bravo manifest" `
+                -Expected $false `
+                -Actual ([bool]$bravoResp.dialog.show_auto_workflow)
+            Assert-Equal -Name "alpha form.show_auto_workflow defaults to true" `
+                -Expected $true `
+                -Actual ([bool]$alphaResp.dialog.show_auto_workflow)
             Assert-Equal -Name "bravo phases count matches bravo manifest" `
                 -Expected 2 `
                 -Actual ([int]$bravoResp.phases.Count)

--- a/tests/Test-ServerStartup.ps1
+++ b/tests/Test-ServerStartup.ps1
@@ -263,6 +263,162 @@ try {
 Write-Host ""
 
 # ═══════════════════════════════════════════════════════════════════
+# PER-WORKFLOW FORM ENDPOINT (issue #235)
+# ═══════════════════════════════════════════════════════════════════
+# Regression coverage: when multiple workflows are installed in
+# .bot/workflows/, GET /api/workflows/{name}/form must return the form
+# config for the requested workflow — not the alphabetically-first one.
+
+Write-Host "  PER-WORKFLOW FORM ENDPOINT" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$projectForm = $null
+$serverForm = $null
+
+try {
+    $projectForm = Initialize-TestBotProject
+
+    # Install two workflows with distinct form blocks directly on disk.
+    # Use alphabetically reversed order (alpha first) so the test would
+    # fail if the endpoint ever reverted to "return first workflow found".
+    $workflowsRoot = Join-Path $projectForm.BotDir "workflows"
+    New-Item -Path (Join-Path $workflowsRoot "alpha") -ItemType Directory -Force | Out-Null
+    New-Item -Path (Join-Path $workflowsRoot "bravo") -ItemType Directory -Force | Out-Null
+
+    $alphaYaml = @"
+name: alpha
+version: "1.0"
+description: Alpha test workflow
+form:
+  description: "ALPHA WORKFLOW FORM"
+  prompt_placeholder: "ALPHA project description..."
+  interview_label: "ALPHA interview"
+  interview_hint: "Alpha hint"
+  show_prompt: true
+  show_files: true
+  show_interview: true
+tasks:
+  - name: "Alpha Phase 1"
+    type: prompt
+    workflow: "alpha-1.md"
+"@
+
+    $bravoYaml = @"
+name: bravo
+version: "1.0"
+description: Bravo test workflow
+form:
+  description: "BRAVO WORKFLOW FORM"
+  prompt_placeholder: "BRAVO project description..."
+  interview_label: "BRAVO interview"
+  interview_hint: "Bravo hint"
+  show_prompt: true
+  show_files: false
+  show_interview: true
+tasks:
+  - name: "Bravo Phase 1"
+    type: prompt
+    workflow: "bravo-1.md"
+  - name: "Bravo Phase 2"
+    type: prompt
+    workflow: "bravo-2.md"
+"@
+
+    Set-Content -Path (Join-Path $workflowsRoot "alpha\workflow.yaml") -Value $alphaYaml -Encoding UTF8
+    Set-Content -Path (Join-Path $workflowsRoot "bravo\workflow.yaml") -Value $bravoYaml -Encoding UTF8
+
+    $serverForm = Start-UiServer -BotDir $projectForm.BotDir
+    $portForm = Wait-ForUiPort -BotDir $projectForm.BotDir
+
+    Assert-True -Name "Form-endpoint server starts" `
+        -Condition ($portForm -gt 0) `
+        -Message "Failed to detect port from ui-port file"
+
+    if ($portForm -gt 0) {
+        [void](Wait-ForServerReady -Port $portForm)
+
+        # --- Fetch alpha form ---
+        $alphaResp = $null
+        try {
+            $r = Invoke-WebRequest -Uri "http://localhost:$portForm/api/workflows/alpha/form" -TimeoutSec 5 -ErrorAction Stop
+            $alphaResp = $r.Content | ConvertFrom-Json
+        } catch { Write-Verbose "alpha form fetch failed: $_" }
+
+        Assert-True -Name "GET /api/workflows/alpha/form returns success" `
+            -Condition ($null -ne $alphaResp -and $alphaResp.success -eq $true) `
+            -Message "Expected success=true, got: $($alphaResp | ConvertTo-Json -Compress -Depth 4)"
+
+        if ($alphaResp -and $alphaResp.success) {
+            Assert-Equal -Name "alpha form.description matches alpha manifest" `
+                -Expected "ALPHA WORKFLOW FORM" `
+                -Actual $alphaResp.dialog.description
+            Assert-Equal -Name "alpha form.prompt_placeholder matches alpha manifest" `
+                -Expected "ALPHA project description..." `
+                -Actual $alphaResp.dialog.prompt_placeholder
+            Assert-Equal -Name "alpha phases count matches alpha manifest" `
+                -Expected 1 `
+                -Actual ([int]$alphaResp.phases.Count)
+        }
+
+        # --- Fetch bravo form — this is the core regression check ---
+        $bravoResp = $null
+        try {
+            $r = Invoke-WebRequest -Uri "http://localhost:$portForm/api/workflows/bravo/form" -TimeoutSec 5 -ErrorAction Stop
+            $bravoResp = $r.Content | ConvertFrom-Json
+        } catch { Write-Verbose "bravo form fetch failed: $_" }
+
+        Assert-True -Name "GET /api/workflows/bravo/form returns success" `
+            -Condition ($null -ne $bravoResp -and $bravoResp.success -eq $true) `
+            -Message "Expected success=true, got: $($bravoResp | ConvertTo-Json -Compress -Depth 4)"
+
+        if ($bravoResp -and $bravoResp.success) {
+            Assert-Equal -Name "bravo form.description matches bravo manifest (not alpha)" `
+                -Expected "BRAVO WORKFLOW FORM" `
+                -Actual $bravoResp.dialog.description
+            Assert-Equal -Name "bravo form.prompt_placeholder matches bravo manifest (not alpha)" `
+                -Expected "BRAVO project description..." `
+                -Actual $bravoResp.dialog.prompt_placeholder
+            Assert-Equal -Name "bravo form.show_files respects bravo manifest" `
+                -Expected $false `
+                -Actual ([bool]$bravoResp.dialog.show_files)
+            Assert-Equal -Name "bravo phases count matches bravo manifest" `
+                -Expected 2 `
+                -Actual ([int]$bravoResp.phases.Count)
+        }
+
+        # --- 404 for unknown workflow ---
+        $unknownStatus = 0
+        try {
+            $r = Invoke-WebRequest -Uri "http://localhost:$portForm/api/workflows/does-not-exist/form" -TimeoutSec 5 -ErrorAction Stop
+            $unknownStatus = [int]$r.StatusCode
+        } catch {
+            $unknownStatus = [int]$_.Exception.Response.StatusCode
+        }
+        Assert-Equal -Name "Unknown workflow returns 404" -Expected 404 -Actual $unknownStatus
+
+        # --- 400 for invalid workflow name (path traversal guard) ---
+        $traversalStatus = 0
+        try {
+            $r = Invoke-WebRequest -Uri "http://localhost:$portForm/api/workflows/..%2Fetc/form" -TimeoutSec 5 -ErrorAction Stop
+            $traversalStatus = [int]$r.StatusCode
+        } catch {
+            $traversalStatus = [int]$_.Exception.Response.StatusCode
+        }
+        Assert-True -Name "Path-traversal workflow name is rejected (400 or 404)" `
+            -Condition ($traversalStatus -eq 400 -or $traversalStatus -eq 404) `
+            -Message "Expected 400/404, got $traversalStatus"
+    }
+
+} catch {
+    Write-TestResult -Name "Per-workflow form endpoint tests" -Status Fail -Message "Exception: $($_.Exception.Message)"
+} finally {
+    Stop-UiServer -Process $serverForm
+    if ($projectForm) { Remove-TestProject -Path $projectForm.ProjectRoot }
+}
+
+Write-Host ""
+
+# ═══════════════════════════════════════════════════════════════════
 # SUMMARY
 # ═══════════════════════════════════════════════════════════════════
 

--- a/workflows/default/systems/ui/server.ps1
+++ b/workflows/default/systems/ui/server.ps1
@@ -301,6 +301,94 @@ function Add-StaticAssetVersions {
     })
 }
 
+# ---------------------------------------------------------------------------
+# Workflow form configuration helper
+# ---------------------------------------------------------------------------
+# Builds the kickstart dialog config for a workflow manifest. Used by both
+# /api/info (active/default workflow) and /api/workflows/{name}/form
+# (per-workflow lookup) so the modal can be re-populated when the user
+# selects a workflow other than the alphabetically-first one.
+function Get-WorkflowFormConfig {
+    param(
+        [Parameter(Mandatory)]
+        [string]$ProjectRoot,
+        [Parameter(Mandatory = $false)]
+        [object]$Manifest
+    )
+
+    $result = @{
+        dialog = $null
+        phases = $null
+        mode   = $null
+    }
+
+    if (-not $Manifest) { return $result }
+
+    $form = if ($Manifest -is [System.Collections.IDictionary]) { $Manifest['form'] } else { $Manifest.form }
+
+    $formModes = $null
+    if ($form) {
+        $formModes = if ($form -is [System.Collections.IDictionary]) { $form['modes'] } else { $form.modes }
+    }
+
+    $kickstartDialog = $null
+    $activeMode = $null
+
+    if ($formModes -and $formModes.Count -gt 0) {
+        foreach ($mode in $formModes) {
+            $modeCondition = if ($mode -is [System.Collections.IDictionary]) { $mode['condition'] } else { $mode.condition }
+            if (Test-ManifestCondition -ProjectRoot $ProjectRoot -Condition $modeCondition) {
+                $activeMode = @{}
+                foreach ($key in @('id', 'label', 'description', 'button', 'prompt_placeholder', 'show_interview', 'show_files', 'show_prompt', 'show_auto_workflow', 'default_prompt', 'hidden', 'interview_label', 'interview_hint')) {
+                    $val = if ($mode -is [System.Collections.IDictionary]) { $mode[$key] } else { $mode.$key }
+                    if ($null -ne $val) { $activeMode[$key] = $val }
+                }
+                $kickstartDialog = @{
+                    description    = $activeMode['description']
+                    show_prompt    = if ($null -ne $activeMode['show_prompt']) { [bool]$activeMode['show_prompt'] } else { $true }
+                    show_files     = if ($null -ne $activeMode['show_files']) { [bool]$activeMode['show_files'] } else { $true }
+                    show_interview = if ($null -ne $activeMode['show_interview']) { [bool]$activeMode['show_interview'] } else { $true }
+                    default_prompt = $activeMode['default_prompt']
+                }
+                foreach ($key in @('interview_label', 'interview_hint', 'prompt_placeholder')) {
+                    if ($activeMode[$key]) { $kickstartDialog[$key] = "$($activeMode[$key])" }
+                }
+                break
+            }
+        }
+    } elseif ($form) {
+        $formDesc = if ($form -is [System.Collections.IDictionary]) { $form['description'] } else { $form.description }
+        if ($formDesc) {
+            $formShowPrompt = if ($form -is [System.Collections.IDictionary]) { $form['show_prompt'] } else { $form.show_prompt }
+            $formShowFiles = if ($form -is [System.Collections.IDictionary]) { $form['show_files'] } else { $form.show_files }
+            $formShowInterview = if ($form -is [System.Collections.IDictionary]) { $form['show_interview'] } else { $form.show_interview }
+            $formDefaultPrompt = if ($form -is [System.Collections.IDictionary]) { $form['default_prompt'] } else { $form.default_prompt }
+            $kickstartDialog = @{
+                description    = "$formDesc"
+                show_prompt    = if ($null -ne $formShowPrompt) { [bool]$formShowPrompt } else { $true }
+                show_files     = if ($null -ne $formShowFiles) { [bool]$formShowFiles } else { $true }
+                show_interview = if ($null -ne $formShowInterview) { [bool]$formShowInterview } else { $true }
+                default_prompt = "$formDefaultPrompt"
+            }
+            foreach ($key in @('interview_label', 'interview_hint', 'prompt_placeholder')) {
+                $val = if ($form -is [System.Collections.IDictionary]) { $form[$key] } else { $form.$key }
+                if ($val) { $kickstartDialog[$key] = "$val" }
+            }
+        }
+    }
+
+    $kickstartPhases = $null
+    $tasks = if ($Manifest -is [System.Collections.IDictionary]) { $Manifest['tasks'] } else { $Manifest.tasks }
+    if ($tasks -and $tasks.Count -gt 0) {
+        $kickstartPhases = @(Convert-ManifestTasksToPhases -Tasks $tasks)
+    }
+
+    $result.dialog = $kickstartDialog
+    $result.phases = $kickstartPhases
+    $result.mode   = $activeMode
+    return $result
+}
+
 try {
     while ($listener.IsListening) {
         $context = $listener.GetContext()
@@ -401,67 +489,18 @@ try {
                         } catch { Write-BotLog -Level Debug -Message "Failed to read settings for workflow name" -Exception $_ }
                     }
 
-                    # Read kickstart dialog + phases from workflow manifest (primary source)
+                    # Read kickstart dialog + phases from workflow manifest (primary source).
+                    # Delegated to Get-WorkflowFormConfig so /api/workflows/{name}/form can
+                    # share the same logic for per-workflow lookups (issue #235).
                     $kickstartDialog = $null
                     $kickstartPhases = $null
                     $activeMode = $null
                     $manifest = Get-ActiveWorkflowManifest -BotRoot $botRoot
                     if ($manifest) {
-                        $form = $manifest.form
-
-                        # Evaluate form.modes if declared (condition-driven CTA)
-                        $formModes = $null
-                        if ($form) {
-                            $formModes = if ($form -is [System.Collections.IDictionary]) { $form['modes'] } else { $form.modes }
-                        }
-                        if ($formModes -and $formModes.Count -gt 0) {
-                            foreach ($mode in $formModes) {
-                                $modeCondition = if ($mode -is [System.Collections.IDictionary]) { $mode['condition'] } else { $mode.condition }
-                                if (Test-ManifestCondition -ProjectRoot $projectRoot -Condition $modeCondition) {
-                                    $activeMode = @{}
-                                    foreach ($key in @('id', 'label', 'description', 'button', 'prompt_placeholder', 'show_interview', 'show_files', 'show_prompt', 'show_auto_workflow', 'default_prompt', 'hidden', 'interview_label', 'interview_hint')) {
-                                        $val = if ($mode -is [System.Collections.IDictionary]) { $mode[$key] } else { $mode.$key }
-                                        if ($null -ne $val) { $activeMode[$key] = $val }
-                                    }
-                                    # Map mode fields to kickstartDialog shape for backward compat
-                                    $kickstartDialog = @{
-                                        description = $activeMode['description']
-                                        show_prompt = if ($null -ne $activeMode['show_prompt']) { [bool]$activeMode['show_prompt'] } else { $true }
-                                        show_files = if ($null -ne $activeMode['show_files']) { [bool]$activeMode['show_files'] } else { $true }
-                                        show_interview = if ($null -ne $activeMode['show_interview']) { [bool]$activeMode['show_interview'] } else { $true }
-                                        default_prompt = $activeMode['default_prompt']
-                                    }
-                                    foreach ($key in @('interview_label', 'interview_hint', 'prompt_placeholder')) {
-                                        if ($activeMode[$key]) { $kickstartDialog[$key] = "$($activeMode[$key])" }
-                                    }
-                                    break
-                                }
-                            }
-                        } elseif ($form) {
-                            # No modes — use flat form fields
-                            $formDesc = if ($form -is [System.Collections.IDictionary]) { $form['description'] } else { $form.description }
-                            if ($formDesc) {
-                                $formShowPrompt = if ($form -is [System.Collections.IDictionary]) { $form['show_prompt'] } else { $form.show_prompt }
-                                $formShowFiles = if ($form -is [System.Collections.IDictionary]) { $form['show_files'] } else { $form.show_files }
-                                $formShowInterview = if ($form -is [System.Collections.IDictionary]) { $form['show_interview'] } else { $form.show_interview }
-                                $formDefaultPrompt = if ($form -is [System.Collections.IDictionary]) { $form['default_prompt'] } else { $form.default_prompt }
-                                $kickstartDialog = @{
-                                    description = "$formDesc"
-                                    show_prompt = if ($null -ne $formShowPrompt) { [bool]$formShowPrompt } else { $true }
-                                    show_files = if ($null -ne $formShowFiles) { [bool]$formShowFiles } else { $true }
-                                    show_interview = if ($null -ne $formShowInterview) { [bool]$formShowInterview } else { $true }
-                                    default_prompt = "$formDefaultPrompt"
-                                }
-                                foreach ($key in @('interview_label', 'interview_hint', 'prompt_placeholder')) {
-                                    $val = if ($form -is [System.Collections.IDictionary]) { $form[$key] } else { $form.$key }
-                                    if ($val) { $kickstartDialog[$key] = "$val" }
-                                }
-                            }
-                        }
-                        # Phases from manifest tasks
-                        if ($manifest.tasks -and $manifest.tasks.Count -gt 0) {
-                            $kickstartPhases = @(Convert-ManifestTasksToPhases -Tasks $manifest.tasks)
-                        }
+                        $formConfig = Get-WorkflowFormConfig -ProjectRoot $projectRoot -Manifest $manifest
+                        $kickstartDialog = $formConfig.dialog
+                        $kickstartPhases = $formConfig.phases
+                        $activeMode = $formConfig.mode
                         if (-not $workflowName) { $workflowName = $manifest.name }
                     }
 
@@ -1790,6 +1829,55 @@ try {
                     $content = @{ workflows = @($installedList) } | ConvertTo-Json -Depth 5 -Compress
                     # Store in response cache
                     $script:workflowsCache = @{ data = $content; timestamp = [datetime]::UtcNow }
+                    break
+                }
+
+                { $_ -like "/api/workflows/*/form" } {
+                    if ($method -eq "GET") {
+                        $contentType = "application/json; charset=utf-8"
+                        try {
+                            $wfName = ($url -replace "^/api/workflows/", "" -replace "/form$", "")
+                            # Validate workflow name to prevent path traversal
+                            if ($wfName -notmatch '^[a-zA-Z0-9_-]+$') {
+                                $statusCode = 400
+                                $content = @{ success = $false; error = "Invalid workflow name: $wfName" } | ConvertTo-Json -Compress
+                                break
+                            }
+
+                            # Resolve workflow directory: installed workflows live at .bot/workflows/{name}/,
+                            # the default/profile workflow at .bot/ root.
+                            $wfDir = Join-Path $botRoot "workflows\$wfName"
+                            if (-not (Test-Path $wfDir)) {
+                                $defaultYaml = Join-Path $botRoot "workflow.yaml"
+                                $defaultManifest = if (Test-Path -LiteralPath $defaultYaml) { Read-WorkflowManifest -WorkflowDir $botRoot } else { $null }
+                                $defaultName = if ($defaultManifest -and $defaultManifest.name) { $defaultManifest.name } else { 'default' }
+                                if ($wfName -eq $defaultName -or $wfName -eq 'default') {
+                                    $wfDir = $botRoot
+                                }
+                            }
+
+                            if (-not (Test-Path (Join-Path $wfDir "workflow.yaml"))) {
+                                $statusCode = 404
+                                $content = @{ success = $false; error = "Workflow not found: $wfName" } | ConvertTo-Json -Compress
+                            } else {
+                                $manifest = Read-WorkflowManifest -WorkflowDir $wfDir
+                                $formConfig = Get-WorkflowFormConfig -ProjectRoot $projectRoot -Manifest $manifest
+                                $content = @{
+                                    success = $true
+                                    workflow = $wfName
+                                    dialog = $formConfig.dialog
+                                    phases = $formConfig.phases
+                                    mode = $formConfig.mode
+                                } | ConvertTo-Json -Depth 5 -Compress
+                            }
+                        } catch {
+                            $statusCode = 500
+                            $content = @{ success = $false; error = "Failed to load workflow form: $($_.Exception.Message)" } | ConvertTo-Json -Compress
+                        }
+                    } else {
+                        $statusCode = 405
+                        $content = @{ success = $false; error = "Method not allowed" } | ConvertTo-Json -Compress
+                    }
                     break
                 }
 

--- a/workflows/default/systems/ui/server.ps1
+++ b/workflows/default/systems/ui/server.ps1
@@ -344,11 +344,12 @@ function Get-WorkflowFormConfig {
                     if ($null -ne $val) { $activeMode[$key] = $val }
                 }
                 $kickstartDialog = @{
-                    description    = $activeMode['description']
-                    show_prompt    = if ($null -ne $activeMode['show_prompt']) { [bool]$activeMode['show_prompt'] } else { $true }
-                    show_files     = if ($null -ne $activeMode['show_files']) { [bool]$activeMode['show_files'] } else { $true }
-                    show_interview = if ($null -ne $activeMode['show_interview']) { [bool]$activeMode['show_interview'] } else { $true }
-                    default_prompt = $activeMode['default_prompt']
+                    description        = $activeMode['description']
+                    show_prompt        = if ($null -ne $activeMode['show_prompt']) { [bool]$activeMode['show_prompt'] } else { $true }
+                    show_files         = if ($null -ne $activeMode['show_files']) { [bool]$activeMode['show_files'] } else { $true }
+                    show_interview     = if ($null -ne $activeMode['show_interview']) { [bool]$activeMode['show_interview'] } else { $true }
+                    show_auto_workflow = if ($null -ne $activeMode['show_auto_workflow']) { [bool]$activeMode['show_auto_workflow'] } else { $true }
+                    default_prompt     = $activeMode['default_prompt']
                 }
                 foreach ($key in @('interview_label', 'interview_hint', 'prompt_placeholder')) {
                     if ($activeMode[$key]) { $kickstartDialog[$key] = "$($activeMode[$key])" }
@@ -362,13 +363,15 @@ function Get-WorkflowFormConfig {
             $formShowPrompt = if ($form -is [System.Collections.IDictionary]) { $form['show_prompt'] } else { $form.show_prompt }
             $formShowFiles = if ($form -is [System.Collections.IDictionary]) { $form['show_files'] } else { $form.show_files }
             $formShowInterview = if ($form -is [System.Collections.IDictionary]) { $form['show_interview'] } else { $form.show_interview }
+            $formShowAutoWorkflow = if ($form -is [System.Collections.IDictionary]) { $form['show_auto_workflow'] } else { $form.show_auto_workflow }
             $formDefaultPrompt = if ($form -is [System.Collections.IDictionary]) { $form['default_prompt'] } else { $form.default_prompt }
             $kickstartDialog = @{
-                description    = "$formDesc"
-                show_prompt    = if ($null -ne $formShowPrompt) { [bool]$formShowPrompt } else { $true }
-                show_files     = if ($null -ne $formShowFiles) { [bool]$formShowFiles } else { $true }
-                show_interview = if ($null -ne $formShowInterview) { [bool]$formShowInterview } else { $true }
-                default_prompt = "$formDefaultPrompt"
+                description        = "$formDesc"
+                show_prompt        = if ($null -ne $formShowPrompt) { [bool]$formShowPrompt } else { $true }
+                show_files         = if ($null -ne $formShowFiles) { [bool]$formShowFiles } else { $true }
+                show_interview     = if ($null -ne $formShowInterview) { [bool]$formShowInterview } else { $true }
+                show_auto_workflow = if ($null -ne $formShowAutoWorkflow) { [bool]$formShowAutoWorkflow } else { $true }
+                default_prompt     = "$formDefaultPrompt"
             }
             foreach ($key in @('interview_label', 'interview_hint', 'prompt_placeholder')) {
                 $val = if ($form -is [System.Collections.IDictionary]) { $form[$key] } else { $form.$key }

--- a/workflows/default/systems/ui/static/modules/kickstart.js
+++ b/workflows/default/systems/ui/static/modules/kickstart.js
@@ -39,71 +39,22 @@ async function initKickstart() {
         updateExecutiveSummary();
     }
 
-    // Apply workflow-driven dialog text from /api/info
+    // Apply workflow-driven dialog text from /api/info (active/default workflow).
+    // Per-workflow modals re-fetch this from /api/workflows/{name}/form via
+    // applyKickstartDialog when openKickstartModal runs (issue #235).
     try {
         const infoResp = await fetch(`${API_BASE}/api/info`);
         if (infoResp.ok) {
             const info = await infoResp.json();
-            kickstartDialog = info.kickstart_dialog || null;
-            kickstartPhases = info.kickstart_phases || [];
-            kickstartMode = info.kickstart_mode || null;
-            const dialog = kickstartDialog;
-            if (dialog) {
-                const descEl = document.getElementById('kickstart-description');
-                const labelEl = document.getElementById('kickstart-interview-label');
-                const hintEl = document.getElementById('kickstart-interview-hint');
-                const promptEl = document.getElementById('kickstart-prompt');
-                if (descEl && dialog.description) descEl.textContent = dialog.description;
-                if (labelEl && dialog.interview_label) labelEl.textContent = dialog.interview_label;
-                if (hintEl && dialog.interview_hint) hintEl.textContent = dialog.interview_hint;
-                if (promptEl && dialog.prompt_placeholder) promptEl.placeholder = dialog.prompt_placeholder;
-
-                // Workflow-driven visibility: hide sections the workflow doesn't need
-                if (dialog.show_prompt === false) {
-                    const promptGroup = promptEl?.closest('.form-group');
-                    if (promptGroup) promptGroup.style.display = 'none';
-                    if (descEl) descEl.style.display = 'none';
-                }
-                if (dialog.show_files === false) {
-                    const filesGroup = document.getElementById('kickstart-dropzone')?.closest('.form-group');
-                    if (filesGroup) filesGroup.style.display = 'none';
-                }
-                if (dialog.show_interview === false) {
-                    const interviewOption = document.getElementById('kickstart-interview')?.closest('.form-option');
-                    if (interviewOption) interviewOption.style.display = 'none';
-                }
-                if (dialog.show_auto_workflow === false) {
-                    const awOption = document.getElementById('kickstart-auto-workflow')?.closest('.form-option');
-                    if (awOption) awOption.style.display = 'none';
-                }
-            }
+            applyKickstartDialog(
+                info.kickstart_dialog || null,
+                info.kickstart_phases || [],
+                info.kickstart_mode || null
+            );
 
             // Re-render executive summary now that dialog/phases are loaded
             if (typeof updateExecutiveSummary === 'function') {
                 updateExecutiveSummary();
-            }
-
-            // Render phase checklist
-            const phases = kickstartPhases;
-            const container = document.getElementById('kickstart-phases-container');
-            const wrapper = document.getElementById('kickstart-phase-list');
-            if (container && phases.length > 0) {
-                wrapper.style.display = 'block';
-                container.innerHTML = phases.map(p => {
-                    if (p.optional) {
-                        return `<div class="phase-item">
-                            <label class="form-checkbox-label">
-                                <input type="checkbox" class="kickstart-phase-toggle" data-phase-id="${p.id}" checked>
-                                <span class="form-checkbox-text">${p.name}</span>
-                            </label>
-                        </div>`;
-                    } else {
-                        return `<div class="phase-item phase-fixed">
-                            <span class="phase-bullet">\u203a</span>
-                            <span class="form-checkbox-text">${p.name}</span>
-                        </div>`;
-                    }
-                }).join('');
             }
         }
     } catch (error) {
@@ -334,9 +285,99 @@ function renderWorkflowCardGrid(container) {
 }
 
 /**
- * Open the kickstart modal
+ * Apply a workflow's kickstart dialog config to the modal DOM.
+ *
+ * Sets description, interview label/hint, prompt placeholder, section
+ * visibility, and renders the phase checklist. Called from initKickstart
+ * (active workflow) and openKickstartModal (per-workflow lookup) so the
+ * modal always reflects the workflow the user actually selected.
+ *
+ * @param {object|null} dialog - kickstart dialog object from manifest form block
+ * @param {Array} phases - phase list converted from manifest tasks
+ * @param {object|null} mode - active form mode (kickstart_mode)
  */
-function openKickstartModal(workflowName, options) {
+function applyKickstartDialog(dialog, phases, mode) {
+    kickstartDialog = dialog || null;
+    kickstartPhases = phases || [];
+    kickstartMode = mode || null;
+
+    const descEl = document.getElementById('kickstart-description');
+    const labelEl = document.getElementById('kickstart-interview-label');
+    const hintEl = document.getElementById('kickstart-interview-hint');
+    const promptEl = document.getElementById('kickstart-prompt');
+    const promptGroup = promptEl?.closest('.form-group');
+    const filesGroup = document.getElementById('kickstart-dropzone')?.closest('.form-group');
+    const interviewOption = document.getElementById('kickstart-interview')?.closest('.form-option');
+    const awOption = document.getElementById('kickstart-auto-workflow')?.closest('.form-option');
+
+    // Reset sections to visible (in case a previous workflow hid them)
+    if (descEl) descEl.style.display = '';
+    if (promptGroup) promptGroup.style.display = '';
+    if (filesGroup) filesGroup.style.display = '';
+    if (interviewOption) interviewOption.style.display = '';
+    if (awOption) awOption.style.display = '';
+
+    if (dialog) {
+        if (descEl && dialog.description) descEl.textContent = dialog.description;
+        if (labelEl && dialog.interview_label) labelEl.textContent = dialog.interview_label;
+        if (hintEl && dialog.interview_hint) hintEl.textContent = dialog.interview_hint;
+        if (promptEl && dialog.prompt_placeholder) promptEl.placeholder = dialog.prompt_placeholder;
+
+        if (dialog.show_prompt === false) {
+            if (promptGroup) promptGroup.style.display = 'none';
+            if (descEl) descEl.style.display = 'none';
+        }
+        if (dialog.show_files === false) {
+            if (filesGroup) filesGroup.style.display = 'none';
+        }
+        if (dialog.show_interview === false) {
+            if (interviewOption) interviewOption.style.display = 'none';
+        }
+        if (dialog.show_auto_workflow === false) {
+            if (awOption) awOption.style.display = 'none';
+        }
+    }
+
+    // Render phase checklist
+    const container = document.getElementById('kickstart-phases-container');
+    const wrapper = document.getElementById('kickstart-phase-list');
+    if (container && wrapper) {
+        if (kickstartPhases.length > 0) {
+            wrapper.style.display = 'block';
+            container.innerHTML = kickstartPhases.map(p => {
+                if (p.optional) {
+                    return `<div class="phase-item">
+                        <label class="form-checkbox-label">
+                            <input type="checkbox" class="kickstart-phase-toggle" data-phase-id="${p.id}" checked>
+                            <span class="form-checkbox-text">${p.name}</span>
+                        </label>
+                    </div>`;
+                } else {
+                    return `<div class="phase-item phase-fixed">
+                        <span class="phase-bullet">\u203a</span>
+                        <span class="form-checkbox-text">${p.name}</span>
+                    </div>`;
+                }
+            }).join('');
+        } else {
+            wrapper.style.display = 'none';
+            container.innerHTML = '';
+        }
+    }
+}
+
+/**
+ * Open the kickstart modal for a specific workflow.
+ *
+ * Fetches the per-workflow form config from /api/workflows/{name}/form
+ * and applies it to the DOM before showing the modal. This ensures the
+ * modal reflects the selected workflow's form rather than the workflow
+ * loaded at page-init time (issue #235).
+ *
+ * @param {string} workflowName - The workflow name from the click context
+ * @param {object} [options] - Optional flags (e.g. { useTaskRunner: true })
+ */
+async function openKickstartModal(workflowName, options) {
     const modal = document.getElementById('kickstart-modal');
     const textarea = document.getElementById('kickstart-prompt');
 
@@ -344,9 +385,57 @@ function openKickstartModal(workflowName, options) {
     kickstartWorkflowName = workflowName || null;
     kickstartUseTaskRunner = !!(options && options.useTaskRunner);
 
+    // Show the modal immediately so the click feels responsive — the form
+    // config is fetched in parallel and applied (or reset) when it arrives.
     if (modal) {
         modal.classList.add('visible');
         setTimeout(() => textarea?.focus(), 100);
+    }
+
+    if (!workflowName) return;
+
+    // Re-fetch this workflow's form config so the modal reflects the
+    // selected workflow rather than whichever workflow was active at init.
+    // Capture the request target so rapid clicks on different workflows
+    // can discard stale responses instead of overwriting the latest one.
+    const requestedFor = workflowName;
+    let applied = false;
+    try {
+        const resp = await fetch(`${API_BASE}/api/workflows/${encodeURIComponent(workflowName)}/form`);
+        if (kickstartWorkflowName !== requestedFor) return; // superseded by a newer click
+        if (resp.ok) {
+            const data = await resp.json();
+            if (kickstartWorkflowName !== requestedFor) return;
+            if (data && data.success) {
+                applyKickstartDialog(data.dialog || null, data.phases || [], data.mode || null);
+                applied = true;
+            } else {
+                console.warn(`Workflow form lookup returned no data for "${workflowName}"`, data);
+            }
+        } else {
+            console.warn(`Workflow form lookup failed for "${workflowName}": HTTP ${resp.status}`);
+        }
+    } catch (error) {
+        if (kickstartWorkflowName !== requestedFor) return;
+        console.warn(`Could not load form config for workflow "${workflowName}":`, error);
+    }
+
+    if (!applied) {
+        // Reset the DOM to a generic placeholder state so we never silently
+        // display another workflow's configuration (the exact bug in #235).
+        applyKickstartDialog(
+            {
+                description: `Configure workflow: ${workflowName}`,
+                interview_label: '',
+                interview_hint: '',
+                prompt_placeholder: ''
+            },
+            [],
+            null
+        );
+        if (typeof showToast === 'function') {
+            showToast(`Could not load form for workflow "${workflowName}"`, 'warning', 6000);
+        }
     }
 }
 

--- a/workflows/default/systems/ui/static/modules/kickstart.js
+++ b/workflows/default/systems/ui/static/modules/kickstart.js
@@ -317,11 +317,18 @@ function applyKickstartDialog(dialog, phases, mode) {
     if (interviewOption) interviewOption.style.display = '';
     if (awOption) awOption.style.display = '';
 
+    // Reset dialog-controlled content before applying new values so a workflow
+    // that omits a field does not inherit the previous workflow's text (#235).
+    if (descEl) descEl.textContent = '';
+    if (labelEl) labelEl.textContent = '';
+    if (hintEl) hintEl.textContent = '';
+    if (promptEl) promptEl.placeholder = '';
+
     if (dialog) {
-        if (descEl && dialog.description) descEl.textContent = dialog.description;
-        if (labelEl && dialog.interview_label) labelEl.textContent = dialog.interview_label;
-        if (hintEl && dialog.interview_hint) hintEl.textContent = dialog.interview_hint;
-        if (promptEl && dialog.prompt_placeholder) promptEl.placeholder = dialog.prompt_placeholder;
+        if (descEl && dialog.description != null) descEl.textContent = dialog.description;
+        if (labelEl && dialog.interview_label != null) labelEl.textContent = dialog.interview_label;
+        if (hintEl && dialog.interview_hint != null) hintEl.textContent = dialog.interview_hint;
+        if (promptEl && dialog.prompt_placeholder != null) promptEl.placeholder = dialog.prompt_placeholder;
 
         if (dialog.show_prompt === false) {
             if (promptGroup) promptGroup.style.display = 'none';
@@ -338,30 +345,54 @@ function applyKickstartDialog(dialog, phases, mode) {
         }
     }
 
-    // Render phase checklist
+    // Render phase checklist. Build nodes via the DOM API (not innerHTML) so
+    // manifest-supplied names/ids cannot inject markup.
     const container = document.getElementById('kickstart-phases-container');
     const wrapper = document.getElementById('kickstart-phase-list');
     if (container && wrapper) {
+        container.replaceChildren();
         if (kickstartPhases.length > 0) {
             wrapper.style.display = 'block';
-            container.innerHTML = kickstartPhases.map(p => {
+            kickstartPhases.forEach(p => {
+                const phaseItem = document.createElement('div');
+                const phaseName = p.name ?? '';
                 if (p.optional) {
-                    return `<div class="phase-item">
-                        <label class="form-checkbox-label">
-                            <input type="checkbox" class="kickstart-phase-toggle" data-phase-id="${p.id}" checked>
-                            <span class="form-checkbox-text">${p.name}</span>
-                        </label>
-                    </div>`;
+                    phaseItem.className = 'phase-item';
+
+                    const label = document.createElement('label');
+                    label.className = 'form-checkbox-label';
+
+                    const checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.className = 'kickstart-phase-toggle';
+                    checkbox.checked = true;
+                    checkbox.dataset.phaseId = String(p.id ?? '');
+
+                    const text = document.createElement('span');
+                    text.className = 'form-checkbox-text';
+                    text.textContent = phaseName;
+
+                    label.appendChild(checkbox);
+                    label.appendChild(text);
+                    phaseItem.appendChild(label);
                 } else {
-                    return `<div class="phase-item phase-fixed">
-                        <span class="phase-bullet">\u203a</span>
-                        <span class="form-checkbox-text">${p.name}</span>
-                    </div>`;
+                    phaseItem.className = 'phase-item phase-fixed';
+
+                    const bullet = document.createElement('span');
+                    bullet.className = 'phase-bullet';
+                    bullet.textContent = '\u203a';
+
+                    const text = document.createElement('span');
+                    text.className = 'form-checkbox-text';
+                    text.textContent = phaseName;
+
+                    phaseItem.appendChild(bullet);
+                    phaseItem.appendChild(text);
                 }
-            }).join('');
+                container.appendChild(phaseItem);
+            });
         } else {
             wrapper.style.display = 'none';
-            container.innerHTML = '';
         }
     }
 }
@@ -406,11 +437,14 @@ async function openKickstartModal(workflowName, options) {
         if (resp.ok) {
             const data = await resp.json();
             if (kickstartWorkflowName !== requestedFor) return;
-            if (data && data.success) {
-                applyKickstartDialog(data.dialog || null, data.phases || [], data.mode || null);
+            if (data && data.success && data.dialog) {
+                applyKickstartDialog(data.dialog, data.phases || [], data.mode || null);
                 applied = true;
             } else {
-                console.warn(`Workflow form lookup returned no data for "${workflowName}"`, data);
+                // success without a usable dialog (e.g. workflow has no form
+                // block) must fall through to the generic fallback below so we
+                // never leave the previous workflow's config on screen (#235).
+                console.warn(`Workflow form lookup returned no usable dialog for "${workflowName}"`, data);
             }
         } else {
             console.warn(`Workflow form lookup failed for "${workflowName}": HTTP ${resp.status}`);


### PR DESCRIPTION
## Summary

Fixes #235 — the kickstart modal now shows the correct workflow's form config when multiple workflows are installed, instead of always rendering the alphabetically-first workflow's form.

## Root cause

- `Get-ActiveWorkflowManifest` returned the first workflow directory found via `Select-Object -First 1`, and `/api/info` used that single result to populate `kickstart_dialog` / `kickstart_phases` / `kickstart_mode` on page load.
- `initKickstart()` fetched `/api/info` **once** and wrote the resolved dialog into the DOM.
- `openKickstartModal(workflowName)` only updated the JS state variable — it never re-fetched or re-applied the form configuration for the selected workflow, so the DOM kept showing the first-workflow values.

## Changes

### Backend — `workflows/default/systems/ui/server.ps1`
- Extracted the kickstart-dialog computation previously inlined in `/api/info` into a new `Get-WorkflowFormConfig -ProjectRoot -Manifest` helper. Handles both `form.modes` (condition-driven) and flat `form:` blocks, plus phase conversion from manifest tasks.
- `/api/info` now delegates to the helper (no behavior change for the active workflow).
- Added new endpoint **`GET /api/workflows/{name}/form`** returning `{ success, workflow, dialog, phases, mode }` for a specific workflow.
  - Validates workflow name against `^[a-zA-Z0-9_-]+$` (path-traversal guard, 400 on violation)
  - Resolves `.bot/workflows/{name}/` first, falls back to the default workflow at `.bot/` root
  - Returns 404 if the workflow doesn't exist, 405 on non-GET

### Frontend — `workflows/default/systems/ui/static/modules/kickstart.js`
- Extracted the DOM-update block from `initKickstart` into a reusable `applyKickstartDialog(dialog, phases, mode)` helper that:
  - Sets description / interview label / interview hint / prompt placeholder
  - Resets section visibility before applying new state (prevents stale hidden sections from a previous workflow)
  - Renders the phase checklist, or clears it when empty
- Made `openKickstartModal(workflowName, options)` **async**:
  - Opens the modal **immediately** so the click feels responsive (fetch runs in parallel)
  - Fetches `/api/workflows/{name}/form` and calls `applyKickstartDialog(...)` with the result
  - **Race-guard:** captures `requestedFor = workflowName` and bails out after each `await` if `kickstartWorkflowName` changed — prevents out-of-order responses from overwriting a newer click
  - **Failure fallback:** if the fetch throws, returns `!ok`, or returns `success: false`, resets the DOM to a generic placeholder (`"Configure workflow: {name}"`) and shows a `showToast` warning — never silently shows another workflow's config (which would re-create the exact bug #235 describes)

### Tests — `tests/Test-ServerStartup.ps1`
Added a **PER-WORKFLOW FORM ENDPOINT** block as regression coverage:
- Creates a test project, writes two workflows (`alpha`, `bravo`) with distinct `form:` blocks directly into `.bot/workflows/`
- Starts the UI server and hits both endpoints:
  - `GET /api/workflows/alpha/form` → asserts `dialog.description`, `dialog.prompt_placeholder`, and phase count match the **alpha** manifest
  - `GET /api/workflows/bravo/form` → asserts the same fields match the **bravo** manifest (not alpha's) — this is the core #235 assertion
  - Verifies `dialog.show_files = false` is propagated correctly
- `GET /api/workflows/does-not-exist/form` → asserts **404**
- `GET /api/workflows/..%2Fetc/form` → asserts **400 or 404** (path-traversal guard)
- Cleans up server + project in `finally`

## Test plan

- [x] Layers 1–3 green locally (CI will re-run)
- [x] Manual: install two workflows with distinct `form:` blocks, click Run on each, verify the modal reflects the correct workflow's description, placeholder, labels, and phase list
- [x] Manual: rename workflows to flip alphabetical order, reload, repeat — behavior identical regardless of directory order
- [x] Manual: DevTools network panel shows `GET /api/workflows/{name}/form` firing on each modal open
- [x] Manual: rapid-click Run on workflow A then B — stale response from A does not overwrite B's config