### PR TITLE
fix(kickstart): four friction fixes + test coverage (batch 1)

### DIFF
--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1038,6 +1038,76 @@ Assert-True -Name "Invoke-KickstartProcess no longer has inline post_script path
 Write-Host ""
 
 # ═══════════════════════════════════════════════════════════════════
+# KICKSTART FRICTION FIXES (batch 1)
+# ═══════════════════════════════════════════════════════════════════
+# Regressions guarding the four fixes that came out of analysing a real
+# kickstart-from-scratch activity.jsonl run in a downstream harness.
+# See the PR description in fix/kickstart-friction-batch-1 for context.
+
+Write-Host "  KICKSTART FRICTION FIXES" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+# ── Fix #1: workflow-manifest.ps1 must import ManifestCondition.psm1 with
+# -Global so Test-ManifestCondition remains visible when workflow-manifest.ps1
+# is dot-sourced from inside a function/scriptblock scope (the pattern
+# server.ps1 and task-get-next/script.ps1 use). Without -Global the imported
+# function ends up in a module scope that HTTP route handlers cannot reach.
+$workflowManifestPath = Join-Path $repoRoot "workflows\default\systems\runtime\modules\workflow-manifest.ps1"
+$workflowManifestSrc = Get-Content $workflowManifestPath -Raw
+
+Assert-True -Name "Fix#1: workflow-manifest.ps1 Import-Module for ManifestCondition uses -Global" `
+    -Condition ($workflowManifestSrc -match 'Import-Module\s+\(Join-Path\s+\$PSScriptRoot\s+"ManifestCondition\.psm1"\)[^\r\n]*-Global')
+
+# Regression: dot-source workflow-manifest.ps1 inside a nested scriptblock and
+# verify Test-ManifestCondition is callable from that child scope via the
+# -Global import. This is the exact failure mode seen in HTTP route handlers.
+Remove-Module ManifestCondition -Force -ErrorAction SilentlyContinue
+$nestedProbe = & {
+    . $workflowManifestPath
+    (Get-Command Test-ManifestCondition -ErrorAction SilentlyContinue) -ne $null
+}
+Assert-True -Name "Fix#1: Test-ManifestCondition visible after nested dot-source of workflow-manifest.ps1" `
+    -Condition $nestedProbe
+
+# ── Fix #2: Invoke-KickstartProcess.ps1 must auto-push phase commits on main/
+# master so the 02-git-pushed.ps1 verify hook does not block task_mark_done.
+Assert-True -Name "Fix#2: Invoke-KickstartProcess auto-pushes on main/master (excludes only task/ branches)" `
+    -Condition ($kickstartSrc -match "currentBranch\s+-notmatch\s+'\^task/'")
+Assert-True -Name "Fix#2: Invoke-KickstartProcess no longer excludes main/master from auto-push" `
+    -Condition (-not ($kickstartSrc -match "'\^\(task/\|master\$\|main\$\)'"))
+Assert-True -Name "Fix#2: auto_push_phase_commits setting is still honoured" `
+    -Condition ($kickstartSrc -match "auto_push_phase_commits")
+
+# ── Fix #3: kickstart prompt templates must instruct agents to retry the same
+# select: query rather than broadening when the MCP server is still warming up.
+$promptFiles = @(
+    (Join-Path $repoRoot "workflows\kickstart-from-scratch\recipes\prompts\03b-expand-task-group.md"),
+    (Join-Path $repoRoot "workflows\kickstart-from-scratch\recipes\prompts\01b-generate-decisions.md"),
+    (Join-Path $repoRoot "workflows\default\recipes\prompts\98-analyse-task.md")
+)
+foreach ($pf in $promptFiles) {
+    $relName = Split-Path $pf -Leaf
+    Assert-PathExists -Name "Fix#3: $relName exists" -Path $pf
+    $promptSrc = Get-Content $pf -Raw
+    Assert-True -Name "Fix#3: $relName forbids broadening ToolSearch queries" `
+        -Condition ($promptSrc -match 'do\s+\*\*NOT\*\*\s+broaden')
+    Assert-True -Name "Fix#3: $relName instructs retry of same select: query" `
+        -Condition ($promptSrc -match 'retry\s+the\s+\*\*exact\s+same\*\*\s+`?select:')
+}
+
+# ── Fix #4: 01b-generate-decisions.md must mark interview-summary.md as an
+# optional read so the new_project kickstart path (show_interview: false)
+# doesn't error on a missing file.
+$decisionsPromptPath = Join-Path $repoRoot "workflows\kickstart-from-scratch\recipes\prompts\01b-generate-decisions.md"
+$decisionsPromptSrc = Get-Content $decisionsPromptPath -Raw
+Assert-True -Name "Fix#4: 01b-generate-decisions.md marks interview-summary.md as optional" `
+    -Condition ($decisionsPromptSrc -match '(?s)interview\s+summary\s+is\s+\*\*optional\*\*.*?interview-summary\.md')
+Assert-True -Name "Fix#4: 01b-generate-decisions.md still reads mission/tech-stack/entity-model unconditionally" `
+    -Condition (($decisionsPromptSrc -match 'mission\.md') -and ($decisionsPromptSrc -match 'tech-stack\.md') -and ($decisionsPromptSrc -match 'entity-model\.md'))
+
+Write-Host ""
+
+# ═══════════════════════════════════════════════════════════════════
 # SUMMARY
 # ═══════════════════════════════════════════════════════════════════
 

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1059,12 +1059,20 @@ Assert-True -Name "Fix#1: workflow-manifest.ps1 Import-Module for ManifestCondit
     -Condition ($workflowManifestSrc -match 'Import-Module\s+\(Join-Path\s+\$PSScriptRoot\s+"ManifestCondition\.psm1"\)[^\r\n]*-Global')
 
 # Regression: dot-source workflow-manifest.ps1 inside a nested scriptblock and
-# verify Test-ManifestCondition is callable from that child scope via the
-# -Global import. This is the exact failure mode seen in HTTP route handlers.
+# verify Test-ManifestCondition remains visible *after that child scope exits*
+# via the -Global import. This reproduces the HTTP route handler failure mode:
+# if the module is imported without -Global, the function would be visible
+# only inside the scriptblock and disappear when it returns. Checking
+# Get-Command outside the scriptblock is what actually validates -Global.
 Remove-Module ManifestCondition -Force -ErrorAction SilentlyContinue
-$nestedProbe = & {
-    . $workflowManifestPath
-    (Get-Command Test-ManifestCondition -ErrorAction SilentlyContinue) -ne $null
+$nestedProbe = $false
+try {
+    & {
+        . $workflowManifestPath
+    }
+    $nestedProbe = (Get-Command Test-ManifestCondition -ErrorAction SilentlyContinue) -ne $null
+} finally {
+    Remove-Module ManifestCondition -Force -ErrorAction SilentlyContinue
 }
 Assert-True -Name "Fix#1: Test-ManifestCondition visible after nested dot-source of workflow-manifest.ps1" `
     -Condition $nestedProbe

--- a/workflows/default/recipes/prompts/98-analyse-task.md
+++ b/workflows/default/recipes/prompts/98-analyse-task.md
@@ -26,7 +26,7 @@ ToolSearch({ query: "select:mcp__dotbot__plan_get" })
 ToolSearch({ query: "select:mcp__dotbot__plan_create" })
 ```
 
-Issue all ToolSearch calls above in a **single parallel batch**. Do not call ToolSearch again after Phase 0, and do **NOT** broaden the queries or try alternative search terms. If a `select:` query returns no schema on the first attempt, the dotbot MCP server is still warming up — retry the **exact same** `select:` query after a brief pause. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
+Issue all ToolSearch calls above in a **single parallel batch** during Phase 0. Do **NOT** broaden the queries or try alternative search terms. If a `select:` query returns no schema on the first attempt, the dotbot MCP server is still warming up — while **still in Phase 0**, wait briefly and retry the **exact same** `select:` call. Once Phase 0 is complete, do not call ToolSearch again. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
 
 ---
 

--- a/workflows/default/recipes/prompts/98-analyse-task.md
+++ b/workflows/default/recipes/prompts/98-analyse-task.md
@@ -26,7 +26,7 @@ ToolSearch({ query: "select:mcp__dotbot__plan_get" })
 ToolSearch({ query: "select:mcp__dotbot__plan_create" })
 ```
 
-Issue all ToolSearch calls above in a **single parallel batch**. Do not call ToolSearch again after Phase 0. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
+Issue all ToolSearch calls above in a **single parallel batch**. Do not call ToolSearch again after Phase 0, and do **NOT** broaden the queries or try alternative search terms. If a `select:` query returns no schema on the first attempt, the dotbot MCP server is still warming up — retry the **exact same** `select:` query after a brief pause. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
 
 ---
 

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-KickstartProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-KickstartProcess.ps1
@@ -672,7 +672,10 @@ Instructions:
                     # unpushed phase commits. Users with branch protection on the
                     # default branch can opt out via `auto_push_phase_commits: false`.
                     $currentBranch = git -C $projectRoot rev-parse --abbrev-ref HEAD 2>$null
-                    if ($currentBranch -and $currentBranch -notmatch '^task/') {
+                    $branchLookupExit = $LASTEXITCODE
+                    if (-not $currentBranch -or $branchLookupExit -ne 0) {
+                        Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Phase $phaseNum push skipped: could not determine current branch (git rev-parse --abbrev-ref HEAD failed or returned empty)"
+                    } elseif ($currentBranch -notmatch '^task/') {
                         $originUrl = git -C $projectRoot remote get-url origin 2>$null
                         if ($LASTEXITCODE -eq 0 -and $originUrl) {
                             $pushOutput = git -C $projectRoot push --quiet origin $currentBranch 2>&1

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-KickstartProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-KickstartProcess.ps1
@@ -665,9 +665,14 @@ Instructions:
                 }
 
                 if ($autoPushPhaseCommits) {
-                    # Skip task branches (merged by framework) and default branches (protect master/main)
+                    # Skip task branches (merged by framework later). Push everything
+                    # else — including main/master — because kickstart runs in fresh
+                    # repos where the user chose the starting branch, and the verify
+                    # hook (02-git-pushed.ps1) will otherwise block task_mark_done on
+                    # unpushed phase commits. Users with branch protection on the
+                    # default branch can opt out via `auto_push_phase_commits: false`.
                     $currentBranch = git -C $projectRoot rev-parse --abbrev-ref HEAD 2>$null
-                    if ($currentBranch -and $currentBranch -notmatch '^(task/|master$|main$)') {
+                    if ($currentBranch -and $currentBranch -notmatch '^task/') {
                         $originUrl = git -C $projectRoot remote get-url origin 2>$null
                         if ($LASTEXITCODE -eq 0 -and $originUrl) {
                             $pushOutput = git -C $projectRoot push --quiet origin $currentBranch 2>&1
@@ -681,7 +686,7 @@ Instructions:
                             Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Phase $phaseNum push skipped: git remote 'origin' is not configured"
                         }
                     } else {
-                        Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Phase $phaseNum push skipped: branch '$currentBranch' is protected or task-scoped"
+                        Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Phase $phaseNum push skipped: branch '$currentBranch' is task-scoped (framework will merge)"
                     }
                 } else {
                     Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Phase $phaseNum push skipped: auto_push_phase_commits setting is disabled"

--- a/workflows/default/systems/runtime/modules/workflow-manifest.ps1
+++ b/workflows/default/systems/runtime/modules/workflow-manifest.ps1
@@ -171,8 +171,13 @@ function Convert-ManifestRequiresToPreflightChecks {
     return $checks
 }
 
-# Test-ManifestCondition lives in its own module for controlled exports.
-Import-Module (Join-Path $PSScriptRoot "ManifestCondition.psm1") -Force -DisableNameChecking
+# Import with -Global so Test-ManifestCondition is visible to callers that
+# dot-source workflow-manifest.ps1 from inside a function/scriptblock scope
+# (e.g. server.ps1 and task-get-next/script.ps1). Without -Global, the
+# imported function ends up in a module scope that is not reached by the
+# lookup chain at some HTTP route handler call sites, producing intermittent
+# "The term 'Test-ManifestCondition' is not recognized" errors.
+Import-Module (Join-Path $PSScriptRoot "ManifestCondition.psm1") -Force -DisableNameChecking -Global
 
 function Ensure-ManifestTaskIds {
     <#

--- a/workflows/kickstart-from-scratch/recipes/prompts/01b-generate-decisions.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/01b-generate-decisions.md
@@ -32,10 +32,13 @@ Issue all ToolSearch calls above in a **single parallel batch**. Do not call Too
 
 ### Step 1: Read Source Documents
 
-Read all available source material:
+Read all available source material. The interview summary is **optional** — it only exists when the kickstart workflow ran in interview mode. If the file does not exist, skip it and continue with the other reads; do not treat the missing file as an error.
 
 ```
+# Optional — only present when an interview was run:
 Read({ file_path: ".bot/workspace/product/interview-summary.md" })
+
+# Always present after phase 1:
 Read({ file_path: ".bot/workspace/product/mission.md" })
 Read({ file_path: ".bot/workspace/product/tech-stack.md" })
 Read({ file_path: ".bot/workspace/product/entity-model.md" })

--- a/workflows/kickstart-from-scratch/recipes/prompts/01b-generate-decisions.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/01b-generate-decisions.md
@@ -20,7 +20,7 @@ ToolSearch({ query: "select:mcp__dotbot__decision_update" })
 ToolSearch({ query: "select:mcp__dotbot__decision_list" })
 ```
 
-Issue all ToolSearch calls above in a **single parallel batch**. Do not call ToolSearch again after Phase 0. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
+Issue all ToolSearch calls above in a **single parallel batch**. Do not call ToolSearch again after Phase 0, and do **NOT** broaden the queries or try alternative search terms. If a `select:` query returns no schema on the first attempt, the dotbot MCP server is still warming up — retry the **exact same** `select:` query after a brief pause. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
 
 ---
 

--- a/workflows/kickstart-from-scratch/recipes/prompts/01b-generate-decisions.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/01b-generate-decisions.md
@@ -20,7 +20,7 @@ ToolSearch({ query: "select:mcp__dotbot__decision_update" })
 ToolSearch({ query: "select:mcp__dotbot__decision_list" })
 ```
 
-Issue all ToolSearch calls above in a **single parallel batch**. Do not call ToolSearch again after Phase 0, and do **NOT** broaden the queries or try alternative search terms. If a `select:` query returns no schema on the first attempt, the dotbot MCP server is still warming up — retry the **exact same** `select:` query after a brief pause. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
+Issue all ToolSearch calls above in a **single parallel batch** during Phase 0. Do **NOT** broaden the queries or try alternative search terms. If a `select:` query returns no schema on the first attempt, the dotbot MCP server is still warming up — while **still in Phase 0**, wait briefly and retry the **exact same** `select:` call. Once Phase 0 is complete, do not call ToolSearch again. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
 
 ---
 

--- a/workflows/kickstart-from-scratch/recipes/prompts/03b-expand-task-group.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/03b-expand-task-group.md
@@ -19,7 +19,7 @@ ToolSearch({ query: "select:mcp__dotbot__decision_get" })
 ToolSearch({ query: "select:mcp__dotbot__task_create_bulk" })
 ```
 
-Issue all ToolSearch calls above in a **single parallel batch**. Do not call ToolSearch again after Phase 0, and do **NOT** broaden the queries or try alternative search terms. If a `select:` query returns no schema on the first attempt, the dotbot MCP server is still warming up — retry the **exact same** `select:` query after a brief pause. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
+Issue all ToolSearch calls above in a **single parallel batch** during Phase 0. Do **NOT** broaden the queries or try alternative search terms. If a `select:` query returns no schema on the first attempt, the dotbot MCP server is still warming up — while **still in Phase 0**, wait briefly and retry the **exact same** `select:` call. Once Phase 0 is complete, do not call ToolSearch again. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
 
 ---
 

--- a/workflows/kickstart-from-scratch/recipes/prompts/03b-expand-task-group.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/03b-expand-task-group.md
@@ -19,7 +19,7 @@ ToolSearch({ query: "select:mcp__dotbot__decision_get" })
 ToolSearch({ query: "select:mcp__dotbot__task_create_bulk" })
 ```
 
-Issue all ToolSearch calls above in a **single parallel batch**. Do not call ToolSearch again after Phase 0. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
+Issue all ToolSearch calls above in a **single parallel batch**. Do not call ToolSearch again after Phase 0, and do **NOT** broaden the queries or try alternative search terms. If a `select:` query returns no schema on the first attempt, the dotbot MCP server is still warming up — retry the **exact same** `select:` query after a brief pause. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
 
 ---
 


### PR DESCRIPTION
Fixes #246.

## Summary

Four kickstart-from-scratch friction fixes + regression tests, identified by analysing a full `activity.jsonl` run from a downstream harness. Each commit is scoped to one fix for easy revert; see the linked issue for log evidence and the full analysis.

## Commits

1. `fix(manifest): Import-Module ManifestCondition with -Global so route handlers see Test-ManifestCondition` — one-line change in `workflow-manifest.ps1` that complements the existing defensive import in `server.ps1`. Makes `workflow-manifest.ps1` self-sufficient for callers that don't go through the server (e.g. `task-get-next/script.ps1`).
2. `fix(kickstart): auto-push phase commits on main/master branches` — `Invoke-KickstartProcess.ps1` regex narrowed to `^task/` only. The existing `auto_push_phase_commits: false` opt-out setting is unchanged.
3. `fix(kickstart-prompts): instruct agents to retry the same select: query, not broaden` — Phase 0 guidance in `03b-expand-task-group.md`, `01b-generate-decisions.md`, and `98-analyse-task.md`.
4. `fix(kickstart-prompts): make interview-summary.md read optional in 01b` — the new_project mode's `show_interview: false` makes the file non-existent; the read is now guarded with an Optional comment.
5. `test: add regression coverage for kickstart friction fixes (batch 1)` — 15 new assertions in `tests/Test-WorkflowManifest.ps1` covering all four fixes, including one behavioural probe that dot-sources `workflow-manifest.ps1` inside a scriptblock and asserts `Test-ManifestCondition` is visible.

## Testing

```
tests/Run-Tests.ps1 -Layer 1   # 268 passed, 0 failed (Workflow Manifest)
tests/Run-Tests.ps1 -Layer 2   # all Layer-2 suites passed
tests/Run-Tests.ps1 -Layer 3   # Mock Claude 13 passed
```

Ran locally on Windows PowerShell 7. Layer 4 (E2E Claude) not run — secrets-gated.

## End-to-end verification plan (next)

- Nuke the Vibetrip harness, reinstall dotbot from this branch, re-run `kickstart-from-scratch`, diff new `activity.jsonl` against the baseline. Expected:
  - 0 `Test-ManifestCondition` errors (was 8)
  - 0 `02-git-pushed.ps1` verification failures (was 3)
  - 0 `File does not exist: ...interview-summary.md` (was 1)
  - ToolSearch retry count per sub-session ≤ 1 (was 2–3)
- Will update this PR description with before/after metrics and flip from draft → ready once verified.

## Out of scope

- Async shutdown ordering (fix #1 removes the symptom; the underlying route-handler-after-shutdown race is cosmetic).
- Caching product docs across expansion sub-sessions (micro-optimization; separate PR).
- Restructuring kickstart phase shape — the 4-phase workflow works; only inter-phase friction needed fixing.

## Checklist

- [x] Tests added (1 new block, 15 assertions)
- [x] Linked issue (#246)
- [x] Every commit scoped to one fix
- [x] Layer 1–3 tests pass locally
- [ ] End-to-end verified via downstream harness rerun (follow-up)
