### PR TITLE
Kickstart prompt hardening: branch-conditional push + 03a rigor parity

### DIFF
--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1168,6 +1168,44 @@ Assert-True -Name "Fix#B: 03b cross-links to 03a for schema/criteria/sizing" `
 Assert-True -Name "Fix#B: 03b tells agent not to relax constraints during expansion" `
     -Condition ($expandTaskGroupSrc -match 'do\s+not\s+relax\s+them\s+during\s+expansion')
 
+# ── Batch 2, Fix C: 98-analyse-task.md must guard mission/tech-stack/entity-model
+# reads against the current task's outputs list, so tasks that produce those
+# files (e.g. kickstart Product Documents) do not error during pre-flight
+# analysis trying to read files they are supposed to create.
+$analyseTaskPath = Join-Path $repoRoot "workflows\default\recipes\prompts\98-analyse-task.md"
+Assert-PathExists -Name "Fix#C: 98-analyse-task.md exists" -Path $analyseTaskPath
+$analyseTaskSrc = Get-Content $analyseTaskPath -Raw
+Assert-True -Name "Fix#C: 98-analyse-task.md has skip-if-produced guard in Phase 2" `
+    -Condition ($analyseTaskSrc -match '(?s)Phase\s+2:\s+Entity\s+Detection.*?Skip-if-produced\s+guard')
+Assert-True -Name "Fix#C: 98-analyse-task.md has skip-if-produced guard in Phase 6" `
+    -Condition ($analyseTaskSrc -match '(?s)Phase\s+6:\s+Product\s+Context\s+Extraction.*?Skip-if-produced\s+guard')
+Assert-True -Name "Fix#C: 98-analyse-task.md entity-model read is marked skip-if-outputs" `
+    -Condition ($analyseTaskSrc -match 'Read\s+entity\s+model[^\r\n]*skip\s+if\s+in\s+task\s+`outputs`')
+Assert-True -Name "Fix#C: 98-analyse-task.md mission read is marked skip-if-outputs" `
+    -Condition ($analyseTaskSrc -match 'Read\s+mission[^\r\n]*skip\s+if\s+in\s+task\s+`outputs`')
+Assert-True -Name "Fix#C: 98-analyse-task.md refers to task outputs list for the guard" `
+    -Condition ($analyseTaskSrc -match "task's\s+``outputs``\s+list")
+
+# ── Batch 2, Fix D: 98-analyse-task.md must treat .bot/recipes/standards/global
+# as an optional directory; skip the glob if it does not exist.
+Assert-True -Name "Fix#D: 98-analyse-task.md marks standards/global listing as skip-if-missing" `
+    -Condition ($analyseTaskSrc -match '(?s)List\s+available\s+standards\s+\(skip\s+if\s+directory\s+missing\)')
+Assert-True -Name "Fix#D: 98-analyse-task.md describes standards/global as optional" `
+    -Condition ($analyseTaskSrc -match '`\.bot/recipes/standards/global/`\s+directory\s+is\s+optional')
+Assert-True -Name "Fix#D: 98-analyse-task.md tells agent not to treat missing standards/global as error" `
+    -Condition ($analyseTaskSrc -match 'Do\s+\*\*not\*\*\s+treat\s+the\s+missing\s+directory\s+as\s+an\s+error')
+
+# ── Batch 2, Fix E: 03a category_hint field-reference row must list the full
+# six-value enum and forbid inventing new categories like `frontend`.
+Assert-True -Name "Fix#E: 03a category_hint row lists ui-ux enum value" `
+    -Condition ($planTaskGroupsSrc -match '(?s)\|\s+`category_hint`.*?`ui-ux`')
+Assert-True -Name "Fix#E: 03a category_hint row lists bugfix enum value" `
+    -Condition ($planTaskGroupsSrc -match '(?s)\|\s+`category_hint`.*?`bugfix`')
+Assert-True -Name "Fix#E: 03a category_hint row forbids inventing new categories" `
+    -Condition ($planTaskGroupsSrc -match '(?s)`category_hint`.*?Do\s+NOT\s+invent\s+new\s+categories')
+Assert-True -Name "Fix#E: 03a category_hint row cites task_create_bulk validator" `
+    -Condition ($planTaskGroupsSrc -match '(?s)`category_hint`.*?`task_create_bulk`\s+validator')
+
 Write-Host ""
 
 # ═══════════════════════════════════════════════════════════════════

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1113,6 +1113,61 @@ Assert-True -Name "Fix#4: 01b-generate-decisions.md marks interview-summary.md a
 Assert-True -Name "Fix#4: 01b-generate-decisions.md still reads mission/tech-stack/entity-model unconditionally" `
     -Condition (($decisionsPromptSrc -match 'mission\.md') -and ($decisionsPromptSrc -match 'tech-stack\.md') -and ($decisionsPromptSrc -match 'entity-model\.md'))
 
+# ── Batch 2, Fix A: 99-autonomous-task.md must teach agents branch-conditional
+# push semantics so tasks that run on shared branches (main/master) are
+# pushed immediately instead of leaving the agent stuck on the
+# 02-git-pushed.ps1 gate at task_mark_done time.
+$autonomousTaskPrompts = @(
+    (Join-Path $repoRoot "workflows\default\recipes\prompts\99-autonomous-task.md"),
+    (Join-Path $repoRoot "workflows\kickstart-via-jira\recipes\prompts\99-autonomous-task.md")
+)
+foreach ($pf in $autonomousTaskPrompts) {
+    $relName = Split-Path $pf -Leaf
+    $parentDir = Split-Path (Split-Path (Split-Path (Split-Path $pf -Parent) -Parent) -Parent) -Leaf
+    Assert-PathExists -Name "Fix#A: $parentDir/$relName exists" -Path $pf
+    $src = Get-Content $pf -Raw
+    Assert-True -Name "Fix#A: $parentDir/$relName has branch-conditional task/ guard" `
+        -Condition ($src -match 'If\s+`\{\{BRANCH_NAME\}\}`\s+starts\s+with\s+`task/`')
+    Assert-True -Name "Fix#A: $parentDir/$relName instructs push on shared branches" `
+        -Condition ($src -match 'push\s+immediately\s+to\s+`origin/\{\{BRANCH_NAME\}\}`')
+    Assert-True -Name "Fix#A: $parentDir/$relName cites 02-git-pushed.ps1 failure mode" `
+        -Condition ($src -match '02-git-pushed\.ps1')
+    Assert-True -Name "Fix#A: $parentDir/$relName no longer hardcodes 'git worktree on branch' assertion" `
+        -Condition (-not ($src -match 'You are working in a \*\*git worktree\*\* on branch'))
+}
+
+# ── Batch 2, Fix B: 03a-plan-task-groups.md must include task-level rigor
+# (schema, acceptance-criteria quality bar, effort sizing, dependency chain)
+# that 03b-expand-task-group.md inherits during expansion.
+$planTaskGroupsPath = Join-Path $repoRoot "workflows\kickstart-from-scratch\recipes\prompts\03a-plan-task-groups.md"
+Assert-PathExists -Name "Fix#B: 03a-plan-task-groups.md exists" -Path $planTaskGroupsPath
+$planTaskGroupsSrc = Get-Content $planTaskGroupsPath -Raw
+
+Assert-True -Name "Fix#B: 03a has Task Schema Reference section" `
+    -Condition ($planTaskGroupsSrc -match '##\s+Task Schema Reference')
+Assert-True -Name "Fix#B: 03a requires per-task acceptance_criteria field" `
+    -Condition ($planTaskGroupsSrc -match '`acceptance_criteria`.*testable')
+Assert-True -Name "Fix#B: 03a requires human_hours / ai_hours estimates" `
+    -Condition (($planTaskGroupsSrc -match '`human_hours`') -and ($planTaskGroupsSrc -match '`ai_hours`'))
+Assert-True -Name "Fix#B: 03a has Good Task Acceptance Criteria section" `
+    -Condition ($planTaskGroupsSrc -match '##\s+Good Task Acceptance Criteria')
+Assert-True -Name "Fix#B: 03a has Effort Sizing section" `
+    -Condition ($planTaskGroupsSrc -match '##\s+Effort Sizing')
+Assert-True -Name "Fix#B: 03a Effort Sizing has XS through XL rows" `
+    -Condition (($planTaskGroupsSrc -match '`XS`') -and ($planTaskGroupsSrc -match '`XL`'))
+Assert-True -Name "Fix#B: 03a Step 3 dependency chain mentions infra/entities/features" `
+    -Condition ($planTaskGroupsSrc -match '(?s)Infrastructure.*entities.*[Ff]eature.*jobs')
+Assert-True -Name "Fix#B: 03a anti-patterns forbid effort-based buckets" `
+    -Condition ($planTaskGroupsSrc -match '[Ee]ffort-based\s+buckets')
+
+# ── Batch 2, Fix B cross-link: 03b-expand-task-group.md must inherit from 03a.
+$expandTaskGroupPath = Join-Path $repoRoot "workflows\kickstart-from-scratch\recipes\prompts\03b-expand-task-group.md"
+$expandTaskGroupSrc = Get-Content $expandTaskGroupPath -Raw
+Assert-True -Name "Fix#B: 03b cross-links to 03a for schema/criteria/sizing" `
+    -Condition ($expandTaskGroupSrc -match 'Inherits\s+from\s+03a-plan-task-groups\.md')
+Assert-True -Name "Fix#B: 03b tells agent not to relax constraints during expansion" `
+    -Condition ($expandTaskGroupSrc -match 'do\s+not\s+relax\s+them\s+during\s+expansion')
+
 Write-Host ""
 
 # ═══════════════════════════════════════════════════════════════════

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1123,6 +1123,9 @@ $autonomousTaskPrompts = @(
 )
 foreach ($pf in $autonomousTaskPrompts) {
     $relName = Split-Path $pf -Leaf
+    # Walk up 3 parents to reach the workflow directory (e.g. "workflows/default")
+    # then take its leaf to get the workflow name ("default", "kickstart-via-jira").
+    # Path structure: workflows/<workflow>/recipes/prompts/<file>.md.
     $parentDir = Split-Path (Split-Path (Split-Path (Split-Path $pf -Parent) -Parent) -Parent) -Leaf
     Assert-PathExists -Name "Fix#A: $parentDir/$relName exists" -Path $pf
     $src = Get-Content $pf -Raw

--- a/workflows/default/recipes/prompts/98-analyse-task.md
+++ b/workflows/default/recipes/prompts/98-analyse-task.md
@@ -245,7 +245,7 @@ Identify which coding standards and decision constraints apply to this task.
    The `.bot/recipes/standards/global/` directory is optional — not every workflow ships it. Before issuing the glob, check whether the directory exists. If it does not exist, skip this step entirely and fall through to applying `{{APPLICABLE_STANDARDS}}` (above) plus whatever the task's own `applicable_standards` list specifies. Do **not** treat the missing directory as an error.
    ```
    # Only run if .bot/recipes/standards/global/ exists:
-   file_glob({ patterns: ["*.md"], search_dir: ".bot/recipes/standards/global", max_matches: 20, max_depth: 1, min_depth: 0 })
+   Glob({ pattern: "*.md", path: ".bot/recipes/standards/global" })
    ```
 
 2. **Determine applicable standards:**

--- a/workflows/default/recipes/prompts/98-analyse-task.md
+++ b/workflows/default/recipes/prompts/98-analyse-task.md
@@ -156,7 +156,9 @@ If `needs_interview` is `false`: Skip directly to Phase 2.
 
 Read the entity model and identify entities involved in this task.
 
-1. **Read entity model:**
+**Skip-if-produced guard.** Before issuing the Read below, check the current task's `outputs` list (from the task JSON returned by `task_get_context` or visible on the task file). If `entity-model.md` is one of this task's declared outputs, **skip this read** — the file is what the task is being asked to produce and will not exist yet. Fall through to the next step and derive entity context from briefing material or PRD instead. The same rule applies to `mission.md` and `tech-stack.md` reads elsewhere in this prompt.
+
+1. **Read entity model (skip if in task `outputs`):**
    ```
    Read({ file_path: ".bot/workspace/product/entity-model.md" })
    ```
@@ -239,8 +241,10 @@ Identify which coding standards and decision constraints apply to this task.
 **Pre-specified standards from task configuration** (use as your starting point):
 {{APPLICABLE_STANDARDS}}
 
-1. **List available standards:**
+1. **List available standards (skip if directory missing):**
+   The `.bot/recipes/standards/global/` directory is optional — not every workflow ships it. Before issuing the glob, check whether the directory exists. If it does not exist, skip this step entirely and fall through to applying `{{APPLICABLE_STANDARDS}}` (above) plus whatever the task's own `applicable_standards` list specifies. Do **not** treat the missing directory as an error.
    ```
+   # Only run if .bot/recipes/standards/global/ exists:
    file_glob({ patterns: ["*.md"], search_dir: ".bot/recipes/standards/global", max_matches: 20, max_depth: 1, min_depth: 0 })
    ```
 
@@ -282,7 +286,9 @@ Identify which coding standards and decision constraints apply to this task.
 
 Extract ONLY the product context needed for this task.
 
-1. **Read mission (if needed):**
+**Skip-if-produced guard.** As in Phase 2, if `mission.md` appears in the current task's `outputs` list, **skip this read** — the file is this task's own product. The same rule applies to `tech-stack.md` and `entity-model.md`. When all three would be skipped (i.e. the task's job is to author the product documents themselves), derive product context from the briefing files under `.bot/workspace/product/briefing/` or from the task description and PRD instead.
+
+1. **Read mission (skip if in task `outputs`):**
    ```
    Read({ file_path: ".bot/workspace/product/mission.md" })
    ```

--- a/workflows/default/recipes/prompts/99-autonomous-task.md
+++ b/workflows/default/recipes/prompts/99-autonomous-task.md
@@ -44,11 +44,21 @@ Issue all ToolSearch calls above in a **single parallel batch**. Do not call Too
 
 ## Working Directory
 
-You are working in a **git worktree** on branch `{{BRANCH_NAME}}`.
-- Make commits to THIS branch (they'll be squash-merged to main after completion)
-- Do NOT push to remote — merging is handled by the framework
-- Do NOT switch branches or modify git configuration
-- The .bot/ MCP tools access the central task queue (shared via junction)
+You are working on branch `{{BRANCH_NAME}}`.
+
+- **If `{{BRANCH_NAME}}` starts with `task/`**: you are in an isolated git
+  worktree. Commit to this branch — the framework will squash-merge to main
+  after the task is complete. **Do NOT push**; the framework handles that.
+- **If `{{BRANCH_NAME}}` does NOT start with `task/`** (e.g. `main`,
+  `master`, or a workflow-shared branch): the task runner did not isolate
+  this task into a worktree, so your commits land directly on a shared
+  branch. After committing, **push immediately to `origin/{{BRANCH_NAME}}`**;
+  otherwise `02-git-pushed.ps1` will block `task_mark_done` with *"N
+  unpushed commit(s) on '{{BRANCH_NAME}}'"* and you will be stuck in a
+  retry loop.
+- Do NOT switch branches or modify git configuration.
+- The `.bot/` MCP tools access the central task queue (shared via junction
+  when in a worktree, direct when on a shared branch).
 
 ## Task Details
 

--- a/workflows/kickstart-from-scratch/recipes/prompts/03a-plan-task-groups.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/03a-plan-task-groups.md
@@ -158,7 +158,7 @@ The file format:
 | `estimated_task_count` | Yes | Expected number of tasks (2-8 per group) |
 | `depends_on` | Yes | Array of group IDs this depends on (empty for root groups) |
 | `priority_range` | Yes | `[min, max]` — priority range for tasks in this group |
-| `category_hint` | Yes | Default category for tasks: infrastructure, core, feature, enhancement |
+| `category_hint` | Yes | Default category for tasks in this group. Must be one of the six valid `category` enum values (see [Task Schema Reference](#task-schema-reference-inherited-by-phase-2b) below): `infrastructure`, `core`, `feature`, `enhancement`, `ui-ux`, or `bugfix`. Use `ui-ux` for all user-facing / frontend work. **Do NOT invent new categories** like `frontend`, `backend`, or `api` — the MCP `task_create_bulk` validator will reject them. |
 
 ---
 

--- a/workflows/kickstart-from-scratch/recipes/prompts/03a-plan-task-groups.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/03a-plan-task-groups.md
@@ -175,7 +175,7 @@ The per-group expansion prompt (`03b-expand-task-group.md`) will produce individ
 | `effort` | Yes | `XS` / `S` / `M` / `L` / `XL` (see sizing table below) |
 | `acceptance_criteria` | Yes | Array of specific, testable success conditions — see quality bar below |
 | `steps` | No | Implementation steps for guidance |
-| `dependencies` | No | Array of task IDs this depends on (within or across groups) |
+| `dependencies` | No | Array of task IDs *or* task names/slugs this depends on (within or across groups). `task_create_bulk` accepts both forms; 03b's intra-batch references use names, cross-batch typically use IDs once known. |
 | `applicable_standards` | No | Standards files to read before implementing |
 | `applicable_agents` | No | Agent files to use for implementation |
 | `applicable_decisions` | No | Decisions constraining this task (narrowed from the group's list) |

--- a/workflows/kickstart-from-scratch/recipes/prompts/03a-plan-task-groups.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/03a-plan-task-groups.md
@@ -62,16 +62,22 @@ Not all projects need all of these. Adapt to the actual project scope. Merge sma
 - Vague "Enhancements" or "Nice-to-haves" — each group should deliver concrete functionality
 - "Intelligence & Rules" unless the product specifically requires AI/ML features
 - Anything that doesn't contribute to a shippable product
+- **Effort-based buckets** (e.g. "Quick Wins", "Tech Debt", "Stretch Goals") — group by *functional area*, not by size or priority.
+- **Groups whose scope cannot yield per-task acceptance criteria** — if you can't state what "done" looks like for each scope item, the group is too vague to expand.
 
 Each group's acceptance criteria should describe a **deployable increment** — something you could demo or ship independently.
 
 ### Step 3: Define Group Dependencies
 
-Groups should have explicit dependencies via `depends_on`:
-- Infrastructure groups have no dependencies
-- Entity/data groups depend on infrastructure
-- Feature groups depend on the entities they use
-- Background jobs depend on the features they orchestrate
+Groups should have explicit dependencies via `depends_on`, following the standard dependency chain:
+
+- **Infrastructure** groups have no dependencies.
+- **Core entities / data layer** groups depend on infrastructure (DB, config, project scaffolding).
+- **Feature handlers** (command/query/API) depend on the core entities they operate on.
+- **Background jobs and workers** depend on the feature handlers they orchestrate.
+- **UI and final integration** groups depend on the features they surface.
+
+Priority ranges (Step 4) already encode execution order within the chain — use `depends_on` for hard technical dependencies only, not for ordering preference.
 
 ### Step 3b: Estimate Effort Days
 
@@ -154,6 +160,56 @@ The file format:
 | `priority_range` | Yes | `[min, max]` — priority range for tasks in this group |
 | `category_hint` | Yes | Default category for tasks: infrastructure, core, feature, enhancement |
 
+---
+
+## Task Schema Reference (inherited by Phase 2b)
+
+The per-group expansion prompt (`03b-expand-task-group.md`) will produce individual tasks from each group's `scope` bullets. You are planning at the group level, but every group you define must be *expandable* into tasks that carry the following schema. Keep this in mind when sizing, scoping, and estimating groups:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Brief, action-oriented title ("Implement X command handler", "Add X entity with migrations") |
+| `description` | Yes | What / where / why / how / patterns to reference |
+| `category` | Yes | `infrastructure` / `core` / `feature` / `enhancement` / `ui-ux` / `bugfix` |
+| `priority` | Yes | 1–100 (within this group's `priority_range`) |
+| `effort` | Yes | `XS` / `S` / `M` / `L` / `XL` (see sizing table below) |
+| `acceptance_criteria` | Yes | Array of specific, testable success conditions — see quality bar below |
+| `steps` | No | Implementation steps for guidance |
+| `dependencies` | No | Array of task IDs this depends on (within or across groups) |
+| `applicable_standards` | No | Standards files to read before implementing |
+| `applicable_agents` | No | Agent files to use for implementation |
+| `applicable_decisions` | No | Decisions constraining this task (narrowed from the group's list) |
+| `human_hours` | Yes | Estimated developer-hours for a skilled human, unassisted |
+| `ai_hours` | Yes | Estimated AI-assisted developer-hours |
+
+Groups whose `scope` items cannot produce tasks matching this schema are too vague — refine them before writing `task-groups.json`.
+
+## Good Task Acceptance Criteria
+
+When 03b expands your groups, each task's `acceptance_criteria` must meet this bar:
+
+- **Specific and testable** — not "works correctly" but "returns 200 with JSON body containing `{id, name}` on success".
+- **Each item starts with a verb** — "Returns…", "Rejects…", "Persists…", "Logs…".
+- **Covers the happy path and key edge cases** — invalid input, missing auth, empty result set, concurrent mutation, etc.
+- **Includes test requirements where appropriate** — "Unit test asserts…", "Integration test verifies…".
+- **No "TODO" or open ends** — if you don't know what done looks like, the task is not ready to create.
+
+When drafting a group's `acceptance_criteria`, make sure each bullet describes a *shippable behavior* of the whole group — not a developer task. If you can't phrase it as a verifiable behavior, split or rescope the group.
+
+## Effort Sizing
+
+Use this table for task-level `effort` values (which feed into the group's `effort_days`):
+
+| Effort | Typical Duration (human) | Examples |
+|--------|--------------------------|----------|
+| `XS`   | < 1 hour   | Add one field to an entity, flip a config, register a handler |
+| `S`    | 1–2 hours  | Simple command/query handler, basic CRUD endpoint |
+| `M`    | 2–4 hours  | Feature with tests, integration wiring, small migration |
+| `L`    | 4–8 hours  | Complex feature, multiple components, end-to-end wiring |
+| `XL`   | 1–2 days   | Major subsystem, significant refactoring, cross-cutting change |
+
+A group's `effort_days` should roughly equal the sum of its tasks' human-hour estimates divided by 6 (focused dev-hours per day). If a group exceeds ~15 `effort_days`, split it.
+
 ### Guidelines
 
 - **Keep it lightweight.** Scope bullets, not detailed task breakdowns.
@@ -177,3 +233,7 @@ Write `.bot/workspace/product/task-groups.json` and confirm with a brief summary
 - Total estimated tasks
 - Total estimated effort (days)
 - Group names and their order
+
+---
+
+**What happens next.** The per-group expansion in `03b-expand-task-group.md` inherits the **Task Schema Reference**, **Good Task Acceptance Criteria**, and **Effort Sizing** sections above. Every constraint stated here must carry through to the tasks 03b produces — do not relax them during expansion. Groups that are under-specified now will produce thin tasks later.

--- a/workflows/kickstart-from-scratch/recipes/prompts/03b-expand-task-group.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/03b-expand-task-group.md
@@ -8,6 +8,8 @@ version: 1.0
 
 You are a task planning assistant. Your job is to create detailed, implementable tasks for ONE specific group of work.
 
+> **Inherits from 03a-plan-task-groups.md.** The **Task Schema Reference**, **Good Task Acceptance Criteria**, and **Effort Sizing** sections defined in `03a-plan-task-groups.md` are the authoritative per-task contract. Every task you create in this phase must satisfy those constraints — do not relax them during expansion. If a group's `scope` or `acceptance_criteria` are too vague to produce tasks that meet that bar, stop and report back rather than fabricating fields.
+
 ## Phase 0: Load Required Tools
 
 **Built-in tools** (`WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`) are always available — never use ToolSearch for them.

--- a/workflows/kickstart-from-scratch/recipes/prompts/03b-expand-task-group.md
+++ b/workflows/kickstart-from-scratch/recipes/prompts/03b-expand-task-group.md
@@ -8,7 +8,7 @@ version: 1.0
 
 You are a task planning assistant. Your job is to create detailed, implementable tasks for ONE specific group of work.
 
-> **Inherits from 03a-plan-task-groups.md.** The **Task Schema Reference**, **Good Task Acceptance Criteria**, and **Effort Sizing** sections defined in `03a-plan-task-groups.md` are the authoritative per-task contract. Every task you create in this phase must satisfy those constraints — do not relax them during expansion. If a group's `scope` or `acceptance_criteria` are too vague to produce tasks that meet that bar, stop and report back rather than fabricating fields.
+> **Inherits from 03a-plan-task-groups.md.** The **Task Schema Reference**, **Good Task Acceptance Criteria**, and **Effort Sizing** sections defined in `03a-plan-task-groups.md` are the authoritative per-task contract. Every task you create in this phase must satisfy those constraints — do not relax them during expansion. Any task-sizing, dependency, or field-population guidance that appears later in this file is supplemental only and must match `03a-plan-task-groups.md`; if anything in `03b-expand-task-group.md` appears to conflict with `03a-plan-task-groups.md`, follow `03a-plan-task-groups.md`. If a group's `scope` or `acceptance_criteria` are too vague to produce tasks that meet that bar, stop and report back rather than fabricating fields.
 
 ## Phase 0: Load Required Tools
 

--- a/workflows/kickstart-via-jira/recipes/prompts/99-autonomous-task.md
+++ b/workflows/kickstart-via-jira/recipes/prompts/99-autonomous-task.md
@@ -46,11 +46,21 @@ Issue all ToolSearch calls from Steps 1 and 2 in a **single parallel batch**. Do
 
 ## Working Directory
 
-You are working in a **git worktree** on branch `{{BRANCH_NAME}}`.
-- Make commits to THIS branch (they'll be squash-merged to main after completion)
-- Do NOT push to remote — merging is handled by the framework
-- Do NOT switch branches or modify git configuration
-- The .bot/ MCP tools access the central task queue (shared via junction)
+You are working on branch `{{BRANCH_NAME}}`.
+
+- **If `{{BRANCH_NAME}}` starts with `task/`**: you are in an isolated git
+  worktree. Commit to this branch — the framework will squash-merge to main
+  after the task is complete. **Do NOT push**; the framework handles that.
+- **If `{{BRANCH_NAME}}` does NOT start with `task/`** (e.g. `main`,
+  `master`, or a workflow-shared branch): the task runner did not isolate
+  this task into a worktree, so your commits land directly on a shared
+  branch. After committing, **push immediately to `origin/{{BRANCH_NAME}}`**;
+  otherwise `02-git-pushed.ps1` will block `task_mark_done` with *"N
+  unpushed commit(s) on '{{BRANCH_NAME}}'"* and you will be stuck in a
+  retry loop.
+- Do NOT switch branches or modify git configuration.
+- The `.bot/` MCP tools access the central task queue (shared via junction
+  when in a worktree, direct when on a shared branch).
 
 ## Task Details
 


### PR DESCRIPTION
Fixes #250.

## Summary

Five prompt-level fixes that came out of debugging kickstart-from-scratch friction across two `activity.jsonl` cycles. Batch A+B shipped with the initial draft; C/D/E were added after a second-cycle debrief.

1. **Fix A — branch-conditional push in `99-autonomous-task.md`.** The "Working Directory" section hardcoded *"you are in a git worktree … do NOT push"* regardless of the actual branch. When the task runner put the agent on `main`, the agent obeyed and then `task_mark_done` → `02-git-pushed.ps1` blocked. Rewritten to branch on `{{BRANCH_NAME}}`: preserve the worktree/no-push contract for `task/*`, add a shared-branch contract that tells the agent to push immediately to `origin/{{BRANCH_NAME}}` and cites the gate script so cause→effect is concrete. Applied to both `workflows/default/recipes/prompts/99-autonomous-task.md` and `workflows/kickstart-via-jira/recipes/prompts/99-autonomous-task.md`.

2. **Fix B — elevate `03a-plan-task-groups.md`.** The kickstart-from-scratch roadmap prompt previously stopped at group-level abstraction while sibling workflows required full task-level schema, acceptance-criteria quality bars, effort sizing, and dependency chains. 03b assumed 03a's output was already well-shaped, so gaps propagated. Additive edits to 03a: new `## Task Schema Reference`, `## Good Task Acceptance Criteria`, and `## Effort Sizing` sections; Step 3 expanded with the standard infra → entities → features → jobs → UI dependency chain; anti-patterns extended; closing inheritance note pointing into 03b. Cross-link added to the top of `03b-expand-task-group.md`, now including an explicit conflict-resolution rule: if anything in 03b appears to conflict with 03a, follow 03a.

3. **Fix C — `98-analyse-task.md` skip-if-produced guards.** Pre-flight analysis Phase 2 (Entity Detection) and Phase 6 (Product Context Extraction) unconditionally read `entity-model.md`, `mission.md`, and `tech-stack.md` as "project context". For the kickstart `Product Documents` task — whose entire job is to produce exactly those three files — both reads always failed with *File does not exist* during the task's own analysis phase (confirmed three times per run in the second-cycle `activity.jsonl`). Added explicit guards instructing the agent to consult the current task's `outputs` list and skip the read when the file is the task's own product.

4. **Fix D — `98-analyse-task.md` tolerate missing `standards/global` dir.** The `file_glob` call on `.bot/recipes/standards/global` errored twice per run because the directory is optional and not every install ships it. Guarded the glob with an explicit skip-if-missing rule matching the `interview-summary.md` pattern from PR #247 Fix #4. **Also** (from Copilot review) switched the call from `file_glob(...)` to the canonical `Glob({ pattern, path })` form — `file_glob` was a pre-existing typo in the default variant; the sibling `kickstart-via-jira/98-analyse-task.md:232` already used `Glob`.

5. **Fix E — `03a-plan-task-groups.md` category_hint enum completeness.** The existing `category_hint` field-reference row listed only four of the six valid categories (missing `ui-ux` and `bugfix`). The second-cycle run showed the agent inventing category `frontend` during grp-2 expansion, which the MCP `task_create_bulk` validator rejected. Row now lists all six enum values, cross-links to the Task Schema Reference section Fix B added, and explicitly forbids inventing new categories like `frontend`/`backend`/`api`. **Also** (from Copilot review) the `dependencies` row in the new Task Schema Reference section now documents that `task_create_bulk` accepts task IDs *or* task names/slugs — 03b already uses names for intra-batch references.

## Commits

```
a154c88 review: address Copilot feedback on PR #251
1128415 test: pin Fixes C/D/E in Test-WorkflowManifest.ps1
dd73dd0 fix(prompts): complete category enum in 03a field-reference row
4a9245a fix(prompts): 98-analyse-task.md robustness for self-producing tasks and optional standards dir
ea5606d test: pin the new prompt conventions in Test-WorkflowManifest.ps1
245916c fix(prompts): cross-link 03b-expand-task-group.md to the 03a task schema
0095f4f fix(prompts): elevate 03a-plan-task-groups.md rigor to match sibling roadmap prompts
0e7f927 fix(prompts): branch-conditional push guidance in 99-autonomous-task.md
```

## Tests

34 new static pattern assertions added to the KICKSTART FRICTION FIXES block in `tests/Test-WorkflowManifest.ps1` — 21 for Fixes A+B in the initial draft, plus 13 more for C/D/E.

- Fix A (10): both `99-autonomous-task.md` files have the `task/` conditional, the `push immediately to origin/{{BRANCH_NAME}}` instruction, the `02-git-pushed.ps1` citation, and no longer contain the legacy "git worktree on branch" hardcoded assertion.
- Fix B (11): 03a has the three new sections, the XS/XL sizing rows, the infra→entities→features dependency chain, and the effort-based-buckets anti-pattern; 03b has the inheritance cross-link and the "do not relax" language.
- Fix C (5): 98-analyse-task.md has skip-if-produced guards in both Phase 2 and Phase 6, entity-model and mission reads are explicitly labelled skip-if-outputs, and the guard text cites the task's outputs list.
- Fix D (3): 98-analyse-task.md marks the standards/global listing as skip-if-directory-missing, describes the directory as optional, and instructs the agent not to treat the missing directory as an error.
- Fix E (4): 03a's `category_hint` row contains `ui-ux`, `bugfix`, forbids inventing new categories, and cites `task_create_bulk` as the validator.

`tests/Run-Tests.ps1 -Layer all` → Layer 1 (302 passed, 0 failed), Layer 2 and Layer 3 green. Ran locally on Windows PowerShell 7. No Layer 4 (secrets-gated).

No PowerShell, runner, or verify-hook changes — pure prompts plus test assertions.

## Out of scope

- Why the task runner ever drops the agent on `main` in the first place (silent worktree-creation failure vs. intentional shared-branch kickstart tasks). Fix A removes the symptom regardless of root cause.
- MCP server warmup latency / ToolSearch wait loops — orchestrator concern, not a prompt fix.
- Restructuring the kickstart-from-scratch workflow phase order.
- Layer 4 E2E (secrets-gated).

## Checklist

- [x] Tests added (34 new assertions across Fixes A–E)
- [x] Linked issue (#250)
- [x] Every commit scoped to one change
- [x] Layer 1–3 tests pass locally
- [x] Copilot review feedback addressed (5 threads resolved)
- [ ] End-to-end verified via downstream harness rerun (follow-up)
