### PR TITLE
fix: overview side panel uses task-runner engine with priority orderi…

### DIFF
--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -522,11 +522,11 @@ try {
     }
     $pzResult = New-WorkflowTask -ProjectBotDir $taskBotDir -WorkflowName "default" -TaskDef $priorityZeroDef
     $pzFile = Join-Path $taskBotDir "workspace\tasks\todo" $pzResult.file
-    if (Test-Path $pzFile) {
-        $pzJson = Get-Content $pzFile -Raw | ConvertFrom-Json
-        Assert-Equal -Name "Priority 0 preserved (not replaced by default)" `
-            -Expected 0 -Actual $pzJson.priority
-    }
+    Assert-True -Name "Priority 0 task file created" `
+        -Condition (Test-Path $pzFile)
+    $pzJson = Get-Content $pzFile -Raw | ConvertFrom-Json
+    Assert-Equal -Name "Priority 0 preserved (not replaced by default)" `
+        -Expected 0 -Actual $pzJson.priority
 
 } finally {
     Remove-Item -Path $taskRoot -Recurse -Force -ErrorAction SilentlyContinue

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -513,6 +513,21 @@ try {
             -Condition ($null -eq $noPostJson.PSObject.Properties['post_script'])
     }
 
+    # Priority 0 — regression for priority=0 falsy bug (was silently replaced by default 50)
+    $priorityZeroDef = @{
+        name = "Highest Priority Task"
+        type = "prompt"
+        workflow = "00-kickstart.md"
+        priority = 0
+    }
+    $pzResult = New-WorkflowTask -ProjectBotDir $taskBotDir -WorkflowName "default" -TaskDef $priorityZeroDef
+    $pzFile = Join-Path $taskBotDir "workspace\tasks\todo" $pzResult.file
+    if (Test-Path $pzFile) {
+        $pzJson = Get-Content $pzFile -Raw | ConvertFrom-Json
+        Assert-Equal -Name "Priority 0 preserved (not replaced by default)" `
+            -Expected 0 -Actual $pzJson.priority
+    }
+
 } finally {
     Remove-Item -Path $taskRoot -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/workflows/default/systems/runtime/modules/workflow-manifest.ps1
+++ b/workflows/default/systems/runtime/modules/workflow-manifest.ps1
@@ -271,7 +271,7 @@ function New-WorkflowTask {
     # Extract fields — align with task-create MCP tool schema
     $name        = $TaskDef['name']
     $type        = if ($TaskDef['type']) { $TaskDef['type'] } else { 'prompt' }
-    $priority    = if ($TaskDef['priority']) { [int]$TaskDef['priority'] } else { 50 }
+    $priority    = if ($null -ne $TaskDef['priority']) { [int]$TaskDef['priority'] } else { 50 }
     $description = if ($TaskDef['description']) { $TaskDef['description'] } else { $name }
     $effort      = if ($TaskDef['effort']) { $TaskDef['effort'] } else { $Effort }
     $category    = if ($TaskDef['category']) { $TaskDef['category'] } else { $Category }

--- a/workflows/default/systems/ui/server.ps1
+++ b/workflows/default/systems/ui/server.ps1
@@ -1529,8 +1529,9 @@ $docContext
                             $bContinue = if ($body.PSObject.Properties['continue']) { $body.continue -eq $true } else { $false }
                             $bDescription = if ($body.PSObject.Properties['description']) { $body.description } else { $null }
                             $bModel = if ($body.PSObject.Properties['model']) { $body.model } else { $null }
+                            $bWorkflowName = if ($body.PSObject.Properties['workflow_name']) { $body.workflow_name } else { $null }
                             # Start-ProcessLaunch auto-detects max_concurrent for workflow type
-                            $result = Start-ProcessLaunch -Type $bType -TaskId $bTaskId -Prompt $bPrompt -Continue $bContinue -Description $bDescription -Model $bModel
+                            $result = Start-ProcessLaunch -Type $bType -TaskId $bTaskId -Prompt $bPrompt -Continue $bContinue -Description $bDescription -Model $bModel -WorkflowName $bWorkflowName
                             $content = $result | ConvertTo-Json -Compress
                         }
                     } else {

--- a/workflows/default/systems/ui/static/css/views.css
+++ b/workflows/default/systems/ui/static/css/views.css
@@ -1791,6 +1791,40 @@
     padding-bottom: 0;
 }
 
+/* Workflow accordion sections (Overview side panel, multi-workflow) */
+.wf-accordion-section {
+    margin-bottom: 6px;
+}
+
+.wf-accordion-section:last-child {
+    margin-bottom: 0;
+}
+
+.wf-accordion-section .wf-accordion-header {
+    display: flex;
+    align-items: center;
+}
+
+.wf-accordion-section.collapsed .wf-accordion-body {
+    display: none;
+}
+
+.wf-accordion-body {
+    padding: 4px 0 2px;
+}
+
+.wf-accordion-body .child-task-progress {
+    padding: 4px 10px 2px 10px;
+}
+
+.wf-accordion-body .child-task-items {
+    padding: 2px 0 2px 8px;
+}
+
+.wf-accordion-body .kickstart-resume-row {
+    padding: 6px 10px 2px;
+}
+
 /* Active phase (task_gen: generation done, tasks running) */
 .kickstart-phase-active .phase-icon {
     color: var(--color-primary);

--- a/workflows/default/systems/ui/static/modules/kickstart.js
+++ b/workflows/default/systems/ui/static/modules/kickstart.js
@@ -1304,8 +1304,8 @@ async function resumeWorkflow(workflowName) {
 /**
  * Build side panel data from /api/state — single source of truth.
  * Returns an array of workflow objects, each with tasks (priority-sorted),
- * counts, and resume state. Workflows with a running process come first,
- * then sorted alphabetically.
+ * counts, and resume state. Workflows are sorted alphabetically for
+ * stable display ordering.
  *
  * Returns: [{ workflow_name, tasks, counts, can_resume, status }, ...] or null
  */
@@ -1348,7 +1348,13 @@ function buildWorkflowPanelData(state) {
             }
         }
 
-        allTasks.sort((a, b) => a.priority - b.priority);
+        allTasks.sort((a, b) => {
+            const priorityDiff = a.priority - b.priority;
+            if (priorityDiff !== 0) return priorityDiff;
+            const nameDiff = String(a.name || '').localeCompare(String(b.name || ''));
+            if (nameDiff !== 0) return nameDiff;
+            return String(a.id).localeCompare(String(b.id));
+        });
 
         // Determine resume state
         const pending = (wf.todo || 0) + (wf.analysing || 0) + (wf.needs_input || 0) +

--- a/workflows/default/systems/ui/static/modules/kickstart.js
+++ b/workflows/default/systems/ui/static/modules/kickstart.js
@@ -1460,8 +1460,8 @@ function renderOverviewKickstartPhases(workflows) {
             : '';
 
         html += `
-            <div class="wf-accordion-section${isCollapsed ? ' collapsed' : ''}" data-workflow="${escapeHtml(wf.workflow_name)}">
-                <div class="chain-layer-header wf-accordion-header" data-workflow="${escapeHtml(wf.workflow_name)}">
+            <div class="wf-accordion-section${isCollapsed ? ' collapsed' : ''}" data-workflow="${escapeAttr(wf.workflow_name)}">
+                <div class="chain-layer-header wf-accordion-header" data-workflow="${escapeAttr(wf.workflow_name)}">
                     ${statusLed}
                     <span class="chain-layer-title">${escapeHtml(wf.workflow_name)}</span>
                     <span class="chain-layer-count">${doneCount}/${totalCount}</span>
@@ -1494,7 +1494,7 @@ function renderOverviewKickstartPhases(workflows) {
         if (wf.status === 'running') {
             html += `<div class="kickstart-resume-row"><button class="kickstart-resume-btn" disabled>RUNNING...</button></div>`;
         } else if (wf.can_resume) {
-            html += `<div class="kickstart-resume-row"><button class="kickstart-resume-btn" data-resume-wf="${escapeHtml(wf.workflow_name)}">RESUME</button></div>`;
+            html += `<div class="kickstart-resume-row"><button class="kickstart-resume-btn" data-resume-wf="${escapeAttr(wf.workflow_name)}">RESUME</button></div>`;
         } else if (wf.status === 'completed') {
             html += `<div class="kickstart-resume-row"><button class="kickstart-resume-btn" disabled>COMPLETED</button></div>`;
         }

--- a/workflows/default/systems/ui/static/modules/kickstart.js
+++ b/workflows/default/systems/ui/static/modules/kickstart.js
@@ -1246,7 +1246,7 @@ function startRoadmapPolling() {
 }
 
 /**
- * Resume an incomplete kickstart from the next pending/failed phase
+ * Resume an incomplete kickstart from the next pending/failed phase (legacy)
  */
 async function resumeKickstart() {
     try {
@@ -1272,32 +1272,139 @@ async function resumeKickstart() {
 }
 
 /**
- * Render kickstart phases panel on the Overview tab
- * Same visual pattern as the Workflow version but targets #overview-kickstart-phases
+ * Resume a workflow by launching a task-runner in continue mode.
+ * Uses /api/process/launch — no new backend endpoint needed.
  */
-function renderOverviewKickstartPhases(data) {
+async function resumeWorkflow(workflowName) {
+    try {
+        const response = await fetch(`${API_BASE}/api/process/launch`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                type: 'task-runner',
+                continue: true,
+                workflow_name: workflowName,
+                description: `Resume workflow: ${workflowName}`
+            })
+        });
+
+        const result = await response.json();
+
+        if (result.success) {
+            showToast(`Workflow "${workflowName}" resuming...`, 'success', 8000);
+        } else {
+            showToast('Failed to resume: ' + (result.error || 'Unknown error'), 'error');
+        }
+    } catch (error) {
+        console.error('Error resuming workflow:', error);
+        showToast('Error resuming workflow: ' + error.message, 'error');
+    }
+}
+
+/**
+ * Build side panel data from /api/state — single source of truth.
+ * Returns an array of workflow objects, each with tasks (priority-sorted),
+ * counts, and resume state. Workflows with a running process come first,
+ * then sorted alphabetically.
+ *
+ * Returns: [{ workflow_name, tasks, counts, can_resume, status }, ...] or null
+ */
+function buildWorkflowPanelData(state) {
+    if (!state || !state.workflows) return null;
+
+    const wfNames = Object.keys(state.workflows).sort();
+    const results = [];
+
+    // Collect all tasks from state.tasks lists into a flat array
+    const taskLists = [
+        { list: state.tasks.current ? [state.tasks.current] : [], status: null },
+        { list: state.tasks.upcoming || [], status: 'todo' },
+        { list: state.tasks.analysed_list || [], status: 'analysed' },
+        { list: state.tasks.analysing_list || [], status: 'analysing' },
+        { list: state.tasks.needs_input_list || [], status: 'needs-input' },
+        { list: state.tasks.recent_completed || [], status: 'done' },
+        { list: state.tasks.skipped_list || [], status: 'skipped' }
+    ];
+
+    for (const wfName of wfNames) {
+        const wf = state.workflows[wfName];
+        if (!wf || wf.total === 0) continue;
+
+        // Collect tasks for this workflow
+        const allTasks = [];
+        const seenIds = new Set();
+        for (const { list, status } of taskLists) {
+            for (const task of list) {
+                if (!task || !task.id) continue;
+                if (task.workflow !== wfName) continue;
+                if (seenIds.has(task.id)) continue;
+                seenIds.add(task.id);
+                allTasks.push({
+                    id: task.id,
+                    name: task.name,
+                    status: task.status || status,
+                    priority: task.priority != null ? parseInt(task.priority) : 99
+                });
+            }
+        }
+
+        allTasks.sort((a, b) => a.priority - b.priority);
+
+        // Determine resume state
+        const pending = (wf.todo || 0) + (wf.analysing || 0) + (wf.needs_input || 0) +
+                        (wf.analysed || 0) + (wf.in_progress || 0);
+        const processRunning = !!wf.process_alive;
+        const allDone = pending === 0 && wf.total > 0;
+
+        let panelStatus, canResume;
+        if (processRunning) {
+            panelStatus = 'running';
+            canResume = false;
+        } else if (allDone) {
+            panelStatus = 'completed';
+            canResume = false;
+        } else if (pending > 0) {
+            panelStatus = 'incomplete';
+            canResume = true;
+        } else {
+            panelStatus = 'not-started';
+            canResume = false;
+        }
+
+        results.push({
+            workflow_name: wfName,
+            tasks: allTasks,
+            counts: wf,
+            status: panelStatus,
+            can_resume: canResume
+        });
+    }
+
+    if (results.length === 0) return null;
+
+    // Stable alphabetical order (running state only affects expand/collapse, not position)
+    results.sort((a, b) => a.workflow_name.localeCompare(b.workflow_name));
+
+    return results;
+}
+
+/**
+ * Render workflow task panel on the Overview tab (multi-workflow accordion).
+ * Each workflow gets a collapsible section with its own task list, progress bar,
+ * and Resume button. Running workflows are expanded by default, others collapsed.
+ * Data comes from /api/state (via buildWorkflowPanelData), not a separate endpoint.
+ *
+ * @param {Array} workflows - Array of workflow objects from buildWorkflowPanelData
+ */
+function renderOverviewKickstartPhases(workflows) {
     const container = document.getElementById('overview-kickstart-phases');
     const sidePanel = document.getElementById('overview-side-panel');
-    if (!container || !sidePanel || !data || !data.phases || data.phases.length === 0) {
+    if (!container || !sidePanel || !workflows || workflows.length === 0) {
         if (sidePanel) sidePanel.style.display = 'none';
         return;
     }
 
-    // Count phases as completed if status is 'completed' or 'active' (generation done, tasks running)
-    const completedCount = data.phases.filter(p => p.status === 'completed' || p.status === 'active').length;
-    const totalCount = data.phases.length;
-
-    const statusIcons = {
-        completed: '<span class="phase-icon phase-completed">&#10003;</span>',
-        active:    '<span class="phase-icon phase-running">&#9679;</span>',
-        running:   '<span class="phase-icon phase-running">&#9679;</span>',
-        failed:    '<span class="phase-icon phase-failed">&#10007;</span>',
-        skipped:   '<span class="phase-icon phase-skipped">&#8211;</span>',
-        pending:   '<span class="phase-icon phase-pending">&#9675;</span>',
-        incomplete:'<span class="phase-icon phase-failed">&#9675;</span>'
-    };
-
-    const childStatusIcons = {
+    const taskStatusIcons = {
         'done':        '<span class="phase-icon phase-completed">&#10003;</span>',
         'in-progress': '<span class="led pulse"></span>',
         'analysing':   '<span class="led pulse"></span>',
@@ -1308,105 +1415,116 @@ function renderOverviewKickstartPhases(data) {
         'cancelled':   '<span class="phase-icon phase-skipped">&#8211;</span>'
     };
 
-    // Preserve collapsed state of inner phases section and child tasks
-    const existing = container.querySelector('.kickstart-phases');
-    const wasCollapsed = existing ? existing.classList.contains('collapsed') : false;
-    const existingChildList = container.querySelector('.child-task-list');
-    const childWasCollapsed = existingChildList ? existingChildList.classList.contains('collapsed') : false;
-
-    let html = `
-        <div class="kickstart-phases${wasCollapsed ? ' collapsed' : ''}">
-            <div class="chain-layer-items">
-    `;
-
-    data.phases.forEach(phase => {
-        const icon = statusIcons[phase.status] || statusIcons.pending;
-        html += `
-            <div class="chain-layer-item kickstart-phase-item kickstart-phase-${phase.status}">
-                ${icon}
-                <span class="item-name">${escapeHtml(phase.name)}</span>
-            </div>
-        `;
-
-        // Render child tasks for task_gen phases
-        if (phase.child_tasks && phase.child_tasks.length > 0 && phase.child_counts) {
-            const c = phase.child_counts;
-            const done = (c.done || 0) + (c.skipped || 0);
-            const total = c.total || 0;
-            const pct = total > 0 ? Math.round((done / total) * 100) : 0;
-            const active = (c.in_progress || 0) + (c.analysing || 0);
-
-            html += `
-                <div class="child-task-progress">
-                    <div class="child-task-bar-track">
-                        <div class="child-task-bar-fill" style="width: ${pct}%"></div>
-                    </div>
-                    <span class="child-task-summary">${done}/${total} done${active ? `, ${active} active` : ''}</span>
-                </div>
-                <div class="child-task-list${childWasCollapsed ? ' collapsed' : ''}">
-                    <div class="child-task-toggle" title="Toggle task list">
-                        <span class="folder-toggle">${childWasCollapsed ? '\u25b6' : '\u25bc'}</span>
-                        <span class="child-task-toggle-label">Tasks</span>
-                    </div>
-                    <div class="child-task-items">
-            `;
-            phase.child_tasks.forEach(task => {
-                const tIcon = childStatusIcons[task.status] || childStatusIcons['todo'];
-                html += `
-                    <div class="chain-layer-item child-task-item child-task-${task.status}">
-                        ${tIcon}
-                        <span class="item-name">${escapeHtml(task.name)}</span>
-                    </div>
-                `;
-            });
-            html += `
-                    </div>
-                </div>
-            `;
-        }
+    // Preserve per-workflow collapsed state from previous render
+    const prevCollapsed = {};
+    container.querySelectorAll('.wf-accordion-section').forEach(section => {
+        const name = section.dataset.workflow;
+        if (name) prevCollapsed[name] = section.classList.contains('collapsed');
     });
 
-    if (data.status === 'incomplete' && data.resume_from) {
+    // Aggregate totals for header
+    let totalDone = 0, totalAll = 0;
+    workflows.forEach(wf => {
+        const c = wf.counts || {};
+        totalDone += (c.done || 0) + (c.skipped || 0);
+        totalAll += c.total || 0;
+    });
+
+    let html = '';
+
+    workflows.forEach((wf, idx) => {
+        const counts = wf.counts || {};
+        const doneCount = (counts.done || 0) + (counts.skipped || 0);
+        const totalCount = counts.total || 0;
+        const activeCount = (counts.in_progress || 0) + (counts.analysing || 0);
+        const pct = totalCount > 0 ? Math.round((doneCount / totalCount) * 100) : 0;
+
+        // Default: running/incomplete expanded, others collapsed (unless user toggled)
+        let isCollapsed;
+        if (wf.workflow_name in prevCollapsed) {
+            isCollapsed = prevCollapsed[wf.workflow_name];
+        } else if (workflows.length === 1) {
+            isCollapsed = false; // Single workflow always expanded
+        } else {
+            isCollapsed = wf.status !== 'running' && wf.status !== 'incomplete';
+        }
+
+        const statusLed = wf.status === 'running'
+            ? '<span class="led pulse" style="margin-right:6px"></span>'
+            : '';
+
         html += `
-            <div class="kickstart-resume-row">
-                <button class="kickstart-resume-btn" onclick="resumeKickstart()">RESUME</button>
+            <div class="wf-accordion-section${isCollapsed ? ' collapsed' : ''}" data-workflow="${escapeHtml(wf.workflow_name)}">
+                <div class="chain-layer-header wf-accordion-header" data-workflow="${escapeHtml(wf.workflow_name)}">
+                    ${statusLed}
+                    <span class="chain-layer-title">${escapeHtml(wf.workflow_name)}</span>
+                    <span class="chain-layer-count">${doneCount}/${totalCount}</span>
+                </div>
+                <div class="wf-accordion-body">
+                    <div class="child-task-progress">
+                        <div class="child-task-bar-track">
+                            <div class="child-task-bar-fill" style="width: ${pct}%"></div>
+                        </div>
+                        <span class="child-task-summary">${doneCount}/${totalCount} done${activeCount ? `, ${activeCount} active` : ''}</span>
+                    </div>
+                    <div class="child-task-items">
+        `;
+
+        (wf.tasks || []).forEach(task => {
+            const icon = taskStatusIcons[task.status] || taskStatusIcons['todo'];
+            html += `
+                        <div class="chain-layer-item child-task-item child-task-${task.status}">
+                            ${icon}
+                            <span class="item-name">${escapeHtml(task.name)}</span>
+                        </div>
+            `;
+        });
+
+        html += `
+                    </div>
+        `;
+
+        // Resume button per workflow
+        if (wf.status === 'running') {
+            html += `<div class="kickstart-resume-row"><button class="kickstart-resume-btn" disabled>RUNNING...</button></div>`;
+        } else if (wf.can_resume) {
+            html += `<div class="kickstart-resume-row"><button class="kickstart-resume-btn" data-resume-wf="${escapeHtml(wf.workflow_name)}">RESUME</button></div>`;
+        } else if (wf.status === 'completed') {
+            html += `<div class="kickstart-resume-row"><button class="kickstart-resume-btn" disabled>COMPLETED</button></div>`;
+        }
+
+        html += `
+                </div>
             </div>
         `;
-    }
-
-    html += `
-            </div>
-        </div>
-    `;
+    });
 
     container.innerHTML = html;
     sidePanel.style.display = 'flex';
 
-    // Update side panel header with workflow name + progress count
+    // Update side panel header with aggregate counts
     const sideTitleEl = document.getElementById('overview-side-title');
     if (sideTitleEl) {
-        sideTitleEl.textContent = data.workflow_name || 'Workflow Progress';
+        sideTitleEl.textContent = workflows.length === 1
+            ? (workflows[0].workflow_name || 'Workflow Progress')
+            : 'Workflow Progress';
     }
     const sideCountEl = document.getElementById('overview-side-count');
     if (sideCountEl) {
-        sideCountEl.textContent = `${completedCount}/${totalCount}`;
+        sideCountEl.textContent = `${totalDone}/${totalAll}`;
     }
 
-    // Add collapse/expand handler for inner phases section
-    const phaseHeader = container.querySelector('.kickstart-phases .chain-layer-header');
-    if (phaseHeader) {
-        phaseHeader.addEventListener('click', () => {
-            phaseHeader.closest('.kickstart-phases').classList.toggle('collapsed');
+    // Accordion collapse/expand handlers
+    container.querySelectorAll('.wf-accordion-header').forEach(header => {
+        header.addEventListener('click', () => {
+            header.closest('.wf-accordion-section').classList.toggle('collapsed');
         });
-    }
+    });
 
-    // Add collapse/expand handler for child task list
-    container.querySelectorAll('.child-task-toggle').forEach(toggle => {
-        toggle.addEventListener('click', () => {
-            const list = toggle.closest('.child-task-list');
-            list.classList.toggle('collapsed');
-            const arrow = toggle.querySelector('.folder-toggle');
-            if (arrow) arrow.textContent = list.classList.contains('collapsed') ? '\u25b6' : '\u25bc';
+    // Resume button handlers (data-attribute based, no inline onclick)
+    container.querySelectorAll('.kickstart-resume-btn[data-resume-wf]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            resumeWorkflow(btn.dataset.resumeWf);
         });
     });
 

--- a/workflows/default/systems/ui/static/modules/polling.js
+++ b/workflows/default/systems/ui/static/modules/polling.js
@@ -38,12 +38,14 @@ async function pollState() {
             Aether.processState(state);
         }
 
-        // Throttled kickstart phase status (every 5th poll cycle, but always on first poll)
+        // Update workflow side panel every poll (no extra fetch — uses state already in hand)
+        updateOverviewWorkflowPanel(state);
+
+        // Throttled: legacy kickstart status + installed workflow controls (both need separate fetch)
         kickstartPollCounter++;
         if (kickstartPollCounter >= 5 || Object.keys(installedWorkflowMap).length === 0) {
             kickstartPollCounter = 0;
-            updateKickstartPhases();
-            // Refresh installed workflow controls (throttled alongside kickstart)
+            updateLegacyKickstartPhases();
             updateInstalledWorkflowControls();
         }
 
@@ -81,25 +83,40 @@ async function updateInstalledWorkflowControls() {
 }
 
 /**
- * Fetch kickstart phase status and update the workflow panel
+ * Update Overview side panel from /api/state (no extra fetch needed)
  */
-async function updateKickstartPhases() {
+function updateOverviewWorkflowPanel(state) {
     try {
-        const response = await fetch(`${API_BASE}/api/kickstart/status`);
-        if (!response.ok) return;
+        if (state && typeof buildWorkflowPanelData === 'function') {
+            const panelData = buildWorkflowPanelData(state);
+            if (panelData && panelData.length > 0) {
+                if (typeof renderOverviewKickstartPhases === 'function') {
+                    renderOverviewKickstartPhases(panelData);
+                }
+            } else {
+                const overviewSidePanel = document.getElementById('overview-side-panel');
+                if (overviewSidePanel) overviewSidePanel.style.display = 'none';
+            }
+        }
+    } catch (error) {
+        // Silently ignore — non-critical
+    }
+}
 
-        const data = await response.json();
-        if (data.phases && data.phases.length > 0) {
-            if (typeof renderKickstartPhases === 'function') {
-                renderKickstartPhases(data);
+/**
+ * Legacy: fetch /api/kickstart/status for the Workflow tab's renderKickstartPhases.
+ * Throttled — called every 5th poll cycle (not every cycle).
+ */
+async function updateLegacyKickstartPhases() {
+    try {
+        if (typeof renderKickstartPhases === 'function') {
+            const response = await fetch(`${API_BASE}/api/kickstart/status`);
+            if (response.ok) {
+                const data = await response.json();
+                if (data.phases && data.phases.length > 0) {
+                    renderKickstartPhases(data);
+                }
             }
-            if (typeof renderOverviewKickstartPhases === 'function') {
-                renderOverviewKickstartPhases(data);
-            }
-        } else {
-            // Hide overview side panel when no phases
-            const overviewSidePanel = document.getElementById('overview-side-panel');
-            if (overviewSidePanel) overviewSidePanel.style.display = 'none';
         }
     } catch (error) {
         // Silently ignore — non-critical


### PR DESCRIPTION
## Summary

Rewrites the Overview tab's side panel to work with the task-runner engine instead of the kickstart engine. Closes #198, #239, #241.

## Changed Files

| File | What changed |
|---|---|
| **`kickstart.js`** | Rewrote `buildWorkflowPanelData` + `renderOverviewKickstartPhases` + new `resumeWorkflow` |
| **`polling.js`** | Split into `updateOverviewWorkflowPanel` (every cycle, no fetch) and `updateLegacyKickstartPhases` (throttled) |
| **`server.ps1`** | Pass `workflow_name` through to `Start-ProcessLaunch` in `/api/process/launch` |
| **`workflow-manifest.ps1`** | Fix priority=0 falsy bug |
| **`views.css`** | Accordion CSS for multi-workflow sections |
| **`Test-WorkflowManifest.ps1`** | Regression test for priority=0 |

## What's Fixed

### 1. Resume button now launches task-runner (not kickstart)
- **Before:** `resumeKickstart()` → started kickstart engine, recreated tasks from scratch
- **After:** `resumeWorkflow(name)` → `POST /api/process/launch { type: 'task-runner', continue: true, workflow_name }` — resumes from task queue

### 2. Task ordering follows manifest order (priority-based)
- **Before:** Side panel showed kickstart phases, tasks in arbitrary order
- **After:** All tasks sorted by `priority` field (preserves workflow.yaml declaration order)

### 3. Priority 0 falsy bug (PowerShell + JavaScript)
- **PowerShell:** `if ($TaskDef['priority'])` treated 0 as falsy → fixed with `if ($null -ne $TaskDef['priority'])`
- **JavaScript:** `parseInt(task.priority) || 99` turned 0 into 99 → fixed with `task.priority != null ? parseInt(task.priority) : 99`

### 4. Single source of truth: `/api/state` (no duplicate fetch)
- **Before:** Side panel fetched `/api/kickstart/status` → `Get-KickstartStatus` → `Resolve-TaskGenChildTasks` → disk scan
- **After:** `buildWorkflowPanelData(state)` extracts data from the already-polled `/api/state` response — zero additional HTTP requests

### 5. Panel update speed: 15s → 3s
- **Before:** Updated every 5th poll cycle (5×3s = 15s) because it needed a separate fetch
- **After:** Updates every poll cycle (3s) — no extra fetch, zero cost

### 6. Multi-workflow accordion
- Single workflow → always expanded (same as before)
- Multiple workflows → each gets a collapsible accordion section; running/incomplete workflows expanded by default
- Stable alphabetical ordering (no jumping when process state changes)
- Each workflow has its own progress bar, task list, and Resume button

### 7. Resume button states

| State | Button |
|---|---|
| Process running | `RUNNING...` (disabled) |
| Pending tasks exist | `RESUME` (enabled) |
| All tasks completed | `COMPLETED` (disabled) |
| No tasks | Panel hidden |

## Not Touched (existing code preserved)
- `Resume-ProductKickstart` — legacy function, untouched
- `Get-KickstartStatus` — Workflow tab still uses it (throttled to every 5th cycle)
- `renderKickstartPhases` — Workflow tab's own renderer, unchanged
- No new backend endpoints or functions added (one-line passthrough in server.ps1 only)

## Test Plan
- [x] Run `pwsh tests/Run-Tests.ps1` — layers 1-3 pass (priority=0 regression test included)
- [x] Install single workflow, verify side panel shows tasks in priority order
- [x] Install two workflows, verify accordion with separate sections
- [x] Click Resume, verify task-runner process starts (not kickstart)
- [x] Stop process, verify accordion LED turns off, task LEDs reflect actual status
- [x] Verify Workflow tab still works (legacy path untouched)

