### PR TITLE
Add support for workflow_prompt in task_gen tasks

### DIFF
--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -878,6 +878,60 @@ try {
         -Condition ($null -ne $badTypeResponse -and $null -ne $badTypeResponse.error) `
         -Message "Expected error for invalid type"
 
+    # task_get_next returns workflow_prompt for task_gen tasks (fix: #263)
+    # Create a task_gen task with workflow_prompt directly in the task file
+    $wfPromptTaskId = [System.Guid]::NewGuid().ToString()
+    $wfPromptTask = [ordered]@{
+        id              = $wfPromptTaskId
+        name            = "Plan Internet Research Test"
+        description     = "Test: task_gen with workflow_prompt"
+        category        = "workflow"
+        priority        = 1
+        effort          = "XS"
+        status          = "todo"
+        type            = "task_gen"
+        workflow        = "kickstart-via-jira"
+        workflow_prompt = "02a-plan-internet-research.md"
+        dependencies    = @()
+        skip_analysis   = $true
+        skip_worktree   = $true
+        created_at      = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
+        updated_at      = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
+        completed_at    = $null
+    }
+    $wfPromptSlug = "plan-internet-research-test-$($wfPromptTaskId.Substring(0,8))"
+    $wfPromptFile = Join-Path (Join-Path $botDir "workspace\tasks\todo") "$wfPromptSlug.json"
+    $wfPromptTask | ConvertTo-Json -Depth 5 | Set-Content $wfPromptFile -Encoding utf8NoBOM
+
+    $requestId++
+    $getNextWfPromptResponse = Send-McpRequest -Process $mcpProcess -Request @{
+        jsonrpc = '2.0'
+        id      = $requestId
+        method  = 'tools/call'
+        params  = @{
+            name      = 'task_get_next'
+            arguments = @{ verbose = $true }
+        }
+    }
+
+    if ($getNextWfPromptResponse -and $getNextWfPromptResponse.result) {
+        $gnWfText = $getNextWfPromptResponse.result.content[0].text
+        $gnWfObj  = $gnWfText | ConvertFrom-Json
+        if ($gnWfObj.success -and $gnWfObj.task) {
+            Assert-Equal -Name "task_get_next returns workflow_prompt field" `
+                -Expected "02a-plan-internet-research.md" -Actual $gnWfObj.task.workflow_prompt
+        } else {
+            Assert-True -Name "task_get_next returns workflow_prompt field" `
+                -Condition $false -Message "No task returned: $gnWfText"
+        }
+    } else {
+        Assert-True -Name "task_get_next returns workflow_prompt field" `
+            -Condition $false -Message "No response from task_get_next"
+    }
+
+    # Cleanup: remove the test task file
+    Remove-Item $wfPromptFile -Force -ErrorAction SilentlyContinue
+
     Write-Host ""
 
     # ═══════════════════════════════════════════════════════════════════

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -513,6 +513,43 @@ try {
             -Condition ($null -eq $noPostJson.PSObject.Properties['post_script'])
     }
 
+    # task_gen with workflow field → stores workflow_prompt (fix: #263)
+    $taskGenWithPromptDef = @{
+        name     = "Plan Internet Research"
+        type     = "task_gen"
+        workflow = "02a-plan-internet-research.md"
+        priority = 3
+    }
+    $tgPromptResult = New-WorkflowTask -ProjectBotDir $taskBotDir -WorkflowName "kickstart-via-jira" -TaskDef $taskGenWithPromptDef
+    $tgPromptFile = Join-Path $taskBotDir "workspace\tasks\todo" $tgPromptResult.file
+    if (Test-Path $tgPromptFile) {
+        $tgPromptJson = Get-Content $tgPromptFile -Raw | ConvertFrom-Json
+        Assert-Equal -Name "task_gen+workflow stores workflow_prompt" `
+            -Expected "02a-plan-internet-research.md" -Actual $tgPromptJson.workflow_prompt
+        Assert-Equal -Name "task_gen+workflow: type remains task_gen" `
+            -Expected "task_gen" -Actual $tgPromptJson.type
+        Assert-Equal -Name "task_gen+workflow: workflow field is workflow name" `
+            -Expected "kickstart-via-jira" -Actual $tgPromptJson.workflow
+    }
+
+    # task_gen WITHOUT workflow field → workflow_prompt absent (keeps JSON clean)
+    $taskGenNoPromptDef = @{
+        name        = "Generate Tasks Script"
+        type        = "task_gen"
+        script      = "gen-tasks.ps1"
+        priority    = 3
+    }
+    $tgNoPromptResult = New-WorkflowTask -ProjectBotDir $taskBotDir -WorkflowName "default" -TaskDef $taskGenNoPromptDef
+    $tgNoPromptFile = Join-Path $taskBotDir "workspace\tasks\todo" $tgNoPromptResult.file
+    if (Test-Path $tgNoPromptFile) {
+        $tgNoPromptJson = Get-Content $tgNoPromptFile -Raw | ConvertFrom-Json
+        Assert-True -Name "task_gen without workflow: workflow_prompt absent" `
+            -Condition ($null -eq $tgNoPromptJson.PSObject.Properties['workflow_prompt']) `
+            -Message "workflow_prompt should be absent when workflow field not set"
+        Assert-Equal -Name "task_gen without workflow: script_path set" `
+            -Expected "gen-tasks.ps1" -Actual $tgNoPromptJson.script_path
+    }
+
 } finally {
     Remove-Item -Path $taskRoot -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -522,15 +522,14 @@ try {
     }
     $tgPromptResult = New-WorkflowTask -ProjectBotDir $taskBotDir -WorkflowName "kickstart-via-jira" -TaskDef $taskGenWithPromptDef
     $tgPromptFile = Join-Path $taskBotDir "workspace\tasks\todo" $tgPromptResult.file
-    if (Test-Path $tgPromptFile) {
-        $tgPromptJson = Get-Content $tgPromptFile -Raw | ConvertFrom-Json
-        Assert-Equal -Name "task_gen+workflow stores workflow_prompt" `
-            -Expected "02a-plan-internet-research.md" -Actual $tgPromptJson.workflow_prompt
-        Assert-Equal -Name "task_gen+workflow: type remains task_gen" `
-            -Expected "task_gen" -Actual $tgPromptJson.type
-        Assert-Equal -Name "task_gen+workflow: workflow field is workflow name" `
-            -Expected "kickstart-via-jira" -Actual $tgPromptJson.workflow
-    }
+    Assert-PathExists -Path $tgPromptFile -Name "task_gen+workflow creates task file"
+    $tgPromptJson = Get-Content $tgPromptFile -Raw | ConvertFrom-Json
+    Assert-Equal -Name "task_gen+workflow stores workflow_prompt" `
+        -Expected "02a-plan-internet-research.md" -Actual $tgPromptJson.workflow_prompt
+    Assert-Equal -Name "task_gen+workflow: type remains task_gen" `
+        -Expected "task_gen" -Actual $tgPromptJson.type
+    Assert-Equal -Name "task_gen+workflow: workflow field is workflow name" `
+        -Expected "kickstart-via-jira" -Actual $tgPromptJson.workflow
 
     # task_gen WITHOUT workflow field → workflow_prompt absent (keeps JSON clean)
     $taskGenNoPromptDef = @{

--- a/workflows/default/systems/mcp/modules/TaskIndexCache.psm1
+++ b/workflows/default/systems/mcp/modules/TaskIndexCache.psm1
@@ -428,6 +428,7 @@ function Update-TaskIndex {
                     ignore = $content.ignore
                     type = $content.type
                     script_path = $content.script_path
+                    workflow_prompt = $content.workflow_prompt
                     mcp_tool = $content.mcp_tool
                     mcp_args = $content.mcp_args
                     skip_analysis = $content.skip_analysis

--- a/workflows/default/systems/mcp/tools/task-get-next/script.ps1
+++ b/workflows/default/systems/mcp/tools/task-get-next/script.ps1
@@ -197,6 +197,7 @@ function Invoke-TaskGetNext {
             skip_analysis = $nextTask.skip_analysis
             skip_worktree = $nextTask.skip_worktree
             workflow = $nextTask.workflow
+            workflow_prompt = $nextTask.workflow_prompt
             model = $nextTask.model
         }
     } else {
@@ -209,6 +210,7 @@ function Invoke-TaskGetNext {
             category = $nextTask.category
             type = $nextTask.type
             script_path = $nextTask.script_path
+            workflow_prompt = $nextTask.workflow_prompt
             mcp_tool = $nextTask.mcp_tool
             mcp_args = $nextTask.mcp_args
             workflow = $nextTask.workflow

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -333,6 +333,24 @@ try {
 
         # --- Task type dispatch (script / mcp / task_gen bypass Claude entirely) ---
         $taskTypeVal = if ($task.type) { $task.type } else { 'prompt' }
+        # task_gen with workflow_prompt: run Claude with a specific prompt to create tasks
+        # — falls through to the normal analysis+execution path below
+        if ($taskTypeVal -eq 'task_gen' -and $task.workflow_prompt) {
+            $promptBase = Join-Path $botRoot "recipes\prompts"
+            if ($task.workflow) {
+                $wfPromptsBase = Join-Path $botRoot "workflows\$($task.workflow)\recipes\prompts"
+                if (Test-Path $wfPromptsBase) { $promptBase = $wfPromptsBase }
+            }
+            $templatePath = Join-Path $promptBase $task.workflow_prompt
+            if (Test-Path $templatePath) {
+                $executionPromptTemplate = Get-Content $templatePath -Raw
+                Write-Status "Using task_gen prompt: $($task.workflow_prompt)" -Type Info
+                Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task-gen prompt: $($task.workflow_prompt)"
+            } else {
+                Write-Status "task_gen prompt not found: $templatePath" -Type Warn
+            }
+            $taskTypeVal = 'prompt'
+        }
         # prompt_template uses Claude but with a workflow-specific prompt file
         # — falls through to the normal analysis+execution path below
         if ($taskTypeVal -eq 'prompt_template' -and $task.prompt) {
@@ -371,6 +389,18 @@ try {
             }
 
             # Pre-flight: verify script exists before attempting execution
+            # task_gen with workflow_prompt is handled above (falls through to prompt path)
+            if ($taskTypeVal -in @('script', 'task_gen') -and -not $task.script_path -and -not $task.workflow_prompt) {
+                $typeError = "Missing script_path for $taskTypeVal task: $($task.name)"
+                Write-Status $typeError -Type Error
+                Write-ProcessActivity -Id $procId -ActivityType "error" -Message "$($task.name): $typeError"
+                try {
+                    Invoke-TaskMarkSkipped -Arguments @{ task_id = $task.id; skip_reason = "non-recoverable" } | Out-Null
+                } catch { Write-BotLog -Level Debug -Message "Logging operation failed" -Exception $_ }
+                $TaskId = $null; $processData.task_id = $null; $processData.task_name = $null
+                Start-Sleep -Seconds 3
+                continue
+            }
             if ($taskTypeVal -in @('script', 'task_gen') -and $task.script_path) {
                 $resolvedScript = Join-Path $scriptBase $task.script_path
                 if (-not (Test-Path $resolvedScript)) {
@@ -386,7 +416,7 @@ try {
                     Write-Status $typeError -Type Error
                     Write-ProcessActivity -Id $procId -ActivityType "error" -Message "$($task.name): $typeError"
                     try {
-                        Invoke-TaskMarkSkipped -Arguments @{ task_id = $task.id; skip_reason = $typeError } | Out-Null
+                        Invoke-TaskMarkSkipped -Arguments @{ task_id = $task.id; skip_reason = "non-recoverable" } | Out-Null
                     } catch { Write-BotLog -Level Debug -Message "Logging operation failed" -Exception $_ }
                     $TaskId = $null; $processData.task_id = $null; $processData.task_name = $null
                     Start-Sleep -Seconds 3
@@ -477,7 +507,7 @@ try {
             } else {
                 Write-Status "Task failed: $($task.name)" -Type Error
                 try {
-                    Invoke-TaskMarkSkipped -Arguments @{ task_id = $task.id; skip_reason = "$taskTypeVal execution failed: $typeError" } | Out-Null
+                    Invoke-TaskMarkSkipped -Arguments @{ task_id = $task.id; skip_reason = "non-recoverable" } | Out-Null
                 } catch { Write-BotLog -Level Debug -Message "Session operation failed" -Exception $_ }
             }
 

--- a/workflows/default/systems/runtime/modules/workflow-manifest.ps1
+++ b/workflows/default/systems/runtime/modules/workflow-manifest.ps1
@@ -308,6 +308,11 @@ function New-WorkflowTask {
 
     # Optional fields — only set if declared (keeps task JSON clean)
     if ($scriptPath)                           { $task["script_path"] = $scriptPath }
+    # task_gen tasks that reference a workflow prompt file — store the prompt filename
+    # so the runtime can run Claude with it (instead of looking for a script)
+    if ($type -eq 'task_gen' -and $TaskDef['workflow']) {
+        $task["workflow_prompt"] = $TaskDef['workflow']
+    }
     if ($mcpTool)                              { $task["mcp_tool"] = $mcpTool }
     if ($mcpArgs -and $mcpArgs.Count -gt 0)    { $task["mcp_args"] = $mcpArgs }
     if ($TaskDef['acceptance_criteria'])        { $task["acceptance_criteria"] = @($TaskDef['acceptance_criteria']) }


### PR DESCRIPTION
This pull request introduces support for `task_gen` tasks that use a `workflow_prompt` file instead of a script, improving flexibility in task generation workflows. It ensures that such tasks are correctly created, indexed, and executed using the specified prompt file. The changes also add comprehensive tests to verify this new behavior and improve error handling for missing required fields.

**Support for `task_gen` tasks with `workflow_prompt`:**

* When creating a `task_gen` task with a `workflow` field, the system now stores the workflow prompt filename in the `workflow_prompt` field of the task JSON, enabling runtime to use it as a prompt instead of a script.
* The task index and `task_get_next` tool now include the `workflow_prompt` field, ensuring this information is available throughout the task lifecycle. [[1]](diffhunk://#diff-2a8c59a4a4a0ed78093ecb6f3758a5383dbe5b71d38736e5fdc598cd48eb7b84R431) [[2]](diffhunk://#diff-2afd365fb58ba345e2c778a057310de577ef5b766a66713e0ac2d160bfd2d618R200) [[3]](diffhunk://#diff-2afd365fb58ba345e2c778a057310de577ef5b766a66713e0ac2d160bfd2d618R213)

**Runtime execution improvements:**

* The workflow process module now detects `task_gen` tasks with a `workflow_prompt`, loads the specified prompt file, and runs it as a Claude prompt, falling back to normal analysis/execution if not found.
* Improved error handling for `task_gen` and `script` tasks: if both `script_path` and `workflow_prompt` are missing, the task is marked as skipped with a "non-recoverable" reason, and similar handling is applied when scripts are missing or fail. [[1]](diffhunk://#diff-7bd4190eb5788549d4368ca5ea8b9f889102cc4c354dfeff424aa355fdec2b12R392-R403) [[2]](diffhunk://#diff-7bd4190eb5788549d4368ca5ea8b9f889102cc4c354dfeff424aa355fdec2b12L389-R419) [[3]](diffhunk://#diff-7bd4190eb5788549d4368ca5ea8b9f889102cc4c354dfeff424aa355fdec2b12L480-R510)

**Testing enhancements:**

* Added tests to verify that `task_gen` tasks with a `workflow` field correctly store the `workflow_prompt`, and that tasks without this field do not include it, keeping the JSON clean.
* Added integration tests to ensure `task_get_next` returns the `workflow_prompt` for `task_gen` tasks, verifying end-to-end support for this feature.
Closes #263 