### PR TITLE
feat(ui): add .txt and image view support to Product Documents Viewer (#212)

### DIFF
--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2762,8 +2762,15 @@ if (Test-Path $productApiModule) {
         # JSON files for type/resolution tests
         Set-Content -Path (Join-Path $productDir "config.json") -Value '{"key":"value"}' -Encoding UTF8
         Set-Content -Path (Join-Path $productDir "mission.json") -Value '{"title":"Mission JSON"}' -Encoding UTF8
-        # Binary file for type/size tests
+        # Image files for type tests
         [System.IO.File]::WriteAllBytes((Join-Path $productDir "logo.png"), [byte[]](0x89, 0x50, 0x4E, 0x47))
+        [System.IO.File]::WriteAllBytes((Join-Path $productDir "screenshot.jpg"), [byte[]](0xFF, 0xD8, 0xFF, 0xE0))
+        [System.IO.File]::WriteAllBytes((Join-Path $productDir "animation.gif"), [byte[]](0x47, 0x49, 0x46, 0x38))
+        Set-Content -Path (Join-Path $productDir "diagram.svg") -Value '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>' -Encoding UTF8
+        # Text file for txt type tests
+        Set-Content -Path (Join-Path $productDir "notes.txt") -Value "Plain text content with <html> special chars" -Encoding UTF8
+        # True binary file for binary type tests
+        [System.IO.File]::WriteAllBytes((Join-Path $productDir "document.pdf"), [byte[]](0x25, 0x50, 0x44, 0x46))
         # .gitkeep should be excluded
         Set-Content -Path (Join-Path $briefingDir ".gitkeep") -Value "" -Encoding UTF8
 
@@ -2771,7 +2778,7 @@ if (Test-Path $productApiModule) {
 
         $docs = @((Get-ProductList).docs)
         Assert-Equal -Name "ProductAPI lists nested product docs" `
-            -Expected 7 `
+            -Expected 12 `
             -Actual $docs.Count
         Assert-Equal -Name "ProductAPI keeps mission first in priority order" `
             -Expected "mission" `
@@ -2800,13 +2807,13 @@ if (Test-Path $productApiModule) {
 
         # Metadata field tests (type, size, depth)
         $logoPng = $docs | Where-Object { $_.name -eq 'logo.png' }
-        Assert-True -Name "ProductAPI includes binary files in list" `
+        Assert-True -Name "ProductAPI includes image files in list" `
             -Condition ($null -ne $logoPng) `
-            -Message "Binary file logo.png missing from product list"
-        Assert-Equal -Name "ProductAPI returns type=binary for non-md files" `
-            -Expected "binary" `
+            -Message "Image file logo.png missing from product list"
+        Assert-Equal -Name "ProductAPI returns type=image for .png files" `
+            -Expected "image" `
             -Actual $logoPng.type
-        Assert-True -Name "ProductAPI returns size field for binary files" `
+        Assert-True -Name "ProductAPI returns size field for image files" `
             -Condition ($logoPng.size -gt 0) `
             -Message "Expected non-zero size for logo.png"
         Assert-Equal -Name "ProductAPI returns depth=0 for root files" `
@@ -2852,6 +2859,125 @@ if (Test-Path $productApiModule) {
         Assert-True -Name "ProductAPI loads explicit .json route when .md also exists" `
             -Condition ($missionJsonDoc.success -eq $true -and $missionJsonDoc.content -match 'Mission JSON') `
             -Message "Expected mission.json content when requested explicitly"
+
+        # ── Text file (.txt) support tests ──
+
+        $notesTxt = $docs | Where-Object { $_.name -eq 'notes.txt' }
+        Assert-True -Name "ProductAPI includes .txt files in list" `
+            -Condition ($null -ne $notesTxt) `
+            -Message "Text file notes.txt missing from product list"
+        Assert-Equal -Name "ProductAPI returns type=txt for .txt files" `
+            -Expected "txt" `
+            -Actual $notesTxt.type
+        Assert-Equal -Name "ProductAPI retains .txt extension in name" `
+            -Expected "notes.txt" `
+            -Actual $notesTxt.name
+
+        $txtDoc = Get-ProductDocument -Name "notes.txt"
+        Assert-True -Name "ProductAPI loads .txt doc by name" `
+            -Condition ($txtDoc.success -eq $true -and $txtDoc.content -match 'Plain text content') `
+            -Message "Text doc notes.txt could not be loaded"
+
+        # ── Image file type detection tests ──
+
+        $screenshotJpg = $docs | Where-Object { $_.name -eq 'screenshot.jpg' }
+        Assert-True -Name "ProductAPI includes .jpg files in list" `
+            -Condition ($null -ne $screenshotJpg) `
+            -Message "Image file screenshot.jpg missing from product list"
+        Assert-Equal -Name "ProductAPI returns type=image for .jpg files" `
+            -Expected "image" `
+            -Actual $screenshotJpg.type
+
+        $animationGif = $docs | Where-Object { $_.name -eq 'animation.gif' }
+        Assert-True -Name "ProductAPI includes .gif files in list" `
+            -Condition ($null -ne $animationGif) `
+            -Message "Image file animation.gif missing from product list"
+        Assert-Equal -Name "ProductAPI returns type=image for .gif files" `
+            -Expected "image" `
+            -Actual $animationGif.type
+
+        $diagramSvg = $docs | Where-Object { $_.name -eq 'diagram.svg' }
+        Assert-True -Name "ProductAPI includes .svg files in list" `
+            -Condition ($null -ne $diagramSvg) `
+            -Message "Image file diagram.svg missing from product list"
+        Assert-Equal -Name "ProductAPI returns type=image for .svg files" `
+            -Expected "image" `
+            -Actual $diagramSvg.type
+
+        Assert-Equal -Name "ProductAPI retains image extension in name" `
+            -Expected "screenshot.jpg" `
+            -Actual $screenshotJpg.name
+
+        # ── True binary files still classified as binary ──
+
+        $documentPdf = $docs | Where-Object { $_.name -eq 'document.pdf' }
+        Assert-True -Name "ProductAPI includes true binary files in list" `
+            -Condition ($null -ne $documentPdf) `
+            -Message "Binary file document.pdf missing from product list"
+        Assert-Equal -Name "ProductAPI returns type=binary for unknown extensions" `
+            -Expected "binary" `
+            -Actual $documentPdf.type
+
+        # ── Get-ProductDocumentRaw tests ──
+
+        $rawPng = Get-ProductDocumentRaw -Name "logo.png"
+        Assert-True -Name "ProductDocumentRaw finds .png file" `
+            -Condition ($rawPng.Found -eq $true) `
+            -Message "Get-ProductDocumentRaw did not find logo.png"
+        Assert-Equal -Name "ProductDocumentRaw returns image/png MIME type" `
+            -Expected "image/png" `
+            -Actual $rawPng.MimeType
+        Assert-True -Name "ProductDocumentRaw returns binary data for .png" `
+            -Condition ($null -ne $rawPng.BinaryData -and $rawPng.BinaryData.Length -gt 0) `
+            -Message "Expected non-empty BinaryData for logo.png"
+
+        $rawJpg = Get-ProductDocumentRaw -Name "screenshot.jpg"
+        Assert-Equal -Name "ProductDocumentRaw returns image/jpeg MIME type for .jpg" `
+            -Expected "image/jpeg" `
+            -Actual $rawJpg.MimeType
+        Assert-True -Name "ProductDocumentRaw returns binary data for .jpg" `
+            -Condition ($null -ne $rawJpg.BinaryData -and $rawJpg.BinaryData.Length -gt 0) `
+            -Message "Expected non-empty BinaryData for screenshot.jpg"
+
+        $rawGif = Get-ProductDocumentRaw -Name "animation.gif"
+        Assert-Equal -Name "ProductDocumentRaw returns image/gif MIME type" `
+            -Expected "image/gif" `
+            -Actual $rawGif.MimeType
+
+        $rawSvg = Get-ProductDocumentRaw -Name "diagram.svg"
+        Assert-True -Name "ProductDocumentRaw finds .svg file" `
+            -Condition ($rawSvg.Found -eq $true) `
+            -Message "Get-ProductDocumentRaw did not find diagram.svg"
+        Assert-Equal -Name "ProductDocumentRaw returns image/svg+xml MIME type" `
+            -Expected "image/svg+xml" `
+            -Actual $rawSvg.MimeType
+        Assert-True -Name "ProductDocumentRaw returns text content for .svg (not binary)" `
+            -Condition ($null -ne $rawSvg.TextContent -and $rawSvg.TextContent -match '<svg') `
+            -Message "Expected SVG text content, not binary data"
+        Assert-True -Name "ProductDocumentRaw does not return binary data for .svg" `
+            -Condition ($null -eq $rawSvg.BinaryData) `
+            -Message "SVG should use TextContent, not BinaryData"
+
+        $rawTxt = Get-ProductDocumentRaw -Name "notes.txt"
+        Assert-True -Name "ProductDocumentRaw finds .txt file" `
+            -Condition ($rawTxt.Found -eq $true) `
+            -Message "Get-ProductDocumentRaw did not find notes.txt"
+        Assert-Equal -Name "ProductDocumentRaw returns text/plain MIME type for .txt" `
+            -Expected "text/plain; charset=utf-8" `
+            -Actual $rawTxt.MimeType
+        Assert-True -Name "ProductDocumentRaw returns text content for .txt" `
+            -Condition ($null -ne $rawTxt.TextContent -and $rawTxt.TextContent -match 'Plain text content') `
+            -Message "Expected text content for notes.txt"
+
+        $rawMissing = Get-ProductDocumentRaw -Name "nonexistent.png"
+        Assert-True -Name "ProductDocumentRaw returns Found=false for missing file" `
+            -Condition ($rawMissing.Found -eq $false) `
+            -Message "Expected Found=false for nonexistent file"
+
+        $rawTraversal = Get-ProductDocumentRaw -Name "../secrets.png"
+        Assert-True -Name "ProductDocumentRaw blocks path traversal" `
+            -Condition ($rawTraversal.Found -eq $false) `
+            -Message "Path traversal should return not found"
 
         # ═════════════════════════════════════════════════════════════════
         # Get-KickstartStatus — script-phase probe + process-type filter

--- a/workflows/default/systems/ui/modules/ProductAPI.psm1
+++ b/workflows/default/systems/ui/modules/ProductAPI.psm1
@@ -30,18 +30,27 @@ function Resolve-ProductDocumentInfo {
     )
 
     $relativePath = [System.IO.Path]::GetRelativePath($ProductDir, $File.FullName) -replace '\\', '/'
-    $isMd = $File.Extension -eq '.md'
-    $isJson = $File.Extension -eq '.json'
-    # Only strip .md; JSON/binary keep extension to avoid name collisions (foo.md vs foo.json)
+    $ext = $File.Extension.ToLower()
+    $isMd = $ext -eq '.md'
+    $isJson = $ext -eq '.json'
+    $isTxt = $ext -eq '.txt'
+    $isImage = $ext -in @('.png', '.jpg', '.jpeg', '.gif', '.svg')
+    # Only strip .md; all other types keep extension to avoid name collisions
     $name = if ($isMd) { $relativePath -replace '\.md$', '' } else { $relativePath }
     $segments = @($name -split '/')
+
+    $type = if ($isMd) { 'md' }
+            elseif ($isJson) { 'json' }
+            elseif ($isTxt) { 'txt' }
+            elseif ($isImage) { 'image' }
+            else { 'binary' }
 
     return [PSCustomObject]@{
         Name = $name
         Filename = $relativePath
         Depth = [Math]::Max(0, $segments.Count - 1)
         BaseName = $File.BaseName
-        Type = if ($isMd) { 'md' } elseif ($isJson) { 'json' } else { 'binary' }
+        Type = $type
         Size = $File.Length
     }
 }
@@ -64,11 +73,15 @@ function Resolve-ProductDocumentPath {
     # If it ends with .md, strip the extension and try .md first then .json.
     # Otherwise, try .md first then .json (default priority).
     $explicitJson = $false
+    $explicitDirect = $false
     if ($normalizedName.EndsWith('.md', [System.StringComparison]::OrdinalIgnoreCase)) {
         $normalizedName = $normalizedName.Substring(0, $normalizedName.Length - 3)
     } elseif ($normalizedName.EndsWith('.json', [System.StringComparison]::OrdinalIgnoreCase)) {
         $explicitJson = $true
         # Keep normalizedName as-is (includes .json) since JSON names retain their extension
+    } elseif ($normalizedName -match '\.(txt|png|jpe?g|gif|svg)$') {
+        $explicitDirect = $true
+        # Viewable non-md/json types keep their extension and resolve directly
     }
 
     if ([string]::IsNullOrWhiteSpace($normalizedName)) {
@@ -89,8 +102,8 @@ function Resolve-ProductDocumentPath {
         "$productDirFull$([System.IO.Path]::DirectorySeparatorChar)"
     }
 
-    if ($explicitJson) {
-        # Explicit .json request — resolve directly without extension loop
+    if ($explicitJson -or $explicitDirect) {
+        # Explicit extension request — resolve directly without extension loop
         $candidatePath = Join-Path $ProductDir $relativePath
         try {
             $candidateFull = [System.IO.Path]::GetFullPath($candidatePath)
@@ -259,6 +272,45 @@ function Get-ProductDocument {
             _statusCode = 404
             success = $false
             error = "Document not found: $Name"
+        }
+    }
+}
+
+function Get-ProductDocumentRaw {
+    param(
+        [Parameter(Mandatory)] [string]$Name
+    )
+    $botRoot = $script:Config.BotRoot
+    $productDir = Join-Path $botRoot "workspace\product"
+    $resolvedDoc = Resolve-ProductDocumentPath -Name $Name -ProductDir $productDir
+
+    if (-not $resolvedDoc -or -not (Test-Path -LiteralPath $resolvedDoc.FullPath)) {
+        return @{ Found = $false }
+    }
+
+    $ext = [System.IO.Path]::GetExtension($resolvedDoc.FullPath).ToLower()
+    $mimeType = switch ($ext) {
+        '.png'  { 'image/png' }
+        '.jpg'  { 'image/jpeg' }
+        '.jpeg' { 'image/jpeg' }
+        '.gif'  { 'image/gif' }
+        '.svg'  { 'image/svg+xml' }
+        '.txt'  { 'text/plain; charset=utf-8' }
+        default { 'application/octet-stream' }
+    }
+
+    $isBinary = $ext -in @('.png', '.jpg', '.jpeg', '.gif')
+    if ($isBinary) {
+        return @{
+            Found = $true
+            MimeType = $mimeType
+            BinaryData = [System.IO.File]::ReadAllBytes($resolvedDoc.FullPath)
+        }
+    } else {
+        return @{
+            Found = $true
+            MimeType = $mimeType
+            TextContent = (Get-Content -LiteralPath $resolvedDoc.FullPath -Raw)
         }
     }
 }
@@ -1017,6 +1069,7 @@ Export-ModuleMember -Function @(
     'Initialize-ProductAPI',
     'Get-ProductList',
     'Get-ProductDocument',
+    'Get-ProductDocumentRaw',
     'Get-PreflightResults',
     'Start-ProductKickstart',
     'Start-ProductAnalyse',

--- a/workflows/default/systems/ui/server.ps1
+++ b/workflows/default/systems/ui/server.ps1
@@ -1301,7 +1301,25 @@ $docContext
                     break
                 }
 
-                { $_ -like "/api/product/*" -and $_ -ne "/api/product/list" -and $_ -ne "/api/product/preflight" -and $_ -ne "/api/product/analyse" -and $_ -notlike "/api/product/kickstart*" } {
+                { $_ -like "/api/product/raw/*" } {
+                    $docName = $url -replace "^/api/product/raw/", ""
+                    $rawResult = Get-ProductDocumentRaw -Name $docName
+                    if ($rawResult.Found) {
+                        $contentType = $rawResult.MimeType
+                        if ($rawResult.BinaryData) {
+                            $binaryContent = $rawResult.BinaryData
+                        } else {
+                            $content = $rawResult.TextContent
+                        }
+                    } else {
+                        $statusCode = 404
+                        $contentType = "text/plain"
+                        $content = "File not found"
+                    }
+                    break
+                }
+
+                { $_ -like "/api/product/*" -and $_ -ne "/api/product/list" -and $_ -ne "/api/product/preflight" -and $_ -ne "/api/product/analyse" -and $_ -notlike "/api/product/kickstart*" -and $_ -notlike "/api/product/raw/*" } {
                     $contentType = "application/json; charset=utf-8"
                     $docName = $url -replace "^/api/product/", ""
                     $result = Get-ProductDocument -Name $docName

--- a/workflows/default/systems/ui/static/css/views.css
+++ b/workflows/default/systems/ui/static/css/views.css
@@ -752,6 +752,58 @@
     padding: 40px;
 }
 
+/* ========== TEXT VIEWER ========== */
+.doc-viewer .txt-viewer {
+    font-family: 'Berkeley Mono', 'JetBrains Mono', 'Fira Code', monospace;
+    font-size: 11px;
+    line-height: 1.6;
+    color: var(--color-primary-dim);
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    margin: 0;
+    padding: 0;
+}
+
+/* ========== IMAGE VIEWER ========== */
+.doc-viewer .image-viewer {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.doc-viewer .image-viewer-header {
+    display: flex;
+    align-items: center;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--bezel-edge);
+    background: var(--primary-05);
+}
+
+.doc-viewer .image-viewer-label {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-primary);
+    opacity: 0.7;
+}
+
+.doc-viewer .image-viewer-content {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    overflow: auto;
+}
+
+.doc-viewer .image-viewer-img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    border-radius: 4px;
+}
+
 /* Document Separator */
 .doc-viewer hr.doc-separator,
 .markdown-content hr.doc-separator {

--- a/workflows/default/systems/ui/static/modules/product.js
+++ b/workflows/default/systems/ui/static/modules/product.js
@@ -25,15 +25,16 @@ async function loadProductDoc(docName, type = 'md') {
         const response = await fetch(`${API_BASE}/api/product/${encodeURIComponent(docName)}`);
         const data = await response.json();
 
-        if (data.success && data.content) {
+        if (data.success) {
+            const content = data.content || '';
             if (type === 'json') {
-                viewer.innerHTML = renderJsonViewer(data.content);
+                viewer.innerHTML = renderJsonViewer(content);
                 initJsonViewer(viewer);
             } else if (type === 'txt') {
-                viewer.innerHTML = `<pre class="txt-viewer">${escapeHtml(data.content)}</pre>`;
+                viewer.innerHTML = `<pre class="txt-viewer">${escapeHtml(content)}</pre>`;
             } else {
                 // Convert markdown to basic HTML
-                viewer.innerHTML = markdownToHtml(data.content);
+                viewer.innerHTML = markdownToHtml(content);
                 // Render any Mermaid diagrams
                 if (typeof renderMermaidDiagrams === 'function') {
                     renderMermaidDiagrams(viewer);
@@ -206,7 +207,7 @@ function showImageViewer(docName, filename) {
             <span class="image-viewer-label">${escapeHtml(displayName)}</span>
         </div>
         <div class="image-viewer-content">
-            <img src="${imgUrl}" alt="${escapeHtml(displayName)}" class="image-viewer-img" />
+            <img src="${escapeAttr(imgUrl)}" alt="${escapeAttr(displayName)}" class="image-viewer-img" />
         </div>
     </div>`;
 
@@ -288,7 +289,7 @@ function renderProductFileItem(doc) {
         : type === 'txt' ? 'Tx'
         : type === 'image' ? '&#x25A3;'
         : escapeHtml(displayName.charAt(0).toUpperCase());
-    return `<div class="file-nav-item${binaryClass}" data-doc="${escapeHtml(doc.name)}" data-type="${escapeHtml(type)}" data-filename="${escapeHtml(doc.filename)}" data-size="${doc.size || 0}">
+    return `<div class="file-nav-item${binaryClass}" data-doc="${escapeAttr(doc.name)}" data-type="${escapeAttr(type)}" data-filename="${escapeAttr(doc.filename)}" data-size="${doc.size || 0}">
         <span class="item-icon doc">${icon}</span>
         <span>${escapeHtml(displayName)}</span>
     </div>`;

--- a/workflows/default/systems/ui/static/modules/product.js
+++ b/workflows/default/systems/ui/static/modules/product.js
@@ -29,6 +29,8 @@ async function loadProductDoc(docName, type = 'md') {
             if (type === 'json') {
                 viewer.innerHTML = renderJsonViewer(data.content);
                 initJsonViewer(viewer);
+            } else if (type === 'txt') {
+                viewer.innerHTML = `<pre class="txt-viewer">${escapeHtml(data.content)}</pre>`;
             } else {
                 // Convert markdown to basic HTML
                 viewer.innerHTML = markdownToHtml(data.content);
@@ -186,6 +188,37 @@ function showBinaryPlaceholder(doc) {
 }
 
 /**
+ * Show an inline image viewer for image product documents
+ * @param {string} docName - Document name (used for the raw API URL)
+ * @param {string} filename - Original filename for display
+ */
+function showImageViewer(docName, filename) {
+    const viewer = document.getElementById('doc-viewer');
+    if (!viewer){
+        return;
+    }
+
+    const imgUrl = `${API_BASE}/api/product/raw/${encodeURIComponent(docName)}`;
+    const displayName = filename.split('/').pop();
+
+    viewer.innerHTML = `<div class="image-viewer">
+        <div class="image-viewer-header">
+            <span class="image-viewer-label">${escapeHtml(displayName)}</span>
+        </div>
+        <div class="image-viewer-content">
+            <img src="${imgUrl}" alt="${escapeHtml(displayName)}" class="image-viewer-img" />
+        </div>
+    </div>`;
+
+    const img = viewer.querySelector('.image-viewer-img');
+    if (img) {
+        img.addEventListener('error', function () {
+            this.parentElement.innerHTML = '<div class="doc-placeholder">Failed to load image</div>';
+        });
+    }
+}
+
+/**
  * Format file size in human-readable form
  * @param {number} bytes
  * @returns {string}
@@ -209,6 +242,8 @@ function activateProductItem(item) {
             filename: item.dataset.filename,
             size: parseInt(item.dataset.size, 10) || 0
         });
+    } else if (type === 'image') {
+        showImageViewer(item.dataset.doc, item.dataset.filename);
     } else {
         loadProductDoc(item.dataset.doc, type);
     }
@@ -245,10 +280,14 @@ function renderProductTree(tree) {
  */
 function renderProductFileItem(doc) {
     const type = doc.type || 'md';
-    const isBinary = type !== 'md' && type !== 'json';
+    const isBinary = type !== 'md' && type !== 'json' && type !== 'txt' && type !== 'image';
     const binaryClass = isBinary ? ' binary' : '';
-    const displayName = doc.filename.split('/').pop().replace(/\.(md|json)$/, '');
-    const icon = isBinary ? '&#x1F4C4;' : (type === 'json' ? '&#x7B;&#x7D;' : escapeHtml(displayName.charAt(0).toUpperCase()));
+    const displayName = doc.filename.split('/').pop().replace(/\.(md|json|txt)$/, '');
+    const icon = isBinary ? '&#x1F4C4;'
+        : type === 'json' ? '&#x7B;&#x7D;'
+        : type === 'txt' ? 'Tx'
+        : type === 'image' ? '&#x25A3;'
+        : escapeHtml(displayName.charAt(0).toUpperCase());
     return `<div class="file-nav-item${binaryClass}" data-doc="${escapeHtml(doc.name)}" data-type="${escapeHtml(type)}" data-filename="${escapeHtml(doc.filename)}" data-size="${doc.size || 0}">
         <span class="item-icon doc">${icon}</span>
         <span>${escapeHtml(displayName)}</span>


### PR DESCRIPTION
## Linked issue

Closes #212

## Summary of changes

Add inline viewing for `.txt` and image files (`.png`, `.jpg`, `.jpeg`, `.gif`, `.svg`) in the Product Documents Viewer. Previously all non-`.md`/`.json` files showed a "Preview not available" placeholder.

- `.txt` files rendered as monospaced plain text via the existing JSON API
- Image files served via new `GET /api/product/raw/*` endpoint with correct MIME types, rendered with `<img src>`
- New `Get-ProductDocumentRaw` backend function with MIME type mapping and binary/text detection
- Updated type classification, path resolution, sidebar icons, and CSS
- True binary files (`.pdf`, `.docx`, etc.) still show the existing placeholder

## Screenshots / recordings

### JPG image viewer (new)
<img width="1278" height="1186" alt="localhost_8686_" src="https://github.com/user-attachments/assets/c66782f4-9fc4-43a0-8cd7-2d7707fb331b" />

### PNG image viewer (new)
<img width="1278" height="1186" alt="localhost_8686_ (1)" src="https://github.com/user-attachments/assets/3dc7344b-dd27-4527-8750-82efecfbe83d" />

### JSON viewer (existing)
<img width="1278" height="1186" alt="localhost_8686_ (2)" src="https://github.com/user-attachments/assets/251bbc93-77c3-4217-bb74-e61740f39d70" />

### Markdown viewer (existing)
<img width="1278" height="1186" alt="localhost_8686_ (3)" src="https://github.com/user-attachments/assets/8fc55617-4a1e-4bf0-b4e5-777c8b942344" />

### TXT plain text viewer (new)
<img width="1278" height="1186" alt="localhost_8686_ (4)" src="https://github.com/user-attachments/assets/be012abf-2222-4465-a66e-445dec20f934" />

### SVG inline viewer (new)
<img width="1278" height="1186" alt="localhost_8686_ (5)" src="https://github.com/user-attachments/assets/a9cd0f69-3271-4655-bcdd-dce4a617de2f" />

## Testing notes

28 new/updated assertions in `tests/Test-Components.ps1` covering type detection, MIME types, binary vs text serving, missing files, and path traversal.

## Checklist

- [x] Tests added or updated
- [x] Layers 1-3 pass
- [x] UI tested manually
