### PR TITLE
Enforce required product document creation in workflow

### DIFF
--- a/workflows/kickstart-via-jira/recipes/prompts/01-plan-product.md
+++ b/workflows/kickstart-via-jira/recipes/prompts/01-plan-product.md
@@ -14,6 +14,9 @@ Create two product documents:
 1. **mission.md** — Specification derived from Jira description + business objective + Confluence docs
 2. **roadmap-overview.md** — The research plan: what research tasks to create, their timeline, and dependencies
 
+**CRITICAL:** You MUST write both files to `.bot/workspace/product/` in this session.
+Existing documents in the briefing or product directory (e.g. spec files from a prior phase) do NOT satisfy this requirement.
+
 **Does NOT create:**
 - `tech-stack.md` — Deferred to Phase 3 (refine-artifacts). Tech stacks can only be determined after deep dives reveal the actual technologies per repo.
 - `entity-model.md` — Not applicable for brownfield. There is no single entity model across repos.
@@ -217,6 +220,16 @@ Per-repo deep dives for MEDIUM+ impact repos (created after Phase 1 completes):
 - External provider/vendor timelines (may block implementation)
 - Stakeholder availability for open questions (Phase 3)
 ```
+
+### Step 7: Verify Required Outputs
+
+Before declaring this phase complete, verify both required files exist:
+
+- [ ] `.bot/workspace/product/mission.md` — MUST exist and begin with `## Executive Summary`
+- [ ] `.bot/workspace/product/roadmap-overview.md` — MUST exist
+
+**If either file is missing, create it now.** Do NOT mark the phase complete until both files have been written.
+Do not rely on documents created in a previous session (spec files, design docs, etc.) as a substitute for these deliverables.
 
 ## Clarifying Questions
 

--- a/workflows/kickstart-via-jira/workflow.yaml
+++ b/workflows/kickstart-via-jira/workflow.yaml
@@ -75,7 +75,7 @@ tasks:
     type: prompt
     workflow: "01-plan-product.md"
     depends_on: ["Fetch Jira Context"]
-    outputs: ["mission.md"]
+    outputs: ["mission.md", "roadmap-overview.md"]
     front_matter_docs: ["mission.md", "roadmap-overview.md", "research-repos.md"]
     commit:
       paths: ["workspace/product/"]


### PR DESCRIPTION
This pull request updates the product planning workflow to clarify and enforce the creation of two essential product documents during the planning phase. The changes make it explicit that both `mission.md` and `roadmap-overview.md` must be generated and verified before the phase can be marked complete. Additionally, the workflow YAML is updated to expect both files as outputs.

**Documentation requirements and enforcement:**

* Updated instructions in `01-plan-product.md` to clearly state that both `mission.md` and `roadmap-overview.md` must be written to `.bot/workspace/product/` during the session, and that existing documents do not fulfill this requirement.
* Added a verification step to the end of the planning phase in `01-plan-product.md` to ensure both required files exist, with explicit instructions not to complete the phase until both have been created.

**Workflow configuration:**

* Modified the `workflow.yaml` to require both `mission.md` and `roadmap-overview.md` as outputs of the planning task, ensuring the workflow enforces the updated documentation requirements.## Linked issue

<!-- Every PR should close an issue. Replace the number below. -->
<!-- PRs without a linked issue will be sent back unless they're trivial. -->

Closes #255 