### PR TITLE
fix(ui): workflow run endpoint hangs due to $response variable shadow…

### DIFF
--- a/tests/Test-WorkflowIntegration.ps1
+++ b/tests/Test-WorkflowIntegration.ps1
@@ -800,6 +800,19 @@ if (Test-Path $serverFile) {
     Assert-True -Name "Briefing file upload uses safe filename sanitization" `
         -Condition ($serverContent -match 'GetInvalidFileNameChars') `
         -Message "File upload does not sanitize filenames with GetInvalidFileNameChars"
+
+    # Regression: the /api/workflows/*/run handler previously assigned its success
+    # payload to a local `$response` variable, shadowing the outer HttpListenerResponse
+    # and causing the response to never be written back to the client.
+    # The handler must use a distinct variable name (e.g. $runResponse) for its payload.
+    $runHandlerMatch = [regex]::Match(
+        $serverContent,
+        "Start-ProcessLaunch -Type 'task-runner'[\s\S]{0,2000}?ConvertTo-Json",
+        'Singleline'
+    )
+    Assert-True -Name "Workflow run handler does not shadow `$response HttpListenerResponse" `
+        -Condition ($runHandlerMatch.Success -and -not ($runHandlerMatch.Value -match '\$response\s*=\s*@\{')) `
+        -Message "Handler assigns to `$response, shadowing the outer HttpListenerResponse and breaking the write loop"
 } else {
     Write-TestResult -Name "server.ps1 form data tests" -Status Skip -Message "Server file not found"
 }

--- a/workflows/default/systems/ui/server.ps1
+++ b/workflows/default/systems/ui/server.ps1
@@ -1895,15 +1895,17 @@ try {
 
                                 # Start-ProcessLaunch auto-detects max_concurrent for workflow type
                                 $launchResult = Start-ProcessLaunch -Type 'task-runner' -Continue $true -Description "Workflow: $wfName" -WorkflowName $wfName
-                                $response = @{
+                                # NOTE: do not assign to $response here — that variable holds the HttpListenerResponse
+                                # used by the outer write loop. Shadowing it causes the response to never be sent.
+                                $runResponse = @{
                                     success = $true
                                     workflow = $wfName
                                     tasks_created = $createdTasks.Count
                                     slots_launched = $launchResult.slots_launched
                                     process_id = $launchResult.process_id
                                 }
-                                if ($failedFiles -gt 0) { $response.files_failed = $failedFiles }
-                                $content = $response | ConvertTo-Json -Compress
+                                if ($failedFiles -gt 0) { $runResponse.files_failed = $failedFiles }
+                                $content = $runResponse | ConvertTo-Json -Compress
                             }
                         } catch {
                             $statusCode = 500

--- a/workflows/default/systems/ui/static/css/modal.css
+++ b/workflows/default/systems/ui/static/css/modal.css
@@ -2077,6 +2077,10 @@
 }
 
 /* Loading state for kickstart submit button */
+#kickstart-submit .btn-loading {
+    display: none;
+}
+
 #kickstart-submit.loading .btn-text {
     display: none;
 }
@@ -2085,10 +2089,6 @@
     display: inline;
 }
 
-#kickstart-submit:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-}
 
 /* ========== PREFLIGHT CHECKLIST ========== */
 

--- a/workflows/default/systems/ui/static/index.html
+++ b/workflows/default/systems/ui/static/index.html
@@ -1532,7 +1532,7 @@
                 <button class="ctrl-btn" id="kickstart-cancel">Cancel</button>
                 <button class="ctrl-btn primary" id="kickstart-submit">
                     <span class="btn-text">Kickstart</span>
-                    <span class="btn-loading" style="display: none;">Starting...</span>
+                    <span class="btn-loading">Starting...</span>
                 </button>
             </div>
             <!-- Footer: Preflight phase -->

--- a/workflows/default/systems/ui/static/modules/controls.js
+++ b/workflows/default/systems/ui/static/modules/controls.js
@@ -678,7 +678,7 @@ function renderWorkflowControls(workflows) {
         const led = row.querySelector('.wf-led');
         if (led) led.id = `wf-led-${wf.name}`;
         const runBtn = row.querySelector('.wf-run-btn');
-        if (runBtn) runBtn.addEventListener('click', () => runWorkflow(wf.name, wf.has_form));
+        if (runBtn) runBtn.addEventListener('click', () => runWorkflow(wf.name, wf.has_form, runBtn));
         const stopBtn = row.querySelector('.wf-stop-btn');
         if (stopBtn) stopBtn.addEventListener('click', () => stopWorkflow(wf.name));
     });
@@ -689,17 +689,33 @@ function renderWorkflowControls(workflows) {
  * If the workflow has a form (show_interview/show_files), open the kickstart modal instead.
  * @param {string} name - Workflow name
  * @param {boolean} hasForm - Whether the workflow defines a form requiring user input
+ * @param {HTMLElement} [runBtn] - The Run button element; disabled during the call to guard against rapid double-clicks.
  */
-async function runWorkflow(name, hasForm) {
+async function runWorkflow(name, hasForm, runBtn) {
+    // Guard against rapid double-clicks: disable the Run button immediately.
+    // For form workflows, the modal's own submit guard takes over once it opens.
+    // For no-form workflows, we re-enable in the finally block after the fetch.
+    if (runBtn) {
+        if (runBtn.disabled) return;
+        runBtn.disabled = true;
+    }
+
     // If workflow has a form, open the kickstart modal so the user can provide
     // project context and upload files before tasks are created.
     // The modal submission routes to the task-runner engine (not kickstart).
     if (hasForm) {
         if (typeof openKickstartModal === 'function') {
-            openKickstartModal(name, { useTaskRunner: true });
+            try {
+                await openKickstartModal(name, { useTaskRunner: true });
+            } finally {
+                // Re-enable the row button once the modal is open — the modal
+                // has its own in-flight guard from here on.
+                if (runBtn) runBtn.disabled = false;
+            }
         } else {
             console.warn('Workflow requires a form but kickstart modal is not available');
             showToast('Kickstart modal is not available', 'warning');
+            if (runBtn) runBtn.disabled = false;
         }
         return;
     }
@@ -721,6 +737,8 @@ async function runWorkflow(name, hasForm) {
     } catch (error) {
         console.error('Run workflow error:', error);
         showSignalFeedback(`Error: ${error.message}`);
+    } finally {
+        if (runBtn) runBtn.disabled = false;
     }
 }
 

--- a/workflows/default/systems/ui/static/modules/controls.js
+++ b/workflows/default/systems/ui/static/modules/controls.js
@@ -27,6 +27,13 @@ let UNFILTERED_MODEL_OPTIONS = null;
 let providerData = null;
 
 /**
+ * In-flight workflow runs keyed by workflow name.
+ * Used by runWorkflow() to guard against rapid double-clicks across all
+ * call sites (control panel row, workflow grid, kickstart workflow list).
+ */
+const runWorkflowInFlight = new Set();
+
+/**
  * Fetch provider data from the API and populate model options
  */
 async function loadProviderData() {
@@ -692,29 +699,30 @@ function renderWorkflowControls(workflows) {
  * @param {HTMLElement} [runBtn] - The Run button element; disabled during the call to guard against rapid double-clicks.
  */
 async function runWorkflow(name, hasForm, runBtn) {
-    // Guard against rapid double-clicks: disable the Run button immediately.
-    // For form workflows, the modal's own submit guard takes over once it opens.
-    // For no-form workflows, we re-enable in the finally block after the fetch.
-    if (runBtn) {
-        if (runBtn.disabled) return;
-        runBtn.disabled = true;
-    }
+    // Guard against rapid double-clicks by tracking in-flight runs by workflow
+    // name. This covers all call sites (control panel row, workflow grid,
+    // kickstart workflow list) regardless of whether the caller passes a
+    // button reference.
+    if (runWorkflowInFlight.has(name)) return;
+    runWorkflowInFlight.add(name);
+    if (runBtn) runBtn.disabled = true;
 
     // If workflow has a form, open the kickstart modal so the user can provide
     // project context and upload files before tasks are created.
     // The modal submission routes to the task-runner engine (not kickstart).
     if (hasForm) {
-        if (typeof openKickstartModal === 'function') {
-            try {
+        try {
+            if (typeof openKickstartModal === 'function') {
                 await openKickstartModal(name, { useTaskRunner: true });
-            } finally {
-                // Re-enable the row button once the modal is open — the modal
-                // has its own in-flight guard from here on.
-                if (runBtn) runBtn.disabled = false;
+            } else {
+                console.warn('Workflow requires a form but kickstart modal is not available');
+                showToast('Kickstart modal is not available', 'warning');
             }
-        } else {
-            console.warn('Workflow requires a form but kickstart modal is not available');
-            showToast('Kickstart modal is not available', 'warning');
+        } finally {
+            // Release the in-flight guard and re-enable the button once the
+            // modal is open. The modal has its own kickstartSubmitting guard
+            // from here on.
+            runWorkflowInFlight.delete(name);
             if (runBtn) runBtn.disabled = false;
         }
         return;
@@ -738,6 +746,7 @@ async function runWorkflow(name, hasForm, runBtn) {
         console.error('Run workflow error:', error);
         showSignalFeedback(`Error: ${error.message}`);
     } finally {
+        runWorkflowInFlight.delete(name);
         if (runBtn) runBtn.disabled = false;
     }
 }

--- a/workflows/default/systems/ui/static/modules/kickstart.js
+++ b/workflows/default/systems/ui/static/modules/kickstart.js
@@ -838,6 +838,12 @@ function resetToFormPhase() {
         submitBtn.classList.remove('loading');
         submitBtn.disabled = false;
     }
+
+    // Clear the in-flight submit guard so returning to the form phase
+    // (via Back button or error path) re-enables resubmission. Without this,
+    // the flag set by submitKickstart() stays true forever and every
+    // subsequent Kickstart click early-returns silently.
+    kickstartSubmitting = false;
 }
 
 /**

--- a/workflows/default/systems/ui/static/modules/kickstart.js
+++ b/workflows/default/systems/ui/static/modules/kickstart.js
@@ -16,6 +16,7 @@ let roadmapPolling = null;     // interval ID for task creation detection
 let kickstartDialog = null;    // workflow-driven dialog config from /api/info
 let kickstartPhases = [];      // workflow-driven phases from /api/info
 let kickstartMode = null;      // server-evaluated form mode from workflow manifest
+let kickstartSubmitting = false; // in-flight guard against double submit
 
 /**
  * Initialize kickstart functionality
@@ -364,6 +365,7 @@ function closeKickstartModal() {
         kickstartFiles = [];
         kickstartWorkflowName = null;
         kickstartUseTaskRunner = false;
+        kickstartSubmitting = false;
         updateFileList();
         const interviewCheckbox = document.getElementById('kickstart-interview');
         if (interviewCheckbox) interviewCheckbox.checked = true;
@@ -483,27 +485,34 @@ async function submitKickstart() {
         return;
     }
 
-    // Set loading state
+    // In-flight guard: prevent double submit while a previous request is still pending
+    if (kickstartSubmitting) {
+        return;
+    }
+    kickstartSubmitting = true;
+
+    // Set loading state — keep the form visible with a disabled-looking submit button
+    // while we decide whether preflight needs to run. This avoids a jarring
+    // form → preflight → form flicker when no preflight checks are configured.
     if (submitBtn) {
         submitBtn.classList.add('loading');
         submitBtn.disabled = true;
     }
 
-    // Show preflight modal immediately with "Checking..." state
-    showPreflightPhaseChecking(prompt, needsInterview, autoWorkflow, skipPhases);
-
     try {
-        // Fetch preflight checks in background
+        // Fetch preflight checks in background — form phase is still visible
         const preResp = await fetch(`${API_BASE}/api/product/preflight`);
         const preflight = await preResp.json();
         const checks = preflight.checks || [];
 
         if (checks.length === 0) {
-            // No preflight configured — go straight to kickstart
-            resetToFormPhase();
+            // No preflight configured — skip the preflight phase entirely and
+            // go straight to kickstart. The form stays visible with the submit
+            // button disabled until executeKickstart resolves and closes the modal.
             await executeKickstart(prompt, needsInterview, autoWorkflow, skipPhases);
         } else {
-            // Update preflight phase with real results and animate
+            // Swap to the preflight phase now that we know we actually have checks to animate
+            showPreflightPhaseChecking(prompt, needsInterview, autoWorkflow, skipPhases);
             updatePreflightWithResults(checks, preflight.success, prompt, needsInterview, autoWorkflow, skipPhases);
         }
     } catch (error) {
@@ -514,6 +523,7 @@ async function submitKickstart() {
             submitBtn.classList.remove('loading');
             submitBtn.disabled = false;
         }
+        kickstartSubmitting = false;
     }
 }
 
@@ -552,6 +562,7 @@ async function executeKickstart(prompt, needsInterview, autoWorkflow, skipPhases
                     submitBtn.classList.remove('loading');
                     submitBtn.disabled = false;
                 }
+                kickstartSubmitting = false;
             }
         } catch (error) {
             console.error('Error starting workflow via task-runner:', error);
@@ -560,6 +571,7 @@ async function executeKickstart(prompt, needsInterview, autoWorkflow, skipPhases
                 submitBtn.classList.remove('loading');
                 submitBtn.disabled = false;
             }
+            kickstartSubmitting = false;
         }
         return;
     }
@@ -604,6 +616,7 @@ async function executeKickstart(prompt, needsInterview, autoWorkflow, skipPhases
                 submitBtn.classList.remove('loading');
                 submitBtn.disabled = false;
             }
+            kickstartSubmitting = false;
         }
     } catch (error) {
         console.error('Error starting kickstart:', error);
@@ -612,6 +625,7 @@ async function executeKickstart(prompt, needsInterview, autoWorkflow, skipPhases
             submitBtn.classList.remove('loading');
             submitBtn.disabled = false;
         }
+        kickstartSubmitting = false;
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #236. The `/api/workflows/{name}/run` endpoint was processing requests successfully (files written, tasks created, process launched) but never returning an HTTP response, causing the kickstart modal to never dismiss and allowing duplicate submits.

## Root cause

In `server.ps1` the run handler reassigned `$response` to a local hashtable:

```powershell
$response = @{ success = $true; workflow = $wfName; ... }
```

This shadowed the outer `HttpListenerResponse` stored in `$response` by the request loop. The response-writing block then evaluated `$response.OutputStream` against the hashtable (missing key → `$null`), silently skipping both `Write()` and `Close()`. The connection hung until the client timed out.

## Changes

**Backend**
- `systems/ui/server.ps1` — rename the local hashtable in the run handler to `$runResponse` so it no longer shadows the `HttpListenerResponse`. Added a comment warning against reusing the variable name.

**Frontend — defensive guards**
- `systems/ui/static/modules/kickstart.js` — add a `kickstartSubmitting` in-flight flag, set at the top of `submitKickstart()` and cleared on all error paths + inside `closeKickstartModal()`. Prevents double submits even if the backend is slow.
- `systems/ui/static/modules/controls.js` — disable the per-workflow row Run button on click; re-enable once the modal is open (form workflows) or the fetch completes (no-form workflows).

**Frontend — UX polish**
- `systems/ui/static/modules/kickstart.js` — fetch preflight checks first without swapping phases. Only swap to the preflight view when there are actual checks to animate. Eliminates the form → preflight → form flicker that occurred when no preflight checks were configured.
- `systems/ui/static/index.html` — remove the inline `style="display: none;"` from the `.btn-loading` span on `#kickstart-submit`. Inline styles were overriding the `.loading` class selector, leaving both the default and loading labels hidden (empty button frame).
- `systems/ui/static/css/modal.css` — add a default `#kickstart-submit .btn-loading { display: none }` rule so the class-based label toggle works correctly without relying on inline styles.

## Test plan

- [x] Restart `.bot\go.ps1` in a project with at least one workflow form
- [x] Click Run on a workflow with a form → modal opens, form visible
- [x] Fill prompt + files, click Kickstart → button label changes to "Starting…", button appears disabled (standard `:disabled` styling), no flicker between phases
- [x] On success: modal dismisses automatically, toast shows task count, process appears in the processes list
- [x] Rapid-click the Kickstart button during the request → only one backend call is made
- [x] Rapid-click the row Run button before the modal appears → only one modal open, no duplicate fetches
- [x] `curl -X POST http://localhost:8686/api/workflows/{name}/run -H "X-Dotbot-Request: 1" -H "Content-Type: application/json" -d '{"prompt":"test"}'` returns a 200 JSON response immediately
- [x] CI layers 1-3 pass on Windows/macOS/Linux

Closes #236
