### PR TITLE
fix: workflow tab uses /api/state instead of legacy /api/kickstart/status

### DIFF
--- a/workflows/default/systems/ui/static/css/views.css
+++ b/workflows/default/systems/ui/static/css/views.css
@@ -1628,7 +1628,8 @@
     padding-bottom: 12px;
 }
 
-.kickstart-phases.collapsed .chain-layer-items {
+.kickstart-phases.collapsed .chain-layer-items,
+.workflow-task-progress.collapsed .chain-layer-items {
     display: none;
 }
 

--- a/workflows/default/systems/ui/static/modules/polling.js
+++ b/workflows/default/systems/ui/static/modules/polling.js
@@ -16,7 +16,7 @@ function startPolling() {
     activityTimer = setInterval(pollActivity, 2000);
 }
 
-let kickstartPollCounter = 0;
+let installedWorkflowPollCounter = 0;
 
 /**
  * Poll server for current state
@@ -38,14 +38,16 @@ async function pollState() {
             Aether.processState(state);
         }
 
-        // Update workflow side panel every poll (no extra fetch — uses state already in hand)
+        // Update Overview side panel every poll (no extra fetch — uses state already in hand)
         updateOverviewWorkflowPanel(state);
 
-        // Throttled: legacy kickstart status + installed workflow controls (both need separate fetch)
-        kickstartPollCounter++;
-        if (kickstartPollCounter >= 5 || Object.keys(installedWorkflowMap).length === 0) {
-            kickstartPollCounter = 0;
-            updateLegacyKickstartPhases();
+        // Update Workflow tab task progress every poll (from state, no extra fetch)
+        updateWorkflowTabProgress(state);
+
+        // Throttled: installed workflow controls (needs separate fetch)
+        installedWorkflowPollCounter++;
+        if (installedWorkflowPollCounter >= 5 || Object.keys(installedWorkflowMap).length === 0) {
+            installedWorkflowPollCounter = 0;
             updateInstalledWorkflowControls();
         }
 
@@ -104,18 +106,14 @@ function updateOverviewWorkflowPanel(state) {
 }
 
 /**
- * Legacy: fetch /api/kickstart/status for the Workflow tab's renderKickstartPhases.
- * Throttled — called every 5th poll cycle (not every cycle).
+ * Update Workflow tab task progress from /api/state (no extra fetch needed).
  */
-async function updateLegacyKickstartPhases() {
+function updateWorkflowTabProgress(state) {
     try {
-        if (typeof renderKickstartPhases === 'function') {
-            const response = await fetch(`${API_BASE}/api/kickstart/status`);
-            if (response.ok) {
-                const data = await response.json();
-                if (data.phases && data.phases.length > 0) {
-                    renderKickstartPhases(data);
-                }
+        if (state && typeof buildWorkflowPanelData === 'function' && typeof renderWorkflowTaskProgress === 'function') {
+            const panelData = buildWorkflowPanelData(state);
+            if (panelData && panelData.length > 0) {
+                renderWorkflowTaskProgress(panelData);
             }
         }
     } catch (error) {

--- a/workflows/default/systems/ui/static/modules/polling.js
+++ b/workflows/default/systems/ui/static/modules/polling.js
@@ -112,9 +112,7 @@ function updateWorkflowTabProgress(state) {
     try {
         if (state && typeof buildWorkflowPanelData === 'function' && typeof renderWorkflowTaskProgress === 'function') {
             const panelData = buildWorkflowPanelData(state);
-            if (panelData && panelData.length > 0) {
-                renderWorkflowTaskProgress(panelData);
-            }
+            renderWorkflowTaskProgress(panelData || []);
         }
     } catch (error) {
         // Silently ignore — non-critical

--- a/workflows/default/systems/ui/static/modules/workflow.js
+++ b/workflows/default/systems/ui/static/modules/workflow.js
@@ -243,34 +243,32 @@ function updateRelationshipTree(chain, selectedType, selectedFile) {
 }
 
 /**
- * Render kickstart phase progress at top of relationship panel
- * @param {Object} data - Response from /api/kickstart/status
+ * Render task-runner workflow progress at top of relationship panel.
+ * Data comes from buildWorkflowPanelData(state) — same source as Overview tab.
+ *
+ * @param {Array} workflows - Array of workflow objects from buildWorkflowPanelData
  */
-function renderKickstartPhases(data) {
+function renderWorkflowTaskProgress(workflows) {
     const container = document.getElementById('relationship-tree');
-    if (!container || !data || !data.phases || data.phases.length === 0) return;
+    if (!container) return;
 
-    // Remove existing kickstart section if present
+    // Remove existing sections
     const existing = container.querySelector('.kickstart-phases');
-    const wasCollapsed = existing ? existing.classList.contains('collapsed') : false;
-    const existingChildList = existing ? existing.querySelector('.child-task-list') : null;
-    const childWasCollapsed = existingChildList ? existingChildList.classList.contains('collapsed') : true;
     if (existing) existing.remove();
 
-    const completedCount = data.phases.filter(p => p.status === 'completed' || p.status === 'active').length;
-    const totalCount = data.phases.length;
+    if (!workflows || workflows.length === 0) return;
 
-    const statusIcons = {
-        completed: '<span class="phase-icon phase-completed">&#10003;</span>',
-        active:    '<span class="phase-icon phase-running">&#9679;</span>',
-        running:   '<span class="phase-icon phase-running">&#9679;</span>',
-        failed:    '<span class="phase-icon phase-failed">&#10007;</span>',
-        skipped:   '<span class="phase-icon phase-skipped">&#8211;</span>',
-        pending:   '<span class="phase-icon phase-pending">&#9675;</span>',
-        incomplete:'<span class="phase-icon phase-failed">&#9675;</span>'
-    };
+    // Preserve per-workflow collapsed state from previous render
+    const prevCollapsed = {};
+    container.querySelectorAll('.wf-accordion-section').forEach(section => {
+        const name = section.dataset.workflow;
+        if (name) prevCollapsed[name] = section.classList.contains('collapsed');
+    });
+    const existingWrapper = container.querySelector('.workflow-task-progress');
+    const wrapperWasCollapsed = existingWrapper ? existingWrapper.classList.contains('collapsed') : false;
+    if (existingWrapper) existingWrapper.remove();
 
-    const childStatusIcons = {
+    const taskStatusIcons = {
         'done':        '<span class="phase-icon phase-completed">&#10003;</span>',
         'in-progress': '<span class="led pulse"></span>',
         'analysing':   '<span class="led pulse"></span>',
@@ -281,94 +279,116 @@ function renderKickstartPhases(data) {
         'cancelled':   '<span class="phase-icon phase-skipped">&#8211;</span>'
     };
 
-    const sectionTitle = data.workflow_name || 'Kickstart Phases';
-    let html = `
-        <div class="kickstart-phases${wasCollapsed ? ' collapsed' : ''}">
-            <div class="chain-layer-header" data-layer="kickstart-phases">
-                <span class="chain-layer-title">${escapeHtml(sectionTitle)}</span>
-                <span class="chain-layer-count">${completedCount}/${totalCount}</span>
-            </div>
-            <div class="chain-layer-items">
-    `;
-
-    data.phases.forEach(phase => {
-        const icon = statusIcons[phase.status] || statusIcons.pending;
-        html += `
-            <div class="chain-layer-item kickstart-phase-item kickstart-phase-${phase.status}">
-                ${icon}
-                <span class="item-name">${escapeHtml(phase.name)}</span>
-            </div>
-        `;
-
-        // Render child tasks for task_gen phases
-        if (phase.child_tasks && phase.child_tasks.length > 0 && phase.child_counts) {
-            const c = phase.child_counts;
-            const done = (c.done || 0) + (c.skipped || 0);
-            const total = c.total || 0;
-            const pct = total > 0 ? Math.round((done / total) * 100) : 0;
-            const active = (c.in_progress || 0) + (c.analysing || 0);
-
-            html += `
-                <div class="child-task-progress">
-                    <div class="child-task-bar-track">
-                        <div class="child-task-bar-fill" style="width: ${pct}%"></div>
-                    </div>
-                    <span class="child-task-summary">${done}/${total} done${active ? `, ${active} active` : ''}</span>
-                </div>
-                <div class="child-task-list${childWasCollapsed ? ' collapsed' : ''}">
-                    <div class="child-task-toggle" title="Toggle task list">
-                        <span class="folder-toggle">${childWasCollapsed ? '\u25b6' : '\u25bc'}</span>
-                        <span class="child-task-toggle-label">Tasks</span>
-                    </div>
-                    <div class="child-task-items">
-            `;
-            phase.child_tasks.forEach(task => {
-                const tIcon = childStatusIcons[task.status] || childStatusIcons['todo'];
-                html += `
-                    <div class="chain-layer-item child-task-item child-task-${task.status}">
-                        ${tIcon}
-                        <span class="item-name">${escapeHtml(task.name)}</span>
-                    </div>
-                `;
-            });
-            html += `
-                    </div>
-                </div>
-            `;
-        }
+    // Aggregate totals
+    let totalDone = 0, totalAll = 0;
+    workflows.forEach(wf => {
+        const c = wf.counts || {};
+        totalDone += (c.done || 0) + (c.skipped || 0);
+        totalAll += c.total || 0;
     });
 
-    if (data.status === 'incomplete' && data.resume_from) {
-        html += `
-            <div class="kickstart-resume-row">
-                <button class="kickstart-resume-btn" onclick="resumeKickstart()">RESUME</button>
+    let innerHtml = '';
+
+    workflows.forEach(wf => {
+        const counts = wf.counts || {};
+        const doneCount = (counts.done || 0) + (counts.skipped || 0);
+        const totalCount = counts.total || 0;
+        const activeCount = (counts.in_progress || 0) + (counts.analysing || 0);
+        const pct = totalCount > 0 ? Math.round((doneCount / totalCount) * 100) : 0;
+
+        // Default: running/incomplete expanded, others collapsed (unless user toggled)
+        let isCollapsed;
+        if (wf.workflow_name in prevCollapsed) {
+            isCollapsed = prevCollapsed[wf.workflow_name];
+        } else if (workflows.length === 1) {
+            isCollapsed = false;
+        } else {
+            isCollapsed = wf.status !== 'running' && wf.status !== 'incomplete';
+        }
+
+        const statusLed = wf.status === 'running'
+            ? '<span class="led pulse" style="margin-right:6px"></span>'
+            : '';
+
+        innerHtml += `
+            <div class="wf-accordion-section${isCollapsed ? ' collapsed' : ''}" data-workflow="${escapeAttr(wf.workflow_name)}">
+                <div class="chain-layer-header wf-accordion-header" data-workflow="${escapeAttr(wf.workflow_name)}">
+                    ${statusLed}
+                    <span class="chain-layer-title">${escapeHtml(wf.workflow_name)}</span>
+                    <span class="chain-layer-count">${doneCount}/${totalCount}</span>
+                </div>
+                <div class="wf-accordion-body">
+                    <div class="child-task-progress">
+                        <div class="child-task-bar-track">
+                            <div class="child-task-bar-fill" style="width: ${pct}%"></div>
+                        </div>
+                        <span class="child-task-summary">${doneCount}/${totalCount} done${activeCount ? `, ${activeCount} active` : ''}</span>
+                    </div>
+                    <div class="child-task-items">
+        `;
+
+        (wf.tasks || []).forEach(task => {
+            const icon = taskStatusIcons[task.status] || taskStatusIcons['todo'];
+            innerHtml += `
+                        <div class="chain-layer-item child-task-item child-task-${task.status}">
+                            ${icon}
+                            <span class="item-name">${escapeHtml(task.name)}</span>
+                        </div>
+            `;
+        });
+
+        innerHtml += `
+                    </div>
+        `;
+
+        // Resume button per workflow
+        if (wf.status === 'running') {
+            innerHtml += `<div class="kickstart-resume-row"><button class="kickstart-resume-btn" disabled>RUNNING...</button></div>`;
+        } else if (wf.can_resume) {
+            innerHtml += `<div class="kickstart-resume-row"><button class="kickstart-resume-btn" data-resume-wf="${escapeAttr(wf.workflow_name)}">RESUME</button></div>`;
+        } else if (wf.status === 'completed') {
+            innerHtml += `<div class="kickstart-resume-row"><button class="kickstart-resume-btn" disabled>COMPLETED</button></div>`;
+        }
+
+        innerHtml += `
+                </div>
             </div>
         `;
-    }
+    });
 
-    html += `
+    const wrapperHtml = `
+        <div class="workflow-task-progress${wrapperWasCollapsed ? ' collapsed' : ''}">
+            <div class="chain-layer-header" data-layer="workflow-task-progress">
+                <span class="chain-layer-title">Task Progress</span>
+                <span class="chain-layer-count">${totalDone}/${totalAll}</span>
+            </div>
+            <div class="chain-layer-items">
+                ${innerHtml}
             </div>
         </div>
     `;
 
-    // Insert at top of relationship tree
-    container.insertAdjacentHTML('afterbegin', html);
+    container.insertAdjacentHTML('afterbegin', wrapperHtml);
 
-    // Add collapse/expand handler
-    const header = container.querySelector('.kickstart-phases .chain-layer-header');
-    if (header) {
-        header.addEventListener('click', () => {
-            header.closest('.kickstart-phases').classList.toggle('collapsed');
+    // Wrapper collapse/expand handler
+    const wrapperHeader = container.querySelector('.workflow-task-progress > .chain-layer-header');
+    if (wrapperHeader) {
+        wrapperHeader.addEventListener('click', () => {
+            wrapperHeader.closest('.workflow-task-progress').classList.toggle('collapsed');
         });
     }
 
-    // Add collapse/expand handler for child task list
-    container.querySelectorAll('.child-task-toggle').forEach(toggle => {
-        toggle.addEventListener('click', () => {
-            const list = toggle.closest('.child-task-list');
-            list.classList.toggle('collapsed');
-            const arrow = toggle.querySelector('.folder-toggle');
-            if (arrow) arrow.textContent = list.classList.contains('collapsed') ? '\u25b6' : '\u25bc';
+    // Accordion collapse/expand handlers
+    container.querySelectorAll('.workflow-task-progress .wf-accordion-header').forEach(header => {
+        header.addEventListener('click', () => {
+            header.closest('.wf-accordion-section').classList.toggle('collapsed');
+        });
+    });
+
+    // Resume button handlers
+    container.querySelectorAll('.workflow-task-progress .kickstart-resume-btn[data-resume-wf]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            resumeWorkflow(btn.dataset.resumeWf);
         });
     });
 }

--- a/workflows/default/systems/ui/static/modules/workflow.js
+++ b/workflows/default/systems/ui/static/modules/workflow.js
@@ -252,13 +252,11 @@ function renderWorkflowTaskProgress(workflows) {
     const container = document.getElementById('relationship-tree');
     if (!container) return;
 
-    // Remove existing sections
-    const existing = container.querySelector('.kickstart-phases');
-    if (existing) existing.remove();
+    // Always clean up previous renders (legacy kickstart + our own wrapper)
+    const existingLegacy = container.querySelector('.kickstart-phases');
+    if (existingLegacy) existingLegacy.remove();
 
-    if (!workflows || workflows.length === 0) return;
-
-    // Preserve per-workflow collapsed state from previous render
+    // Preserve collapsed state before removing
     const prevCollapsed = {};
     container.querySelectorAll('.wf-accordion-section').forEach(section => {
         const name = section.dataset.workflow;
@@ -267,6 +265,8 @@ function renderWorkflowTaskProgress(workflows) {
     const existingWrapper = container.querySelector('.workflow-task-progress');
     const wrapperWasCollapsed = existingWrapper ? existingWrapper.classList.contains('collapsed') : false;
     if (existingWrapper) existingWrapper.remove();
+
+    if (!workflows || workflows.length === 0) return;
 
     const taskStatusIcons = {
         'done':        '<span class="phase-icon phase-completed">&#10003;</span>',


### PR DESCRIPTION
## Summary
- Workflow tab now reads task-runner progress from `/api/state` via `buildWorkflowPanelData()` — same data source as Overview tab (PR #258)
- Removed `renderKickstartPhases()` and `updateLegacyKickstartPhases()` — no tab uses the legacy `/api/kickstart/status` fetch anymore
- Poll frequency improved from ~15s (every 5th cycle) to ~3s (every cycle) with zero additional HTTP requests

## Changed Files

| File | What changed |
|---|---|
| **`polling.js`** | Replaced `updateLegacyKickstartPhases` with `updateWorkflowTabProgress` that reads from state; removed legacy `/api/kickstart/status` fetch |
| **`workflow.js`** | Replaced `renderKickstartPhases` with `renderWorkflowTaskProgress` — renders per-task progress with accordion, progress bar, LED indicators, and resume button |

## What's Fixed

### Workflow tab shows real task-runner progress
- **Before:** All phases stuck on "pending" because task-runner has no `phases` array and `Resolve-PhaseStatusFromOutputs` checks for product documents that task-runner doesn't create
- **After:** Shows actual task states (todo/analysing/in-progress/done) with progress bar and active LED

### Single data source — no extra fetch
- **Before:** `updateLegacyKickstartPhases()` → `GET /api/kickstart/status` → backend disk scan every 15s
- **After:** `updateWorkflowTabProgress(state)` → extracts from already-polled `/api/state` — zero cost

### Legacy kickstart code removed
- `renderKickstartPhases()` — no longer called from anywhere
- `updateLegacyKickstartPhases()` — replaced by state-driven path
- `kickstartPollCounter` → renamed to `installedWorkflowPollCounter` (only controls workflow metadata fetch now)

## Test Plan
- [x] Run `pwsh tests/Run-Tests.ps1` — layers 1-3 pass
- [x] Workflow tab shows task progress when task-runner is running
- [x] Task status LEDs update in real-time (~3s)
- [x] Resume button launches task-runner (not kickstart)
- [x] Overview tab side panel still works (regression check for #258)

Closes #259