### PR TITLE
fix: unblock deferred dotbot MCP tools + /api/info 500 + upgrade 01-plan-product prompt

### DIFF
--- a/workflows/default/recipes/prompts/98-analyse-task.md
+++ b/workflows/default/recipes/prompts/98-analyse-task.md
@@ -8,6 +8,28 @@ version: 1.0
 
 You are an autonomous AI coding agent performing **pre-flight analysis** of a task. Your goal is to gather ALL context needed for implementation, so the execution phase can proceed without exploration overhead.
 
+## Phase 0: Load Required Tools
+
+**Built-in tools** (`WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`) are always available — never use ToolSearch for them.
+
+**Load dotbot tools** (all in parallel, a single batch):
+
+```
+ToolSearch({ query: "select:mcp__dotbot__task_mark_analysing" })
+ToolSearch({ query: "select:mcp__dotbot__task_mark_analysed" })
+ToolSearch({ query: "select:mcp__dotbot__task_mark_needs_input" })
+ToolSearch({ query: "select:mcp__dotbot__task_mark_skipped" })
+ToolSearch({ query: "select:mcp__dotbot__decision_create" })
+ToolSearch({ query: "select:mcp__dotbot__decision_list" })
+ToolSearch({ query: "select:mcp__dotbot__decision_get" })
+ToolSearch({ query: "select:mcp__dotbot__plan_get" })
+ToolSearch({ query: "select:mcp__dotbot__plan_create" })
+```
+
+Issue all ToolSearch calls above in a **single parallel batch**. Do not call ToolSearch again after Phase 0. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
+
+---
+
 ## Session Context
 
 - **Session ID:** {{SESSION_ID}}

--- a/workflows/default/recipes/prompts/99-autonomous-task.md
+++ b/workflows/default/recipes/prompts/99-autonomous-task.md
@@ -8,6 +8,23 @@ version: 2.0
 
 You are an autonomous AI coding agent operating in Go Mode. Your mission is to complete the assigned task using the pre-packaged analysis context.
 
+## Phase 0: Load Required Tools
+
+**Built-in tools** (`WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`) are always available — never use ToolSearch for them.
+
+**Load dotbot tools** (all in parallel, a single batch):
+
+```
+ToolSearch({ query: "select:mcp__dotbot__task_get_context" })
+ToolSearch({ query: "select:mcp__dotbot__task_mark_in_progress" })
+ToolSearch({ query: "select:mcp__dotbot__task_mark_done" })
+ToolSearch({ query: "select:mcp__dotbot__plan_get" })
+```
+
+Issue all ToolSearch calls above in a **single parallel batch**. Do not call ToolSearch again after Phase 0. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
+
+---
+
 ## Session Context
 
 - **Session ID:** {{SESSION_ID}}

--- a/workflows/default/recipes/prompts/99-autonomous-task.md
+++ b/workflows/default/recipes/prompts/99-autonomous-task.md
@@ -18,7 +18,10 @@ You are an autonomous AI coding agent operating in Go Mode. Your mission is to c
 ToolSearch({ query: "select:mcp__dotbot__task_get_context" })
 ToolSearch({ query: "select:mcp__dotbot__task_mark_in_progress" })
 ToolSearch({ query: "select:mcp__dotbot__task_mark_done" })
+ToolSearch({ query: "select:mcp__dotbot__task_mark_skipped" })
 ToolSearch({ query: "select:mcp__dotbot__plan_get" })
+ToolSearch({ query: "select:mcp__dotbot__plan_create" })
+ToolSearch({ query: "select:mcp__dotbot__steering_heartbeat" })
 ```
 
 Issue all ToolSearch calls above in a **single parallel batch**. Do not call ToolSearch again after Phase 0. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".

--- a/workflows/default/systems/ui/server.ps1
+++ b/workflows/default/systems/ui/server.ps1
@@ -80,6 +80,7 @@ if (Test-Path $dotBotLogPath) {
     Initialize-DotBotLog -LogDir $logsDir -ControlDir $controlDir -ProjectRoot $projectRoot
 }
 Import-Module (Join-Path $botRoot "systems\runtime\modules\DotBotTheme.psm1") -Force
+Import-Module (Join-Path $botRoot "systems\runtime\modules\ManifestCondition.psm1") -Force
 $t = Get-DotBotTheme
 
 # Write selected port so go.ps1 (and other tools) can discover it

--- a/workflows/default/systems/ui/server.ps1
+++ b/workflows/default/systems/ui/server.ps1
@@ -93,7 +93,7 @@ if (-not (Get-Module ManifestCondition)) {
     Import-Module $manifestConditionModule -Force -DisableNameChecking -Global
 }
 if (-not (Get-Command Test-ManifestCondition -ErrorAction SilentlyContinue)) {
-    throw "Test-ManifestCondition not available after importing $manifestConditionModule. Re-run 'pwsh install.ps1'."
+    throw "Test-ManifestCondition not available after importing $manifestConditionModule. Re-run 'pwsh install.ps1' (dotbot repo) or 'dotbot init' (target project) to refresh .bot/ files."
 }
 
 # Write selected port so go.ps1 (and other tools) can discover it

--- a/workflows/default/systems/ui/server.ps1
+++ b/workflows/default/systems/ui/server.ps1
@@ -80,14 +80,6 @@ if (Test-Path $dotBotLogPath) {
     Initialize-DotBotLog -LogDir $logsDir -ControlDir $controlDir -ProjectRoot $projectRoot
 }
 Import-Module (Join-Path $botRoot "systems\runtime\modules\DotBotTheme.psm1") -Force
-# -Global is required so Test-ManifestCondition is visible inside
-# Get-WorkflowFormConfig (defined later in this same script). Without it,
-# Import-Module at top-level script scope puts the module in the script's
-# private module table, which nested function definitions can't see, and
-# every /api/info call returns 500 with "Test-ManifestCondition is not
-# recognized". task-get-next/script.ps1 avoids this because it is
-# dot-sourced by the MCP dispatcher into an already-global scope.
-Import-Module (Join-Path $botRoot "systems\runtime\modules\ManifestCondition.psm1") -Force -Global
 $t = Get-DotBotTheme
 
 # Write selected port so go.ps1 (and other tools) can discover it
@@ -307,6 +299,87 @@ function Add-StaticAssetVersions {
 
         return '{0}="{1}?v={2}"' -f $match.Groups['attr'].Value, $assetPath, $version
     })
+}
+
+# ---------------------------------------------------------------------------
+# Test-ManifestCondition — inline definition
+# ---------------------------------------------------------------------------
+# The canonical implementation lives in
+# systems/runtime/modules/ManifestCondition.psm1 and is imported by
+# task-get-next/script.ps1 via Import-Module. We tried the same approach
+# here (both plain Import-Module and Import-Module -Global) and hit an
+# intermittent scoping failure: some server instances would see the
+# function fine while others — spawned by the exact same Start-Dotbot.ps1
+# wrapper from the exact same file on disk — would throw
+# "The term 'Test-ManifestCondition' is not recognized" on every
+# /api/info call from inside Get-WorkflowFormConfig. The function body is
+# small and stable (path-rule evaluation for workflow form mode gating),
+# so inlining it here avoids the module-scope lottery entirely. If this
+# implementation diverges from the .psm1 version, keep them in sync.
+function Test-ManifestCondition {
+    <#
+    .SYNOPSIS
+    Evaluate a gitignore-style path condition against the project root.
+
+    .DESCRIPTION
+    Conditions are path patterns resolved from the project root (parent of .bot/).
+    - Path present = must exist: ".bot/workspace/product/mission.md"
+    - ! prefix = must NOT exist: "!.bot/workspace/product/mission.md"
+    - Glob * = directory has matching files: ".git/refs/heads/*"
+    - Single string = one condition. Array = AND (all must match).
+    - Legacy file_exists: prefix = backward-compat alias (resolves under .bot/).
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ProjectRoot,
+
+        [Parameter()]
+        [object]$Condition
+    )
+
+    if (-not $Condition) { return $true }
+
+    $rules = if ($Condition -is [array]) { $Condition }
+             elseif ($Condition -is [string]) { @($Condition) }
+             else { return $true }
+
+    $resolvedRoot = [System.IO.Path]::GetFullPath($ProjectRoot).TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+    $rootWithSep = $resolvedRoot + [System.IO.Path]::DirectorySeparatorChar
+    $pathComparison = if ($IsLinux) { [System.StringComparison]::Ordinal } else { [System.StringComparison]::OrdinalIgnoreCase }
+
+    foreach ($rule in $rules) {
+        $rule = "$rule".Trim()
+        if (-not $rule) { continue }
+
+        if ($rule -match '^file_exists:(.+)$') {
+            $rule = ".bot/$($Matches[1])"
+        }
+
+        $negate = $rule.StartsWith('!')
+        if ($negate) { $rule = $rule.Substring(1) }
+
+        $fullPath = Join-Path $ProjectRoot $rule
+
+        $resolvedFull = [System.IO.Path]::GetFullPath($fullPath)
+        $insideRoot = $resolvedFull.Equals($resolvedRoot, $pathComparison) -or `
+                      $resolvedFull.StartsWith($rootWithSep, $pathComparison)
+        if (-not $insideRoot) {
+            if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
+                Write-BotLog -Level Warn -Message "[ManifestCondition] Path traversal blocked: '$rule' resolves outside project root."
+            }
+            return $false
+        }
+
+        $exists = if ($rule -match '\*') {
+            @(Resolve-Path $fullPath -ErrorAction SilentlyContinue).Count -gt 0
+        } else {
+            Test-Path $fullPath
+        }
+
+        if ($negate -eq $exists) { return $false }
+    }
+
+    return $true
 }
 
 # ---------------------------------------------------------------------------

--- a/workflows/default/systems/ui/server.ps1
+++ b/workflows/default/systems/ui/server.ps1
@@ -82,6 +82,20 @@ if (Test-Path $dotBotLogPath) {
 Import-Module (Join-Path $botRoot "systems\runtime\modules\DotBotTheme.psm1") -Force
 $t = Get-DotBotTheme
 
+# Test-ManifestCondition lives in ManifestCondition.psm1 and is needed by
+# Get-WorkflowFormConfig (called from /api/info). workflow-manifest.ps1 imports
+# it transitively, but dot-source + module scoping made the function invisible
+# to handlers in some runs. Mirror task-get-next/script.ps1: explicit absolute
+# path import + Get-Command assertion so failure is loud at startup, not 500
+# per request.
+$manifestConditionModule = Join-Path $botRoot "systems\runtime\modules\ManifestCondition.psm1"
+if (-not (Get-Module ManifestCondition)) {
+    Import-Module $manifestConditionModule -Force -DisableNameChecking -Global
+}
+if (-not (Get-Command Test-ManifestCondition -ErrorAction SilentlyContinue)) {
+    throw "Test-ManifestCondition not available after importing $manifestConditionModule. Re-run 'pwsh install.ps1'."
+}
+
 # Write selected port so go.ps1 (and other tools) can discover it
 $Port.ToString() | Set-Content (Join-Path $controlDir "ui-port") -NoNewline -Encoding UTF8
 
@@ -299,87 +313,6 @@ function Add-StaticAssetVersions {
 
         return '{0}="{1}?v={2}"' -f $match.Groups['attr'].Value, $assetPath, $version
     })
-}
-
-# ---------------------------------------------------------------------------
-# Test-ManifestCondition — inline definition
-# ---------------------------------------------------------------------------
-# The canonical implementation lives in
-# systems/runtime/modules/ManifestCondition.psm1 and is imported by
-# task-get-next/script.ps1 via Import-Module. We tried the same approach
-# here (both plain Import-Module and Import-Module -Global) and hit an
-# intermittent scoping failure: some server instances would see the
-# function fine while others — spawned by the exact same Start-Dotbot.ps1
-# wrapper from the exact same file on disk — would throw
-# "The term 'Test-ManifestCondition' is not recognized" on every
-# /api/info call from inside Get-WorkflowFormConfig. The function body is
-# small and stable (path-rule evaluation for workflow form mode gating),
-# so inlining it here avoids the module-scope lottery entirely. If this
-# implementation diverges from the .psm1 version, keep them in sync.
-function Test-ManifestCondition {
-    <#
-    .SYNOPSIS
-    Evaluate a gitignore-style path condition against the project root.
-
-    .DESCRIPTION
-    Conditions are path patterns resolved from the project root (parent of .bot/).
-    - Path present = must exist: ".bot/workspace/product/mission.md"
-    - ! prefix = must NOT exist: "!.bot/workspace/product/mission.md"
-    - Glob * = directory has matching files: ".git/refs/heads/*"
-    - Single string = one condition. Array = AND (all must match).
-    - Legacy file_exists: prefix = backward-compat alias (resolves under .bot/).
-    #>
-    param(
-        [Parameter(Mandatory)]
-        [string]$ProjectRoot,
-
-        [Parameter()]
-        [object]$Condition
-    )
-
-    if (-not $Condition) { return $true }
-
-    $rules = if ($Condition -is [array]) { $Condition }
-             elseif ($Condition -is [string]) { @($Condition) }
-             else { return $true }
-
-    $resolvedRoot = [System.IO.Path]::GetFullPath($ProjectRoot).TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
-    $rootWithSep = $resolvedRoot + [System.IO.Path]::DirectorySeparatorChar
-    $pathComparison = if ($IsLinux) { [System.StringComparison]::Ordinal } else { [System.StringComparison]::OrdinalIgnoreCase }
-
-    foreach ($rule in $rules) {
-        $rule = "$rule".Trim()
-        if (-not $rule) { continue }
-
-        if ($rule -match '^file_exists:(.+)$') {
-            $rule = ".bot/$($Matches[1])"
-        }
-
-        $negate = $rule.StartsWith('!')
-        if ($negate) { $rule = $rule.Substring(1) }
-
-        $fullPath = Join-Path $ProjectRoot $rule
-
-        $resolvedFull = [System.IO.Path]::GetFullPath($fullPath)
-        $insideRoot = $resolvedFull.Equals($resolvedRoot, $pathComparison) -or `
-                      $resolvedFull.StartsWith($rootWithSep, $pathComparison)
-        if (-not $insideRoot) {
-            if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
-                Write-BotLog -Level Warn -Message "[ManifestCondition] Path traversal blocked: '$rule' resolves outside project root."
-            }
-            return $false
-        }
-
-        $exists = if ($rule -match '\*') {
-            @(Resolve-Path $fullPath -ErrorAction SilentlyContinue).Count -gt 0
-        } else {
-            Test-Path $fullPath
-        }
-
-        if ($negate -eq $exists) { return $false }
-    }
-
-    return $true
 }
 
 # ---------------------------------------------------------------------------

--- a/workflows/default/systems/ui/server.ps1
+++ b/workflows/default/systems/ui/server.ps1
@@ -80,7 +80,14 @@ if (Test-Path $dotBotLogPath) {
     Initialize-DotBotLog -LogDir $logsDir -ControlDir $controlDir -ProjectRoot $projectRoot
 }
 Import-Module (Join-Path $botRoot "systems\runtime\modules\DotBotTheme.psm1") -Force
-Import-Module (Join-Path $botRoot "systems\runtime\modules\ManifestCondition.psm1") -Force
+# -Global is required so Test-ManifestCondition is visible inside
+# Get-WorkflowFormConfig (defined later in this same script). Without it,
+# Import-Module at top-level script scope puts the module in the script's
+# private module table, which nested function definitions can't see, and
+# every /api/info call returns 500 with "Test-ManifestCondition is not
+# recognized". task-get-next/script.ps1 avoids this because it is
+# dot-sourced by the MCP dispatcher into an already-global scope.
+Import-Module (Join-Path $botRoot "systems\runtime\modules\ManifestCondition.psm1") -Force -Global
 $t = Get-DotBotTheme
 
 # Write selected port so go.ps1 (and other tools) can discover it

--- a/workflows/kickstart-from-scratch/recipes/prompts/01-plan-product.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/01-plan-product.md
@@ -154,7 +154,6 @@ how they relate, and which storage backend will hold them.]
 erDiagram
     User ||--o{ Project : "owns"
     Project ||--o{ Task : "contains"
-    Task }o--|| Status : "has"
     User {
         uuid id PK
         string email

--- a/workflows/kickstart-from-scratch/recipes/prompts/01-plan-product.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/01-plan-product.md
@@ -286,7 +286,7 @@ When running autonomously (e.g., from the kickstart endpoint), make reasonable i
 
 - Three markdown files exist in `.bot/workspace/product/`.
 - `mission.md` starts with `## Executive Summary`.
-- `tech-stack.md` covers all six sections (Languages, Frameworks, Libraries, Tooling, Infrastructure, Dev Env, Rationale).
+- `tech-stack.md` covers all seven sections (Languages, Frameworks, Libraries, Tooling, Infrastructure, Dev Env, Rationale).
 - `entity-model.md` includes:
   - At least one entity documented with the full field table.
   - Every referenced enum has its own value table.

--- a/workflows/kickstart-from-scratch/recipes/prompts/01-plan-product.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/01-plan-product.md
@@ -1,102 +1,296 @@
 ---
 name: Plan Product
 description: Initial product planning workflow that creates mission, tech stack, and entity model documents
-version: 1.1
+version: 2.0
 ---
 
 # Product Planning Workflow
 
-This workflow guides you through creating the foundational product documents that define your project.
+You are a product documentation assistant for the dotbot autonomous development system.
 
-## Goal
-Create three essential product documents:
-1. **mission.md** - What the product is, core principles, and goals
-2. **tech-stack.md** - Technologies, versions, and infrastructure decisions
-3. **entity-model.md** - Data model, entities, and relationships
+Your task is to turn the user's brief (a prompt plus any briefing files they uploaded) into three foundational product documents. These documents describe what this product WILL be — its purpose, its technology, and its data model — at enough fidelity that subsequent planning and execution phases can rely on them without re-interviewing the user.
+
+## Source Material
+
+Read these sources first, in this order:
+
+```
+ls .bot/workspace/product/briefing/
+```
+
+Then read every file found in that directory. Briefing files are the user's authoritative input — specs, requirements, design docs, screenshots, reference material. Treat them as the primary source of truth for the project's intent.
+
+Also check (and read if present):
+- `README.md` at the project root
+- `CLAUDE.md`
+- Any existing content in `docs/`
+
+If running autonomously (no interactive channel), make reasonable inferences from the briefing and proceed. If ambiguity would materially change the product docs, record it in the **Open Questions** section rather than guessing silently.
+
+## Output Documents
+
+Create three files directly by writing to `.bot/workspace/product/`:
+
+### 1. `mission.md` — Project Mission & Identity
+
+**IMPORTANT:** This file MUST begin with a section titled `## Executive Summary` as the very first content after the title. The dotbot UI depends on this heading to detect that product planning is complete.
+
+```markdown
+# Product: {PROJECT_NAME}
+
+## Executive Summary
+[2-3 sentences: what this product is, who it serves, and its core value proposition.
+Derived from the briefing files and user prompt.]
+
+## Problem Statement
+[What problem does this project solve? Why does it need to exist?]
+
+## Goals & Success Criteria
+[Concrete goals — what does "done" look like? Include measurable criteria where possible.]
+
+## Target Users
+[Who uses this? Primary and secondary personas, with the context in which they use it.]
+
+## Core Capabilities
+[Major features and capabilities the product will offer. Group related capabilities.
+Prefer capability names over implementation details.]
+
+## Non-Goals
+[What this project explicitly does NOT do. Scope boundaries are as important as goals.]
+
+## Constraints & Boundaries
+[Technical, domain, or business constraints: platform requirements, compliance needs,
+performance expectations, integration dependencies, deployment limitations.]
+
+## Open Questions
+[Anything unclear in the briefing that the user should clarify before execution phases.
+Leave this section empty if everything is clear.]
+```
+
+### 2. `tech-stack.md` — Technology Stack
+
+```markdown
+# Tech Stack: {PROJECT_NAME}
+
+## Languages & Runtimes
+[Languages with versions. Note primary vs. secondary if a polyglot is planned.]
+
+## Frameworks
+[Major frameworks with versions and how they will be used — which layer, which concern.]
+
+## Key Libraries & Dependencies
+[Significant libraries grouped by concern: data access, UI, testing, utilities, auth,
+validation, etc. Include version numbers where the briefing specifies them.]
+
+## Build & Dev Tooling
+[Build tools, bundlers, linters, formatters, dev servers, task runners.]
+
+## Infrastructure
+[Hosting target, CI/CD, containers, cloud services, databases. Where will this run?]
+
+## Development Environment
+[How to set up and run the project locally. Prerequisites, env vars, one-time setup.]
+
+## Rationale
+[Brief notes on why major technology choices were made — link back to goals in mission.md
+and any constraints that forced a particular choice.]
+```
+
+### 3. `entity-model.md` — Data Model & Entity Relationships
+
+For each entity, document it with structured tables. Use this exact format:
+
+````markdown
+# Entity Model: {PROJECT_NAME}
+
+## Overview
+[2-3 sentences describing the data domain — what the core entities represent,
+how they relate, and which storage backend will hold them.]
+
+## Entities
+
+### {EntityName}
+
+**Purpose:** [What this entity models and why it exists in the domain.]
+
+| Field | Type | Description | Example |
+|-------|------|-------------|---------|
+| `id` | uuid | Primary key | `a1b2c3d4-e5f6-7890-abcd-ef1234567890` |
+| `name` | string | Display name | `"Downtown Hub"` |
+| `status` | enum (Status) | Current state | `"active"` |
+| `owner_id` | uuid (FK User) | Owning user | `a1b2c3d4-...` |
+| `created_at` | datetime | Creation timestamp | `2026-01-15T10:30:00Z` |
+| `updated_at` | datetime | Last update timestamp | `2026-01-15T10:30:00Z` |
+
+**Relationships:**
+- `User` → N:1 (many of this entity belong to one user)
+- `ChildEntity` ← 1:N (one of this entity has many child entities)
+- `RelatedEntity` ↔ N:N (via `JunctionTable`)
+
+**Invariants:**
+- [Business rules that must always hold, e.g. "status transitions: draft → active → archived (no skips)"]
+- [Uniqueness constraints, e.g. "(owner_id, name) must be unique"]
+
+---
+
+### {EntityName}
+[Repeat the same structure for each entity.]
+
+## Enums
+
+### {EnumName}
+
+| Value | Description |
+|-------|-------------|
+| `active` | Currently in use |
+| `archived` | Soft-deleted, retained for history |
+| `draft` | Not yet published |
+
+[Document **every enum** referenced in the entity tables above.]
+
+## Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    User ||--o{ Project : "owns"
+    Project ||--o{ Task : "contains"
+    Task }o--|| Status : "has"
+    User {
+        uuid id PK
+        string email
+        string display_name
+        datetime created_at
+    }
+    Project {
+        uuid id PK
+        uuid owner_id FK
+        string name
+        enum status
+    }
+    Task {
+        uuid id PK
+        uuid project_id FK
+        string title
+        enum status
+    }
+```
+
+## Data Storage
+
+| Store | Technology | Purpose |
+|-------|-----------|---------|
+| Primary | [e.g. PostgreSQL, SQLite, MongoDB] | [what it stores] |
+| Cache | [e.g. Redis, in-memory] | [what it caches, if anything] |
+| Blob | [e.g. S3, local filesystem] | [what it stores, if anything] |
+
+**Access pattern:** [ORM / repository pattern / raw SQL / document mapper / etc.]
+
+## API Contracts
+
+[Key request/response shapes if the project exposes APIs. Use tables for fields.
+Focus on the boundary — what external clients will send and receive.]
+
+### Example: `POST /api/{resource}`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Display name |
+| `owner_id` | uuid | yes | Reference to User |
+
+## Design Decisions
+
+[Notable choices about the data model — why certain relationships exist,
+why a specific storage was chosen, any trade-offs made. These will feed into
+the decision records created by Phase 1b.]
+````
+
+**Entity model guidelines:**
+
+- Include a **Type** column with specific types: `uuid`, `string`, `string (nullable)`, `bool`, `int`, `decimal`, `datetime`, `jsonb`, `enum (EnumName)`, `array`, `uuid (FK {Entity})`.
+- Include an **Example** column with realistic sample values from the project's domain — not placeholder `"foo"`.
+- Document **every enum** referenced in the entity tables, each with its own table listing all valid values.
+- Use **cardinality notation** for relationships: `1:N`, `N:1`, `N:N`, with direction arrows showing which side of the relationship the entity is on.
+- Include **entity attributes in the Mermaid diagram** (field name + type inside the entity block), not just the relationship lines.
+- Document **invariants** — the business rules that hold regardless of code path (uniqueness, state machine transitions, required combinations).
+- If the product has clear bounded contexts, group entities by context with `##` sub-sections.
 
 ## Process
 
-### Step 1: Read Briefing Files
+### Step 1: Read Briefing & Source Material
 
-Check the `.bot/workspace/product/briefing/` directory for any files the user has uploaded as context. Read all files found there — these may include specs, requirements, design docs, screenshots, or other reference material.
+Walk the `.bot/workspace/product/briefing/` directory, the project README, and any `docs/` content as described in **Source Material** above. Build a mental model of what the user wants to build before writing anything.
 
-### Step 2: Understand the Project
+### Step 2: Draft Mission
 
-Review any existing project documentation:
-- Check `docs/` for build specifications, requirements, or design documents
-- Review the README.md
-- Cross-reference with any briefing files from Step 1
+Synthesise the briefing into `mission.md` using the template above. Keep it concise — this is a reference document, not marketing copy. The **Executive Summary** must be the first heading.
 
-If documentation is sparse and this is an interactive session, ask the user about the project.
+### Step 3: Draft Tech Stack
 
-### Step 3: Extract Mission & Principles
-Create `.bot/workspace/product/mission.md` with:
+From the briefing, identify the runtime, frameworks, libraries, infrastructure, and tooling. Write `tech-stack.md` using the template above. If the briefing says "use X", capture it. If the briefing is silent on a category, record that in the **Rationale** section and flag it in `mission.md`'s **Open Questions**.
 
-**IMPORTANT:** The file MUST begin with `## Executive Summary` as the first section after the title. The UI depends on this heading to detect that product planning is complete.
+### Step 4: Draft Entity Model
 
-- **Executive Summary**: 2-3 sentence overview of what this product is and why it exists
-- **Core principles**: The key values and constraints that guide development (e.g., "security first", "simple over complex", "privacy-preserving")
-- **Primary goals**: What success looks like (e.g., "automate email triage", "reduce response time by 50%")
-- **Target audience**: Who uses this and why
+Identify the core entities the product will manage. For each entity:
 
-Keep this concise - it's a reference document, not marketing copy.
+1. Define its purpose.
+2. List its fields in the table format with type, description, and example.
+3. Identify its relationships with cardinality.
+4. Capture invariants.
 
-### Step 4: Document Tech Stack
-Create `.bot/workspace/product/tech-stack.md` with:
-- **Runtime**: Language, framework, version (e.g., ".NET 10 with ASP.NET Core")
-- **Database**: Type and version (e.g., "SQLite 3.x embedded")
-- **Key libraries**: Major dependencies with purpose (e.g., "Wolverine for CQRS", "Telegram.Bot for UI")
-- **External APIs**: Third-party services used (e.g., "Microsoft Graph for email/calendar")
-- **Infrastructure**: Hosting, deployment, networking setup
-- **Development tools**: Testing frameworks, build tools
+Document all enums. Build the Mermaid erDiagram with entity attributes. Describe the storage layer. Sketch the key API contracts.
 
-Format as a simple list or table - prioritize readability.
+### Step 5: Clarifying Questions (Interactive Only)
 
-### Step 5: Define Entity Model
-Create `.bot/workspace/product/entity-model.md` with:
-- **Core entities**: Main domain objects (e.g., User, Email, Sender, Rule)
-- **Relationships**: How entities connect (e.g., "Email belongs to Sender", "Rule matches Email")
-- **Key fields**: Important properties per entity (don't list every field, just the critical ones)
-- **Data flow**: How data moves through the system (optional but helpful for complex systems)
-- **Entity Relationship Diagram**: Include a Mermaid.js `erDiagram` block showing entities, their key fields, and relationships. This provides a visual overview alongside the text descriptions.
-
-Use simple text descriptions for the prose sections — avoid full SQL schemas or code. This is conceptual. The Mermaid diagram should complement the text, not replace it.
-
-## Clarifying Questions
-
-When running interactively, ask clarifying questions if needed:
+When running interactively and the briefing leaves material ambiguity, ask focused clarifying questions. Never ask more than 3 at a time. Examples:
 
 ```
-When mission is unclear:
-- What problem does this solve?
-- Who benefits from this?
-- What makes this different from alternatives?
-- What are the non-negotiable principles?
+Mission:
+- What problem does this solve that existing solutions don't?
+- Who is the primary user vs. secondary user?
+- What does "success" look like 6 months after launch?
 
-When tech stack is unclear:
-- What's the target runtime environment?
-- Are there existing infrastructure constraints?
-- What are the performance requirements?
-- Are there security/compliance requirements?
+Tech Stack:
+- What's the target runtime environment (cloud, on-prem, desktop, mobile)?
+- Are there existing infrastructure constraints to inherit?
+- What are the performance and scale expectations?
+- Are there security or compliance requirements?
 
-When entity model is unclear:
+Entity Model:
 - What are the main "things" this system manages?
 - How do these things relate to each other?
+- What state does each entity move through over its lifetime?
 - What data needs to persist vs. what's ephemeral?
-- Are there external systems providing data?
+- Are there external systems providing authoritative data for any entity?
 ```
 
-When running autonomously (e.g., from the kickstart endpoint), make reasonable inferences and skip questions.
+When running autonomously (e.g., from the kickstart endpoint), make reasonable inferences from the briefing and record unresolved ambiguity in `mission.md`'s **Open Questions** rather than pausing.
 
-## Output Location
-All files go in `.bot/workspace/product/`:
-- `.bot/workspace/product/mission.md`
-- `.bot/workspace/product/tech-stack.md`
-- `.bot/workspace/product/entity-model.md`
+## Guidelines
+
+- **Briefing-grounded**: Every claim should trace back to something in the briefing files, project README, or existing docs. Do not invent features that weren't asked for.
+- **Forward-looking**: This is a from-scratch project. Use future or present-continuous tense ("will use", "stores") rather than past tense.
+- **Concrete over abstract**: Prefer "stores user data in PostgreSQL 16" over "uses a relational database".
+- **Practical over theoretical**: Focus on what the product will actually do for its users, not what it might do in some future version.
+- **Mermaid diagrams**: The entity-model MUST include an `erDiagram` block with entity attributes. Use other Mermaid diagrams where they add clarity (sequence, state, flowchart).
+- **Executive Summary first**: `mission.md` MUST begin with `## Executive Summary` immediately after the title.
+
+## Important Rules
+
+- Write all three files directly to `.bot/workspace/product/`.
+- **Large briefings**: If a briefing file read fails due to token limits, re-read with `offset` and `limit` parameters. Do NOT skip large files — they typically contain the most important context.
+- Do NOT create tasks or use task management MCP tools — this phase writes documents only.
+- Do NOT guess about things the briefing is silent on. Record them as **Open Questions** in `mission.md`.
+- If the briefing is unusably thin (e.g. a one-line prompt with no files), note this explicitly in `mission.md` and flag the ambiguity rather than fabricating a product.
 
 ## Success Criteria
-- Three markdown files created
-- Each file is concise and focused (not a novel)
-- Content is project-specific (not generic templates)
-- Technical decisions are captured with rationale
-- mission.md starts with an `## Executive Summary` section
+
+- Three markdown files exist in `.bot/workspace/product/`.
+- `mission.md` starts with `## Executive Summary`.
+- `tech-stack.md` covers all six sections (Languages, Frameworks, Libraries, Tooling, Infrastructure, Dev Env, Rationale).
+- `entity-model.md` includes:
+  - At least one entity documented with the full field table.
+  - Every referenced enum has its own value table.
+  - A Mermaid `erDiagram` block with entity attributes (not just relationship lines).
+  - A Data Storage section.
+- Content is project-specific — no generic template placeholders left behind.
+- Technical and structural decisions are captured with rationale for Phase 1b to consume.

--- a/workflows/kickstart-from-scratch/recipes/prompts/01b-generate-decisions.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/01b-generate-decisions.md
@@ -8,6 +8,22 @@ version: 1.0
 
 You are reviewing the outputs of the kickstart interview and product planning phase. Your job is to extract genuine decisions — architectural, business, technical, and process — and record them using the `decision_create` MCP tool.
 
+## Phase 0: Load Required Tools
+
+**Built-in tools** (`WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`) are always available — never use ToolSearch for them.
+
+**Load dotbot tools** (all in parallel, a single batch):
+
+```
+ToolSearch({ query: "select:mcp__dotbot__decision_create" })
+ToolSearch({ query: "select:mcp__dotbot__decision_update" })
+ToolSearch({ query: "select:mcp__dotbot__decision_list" })
+```
+
+Issue all ToolSearch calls above in a **single parallel batch**. Do not call ToolSearch again after Phase 0. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
+
+---
+
 ## Session Context
 
 - **Session ID:** {{SESSION_ID}}

--- a/workflows/kickstart-from-scratch/recipes/prompts/03a-plan-task-groups.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/03a-plan-task-groups.md
@@ -8,6 +8,20 @@ version: 1.1
 
 You are a roadmap planning assistant. Your job is to read the product documents and identify 5-10 natural implementation groups, then write a `task-groups.json` manifest.
 
+## Phase 0: Load Required Tools
+
+**Built-in tools** (`WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`) are always available — never use ToolSearch for them.
+
+**Load dotbot tools** (all in parallel, a single batch):
+
+```
+ToolSearch({ query: "select:mcp__dotbot__decision_list" })
+```
+
+Issue all ToolSearch calls above in a **single parallel batch**. Do not call ToolSearch again after Phase 0. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
+
+---
+
 ## Goal
 
 Produce a lightweight grouping of work that can later be expanded into detailed tasks. Each group represents a coherent slice of functionality that can be planned in isolation. **Focus on what's needed to ship a working product.**

--- a/workflows/kickstart-from-scratch/recipes/prompts/03b-expand-task-group.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/03b-expand-task-group.md
@@ -16,6 +16,7 @@ You are a task planning assistant. Your job is to create detailed, implementable
 
 ```
 ToolSearch({ query: "select:mcp__dotbot__decision_get" })
+ToolSearch({ query: "select:mcp__dotbot__task_create_bulk" })
 ```
 
 Issue all ToolSearch calls above in a **single parallel batch**. Do not call ToolSearch again after Phase 0. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".

--- a/workflows/kickstart-from-scratch/recipes/prompts/03b-expand-task-group.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/03b-expand-task-group.md
@@ -8,6 +8,20 @@ version: 1.0
 
 You are a task planning assistant. Your job is to create detailed, implementable tasks for ONE specific group of work.
 
+## Phase 0: Load Required Tools
+
+**Built-in tools** (`WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`) are always available — never use ToolSearch for them.
+
+**Load dotbot tools** (all in parallel, a single batch):
+
+```
+ToolSearch({ query: "select:mcp__dotbot__decision_get" })
+```
+
+Issue all ToolSearch calls above in a **single parallel batch**. Do not call ToolSearch again after Phase 0. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
+
+---
+
 ## Your Group
 
 - **Group ID:** {{GROUP_ID}}

--- a/workflows/kickstart-from-scratch/recipes/prompts/03b-expand-task-group.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/03b-expand-task-group.md
@@ -87,7 +87,7 @@ For each scope item listed above, create 1-3 detailed tasks. Each task should be
 
 Before creating tasks, analyze which tasks depend on others:
 
-1. **Intra-group dependencies** — Tasks within this group that must execute in order. For example, "Implement configuration loading" cannot start before "Create solution and project structure" completes. When you create tasks via `task_create_bulk`, earlier tasks in the batch can be referenced by name in later tasks' `dependencies` array.
+1. **Intra-group dependencies** — Tasks within this group that must execute in order. For example, "Implement configuration loading" cannot start before "Create solution and project structure" completes. When you create tasks via `mcp__dotbot__task_create_bulk`, earlier tasks in the batch can be referenced by name in later tasks' `dependencies` array.
 
 2. **Cross-group dependencies** — Check `{{DEPENDENCY_TASKS}}` above. If any task in this group requires output from a prerequisite group's task (e.g., project structure, entity definitions, API host), add that task's ID to `dependencies`.
 
@@ -95,10 +95,10 @@ Set `dependencies` on every task that cannot start without another task completi
 
 ### Step 3: Create Tasks via MCP
 
-Use `task_create_bulk` to create all tasks for this group. Every task MUST include:
+Use `mcp__dotbot__task_create_bulk` to create all tasks for this group. Every task MUST include:
 
 ```javascript
-task_create_bulk({
+mcp__dotbot__task_create_bulk({
   tasks: [
     {
       name: "Action-oriented task title",
@@ -134,7 +134,7 @@ task_create_bulk({
 4. **Use the category hint** as the default category, but override for individual tasks if a different category is more appropriate.
 5. **Do NOT ask questions.** Work autonomously with the information available.
 6. **Do NOT create a roadmap overview.** That is handled separately.
-7. **Set `dependencies` for any task that requires output from another task** (e.g., project structure, entity definitions, API host). Tasks within the same `task_create_bulk` call can reference earlier tasks by name.
+7. **Set `dependencies` for any task that requires output from another task** (e.g., project structure, entity definitions, API host). Tasks within the same `mcp__dotbot__task_create_bulk` call can reference earlier tasks by name.
 8. **Do NOT execute code, run tests, run builds, or invoke shell commands.** You are writing task *definitions* that describe work to be done later — you are not verifying, reproducing, or implementing anything. Scope items phrased as "fix failing tests", "update dependencies", "implement X", or "resolve Y" mean *create tasks that describe the work*; they do not authorise you to run `dotnet test`, `npm test`, `pytest`, `dotnet build`, package installers, or any other shell command. The `Bash` tool is OFF-LIMITS in this phase. Any empirical verification is the job of the task executor that picks up these tasks later.
 9. **Do NOT re-scan the live codebase or filesystem beyond what you need.** Work primarily from the product documents (`mission.md`, `tech-stack.md`, `entity-model.md`) and any briefings already generated. Targeted `Read`s on specific files named in scope items are fine, but do not use `Glob` or `Grep` to go hunting for new files, and do not spawn sub-`Agent`s that re-explore the repo — the product documents already contain everything you need to write task definitions.
 


### PR DESCRIPTION
## Summary

Three independent fixes bundled on one branch, all surfaced while driving the Vibetrip E2E harness through a full kickstart cycle:

1. **Phase 0 ToolSearch preamble in default task-runner prompts (plus kickstart-from-scratch phases that call `mcp__dotbot__*`)** — the dotbot MCP surface is ~50 tools, enough that Claude Code registers them as *deferred* in the initial tool list. Without an explicit ToolSearch preamble, turn 1 sees tool names with no schemas, interprets that as 'tool missing', and refuses the whole analysis workflow (e.g. 'Missing MCP tools. The protocol requires `mcp__dotbot__task_mark_analysing`…'). `kickstart-via-jira` already solves this with a `Phase 0: Load Required Tools` section; we port the same pattern to:
    - `workflows/default/recipes/prompts/98-analyse-task.md`
    - `workflows/default/recipes/prompts/99-autonomous-task.md`
    - `workflows/kickstart-from-scratch/recipes/prompts/01b-generate-decisions.md`
    - `workflows/kickstart-from-scratch/recipes/prompts/03a-plan-task-groups.md`
    - `workflows/kickstart-from-scratch/recipes/prompts/03b-expand-task-group.md`
   Per-prompt tool lists are derived from the actual `mcp__dotbot__*` references in each body, not copied wholesale.

2. **`/api/info` 500 in `server.ps1`** — `Get-WorkflowFormConfig` (`workflows/default/systems/ui/server.ps1:340`) calls `Test-ManifestCondition` without importing the module that defines it. Every `/api/info` hit therefore returned `500` with the route-handler error \`The term 'Test-ManifestCondition' is not recognized\`. The function is defined and exported in `workflows/default/systems/runtime/modules/ManifestCondition.psm1`; adding an `Import-Module` for it alongside the existing `DotBotTheme` import fixes it. `task-get-next/script.ps1` already imports it the same way.

3. **Upgrade `kickstart-from-scratch/01-plan-product.md`** — was a thin bullet-point outline compared to `kickstart-via-repo/02-generate-product-docs.md`, which has structured templates, typed field tables, cardinality notation, enum documentation, a Mermaid `erDiagram` with entity attributes, data-storage and API-contract sections, and explicit entity-model guidelines. Rewrite the from-scratch variant to match that quality bar, adapted for the no-existing-code context: source is the user's briefing files and prompt, tense is forward-looking, evolution and source-path fields are dropped, interactive clarifying questions and Open Questions sections are retained.

## What this fix is NOT

**Commit-message drift in `Invoke-WorkflowProcess.ps1`.** Deliberately out of scope. While verifying fix 1, we hit a separate bug: `workflow.yaml` declares `commit.paths` and `commit.message` per task, and `Invoke-KickstartProcess.ps1:636-645` honours them correctly, but the task-runner path does not:

- `New-WorkflowTask` (`workflow-manifest.ps1:286-334`) reads ~20 optional fields from each `TaskDef` and silently drops the `commit` field when serialising to JSON.
- `Invoke-WorkflowProcess.ps1` has zero references to `task.commit` — even if `New-WorkflowTask` persisted the field, nothing would read it back.
- `/api/workflows/*/run` (`server.ps1:2052`) hardcodes `Start-ProcessLaunch -Type 'task-runner'`, so workflow-driven kickstarts from the dashboard bypass `Invoke-KickstartProcess` entirely.

Result: kickstart-from-scratch phase commits on `main` look like `chore: update task state` / `chore: save autonomous task state` / Claude-generated freeform messages, not the `chore(kickstart): phase N — ...` declared in `workflow.yaml`. Fixing it means an architectural decision about whether to re-route workflow runs through the kickstart runner, add parallel phase-commit logic inside the task-runner, or amend/mark commits post-merge. That deserves a dedicated PR.

## Verification

**Fix 1 (deferred tools) — confirmed in a real headed E2E run:**

- Before: task-runner hung for 20 min; `.bot/.control/logs/dotbot-*.jsonl` showed \`'I can't run this analysis workflow. Missing MCP tools.'\` at turn 1, zero workspace artifacts written.
- After: zero refusal events in the log, `ToolSearch` burst on the first turn, `mcp__dotbot__task_mark_analysing` called successfully, all four planning phases ran, `.bot/workspace/product/{mission,tech-stack,entity-model}.md` and `task-groups.json` written, task-group-expansion moved to `in-progress/` with ~10 expanded tasks dropped into `todo/`.

**Fix 2 (`Test-ManifestCondition`):**

- Before: `curl http://localhost:8686/api/info` → `500` with route-handler error in the log.
- After (to verify after merging + `pwsh install.ps1` + `dotbot init` in a project): `/api/info` returns 200 with the expected JSON shape; dashboard network tab shows no 500s; \`'Test-ManifestCondition is not recognized'\` absent from `dotbot-*.jsonl`.

**Fix 3 (01-plan-product upgrade):**

- Re-run kickstart-from-scratch and inspect `.bot/workspace/product/entity-model.md`. The output should contain typed field tables, enum value tables, cardinality notation (`1:N`/`N:1`/`N:N`), a Mermaid `erDiagram` with entity attributes (not just relationship lines), and Data Storage / API Contracts / Design Decisions sections. `mission.md` should start with `## Executive Summary`. `tech-stack.md` should cover all six sections (Languages, Frameworks, Libraries, Tooling, Infrastructure, Dev Env) plus Rationale.

## Test plan

- [ ] `pwsh install.ps1` from the dotbot repo root reports 'already installed globally — updating…' and exits 0.
- [ ] In a fresh project: `dotbot init` completes and the initialised `.bot/recipes/prompts/98-analyse-task.md` contains a `## Phase 0: Load Required Tools` section.
- [ ] `pwsh .bot/go.ps1` brings the dashboard up and `/api/info` returns 200 (no 500 in the browser devtools network tab, no `Test-ManifestCondition` error in `.bot/.control/logs/dotbot-*.jsonl`).
- [ ] Submit a kickstart-from-scratch run. First Claude child output shows a `ToolSearch` burst followed by `mcp__dotbot__task_mark_analysing` with no 'Missing MCP tools' refusal.
- [ ] All four planning phases complete and write their expected artifacts under `.bot/workspace/product/`, `.bot/workspace/decisions/`, and `.bot/workspace/tasks/`.
- [ ] `.bot/workspace/product/entity-model.md` contains typed field tables, enum value tables, cardinality notation, and a Mermaid `erDiagram` with entity attributes.