### PR TITLE
fix(ui): kickstart overview completes script phases with committed dirs

### DIFF
--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2976,6 +2976,24 @@ if (Test-Path $productApiModule) {
             -Expected "completed" -Actual $statusWithDone
         Remove-Item (Join-Path $kickstartTasksDir 'done/expanded-task-1.json') -Force
 
+        # Case C2: task only in tasks/skipped/ → completed (pipeline-dir list
+        # must stay aligned with the outputs_dir branch, which also counts
+        # skipped + cancelled as evidence the phase ran).
+        Set-Content -Path (Join-Path $kickstartTasksDir 'skipped/expanded-task-s.json') `
+            -Value '{"id":"ts","name":"skipped"}' -Encoding UTF8
+        $statusWithSkipped = & $productApiModuleObj $resolvePhaseStatus $scriptPhaseCommitTasks $kickstartBotRoot
+        Assert-Equal -Name "Resolve-PhaseStatusFromOutputs: task in tasks/skipped/ → completed" `
+            -Expected "completed" -Actual $statusWithSkipped
+        Remove-Item (Join-Path $kickstartTasksDir 'skipped/expanded-task-s.json') -Force
+
+        # Case C3: task only in tasks/cancelled/ → completed
+        Set-Content -Path (Join-Path $kickstartTasksDir 'cancelled/expanded-task-c.json') `
+            -Value '{"id":"tc","name":"cancelled"}' -Encoding UTF8
+        $statusWithCancelled = & $productApiModuleObj $resolvePhaseStatus $scriptPhaseCommitTasks $kickstartBotRoot
+        Assert-Equal -Name "Resolve-PhaseStatusFromOutputs: task in tasks/cancelled/ → completed" `
+            -Expected "completed" -Actual $statusWithCancelled
+        Remove-Item (Join-Path $kickstartTasksDir 'cancelled/expanded-task-c.json') -Force
+
         # Case D: only .gitkeep sentinels in pipeline dirs → pending
         # (Sentinels must not trip the probe — that would mask a never-ran state.)
         Set-Content -Path (Join-Path $kickstartTasksDir 'todo/.gitkeep') -Value '' -Encoding UTF8

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2871,8 +2871,9 @@ if (Test-Path $productApiModule) {
         foreach ($d in @($kickstartControl, (Join-Path $kickstartControl 'processes'), $kickstartSettings, $kickstartProductDir, $kickstartDecisionsDir)) {
             New-Item -Path $d -ItemType Directory -Force | Out-Null
         }
-        # Create the task pipeline dirs
-        foreach ($td in @('todo','analysing','analysed','in-progress','done','skipped','cancelled')) {
+        # Create the full canonical task pipeline dir set (matches
+        # workflow-manifest.ps1 Clear-WorkspaceTaskDirs).
+        foreach ($td in @('todo','analysing','needs-input','analysed','in-progress','done','skipped','cancelled','split')) {
             New-Item -Path (Join-Path $kickstartTasksDir $td) -ItemType Directory -Force | Out-Null
         }
 
@@ -2993,6 +2994,24 @@ if (Test-Path $productApiModule) {
         Assert-Equal -Name "Resolve-PhaseStatusFromOutputs: task in tasks/cancelled/ → completed" `
             -Expected "completed" -Actual $statusWithCancelled
         Remove-Item (Join-Path $kickstartTasksDir 'cancelled/expanded-task-c.json') -Force
+
+        # Case C4: task only in tasks/needs-input/ → completed
+        # (Split/needs-input are legitimate pipeline statuses per
+        # workflow-manifest.ps1 Clear-WorkspaceTaskDirs — must be recognized.)
+        Set-Content -Path (Join-Path $kickstartTasksDir 'needs-input/expanded-task-n.json') `
+            -Value '{"id":"tn","name":"needs-input"}' -Encoding UTF8
+        $statusWithNeedsInput = & $productApiModuleObj $resolvePhaseStatus $scriptPhaseCommitTasks $kickstartBotRoot
+        Assert-Equal -Name "Resolve-PhaseStatusFromOutputs: task in tasks/needs-input/ → completed" `
+            -Expected "completed" -Actual $statusWithNeedsInput
+        Remove-Item (Join-Path $kickstartTasksDir 'needs-input/expanded-task-n.json') -Force
+
+        # Case C5: task only in tasks/split/ → completed
+        Set-Content -Path (Join-Path $kickstartTasksDir 'split/expanded-task-sp.json') `
+            -Value '{"id":"tsp","name":"split"}' -Encoding UTF8
+        $statusWithSplit = & $productApiModuleObj $resolvePhaseStatus $scriptPhaseCommitTasks $kickstartBotRoot
+        Assert-Equal -Name "Resolve-PhaseStatusFromOutputs: task in tasks/split/ → completed" `
+            -Expected "completed" -Actual $statusWithSplit
+        Remove-Item (Join-Path $kickstartTasksDir 'split/expanded-task-sp.json') -Force
 
         # Case D: only .gitkeep sentinels in pipeline dirs → pending
         # (Sentinels must not trip the probe — that would mask a never-ran state.)

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2852,9 +2852,281 @@ if (Test-Path $productApiModule) {
         Assert-True -Name "ProductAPI loads explicit .json route when .md also exists" `
             -Condition ($missionJsonDoc.success -eq $true -and $missionJsonDoc.content -match 'Mission JSON') `
             -Message "Expected mission.json content when requested explicitly"
+
+        # ═════════════════════════════════════════════════════════════════
+        # Get-KickstartStatus — script-phase probe + process-type filter
+        # Regression tests for #244: Overview stuck on Task Group Expansion
+        # ═════════════════════════════════════════════════════════════════
+
+        # Set up a fresh, isolated workspace for kickstart status tests so
+        # state doesn't leak into the doc tests above.
+        $kickstartTestRoot = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-kickstart-status-$([guid]::NewGuid().ToString().Substring(0,8))"
+        $kickstartBotRoot  = Join-Path $kickstartTestRoot ".bot"
+        $kickstartControl  = Join-Path $kickstartBotRoot ".control"
+        $kickstartSettings = Join-Path $kickstartBotRoot "settings"
+        $kickstartTasksDir = Join-Path $kickstartBotRoot "workspace\tasks"
+        $kickstartProductDir = Join-Path $kickstartBotRoot "workspace\product"
+        $kickstartDecisionsDir = Join-Path $kickstartBotRoot "workspace\decisions"
+
+        foreach ($d in @($kickstartControl, (Join-Path $kickstartControl 'processes'), $kickstartSettings, $kickstartProductDir, $kickstartDecisionsDir)) {
+            New-Item -Path $d -ItemType Directory -Force | Out-Null
+        }
+        # Create the task pipeline dirs
+        foreach ($td in @('todo','analysing','analysed','in-progress','done','skipped','cancelled')) {
+            New-Item -Path (Join-Path $kickstartTasksDir $td) -ItemType Directory -Force | Out-Null
+        }
+
+        # Mark the first three phases complete via disk artifacts
+        Set-Content -Path (Join-Path $kickstartProductDir 'mission.md') -Value '# Mission' -Encoding UTF8
+        Set-Content -Path (Join-Path $kickstartProductDir 'tech-stack.md') -Value '# Tech' -Encoding UTF8
+        Set-Content -Path (Join-Path $kickstartProductDir 'entity-model.md') -Value '# Entities' -Encoding UTF8
+        Set-Content -Path (Join-Path $kickstartProductDir 'task-groups.json') -Value '{"groups":[]}' -Encoding UTF8
+        Set-Content -Path (Join-Path $kickstartDecisionsDir 'dec-0001.md') -Value '# Decision 1' -Encoding UTF8
+
+        # Minimal legacy kickstart phase list via settings.default.json — the
+        # Get-KickstartStatus fallback path. Avoids needing a YAML parser in
+        # the test environment.
+        $kickstartPhasesJson = @'
+{
+  "kickstart": {
+    "phases": [
+      {
+        "id": "product-documents",
+        "name": "Product Documents",
+        "type": "prompt",
+        "outputs": ["mission.md", "tech-stack.md", "entity-model.md"]
+      },
+      {
+        "id": "generate-decisions",
+        "name": "Generate Decisions",
+        "type": "prompt",
+        "outputs_dir": "decisions",
+        "min_output_count": 1
+      },
+      {
+        "id": "task-groups",
+        "name": "Task Groups",
+        "type": "prompt",
+        "outputs": ["task-groups.json"]
+      },
+      {
+        "id": "task-group-expansion",
+        "name": "Task Group Expansion",
+        "type": "script",
+        "script": "expand-task-groups.ps1",
+        "commit": { "paths": ["workspace/tasks/"] }
+      }
+    ]
+  }
+}
+'@
+        Set-Content -Path (Join-Path $kickstartSettings 'settings.default.json') -Value $kickstartPhasesJson -Encoding UTF8
+
+        # Get-KickstartStatus dot-sources $BotRoot/systems/runtime/modules/workflow-manifest.ps1
+        # and that file imports ManifestCondition.psm1 from the same directory.
+        # Copy both helpers into the test bot root so the integration test can run.
+        $runtimeModulesDir = Join-Path $kickstartBotRoot "systems\runtime\modules"
+        New-Item -Path $runtimeModulesDir -ItemType Directory -Force | Out-Null
+        $repoRootForTest = Split-Path $PSScriptRoot -Parent
+        $realRuntimeModules = Join-Path $repoRootForTest "workflows\default\systems\runtime\modules"
+        Copy-Item -Path (Join-Path $realRuntimeModules 'workflow-manifest.ps1') -Destination $runtimeModulesDir -Force
+        Copy-Item -Path (Join-Path $realRuntimeModules 'ManifestCondition.psm1') -Destination $runtimeModulesDir -Force
+
+        # Re-initialize ProductAPI against the isolated kickstart test root
+        Initialize-ProductAPI -BotRoot $kickstartBotRoot -ControlDir $kickstartControl
+
+        # Helper: invoke the module-private Resolve-PhaseStatusFromOutputs
+        # directly. It's not exported so we use module-scope invocation.
+        $productApiModuleObj = Get-Module ProductAPI
+        $resolvePhaseStatus = {
+            param($Phase, $BotRoot)
+            Resolve-PhaseStatusFromOutputs -Phase $Phase -BotRoot $BotRoot
+        }
+
+        # ── Defect 2: script-phase probe (Resolve-PhaseStatusFromOutputs) ──
+
+        $scriptPhaseCommitTasks = [pscustomobject]@{
+            id = 'task-group-expansion'
+            name = 'Task Group Expansion'
+            type = 'script'
+            script = 'expand-task-groups.ps1'
+            commit = [pscustomobject]@{ paths = @('workspace/tasks/') }
+        }
+
+        # Case A: entirely empty pipeline dirs → pending (was: pending — same)
+        $statusEmpty = & $productApiModuleObj $resolvePhaseStatus $scriptPhaseCommitTasks $kickstartBotRoot
+        Assert-Equal -Name "Resolve-PhaseStatusFromOutputs: empty tasks/ → pending" `
+            -Expected "pending" -Actual $statusEmpty
+
+        # Case B: a task file in tasks/todo/ → completed
+        # (This is the #244 bug: before the fix, returned "pending" because
+        # Get-ChildItem -File on the tasks/ parent had no top-level files.)
+        Set-Content -Path (Join-Path $kickstartTasksDir 'todo/expanded-task-1.json') `
+            -Value '{"id":"t1","name":"test"}' -Encoding UTF8
+        $statusWithTodo = & $productApiModuleObj $resolvePhaseStatus $scriptPhaseCommitTasks $kickstartBotRoot
+        Assert-Equal -Name "Resolve-PhaseStatusFromOutputs: task in tasks/todo/ → completed (#244 regression)" `
+            -Expected "completed" -Actual $statusWithTodo
+
+        # Case C: task only in tasks/done/ (workflow task moved through pipeline) → completed
+        Remove-Item (Join-Path $kickstartTasksDir 'todo/expanded-task-1.json') -Force
+        Set-Content -Path (Join-Path $kickstartTasksDir 'done/expanded-task-1.json') `
+            -Value '{"id":"t1","name":"test"}' -Encoding UTF8
+        $statusWithDone = & $productApiModuleObj $resolvePhaseStatus $scriptPhaseCommitTasks $kickstartBotRoot
+        Assert-Equal -Name "Resolve-PhaseStatusFromOutputs: task in tasks/done/ → completed" `
+            -Expected "completed" -Actual $statusWithDone
+        Remove-Item (Join-Path $kickstartTasksDir 'done/expanded-task-1.json') -Force
+
+        # Case D: only .gitkeep sentinels in pipeline dirs → pending
+        # (Sentinels must not trip the probe — that would mask a never-ran state.)
+        Set-Content -Path (Join-Path $kickstartTasksDir 'todo/.gitkeep') -Value '' -Encoding UTF8
+        Set-Content -Path (Join-Path $kickstartTasksDir 'done/.gitkeep') -Value '' -Encoding UTF8
+        $statusOnlyGitkeep = & $productApiModuleObj $resolvePhaseStatus $scriptPhaseCommitTasks $kickstartBotRoot
+        Assert-Equal -Name "Resolve-PhaseStatusFromOutputs: only .gitkeep sentinels → pending" `
+            -Expected "pending" -Actual $statusOnlyGitkeep
+        Remove-Item (Join-Path $kickstartTasksDir 'todo/.gitkeep') -Force
+        Remove-Item (Join-Path $kickstartTasksDir 'done/.gitkeep') -Force
+
+        # Case E: general recursive case — a non-tasks commit path with
+        # committed files nested two levels deep. The old probe used a flat
+        # file count on the top-level dir and would have missed these.
+        $customDir = Join-Path $kickstartBotRoot 'workspace\custom\nested\deep'
+        New-Item -Path $customDir -ItemType Directory -Force | Out-Null
+        Set-Content -Path (Join-Path $customDir 'artifact.txt') -Value 'hello' -Encoding UTF8
+        $scriptPhaseCustom = [pscustomobject]@{
+            id = 'custom-phase'
+            name = 'Custom Phase'
+            type = 'script'
+            script = 'custom.ps1'
+            commit = [pscustomobject]@{ paths = @('workspace/custom/') }
+        }
+        $statusRecursive = & $productApiModuleObj $resolvePhaseStatus $scriptPhaseCustom $kickstartBotRoot
+        Assert-Equal -Name "Resolve-PhaseStatusFromOutputs: nested artifacts → completed (recursive general case)" `
+            -Expected "completed" -Actual $statusRecursive
+
+        # Case F: general recursive case with only .gitkeep → pending
+        Remove-Item (Join-Path $customDir 'artifact.txt') -Force
+        Set-Content -Path (Join-Path $customDir '.gitkeep') -Value '' -Encoding UTF8
+        $statusRecursiveGitkeep = & $productApiModuleObj $resolvePhaseStatus $scriptPhaseCustom $kickstartBotRoot
+        Assert-Equal -Name "Resolve-PhaseStatusFromOutputs: nested .gitkeep only → pending" `
+            -Expected "pending" -Actual $statusRecursiveGitkeep
+
+        # ── Integration: Get-KickstartStatus full-stack ──
+
+        # With a real task file and no process record, all four phases should
+        # report completed via filesystem inference (P1 + P3 working end-to-end).
+        Set-Content -Path (Join-Path $kickstartTasksDir 'todo/expanded-task-1.json') `
+            -Value '{"id":"t1","name":"test"}' -Encoding UTF8
+
+        $statusNoProc = Get-KickstartStatus
+        Assert-Equal -Name "Get-KickstartStatus: overall status with 4 complete phases (no proc)" `
+            -Expected "completed" -Actual $statusNoProc.status
+        $expansionPhase = $statusNoProc.phases | Where-Object { $_.id -eq 'task-group-expansion' }
+        Assert-Equal -Name "Get-KickstartStatus: expansion phase completed via filesystem inference" `
+            -Expected "completed" -Actual $expansionPhase.status
+        Assert-True -Name "Get-KickstartStatus: resume_from is null when all phases complete" `
+            -Condition ([string]::IsNullOrEmpty($statusNoProc.resume_from)) `
+            -Message "Expected resume_from null/empty, got '$($statusNoProc.resume_from)'"
+
+        # ── Defect 1: process-type filter (P2) ──
+
+        $procDir = Join-Path $kickstartControl 'processes'
+
+        # P2 positive: task-runner process with matching workflow_name IS picked up.
+        # This case requires a real YAML manifest so that $workflowName gets
+        # populated inside Get-KickstartStatus (the legacy settings.default.json
+        # fallback leaves workflowName null, which would short-circuit the match).
+        # Skip if powershell-yaml is unavailable in the test environment.
+        $haveYamlModule = $null -ne (Get-Module -ListAvailable powershell-yaml -ErrorAction SilentlyContinue)
+        if ($haveYamlModule) {
+            $manifestDir = Join-Path $kickstartBotRoot "workflows\kickstart-from-scratch"
+            New-Item -Path $manifestDir -ItemType Directory -Force | Out-Null
+            $manifestYaml = @'
+name: kickstart-from-scratch
+version: "1.0"
+description: Test manifest for #244 regression
+tasks:
+  - name: "Product Documents"
+    id: product-documents
+    type: prompt
+    outputs: ["mission.md", "tech-stack.md", "entity-model.md"]
+  - name: "Generate Decisions"
+    id: generate-decisions
+    type: prompt
+    outputs_dir: "decisions"
+    min_output_count: 1
+  - name: "Task Groups"
+    id: task-groups
+    type: prompt
+    outputs: ["task-groups.json"]
+  - name: "Task Group Expansion"
+    id: task-group-expansion
+    type: script
+    script: "expand-task-groups.ps1"
+    outputs_dir: "tasks/todo"
+    min_output_count: 1
+    commit:
+      paths: ["workspace/tasks/"]
+'@
+            Set-Content -Path (Join-Path $manifestDir 'workflow.yaml') -Value $manifestYaml -Encoding UTF8
+
+            $matchingProc = @{
+                id = 'proc-test-match'
+                type = 'task-runner'
+                workflow_name = 'kickstart-from-scratch'
+                status = 'completed'
+                phases = @()
+            } | ConvertTo-Json -Depth 4
+            Set-Content -Path (Join-Path $procDir 'proc-test-match.json') -Value $matchingProc -Encoding UTF8
+            $statusMatch = Get-KickstartStatus
+            Assert-Equal -Name "Get-KickstartStatus P2: task-runner proc with matching workflow_name → process_id populated" `
+                -Expected 'proc-test-match' -Actual $statusMatch.process_id
+            Assert-Equal -Name "Get-KickstartStatus P2: workflow_name surfaced in response" `
+                -Expected 'kickstart-from-scratch' -Actual $statusMatch.workflow_name
+            Remove-Item (Join-Path $procDir 'proc-test-match.json') -Force
+            # Leave the manifest in place for the remaining P2 tests.
+        } else {
+            Write-TestResult -Name "Get-KickstartStatus P2: task-runner proc with matching workflow_name" `
+                -Status Skip -Message "powershell-yaml module not available"
+        }
+
+        # P2 regression: task-runner process with DIFFERENT workflow_name is ignored
+        $otherProc = @{
+            id = 'proc-test-other'
+            type = 'task-runner'
+            workflow_name = 'some-other-workflow'
+            status = 'completed'
+            phases = @()
+        } | ConvertTo-Json -Depth 4
+        Set-Content -Path (Join-Path $procDir 'proc-test-other.json') -Value $otherProc -Encoding UTF8
+        $statusOther = Get-KickstartStatus
+        Assert-True -Name "Get-KickstartStatus P2: task-runner proc with non-matching workflow_name → process_id null" `
+            -Condition ([string]::IsNullOrEmpty($statusOther.process_id)) `
+            -Message "Expected null process_id, got '$($statusOther.process_id)'"
+        Remove-Item (Join-Path $procDir 'proc-test-other.json') -Force
+
+        # P2 compatibility: type=kickstart still works (back-compat)
+        $legacyProc = @{
+            id = 'proc-test-legacy'
+            type = 'kickstart'
+            status = 'completed'
+            phases = @()
+        } | ConvertTo-Json -Depth 4
+        Set-Content -Path (Join-Path $procDir 'proc-test-legacy.json') -Value $legacyProc -Encoding UTF8
+        $statusLegacy = Get-KickstartStatus
+        Assert-Equal -Name "Get-KickstartStatus P2: legacy type=kickstart proc still matched" `
+            -Expected 'proc-test-legacy' -Actual $statusLegacy.process_id
+        Remove-Item (Join-Path $procDir 'proc-test-legacy.json') -Force
+
+        # Cleanup isolated kickstart test root
+        if (Test-Path $kickstartTestRoot) {
+            Remove-Item $kickstartTestRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
     } finally {
         Remove-TestProject -Path $productApiTestProject
         Remove-Module ProductAPI -ErrorAction SilentlyContinue
+        if ($kickstartTestRoot -and (Test-Path $kickstartTestRoot)) {
+            Remove-Item $kickstartTestRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
     }
 } else {
     Write-TestResult -Name "ProductAPI direct tests" -Status Skip -Message "Module not found at $productApiModule"

--- a/workflows/default/systems/runtime/expand-task-groups.ps1
+++ b/workflows/default/systems/runtime/expand-task-groups.ps1
@@ -269,3 +269,9 @@ Write-GroupActivity "Expansion results appended to: $overviewPath"
 # Final summary
 Write-Header "Expansion Complete"
 Write-GroupActivity "Task group expansion complete: $totalTasksCreated tasks created across $($sortedGroups.Count) groups"
+
+# Emit a structured phase-completion marker so UI/state code can latch on
+# without parsing the free-text Write-GroupActivity message above.
+try {
+    Write-ActivityLog -Type "phase_complete" -Message "phase=task-group-expansion tasks_created=$totalTasksCreated groups=$($sortedGroups.Count)"
+} catch { Write-BotLog -Level Debug -Message "phase_complete marker write failed" -Exception $_ }

--- a/workflows/default/systems/ui/modules/ProductAPI.psm1
+++ b/workflows/default/systems/ui/modules/ProductAPI.psm1
@@ -643,9 +643,35 @@ function Resolve-PhaseStatusFromOutputs {
         if ($commitPaths) {
             foreach ($cp in $commitPaths) {
                 $cpPath = Join-Path $BotRoot $cp
-                if ((Test-Path $cpPath) -and @(Get-ChildItem $cpPath -File -ErrorAction SilentlyContinue | Where-Object { $_.Name -ne '.gitkeep' }).Count -gt 0) {
-                    return "completed"
+                if (-not (Test-Path $cpPath)) { continue }
+
+                # Special-case: a commit path of `workspace/tasks/` (or `tasks/`)
+                # means the phase generates task files into the pipeline dirs.
+                # The top level of tasks/ has no files — only subdirs — so a
+                # flat count always returns 0. Probe the pipeline dirs instead,
+                # matching the semantics of the outputs_dir branch above.
+                $normalized = ($cp -replace '\\','/').Trim('/')
+                if ($normalized -match '^(workspace/)?tasks/?$') {
+                    $taskDirs = @('todo','analysing','analysed','in-progress','done')
+                    $matched = $false
+                    foreach ($td in $taskDirs) {
+                        $tdPath = Join-Path $cpPath $td
+                        if (Test-Path $tdPath) {
+                            $n = @(Get-ChildItem $tdPath -Filter '*.json' -File -ErrorAction SilentlyContinue).Count
+                            if ($n -gt 0) { $matched = $true; break }
+                        }
+                    }
+                    if ($matched) { return "completed" }
+                    continue
                 }
+
+                # General case: recursive file count under the commit path,
+                # ignoring .gitkeep sentinels. Recurse so a commit path that
+                # points at a directory-of-directories still registers real
+                # committed artifacts underneath.
+                $files = @(Get-ChildItem $cpPath -File -Recurse -ErrorAction SilentlyContinue |
+                           Where-Object { $_.Name -ne '.gitkeep' })
+                if ($files.Count -gt 0) { return "completed" }
             }
         }
     }
@@ -770,7 +796,15 @@ function Get-KickstartStatus {
         foreach ($pf in $procFiles) {
             try {
                 $pData = Get-Content $pf.FullName -Raw | ConvertFrom-Json
-                if ($pData.type -eq 'kickstart') {
+                # Accept both 'kickstart' (UI-launched kickstart flow) and
+                # 'task-runner' processes whose workflow_name matches the
+                # active manifest (generic workflow-runner launching a
+                # kickstart-style workflow). Either one is the authoritative
+                # record for this kickstart run.
+                $isKickstart = $pData.type -eq 'kickstart'
+                $isWorkflowRunner = $pData.type -eq 'task-runner' -and $workflowName -and
+                                    $pData.workflow_name -eq $workflowName
+                if ($isKickstart -or $isWorkflowRunner) {
                     $latestProc = $pData
                     break
                 }

--- a/workflows/default/systems/ui/modules/ProductAPI.psm1
+++ b/workflows/default/systems/ui/modules/ProductAPI.psm1
@@ -625,7 +625,10 @@ function Resolve-PhaseStatusFromOutputs {
         if ($Phase.outputs_dir -match '^tasks/') {
             $taskBaseDir = Join-Path $BotRoot "workspace\tasks"
             $totalTasks = 0
-            foreach ($td in @("todo","analysing","analysed","in-progress","done","skipped","cancelled")) {
+            # Canonical task-pipeline status dirs. Keep in sync with the list
+            # in the script-phase probe below and with workflow-manifest.ps1
+            # (Clear-WorkspaceTaskDirs) which owns the authoritative enumeration.
+            foreach ($td in @('todo','analysing','needs-input','analysed','in-progress','done','skipped','cancelled','split')) {
                 $tdPath = Join-Path $taskBaseDir $td
                 if (Test-Path $tdPath) {
                     $totalTasks += @(Get-ChildItem $tdPath -Filter "*.json" -File -ErrorAction SilentlyContinue).Count
@@ -649,11 +652,15 @@ function Resolve-PhaseStatusFromOutputs {
                 # means the phase generates task files into the pipeline dirs.
                 # The top level of tasks/ has no files — only subdirs — so a
                 # flat count always returns 0. Probe the pipeline dirs instead,
-                # matching the semantics of the outputs_dir branch above
-                # (including skipped/cancelled — consistent with that branch).
+                # matching the semantics of the outputs_dir branch above.
+                # Keep this list in sync with the outputs_dir fallback above
+                # and with workflow-manifest.ps1 (Clear-WorkspaceTaskDirs) which
+                # owns the authoritative enumeration — tasks can legitimately
+                # sit in any of these statuses (incl. needs-input / split)
+                # after generation.
                 $normalized = ($cp -replace '\\','/').Trim('/')
                 if ($normalized -match '^(workspace/)?tasks/?$') {
-                    $taskDirs = @('todo','analysing','analysed','in-progress','done','skipped','cancelled')
+                    $taskDirs = @('todo','analysing','needs-input','analysed','in-progress','done','skipped','cancelled','split')
                     $matched = $false
                     foreach ($td in $taskDirs) {
                         $tdPath = Join-Path $cpPath $td

--- a/workflows/default/systems/ui/modules/ProductAPI.psm1
+++ b/workflows/default/systems/ui/modules/ProductAPI.psm1
@@ -649,29 +649,35 @@ function Resolve-PhaseStatusFromOutputs {
                 # means the phase generates task files into the pipeline dirs.
                 # The top level of tasks/ has no files — only subdirs — so a
                 # flat count always returns 0. Probe the pipeline dirs instead,
-                # matching the semantics of the outputs_dir branch above.
+                # matching the semantics of the outputs_dir branch above
+                # (including skipped/cancelled — consistent with that branch).
                 $normalized = ($cp -replace '\\','/').Trim('/')
                 if ($normalized -match '^(workspace/)?tasks/?$') {
-                    $taskDirs = @('todo','analysing','analysed','in-progress','done')
+                    $taskDirs = @('todo','analysing','analysed','in-progress','done','skipped','cancelled')
                     $matched = $false
                     foreach ($td in $taskDirs) {
                         $tdPath = Join-Path $cpPath $td
                         if (Test-Path $tdPath) {
-                            $n = @(Get-ChildItem $tdPath -Filter '*.json' -File -ErrorAction SilentlyContinue).Count
-                            if ($n -gt 0) { $matched = $true; break }
+                            # Short-circuit: stop at the first match to avoid
+                            # enumerating entire pipeline dirs on every UI poll.
+                            $firstTaskFile = Get-ChildItem $tdPath -Filter '*.json' -File -ErrorAction SilentlyContinue |
+                                Select-Object -First 1
+                            if ($null -ne $firstTaskFile) { $matched = $true; break }
                         }
                     }
                     if ($matched) { return "completed" }
                     continue
                 }
 
-                # General case: recursive file count under the commit path,
+                # General case: check for any real file under the commit path,
                 # ignoring .gitkeep sentinels. Recurse so a commit path that
                 # points at a directory-of-directories still registers real
-                # committed artifacts underneath.
-                $files = @(Get-ChildItem $cpPath -File -Recurse -ErrorAction SilentlyContinue |
-                           Where-Object { $_.Name -ne '.gitkeep' })
-                if ($files.Count -gt 0) { return "completed" }
+                # committed artifacts underneath, but stop at the first match
+                # to avoid materializing the full file list on every UI poll.
+                $firstFile = Get-ChildItem $cpPath -File -Recurse -ErrorAction SilentlyContinue |
+                             Where-Object { $_.Name -ne '.gitkeep' } |
+                             Select-Object -First 1
+                if ($firstFile) { return "completed" }
             }
         }
     }

--- a/workflows/kickstart-from-scratch/workflow.yaml
+++ b/workflows/kickstart-from-scratch/workflow.yaml
@@ -60,6 +60,8 @@ tasks:
     type: script
     script: "expand-task-groups.ps1"
     depends_on: ["Task Groups"]
+    outputs_dir: "tasks/todo"
+    min_output_count: 1
     commit:
       paths: ["workspace/tasks/"]
       message: "chore(kickstart): phase 2b — expanded task roadmap"


### PR DESCRIPTION
Fixes #244.

## Summary

After a successful `kickstart-from-scratch` run the dashboard Overview sidebar stuck at ○ **Task Group Expansion** with a RESUME button, even though the script-phase had completed cleanly and produced task files on disk. Two defects in `workflows/default/systems/ui/modules/ProductAPI.psm1` combined to cause it.

## Root cause

**Defect 1 — process-type filter.** `Get-KickstartStatus` only accepted processes with `type: "kickstart"` when locating the authoritative record. When a kickstart-style workflow runs through the generic workflow task-runner (as `kickstart-from-scratch` does in most real flows), the process file records `type: "task-runner"` — so `$latestProc` stayed `$null`, and the function fell through to filesystem inference.

**Defect 2 — non-recursive script-phase probe.** The filesystem-inference branch for script-type phases (`Resolve-PhaseStatusFromOutputs`, line 640) did `Get-ChildItem $cpPath -File` **without `-Recurse`**. The Task Group Expansion phase declares `commit.paths: ["workspace/tasks/"]`, and that directory at the top level contains only subdirectories (`todo/`, `done/`, `analysing/`, …) — zero files. The probe returned 0, fell through, and reported "pending". The 51 generated tasks in `workspace/tasks/todo/` were invisible.

## Changes

- **`ProductAPI.psm1` (P1)** — script-phase probe is now recursive, ignores `.gitkeep`, and special-cases a `workspace/tasks/` (or `tasks/`) commit path to walk the standard pipeline dirs (`todo/`, `analysing/`, `analysed/`, `in-progress/`, `done/`) for `*.json` evidence. This matches the semantics of the existing `outputs_dir` branch and avoids miscounting root-level task fixtures.
- **`ProductAPI.psm1` (P2)** — process-type filter now accepts both `type: "kickstart"` and `type: "task-runner"` when `workflow_name` matches the active manifest, closing a latent divergence between filesystem inference and the process record.
- **`workflows/kickstart-from-scratch/workflow.yaml` (P3)** — adds `outputs_dir: "tasks/todo"` + `min_output_count: 1` to the Task Group Expansion phase so detection can route through the long-exercised `outputs_dir` branch as well. Belt-and-braces.
- **`workflows/default/systems/runtime/expand-task-groups.ps1` (P4)** — emits a structured `phase_complete` activity marker alongside the existing free-text summary so future UI/state detection can latch on without parsing the message string.

## Verification

Reproduced against a real Vibetrip harness run where Task Group Expansion had finished successfully and left 51 tasks in `workspace/tasks/todo/` + the workflow task file in `workspace/tasks/done/`.

**Before:**
```json
{
  "status": "incomplete",
  "resume_from": "task-group-expansion",
  "process_id": null,
  "phases": [
    { "id": "task-group-expansion", "status": "pending" }
  ]
}
```

**After (with only the edited ProductAPI.psm1 swapped into `.bot/`, before full install):**
```json
{
  "status": "completed",
  "resume_from": null,
  "process_id": "proc-f9c42e",
  "phases": [
    { "id": "task-group-expansion", "status": "completed" }
  ]
}
```

All four phases report `completed`, the authoritative process record is located via the relaxed filter (P2), and the script-phase probe reports the 51 generated tasks as committed evidence (P1).

## Test plan

- [x] Reproduce baseline (expansion phase stuck pending, overall `incomplete`) against a real kickstart-from-scratch run
- [x] Confirm `Get-KickstartStatus` returns all four phases `completed` + overall `completed` after the fix
- [x] PowerShell parse-check both modified `.ps1` / `.psm1` files
- [ ] Full `install.ps1` + `dotbot init -Force` into Vibetrip harness, re-run kickstart-from-scratch end-to-end, confirm dashboard Overview shows four ✓ automatically on completion (no manual refresh)
- [ ] Regression: run `grep -rn 'commit:' workflows -A2` and flag any other phase whose only output signal is a parent-of-dirs path
- [ ] `kickstart-via-repo` smoke test to confirm the relaxed probe doesn't regress there

## Out of scope

- Refactoring `expand-task-groups.ps1` internals — already works.
- Adding a `post-expansion-tasks.ps1` post-script.
- Rewriting the 03b expansion prompt.
- Fixing the parallel bug in `Invoke-KickstartProcess.ps1` script-phase branch (lines 325–336) that affects the UI-launched kickstart flow — separate issue if/when needed.
