### PR TITLE
Consolidate duplicate function definitions across modules (#123)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,9 +47,6 @@ server/publish.zip
 server/teams-app/manifest.json
 server/teams-app/*.zip
 
-# Specs (local design docs)
-specs/
-
 # Enterprise proposal analysis (proprietary)
 docs/proposal-v4/
 

--- a/install.ps1
+++ b/install.ps1
@@ -53,6 +53,10 @@ $platformFunctionsPath = Join-Path $ScriptDir "scripts\Platform-Functions.psm1"
 if (Test-Path $platformFunctionsPath) {
     Import-Module $platformFunctionsPath -Force
 }
+$dotBotThemePath = Join-Path $ScriptDir "workflows\default\systems\runtime\modules\DotBotTheme.psm1"
+if (Test-Path $dotBotThemePath) {
+    Import-Module $dotBotThemePath -Force -DisableNameChecking
+}
 
 # Check PowerShell version
 if ($PSVersionTable.PSVersion.Major -lt 7) {

--- a/scripts/Platform-Functions.psm1
+++ b/scripts/Platform-Functions.psm1
@@ -168,12 +168,6 @@ function Set-ExecutablePermission {
     # Windows doesn't need chmod - files are executable by default
 }
 
-function Write-Status {
-    param([string]$Message)
-    $c = $script:C
-    Write-Host "$($c.Info)  › $($c.Muted)$Message$($c.Reset)"
-}
-
 function Write-Success {
     param([string]$Message)
     $c = $script:C
@@ -269,7 +263,6 @@ Export-ModuleMember -Function @(
     'Add-ToPath',
     'Set-ExecutablePermission',
     'Open-Url',
-    'Write-Status',
     'Write-Success',
     'Write-DotbotWarning',
     'Write-DotbotError',

--- a/scripts/init-project.ps1
+++ b/scripts/init-project.ps1
@@ -62,6 +62,7 @@ $BotDir = Join-Path $ProjectDir ".bot"
 
 # Import platform functions
 Import-Module (Join-Path $DotbotBase "scripts\Platform-Functions.psm1") -Force
+Import-Module (Join-Path $DotbotBase "workflows\default\systems\runtime\modules\DotBotTheme.psm1") -Force -DisableNameChecking
 
 # Deprecated workflow aliases
 $workflowAliases = @{

--- a/scripts/install-global.ps1
+++ b/scripts/install-global.ps1
@@ -24,6 +24,7 @@ $BinDir = Join-Path $BaseDir "bin"
 
 # Import platform functions
 Import-Module (Join-Path $ScriptDir "Platform-Functions.psm1") -Force
+Import-Module (Join-Path $ScriptDir "..\workflows\default\systems\runtime\modules\DotBotTheme.psm1") -Force -DisableNameChecking
 
 Write-Status "Installing dotbot to $BaseDir"
 

--- a/scripts/registry-add.ps1
+++ b/scripts/registry-add.ps1
@@ -47,6 +47,7 @@ if (-not (Test-Path $PlatformFunctionsModule)) {
     exit 1
 }
 Import-Module $PlatformFunctionsModule -Force -ErrorAction Stop
+Import-Module (Join-Path $DotbotBase "workflows\default\systems\runtime\modules\DotBotTheme.psm1") -Force -DisableNameChecking
 
 Write-DotbotBanner -Title "D O T B O T   v3.5" -Subtitle "Registry: Add"
 

--- a/scripts/registry-list.ps1
+++ b/scripts/registry-list.ps1
@@ -27,6 +27,7 @@ if (-not (Test-Path $PlatformFunctionsModule)) {
     exit 1
 }
 Import-Module $PlatformFunctionsModule -Force -ErrorAction Stop
+Import-Module (Join-Path $DotbotBase "workflows\default\systems\runtime\modules\DotBotTheme.psm1") -Force -DisableNameChecking
 
 Write-DotbotBanner -Title "D O T B O T   v3.5" -Subtitle "Registries"
 

--- a/scripts/registry-update.ps1
+++ b/scripts/registry-update.ps1
@@ -40,6 +40,7 @@ if (-not (Test-Path $PlatformFunctionsModule)) {
     exit 1
 }
 Import-Module $PlatformFunctionsModule -Force -ErrorAction Stop
+Import-Module (Join-Path $DotbotBase "workflows\default\systems\runtime\modules\DotBotTheme.psm1") -Force -DisableNameChecking
 
 Write-DotbotBanner -Title "D O T B O T   v3.5" -Subtitle "Registry: Update"
 

--- a/scripts/workflow-add.ps1
+++ b/scripts/workflow-add.ps1
@@ -22,6 +22,7 @@ $ProjectDir = Get-Location
 $BotDir = Join-Path $ProjectDir ".bot"
 
 Import-Module (Join-Path $DotbotBase "scripts\Platform-Functions.psm1") -Force
+Import-Module (Join-Path $DotbotBase "workflows\default\systems\runtime\modules\DotBotTheme.psm1") -Force -DisableNameChecking
 
 if (-not (Test-Path $BotDir)) {
     Write-DotbotError "No .bot directory found. Run 'dotbot init' first."

--- a/scripts/workflow-remove.ps1
+++ b/scripts/workflow-remove.ps1
@@ -18,6 +18,7 @@ $ProjectDir = Get-Location
 $BotDir = Join-Path $ProjectDir ".bot"
 
 Import-Module (Join-Path $DotbotBase "scripts\Platform-Functions.psm1") -Force
+Import-Module (Join-Path $DotbotBase "workflows\default\systems\runtime\modules\DotBotTheme.psm1") -Force -DisableNameChecking
 
 if (-not (Test-Path $BotDir)) {
     Write-DotbotError "No .bot directory found."

--- a/scripts/workflow-run.ps1
+++ b/scripts/workflow-run.ps1
@@ -23,6 +23,7 @@ $ProjectDir = Get-Location
 $BotDir = Join-Path $ProjectDir ".bot"
 
 Import-Module (Join-Path $DotbotBase "scripts\Platform-Functions.psm1") -Force
+Import-Module (Join-Path $DotbotBase "workflows\default\systems\runtime\modules\DotBotTheme.psm1") -Force -DisableNameChecking
 
 if (-not (Test-Path $BotDir)) {
     Write-DotbotError "No .bot directory found. Run 'dotbot init' first."

--- a/specs/plans/issue-123-duplicate-function-consolidation-plan.md
+++ b/specs/plans/issue-123-duplicate-function-consolidation-plan.md
@@ -1,0 +1,262 @@
+# Issue 123: Duplicate Function Consolidation Plan
+
+## Challenge Assessment
+
+- Issue: Consolidate duplicate PowerShell function definitions across modules where signature drift or ambiguous ownership creates bugs.
+- Soundness: 100%
+- Why this is sound:
+  - The reported duplicates exist in the current tree.
+  - At least one duplicate set already caused a real bug around `Write-Status` import behavior (PowerShell runs the most recently imported same-name command; importing the wrong module last silently replaces the intended implementation).
+  - Several duplicates represent shared task-domain logic that has already drifted.
+  - All design questions are resolved in the step definitions and consolidation categories.
+
+## Context Sources
+
+- GitHub issue 123: duplicate function audit and suggested approach.
+- `CLAUDE.md`
+- `scripts/Platform-Functions.psm1`
+- `stacks/dotnet/hooks/dev/Common.ps1`
+- `workflows/default/systems/runtime/modules/DotBotTheme.psm1`
+- `workflows/default/systems/runtime/modules/WorktreeManager.psm1`
+- `workflows/default/systems/mcp/modules/TaskMutation.psm1`
+- `workflows/default/systems/mcp/modules/TaskStore.psm1`
+- `workflows/default/systems/ui/modules/TaskAPI.psm1`
+- `workflows/default/systems/ui/modules/StateBuilder.psm1`
+- `workflows/default/systems/ui/modules/ControlAPI.psm1`
+- `workflows/default/hooks/scripts/steering.ps1`
+- `tests/Test-Helpers.psm1`
+- `tests/Test-TaskActions.ps1`
+
+## Classes Dependency Hierarchy
+
+### Level 0: Shared Helper Ownership Decisions
+
+- `TaskStore.psm1` — receives `Get-TasksBaseDir` (canonical) and `Get-TodoTaskRecord` (canonical, rich shape from `TaskMutation.psm1`)
+  - Responsibility: Own task-directory resolution and todo-record lookup for both MCP and UI layers.
+  - Reason: Issue explicitly names `TaskStore.psm1` as the consolidation target for path resolution. Grouping `Get-TodoTaskRecord` here keeps storage layout knowledge co-located.
+
+- `TaskMutation.psm1` — retains `Get-RoadmapOverviewDependencyMap` as canonical host
+  - Responsibility: Roadmap dependency parsing stays in the module that owns task data. `StateBuilder.psm1` delegates to this version.
+  - Issue direction: "likely TaskMutation since it owns task data."
+  - **Dependency direction note**: `systems/ui/` modules (`TaskAPI.psm1`, `StateBuilder.psm1`) depend on modules under `systems/mcp/`. This is a deliberate cross-system dependency that should be made explicit in any module manifest or import comments so future contributors do not reverse it.
+  - **No new module needed** — `TaskStore.psm1` and `TaskMutation.psm1` absorb all consolidations.
+
+- `dotbot-mcp-helpers.ps1` (already exists)
+  - Responsibility: JSON-RPC response/error writers and date parsing helpers for MCP tool tests. Does **not** own `Send-McpRequest` — that is test infrastructure and belongs in `Test-Helpers.psm1`.
+  - Placement: `workflows/default/systems/mcp/dotbot-mcp-helpers.ps1` — already dot-sourced by every tool test.ps1.
+
+### Level 1: Shared Task-Domain Consumers
+
+- `TaskMutation.psm1`
+  - Responsibility: Continue to own task mutation workflows, but stop owning duplicated general-purpose task helper implementations.
+  - Depends on: `TaskStore.psm1`.
+
+- `TaskAPI.psm1`
+  - Responsibility: UI-facing task operations should consume the same task lookup and path-resolution helpers as MCP.
+  - Depends on: `TaskStore.psm1`.
+
+- `StateBuilder.psm1`
+  - Responsibility: Continue building UI state, but read roadmap dependency fallback data through the shared task-domain helper.
+  - Depends on: `TaskMutation.psm1`.
+
+### Level 2: Naming Clarification Consumers
+
+- `Platform-Functions.psm1`
+  - Responsibility: Keep install and script output helpers. `Write-Status` is removed from this module (Step 2) — it had no `-Type` support and caused load-order bugs.
+
+- `Common.ps1`
+  - Responsibility: Remove local `Write-Status` definition; import from `DotBotTheme.psm1` instead.
+
+- `DotBotTheme.psm1`
+  - Responsibility: The canonical runtime/UI themed status writer — sole source of `Write-Status` after Step 2.
+
+- `steering.ps1`
+  - Responsibility: Hosts `Send-WhisperToSession` (renamed from `Send-Whisper` in Step 3) — sends a whisper to a specific session/process target.
+
+- `ControlAPI.psm1`
+  - Responsibility: Hosts `Send-WhisperToInstance` (renamed from `Send-Whisper` in Step 3) — sends a whisper to one or more running instances selected by type.
+
+- `WorktreeManager.psm1`
+  - Responsibility: Delegates `Get-TaskSlug` to `TaskStore.psm1` (Step 6). Slug generation is unified; WorktreeManager removes its local definition and imports the canonical algorithm.
+  - Note: The 50-char truncation in WorktreeManager is a **Windows MAX_PATH defensive measure** (worktree paths become subdirectories on disk), not a Git protocol requirement. Git itself imposes no branch name length limit; `git check-ref-format` enforces character rules only.
+
+## Consolidation Categories
+
+### Category A: Safe Quick Wins
+
+- `Send-McpRequest`
+  - Consolidate into `tests/Test-Helpers.psm1` — it is test infrastructure and that is where it belongs.
+  - Remove the embedded copies from all 15 MCP tool `test.ps1` files; each file gains one `Import-Module` for `Test-Helpers.psm1`.
+  - **Parameter order must be unified**: `Test-Helpers.psm1` declares `($Process, $Request)`; tool test copies declare `($Request, $Process)`. All current call sites use named parameters so both work today, but the canonical version must pick one order and all callers audited for any positional use.
+  - Update `README-NEWTOOL.md`: the `test.ps1` template currently shows an inline `Send-McpRequest` definition — replace it with an `Import-Module Test-Helpers` line.
+
+- `Get-TodoTaskRecord`
+  - **Issue recommendation accepted**: Consolidate into `TaskStore.psm1` or `TaskMutation.psm1`; `TaskAPI.psm1` calls the shared version.
+  - **Concretization**: Host in `TaskStore.psm1` — groups path resolution (`Get-TasksBaseDir`) and record lookup together; both are storage layout concerns. The issue lists both modules as acceptable; `TaskStore.psm1` is the tiebreaker choice here.
+  - Use the richer `TaskMutation.psm1` record shape (`todo_dir`, `edited_dir`, `deleted_dir`, `tasks_base_dir`) as the canonical result.
+
+- `Get-RoadmapOverviewDependencyMap`
+  - **Issue recommendation accepted**: "Consolidate into one location (likely TaskMutation since it owns task data). StateBuilder calls the shared version."
+  - No new module needed — canonicalize the `TaskMutation.psm1` version; remove the `StateBuilder.psm1` duplicate.
+  - Preserve existing roadmap-overview parsing behavior.
+
+### Category B: Shared Logic With Signature Alignment
+
+- `Get-TasksBaseDir`
+  - **Issue recommendation accepted**: "Consolidate into `TaskStore.psm1` as the single source. TaskMutation and TaskAPI should call TaskStore's version."
+  - **Concretization**: The optional override param from `TaskMutation.psm1` (`param([string]$TasksBaseDir)`) is preserved as a local wrapper in `TaskMutation.psm1` if needed for test injection. Issue says "if truly needed" — keep it conditional on test-coverage requirements.
+
+### Category C: Accepted Recommendations
+
+- `Write-Status`
+  - **Issue recommendation accepted**: Remove `Write-Status` from `Platform-Functions.psm1` — it is the odd one out (no `-Type` support). `DotBotTheme.psm1` is the single source of truth for runtime and UI contexts.
+  - `Common.ps1` in the dotnet stack should import from `DotBotTheme.psm1` or have its local definition removed if `DotBotTheme` is always available in that context.
+  - No rename needed for `DotBotTheme.psm1` — existing `-Type` call sites already target the correct implementation.
+
+- `Send-Whisper`
+  - **Issue recommendation accepted**: Rename to clarify targeting model.
+  - **Concretization**: Use `Send-WhisperToSession` (`steering.ps1`) and `Send-WhisperToInstance` (`ControlAPI.psm1`) — the specific names the issue suggests.
+  - Optionally share a low-level whisper-file append helper in a follow-up; the public rename is the priority.
+
+### Category D: Accepted Recommendation
+
+- `Get-TaskSlug`
+  - **Issue recommendation accepted**: extract into a shared module and use the WorktreeManager algorithm as the canonical implementation.
+  - The WorktreeManager version is a strict superset of the TaskMutation version: it lowercases first, collapses any non-alphanumeric run to a single dash, trims leading/trailing dashes, and caps at 50 chars. The TaskMutation version does none of the last three.
+  - There is no scenario where the weaker TaskMutation algorithm is preferable for worktree naming; adopting the stronger one in both places is safe.
+  - Target module: `TaskStore.psm1` — already imported by `TaskMutation.psm1`, avoids a new file, and sits in a location both consumers can reach. `SharedUtils.psm1` is not needed.
+
+## Implementation Steps
+
+### Step 1: Consolidate `Send-McpRequest` into `Test-Helpers.psm1`
+
+- Files to modify:
+  - `tests/Test-Helpers.psm1` — ensure `Send-McpRequest` is defined here with the canonical parameter order; align with the version in the tool tests if needed
+  - `workflows/default/systems/mcp/tools/*/test.ps1` — remove the 15 embedded `Send-McpRequest` definitions; add `Import-Module` for `Test-Helpers.psm1` in each file
+  - `workflows/default/systems/mcp/README-NEWTOOL.md` — replace the inline `Send-McpRequest` block in the `test.ps1` template with an `Import-Module Test-Helpers.psm1` line
+- Purpose:
+  - Make `Test-Helpers.psm1` the single authoritative source for `Send-McpRequest` — it is test infrastructure and belongs there.
+  - Resolve the latent parameter order reversal (`($Process, $Request)` vs `($Request, $Process)`) as part of the same change.
+  - Keep `dotbot-mcp-helpers.ps1` free of test-only concerns; it remains the home for production MCP script helpers (JSON-RPC writers, date parsing).
+- Serena: use `safe_delete_symbol` on each tool test's `Send-McpRequest` before removing it to confirm no other callers exist. Use `replace_content` (regex) to bulk-remove the function definition blocks across all 15 files.
+- Expected risk: Low
+- Checkpoint: `Send-McpRequest` is defined once in `Test-Helpers.psm1`. No local definitions remain in tool `test.ps1` files. `README-NEWTOOL.md` template no longer shows an inline definition.
+
+### Step 2: Remove `Write-Status` from `Platform-Functions.psm1` and redirect `Common.ps1`
+
+- Files to modify:
+  - `scripts/Platform-Functions.psm1`
+  - `stacks/dotnet/hooks/dev/Common.ps1`
+  - `workflows/default/systems/runtime/modules/DotBotTheme.psm1`
+  - call sites in install scripts, stack hooks, and runtime/UI scripts as needed
+- Pre-work — call-site classification (do this before any edits):
+  - Use `find_referencing_symbols` to enumerate every `Write-Status` call site.
+  - Classify each into one of two groups:
+    - **Group A — calls with `-Type`**: currently broken if `Platform-Functions.psm1` loads last (the bug #122 surfaced). After removal these work correctly as long as `DotBotTheme.psm1` is imported by their script.
+    - **Group B — calls without `-Type`**: currently resolved by `Platform-Functions.psm1`. After removal they must import `DotBotTheme.psm1` instead. Visual output is identical: `DotBotTheme.psm1` defaults `-Type` to `'Info'`, which renders the same `›` cyan-muted line as the `Platform-Functions.psm1` version.
+  - For every Group B call site, confirm `DotBotTheme.psm1` is (or will be) imported by that script. Add the import where missing as part of this step.
+- Purpose:
+  - Remove `Write-Status` from `Platform-Functions.psm1` — it is the odd one out with no `-Type` support (issue direction: this is a removal, not a rename).
+  - Remove or redirect `Common.ps1`'s copy to import from `DotBotTheme.psm1`.
+  - Make `DotBotTheme.psm1` the sole `Write-Status` source for runtime and UI contexts.
+  - Ensure every call site — with or without `-Type` — is served by `DotBotTheme.psm1` via an explicit import, not by load-order luck.
+- Serena: use `find_referencing_symbols` for the pre-work classification. Use `safe_delete_symbol` on `Platform-Functions.psm1`'s definition to confirm the Group B call-site list is complete before deletion. Use `replace_symbol_body` to redirect `Common.ps1`'s copy if it cannot simply be removed.
+- Expected risk: Medium
+- Checkpoint: `DotBotTheme.psm1`'s `Write-Status` is the sole definition. Every call site (with and without `-Type`) imports `DotBotTheme.psm1` explicitly. No `Write-Status` definition remains in `Platform-Functions.psm1`.
+
+### Step 3: Rename `Send-Whisper` to `Send-WhisperToSession` and `Send-WhisperToInstance`
+
+- Files to modify:
+  - `workflows/default/hooks/scripts/steering.ps1`
+  - `workflows/default/systems/ui/modules/ControlAPI.psm1`
+  - `workflows/default/systems/ui/server.ps1`
+  - related tests if added or updated
+- Purpose:
+  - Rename `Send-Whisper` in `steering.ps1` → `Send-WhisperToSession` and in `ControlAPI.psm1` → `Send-WhisperToInstance` — the specific names the issue suggests.
+  - Avoid same-name functions with different semantics.
+- Serena: use `rename_symbol` on each `Send-Whisper` definition independently (scoped to its file) to apply the chosen name. Codebase-wide reference updates are automatic.
+- Expected risk: Low
+- Checkpoint: `Send-WhisperToSession` exists in `steering.ps1` and `Send-WhisperToInstance` exists in `ControlAPI.psm1`. No `Send-Whisper` definition remains in either file.
+
+### Step 4: Consolidate task path and record helpers into `TaskStore.psm1` and `TaskMutation.psm1`
+
+- Files to create or modify:
+  - `workflows/default/systems/mcp/modules/TaskStore.psm1` — add `Get-TasksBaseDir` (canonical) and `Get-TodoTaskRecord` (canonical, rich shape); remove its existing weaker `Get-TasksBaseDir`
+  - `workflows/default/systems/mcp/modules/TaskMutation.psm1` — retain `Get-RoadmapOverviewDependencyMap` as canonical; delegate `Get-TasksBaseDir` and `Get-TodoTaskRecord` to `TaskStore.psm1`
+  - `workflows/default/systems/ui/modules/TaskAPI.psm1` — delegate `Get-TasksBaseDir` and `Get-TodoTaskRecord` to `TaskStore.psm1`
+  - `workflows/default/systems/ui/modules/StateBuilder.psm1` — delegate `Get-RoadmapOverviewDependencyMap` to `TaskMutation.psm1`
+  - No new module — issue-named existing modules absorb all consolidations
+- Purpose:
+  - Establish one owner per function per issue assignment: `TaskStore.psm1` for path/record helpers, `TaskMutation.psm1` for roadmap dependency parsing.
+  - Prevent UI and MCP task behavior from drifting further.
+- Serena: use `find_referencing_symbols` on each function before moving it to enumerate every consumer precisely. Use `replace_symbol_body` to replace each duplicate body with a delegation call once the shared module exists.
+- Expected risk: Medium
+- Checkpoint: One canonical owner exists for `Get-TasksBaseDir`, `Get-RoadmapOverviewDependencyMap`, and `Get-TodoTaskRecord`. All consumers import from the shared module.
+
+### Step 5: Update task-domain tests after helper consolidation
+
+- Files to modify:
+  - `tests/Test-TaskActions.ps1`
+  - `tests/Test-Components.ps1`
+  - any MCP or UI tests that assume the old helper ownership
+- Purpose:
+  - Verify shared helpers work through both MCP and UI code paths.
+  - Preserve task lookup, ignore-state, and roadmap fallback behavior.
+- Expected risk: Medium
+- Checkpoint: MCP and UI task flows both pass against the shared helper implementation. Ignore-state and roadmap fallback behavior is unchanged.
+
+### Step 6: Consolidate `Get-TaskSlug` into `TaskStore.psm1`
+
+- Files to modify:
+  - `workflows/default/systems/mcp/modules/TaskStore.psm1` — add the canonical `Get-TaskSlug` (WorktreeManager algorithm)
+  - `workflows/default/systems/mcp/modules/TaskMutation.psm1` — remove local definition; import from `TaskStore.psm1`
+  - `workflows/default/systems/runtime/modules/WorktreeManager.psm1` — remove local definition; import from `TaskStore.psm1`
+  - tests covering task creation and worktree naming
+- Algorithm to use: WorktreeManager's — lowercase first, collapse any non-alphanumeric run to a single dash, trim edge dashes, cap at 50 chars with trailing-dash cleanup.
+- Purpose:
+  - Ensure task-reference aliases and worktree branch names are generated by the same algorithm so they cannot diverge for the same task name.
+  - Eliminate the weaker TaskMutation variant.
+- Serena: use `find_referencing_symbols` on each consumer's `Get-TaskSlug` to confirm call sites before removing. Use `replace_symbol_body` to replace each local definition with a delegation shim or remove it after the import is in place.
+- Expected risk: Medium because branch-name behavior and task-reference behavior may already be relied on indirectly.
+- Note: The 50-char cap is a Windows MAX_PATH guard for worktree subdirectory paths, not a Git naming constraint. It must be preserved in the shared algorithm.
+- Checkpoint: One `Get-TaskSlug` exists in `TaskStore.psm1`. Both `TaskMutation.psm1` and `WorktreeManager.psm1` import and call it. No local definitions remain.
+
+## Testing Requirements
+
+### Functional Scenarios
+
+- MCP tool tests can still start the MCP process, send requests, and parse responses after `Send-McpRequest` consolidation.
+- UI and MCP task operations resolve the same base task directory in normal repo execution.
+- Test paths that inject a temporary tasks base directory still work.
+- Roadmap-overview dependency fallback remains identical for task mutation and UI state building.
+- Todo task lookup returns the same task records expected by edit, delete, restore, and ignore flows.
+
+### Regression Scenarios
+
+- Importing output helper modules no longer changes behavior based on load order.
+- Runtime/UI scripts that use `Write-Status -Type ...` continue to work with the intended implementation.
+- Stack-local dev hooks still emit readable status output after any rename or consolidation.
+- Session-targeted steering and instance-targeted UI whispers still write the expected whisper files.
+- Long task names do not create mismatched task references or invalid worktree branch names after any slug decision.
+
+### Test Execution
+
+- Run install/update cycle from repo root:
+  - `pwsh install.ps1`
+- Run layers 1-3:
+  - `pwsh tests/Run-Tests.ps1`
+- If iteration is needed, run the smallest targeted test file first, then rerun the full suite at the end.
+
+## Serena Tool Guidance
+
+The Serena MCP server is available for this project and changes the risk profile and execution approach for several steps.
+
+### Tool-to-step mapping
+
+- `find_referencing_symbols` — use before every step to generate a precise LSP-backed call-site map. Replaces grep-based discovery and eliminates the risk of missing a call site.
+- `safe_delete_symbol` — use in Step 1 before removing each embedded `Send-McpRequest` copy. Returns a reference list if any callers exist, preventing silent breakage.
+- `replace_content` (regex mode) — use in Step 1 to bulk-remove the embedded function definitions from the 15 tool `test.ps1` files in a single targeted pass.
+- `replace_symbol_body` — use in Step 4 to replace duplicate function bodies with delegation calls once the shared module is in place.
+- `rename_symbol` — use in Step 3. Performs a codebase-wide rename including all call sites. This is the primary reason that step has a Low risk rating despite touching multiple files.
+- `get_symbols_overview` — use when exploring a module before editing to avoid reading the full file.
+

--- a/stacks/dotnet/hooks/dev/Common.ps1
+++ b/stacks/dotnet/hooks/dev/Common.ps1
@@ -1,6 +1,12 @@
 # Common.ps1
 # Shared utilities for dev scripts
 
+# Import DotBotTheme for Write-Status and other theme helpers (deployed path)
+$_dotBotTheme = Join-Path $PSScriptRoot "..\..\systems\runtime\modules\DotBotTheme.psm1"
+if (Test-Path $_dotBotTheme) {
+    Import-Module $_dotBotTheme -Force -DisableNameChecking
+}
+
 function Invoke-InProjectRoot {
     $root = git rev-parse --show-toplevel 2>$null
     if (-not $root) {
@@ -34,32 +40,6 @@ function Load-EnvFile {
         }
     }
     return $env
-}
-
-function Write-Status {
-    param(
-        [string]$Message,
-        [ValidateSet("Success", "Info", "Warning", "Error", "Neutral")]
-        [string]$Type = "Info"
-    )
-    
-    $prefix = switch ($Type) {
-        "Success" { "[OK]" }
-        "Info"    { "[--]" }
-        "Warning" { "[!!]" }
-        "Error"   { "[XX]" }
-        "Neutral" { "[  ]" }
-    }
-    
-    $color = switch ($Type) {
-        "Success" { "Green" }
-        "Info"    { "Cyan" }
-        "Warning" { "Yellow" }
-        "Error"   { "Red" }
-        "Neutral" { "Gray" }
-    }
-    
-    Write-Host "$prefix $Message" -ForegroundColor $color
 }
 
 function Get-ProjectName {

--- a/stacks/dotnet/hooks/dev/Stop-Dev.ps1
+++ b/stacks/dotnet/hooks/dev/Stop-Dev.ps1
@@ -54,7 +54,7 @@ if ($savedPids) {
                 Write-Status "Stopped API process tree (PID: $($savedPids.api_pid))" -Type Success
             }
         } elseif (-not $Quiet) {
-            Write-Status "API window already closed" -Type Neutral
+            Write-Status "API window already closed" -Type Info
         }
     }
 } elseif (-not $Quiet) {
@@ -66,7 +66,7 @@ if ($savedPids) {
 if (Test-Path $pidFile) {
     Remove-Item $pidFile -Force
     if (-not $Quiet) {
-        Write-Status "Cleaned up PID file" -Type Neutral
+        Write-Status "Cleaned up PID file" -Type Info
     }
 }
 

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -199,6 +199,9 @@ try {
     Assert-True -Name "TaskStore exports Get-TodoTaskRecord" `
         -Condition ($null -ne (Get-Command Get-TodoTaskRecord -ErrorAction SilentlyContinue)) `
         -Message "Expected Get-TodoTaskRecord to be exported from TaskStore"
+    Assert-True -Name "TaskStore exports Get-TaskSlug" `
+        -Condition ($null -ne (Get-Command Get-TaskSlug -ErrorAction SilentlyContinue)) `
+        -Message "Expected Get-TaskSlug to be exported from TaskStore"
 
     New-TestTaskFile -TasksTodoDir $todoDir -TaskId "task-root" -Name "Root dependency" -Description "Dependency task" -Priority 10 | Out-Null
     New-TestTaskFile -TasksTodoDir $todoDir -TaskId "task-dependent" -Name "Dependent task" -Description "Depends on root" -Priority 20 -Dependencies @("task-root") | Out-Null
@@ -359,6 +362,25 @@ try {
     Assert-FileContains -Name "StateBuilder delegates roadmap dependency map to TaskMutation" `
         -Path (Join-Path $botDir "systems\ui\modules\StateBuilder.psm1") `
         -Pattern 'TaskMutation\\Get-RoadmapOverviewDependencyMap'
+    Assert-FileContains -Name "TaskStore defines canonical Get-TaskSlug" `
+        -Path $taskStoreModule `
+        -Pattern 'function Get-TaskSlug'
+    Assert-True -Name "TaskMutation does not define Get-TaskSlug (delegated to TaskStore)" `
+        -Condition (-not (Select-String -Path $taskMutationModule -Pattern 'function Get-TaskSlug' -Quiet)) `
+        -Message "Expected TaskMutation to use TaskStore's Get-TaskSlug, not define it locally"
+    $worktreeManagerModule = Join-Path $botDir "systems\runtime\modules\WorktreeManager.psm1"
+    Assert-True -Name "WorktreeManager does not define Get-TaskSlug (delegated to TaskStore)" `
+        -Condition (-not (Select-String -Path $worktreeManagerModule -Pattern 'function Get-TaskSlug' -Quiet)) `
+        -Message "Expected WorktreeManager to use TaskStore's Get-TaskSlug, not define it locally"
+    Assert-Equal -Name "Get-TaskSlug lowercases and collapses special chars" `
+        -Expected "hello-world" `
+        -Actual (Get-TaskSlug -TaskName "Hello World!")
+    Assert-Equal -Name "Get-TaskSlug trims leading and trailing dashes" `
+        -Expected "dotnet-upgrade" `
+        -Actual (Get-TaskSlug -TaskName "--dotnet-upgrade--")
+    Assert-Equal -Name "Get-TaskSlug caps at 50 chars and strips trailing dash" `
+        -Expected ("a" * 50) `
+        -Actual (Get-TaskSlug -TaskName ("a" * 55))
 
 
     $firstEdit = Update-TaskContent -TaskId "task-free" -Actor "dotbot-test" -Updates @{

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -359,9 +359,9 @@ try {
     Assert-True -Name "TaskMutation does not define Get-TodoTaskRecord (delegated to TaskStore)" `
         -Condition (-not (Select-String -Path $taskMutationModule -Pattern 'function Get-TodoTaskRecord' -Quiet)) `
         -Message "Expected TaskMutation to delegate Get-TodoTaskRecord to TaskStore, not define it locally"
-    Assert-FileContains -Name "StateBuilder delegates roadmap dependency map to TaskMutation" `
-        -Path (Join-Path $botDir "systems\ui\modules\StateBuilder.psm1") `
-        -Pattern 'TaskMutation\\Get-RoadmapOverviewDependencyMap'
+    Assert-True -Name "StateBuilder does not define Get-RoadmapOverviewDependencyMap (uses TaskMutation's)" `
+        -Condition (-not (Select-String -Path (Join-Path $botDir "systems\ui\modules\StateBuilder.psm1") -Pattern 'function Get-RoadmapOverviewDependencyMap' -Quiet)) `
+        -Message "Expected StateBuilder to use TaskMutation's Get-RoadmapOverviewDependencyMap, not define it locally"
     Assert-FileContains -Name "TaskStore defines canonical Get-TaskSlug" `
         -Path $taskStoreModule `
         -Pattern 'function Get-TaskSlug'

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -180,6 +180,25 @@ try {
     Assert-True -Name "TaskMutation exports Get-TaskIgnoreStateMap" `
         -Condition ($null -ne (Get-Command Get-TaskIgnoreStateMap -ErrorAction SilentlyContinue)) `
         -Message "Expected Get-TaskIgnoreStateMap to be exported"
+    Assert-True -Name "TaskMutation exports Get-RoadmapOverviewDependencyMap" `
+        -Condition ($null -ne (Get-Command Get-RoadmapOverviewDependencyMap -ErrorAction SilentlyContinue)) `
+        -Message "Expected Get-RoadmapOverviewDependencyMap to be exported from TaskMutation"
+
+    $taskStoreModule = Join-Path $botDir "systems\mcp\modules\TaskStore.psm1"
+    Assert-PathExists -Name "TaskStore module exists" -Path $taskStoreModule
+    Import-Module $taskStoreModule -Force -DisableNameChecking
+    Assert-True -Name "TaskStore exports Get-TasksBaseDir" `
+        -Condition ($null -ne (Get-Command Get-TasksBaseDir -ErrorAction SilentlyContinue)) `
+        -Message "Expected Get-TasksBaseDir to be exported from TaskStore"
+    Assert-True -Name "TaskStore exports Get-TodoDirectories" `
+        -Condition ($null -ne (Get-Command Get-TodoDirectories -ErrorAction SilentlyContinue)) `
+        -Message "Expected Get-TodoDirectories to be exported from TaskStore"
+    Assert-True -Name "TaskStore exports Ensure-TodoDirectories" `
+        -Condition ($null -ne (Get-Command Ensure-TodoDirectories -ErrorAction SilentlyContinue)) `
+        -Message "Expected Ensure-TodoDirectories to be exported from TaskStore"
+    Assert-True -Name "TaskStore exports Get-TodoTaskRecord" `
+        -Condition ($null -ne (Get-Command Get-TodoTaskRecord -ErrorAction SilentlyContinue)) `
+        -Message "Expected Get-TodoTaskRecord to be exported from TaskStore"
 
     New-TestTaskFile -TasksTodoDir $todoDir -TaskId "task-root" -Name "Root dependency" -Description "Dependency task" -Priority 10 | Out-Null
     New-TestTaskFile -TasksTodoDir $todoDir -TaskId "task-dependent" -Name "Dependent task" -Description "Depends on root" -Priority 20 -Dependencies @("task-root") | Out-Null
@@ -331,6 +350,15 @@ try {
     Assert-FileContains -Name "TaskIndexCache resolves fallback roadmap dependencies" `
         -Path $taskIndexModule `
         -Pattern 'function Get-ResolvedIgnoreDependencies'
+    Assert-FileContains -Name "TaskStore defines canonical Get-TodoTaskRecord" `
+        -Path $taskStoreModule `
+        -Pattern 'function Get-TodoTaskRecord'
+    Assert-True -Name "TaskMutation does not define Get-TodoTaskRecord (delegated to TaskStore)" `
+        -Condition (-not (Select-String -Path $taskMutationModule -Pattern 'function Get-TodoTaskRecord' -Quiet)) `
+        -Message "Expected TaskMutation to delegate Get-TodoTaskRecord to TaskStore, not define it locally"
+    Assert-FileContains -Name "StateBuilder delegates roadmap dependency map to TaskMutation" `
+        -Path (Join-Path $botDir "systems\ui\modules\StateBuilder.psm1") `
+        -Pattern 'TaskMutation\\Get-RoadmapOverviewDependencyMap'
 
 
     $firstEdit = Update-TaskContent -TaskId "task-free" -Actor "dotbot-test" -Updates @{

--- a/workflows/default/hooks/scripts/steering.ps1
+++ b/workflows/default/hooks/scripts/steering.ps1
@@ -69,7 +69,7 @@ function Get-RunningProcesses {
     return $procs
 }
 
-function Send-Whisper {
+function Send-WhisperToSession {
     param(
         [Parameter(Mandatory)]
         [string]$SessionId,
@@ -173,7 +173,7 @@ function Send-Abort {
         [string]$SessionId
     )
 
-    Send-Whisper -SessionId $SessionId -Message "ABORT: Commit any work in progress and exit gracefully." -Priority "abort"
+    Send-WhisperToSession -SessionId $SessionId -Message "ABORT: Commit any work in progress and exit gracefully." -Priority "abort"
     Write-Host ""
     Write-Host "$($t.Warning)!$($t.Reset) Abort signal sent. Session should commit WIP and exit."
 }
@@ -245,7 +245,7 @@ switch ($Command) {
             Write-Host "$($t.Error)x$($t.Reset) -Message required"
             exit 1
         }
-        Send-Whisper -SessionId $SessionId -Message $Message -Priority $Priority
+        Send-WhisperToSession -SessionId $SessionId -Message $Message -Priority $Priority
     }
     'status' {
         Get-SteeringStatus

--- a/workflows/default/systems/mcp/README-NEWTOOL.md
+++ b/workflows/default/systems/mcp/README-NEWTOOL.md
@@ -76,26 +76,7 @@ param(
 )
 
 . "$PSScriptRoot\..\..\dotbot-mcp-helpers.ps1"
-
-function Send-McpRequest {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Request,
-        [Parameter(Mandatory)]
-        [System.Diagnostics.Process]$Process
-    )
-    
-    $json = $Request | ConvertTo-Json -Depth 10 -Compress
-    $Process.StandardInput.WriteLine($json)
-    $Process.StandardInput.Flush()
-    Start-Sleep -Milliseconds 100
-    $response = $Process.StandardOutput.ReadLine()
-    
-    if ($response) {
-        return $response | ConvertFrom-Json
-    }
-    return $null
-}
+Import-Module "$PSScriptRoot\..\..\..\..\..\..\tests\Test-Helpers.psm1" -Force
 
 Write-Host "Test: Your tool description" -ForegroundColor Yellow
 $response = Send-McpRequest -Process $Process -Request @{

--- a/workflows/default/systems/mcp/modules/TaskMutation.psm1
+++ b/workflows/default/systems/mcp/modules/TaskMutation.psm1
@@ -107,18 +107,6 @@ function ConvertTo-TaskArray {
     return @($Value)
 }
 
-function Get-TaskSlug {
-    param(
-        [string]$Name
-    )
-
-    if (-not $Name) {
-        return ""
-    }
-
-    return (($Name -replace '[^a-zA-Z0-9\s-]', '' -replace '\s+', '-').ToLower())
-}
-
 function Get-TaskPriorityValue {
     param(
         [object]$Task
@@ -396,7 +384,7 @@ function Get-TodoTaskLookup {
         $position += 1
         Add-TaskReferenceAlias -ReferenceMap $referenceMap -TaskId $task.id -Alias $task.id
         Add-TaskReferenceAlias -ReferenceMap $referenceMap -TaskId $task.id -Alias $task.name
-        Add-TaskReferenceAlias -ReferenceMap $referenceMap -TaskId $task.id -Alias (Get-TaskSlug -Name $task.name)
+        Add-TaskReferenceAlias -ReferenceMap $referenceMap -TaskId $task.id -Alias (Get-TaskSlug -TaskName $task.name)
         Add-TaskReferenceAlias -ReferenceMap $referenceMap -TaskId $task.id -Alias $position
         Add-TaskReferenceAlias -ReferenceMap $referenceMap -TaskId $task.id -Alias "task $position"
     }

--- a/workflows/default/systems/mcp/modules/TaskMutation.psm1
+++ b/workflows/default/systems/mcp/modules/TaskMutation.psm1
@@ -8,72 +8,7 @@ archived under todo\edited_tasks and todo\deleted_tasks so operators can view
 or restore previous versions.
 #>
 
-function Get-TaskMutationProjectRoot {
-    if ($global:DotbotProjectRoot) {
-        return $global:DotbotProjectRoot
-    }
-
-    $cursor = $PSScriptRoot
-    while ($cursor) {
-        if ((Split-Path -Leaf $cursor) -eq ".bot") {
-            return (Split-Path -Parent $cursor)
-        }
-
-        $parent = Split-Path -Parent $cursor
-        if (-not $parent -or $parent -eq $cursor) {
-            break
-        }
-        $cursor = $parent
-    }
-
-    throw "Dotbot project root could not be resolved"
-}
-
-function Get-TasksBaseDir {
-    param(
-        [string]$TasksBaseDir
-    )
-
-    if ($TasksBaseDir) {
-        return $TasksBaseDir
-    }
-
-    $projectRoot = Get-TaskMutationProjectRoot
-    return (Join-Path $projectRoot ".bot\workspace\tasks")
-}
-
-function Get-TodoDirectories {
-    param(
-        [string]$TasksBaseDir
-    )
-
-    $resolvedBaseDir = Get-TasksBaseDir -TasksBaseDir $TasksBaseDir
-    $todoDir = Join-Path $resolvedBaseDir "todo"
-    $editedDir = Join-Path $todoDir "edited_tasks"
-    $deletedDir = Join-Path $todoDir "deleted_tasks"
-
-    return @{
-        TasksBaseDir = $resolvedBaseDir
-        TodoDir = $todoDir
-        EditedDir = $editedDir
-        DeletedDir = $deletedDir
-    }
-}
-
-function Ensure-TodoDirectories {
-    param(
-        [string]$TasksBaseDir
-    )
-
-    $paths = Get-TodoDirectories -TasksBaseDir $TasksBaseDir
-    foreach ($dir in @($paths.TodoDir, $paths.EditedDir, $paths.DeletedDir)) {
-        if (-not (Test-Path $dir)) {
-            New-Item -ItemType Directory -Path $dir -Force | Out-Null
-        }
-    }
-
-    return $paths
-}
+Import-Module (Join-Path $PSScriptRoot "TaskStore.psm1") -Force
 
 function Get-ArchiveActor {
     param(
@@ -343,38 +278,6 @@ function Get-ResolvedTaskDependencies {
     }
 
     return @()
-}
-
-function Get-TodoTaskRecord {
-    param(
-        [Parameter(Mandatory)]
-        [string]$TaskId,
-        [string]$TasksBaseDir
-    )
-
-    $paths = Ensure-TodoDirectories -TasksBaseDir $TasksBaseDir
-    $files = Get-ChildItem -Path $paths.TodoDir -Filter "*.json" -File -ErrorAction SilentlyContinue
-
-    foreach ($file in $files) {
-        try {
-            $task = Get-Content -Path $file.FullName -Raw | ConvertFrom-Json
-            if ($task.id -eq $TaskId) {
-                return @{
-                    task = $task
-                    path = $file.FullName
-                    file_name = $file.Name
-                    todo_dir = $paths.TodoDir
-                    edited_dir = $paths.EditedDir
-                    deleted_dir = $paths.DeletedDir
-                    tasks_base_dir = $paths.TasksBaseDir
-                }
-            }
-        } catch {
-            Write-BotLog -Level Warn -Message "[TaskMutation] Failed to read task file '$($file.FullName)'" -Exception $_
-        }
-    }
-
-    return $null
 }
 
 function Save-TaskFile {
@@ -900,7 +803,8 @@ Export-ModuleMember -Function @(
     'Remove-TaskFromTodo',
     'Get-TaskVersionHistory',
     'Restore-TaskVersion',
-    'Get-TaskIgnoreStateMap'
+    'Get-TaskIgnoreStateMap',
+    'Get-RoadmapOverviewDependencyMap'
 )
 
 

--- a/workflows/default/systems/mcp/modules/TaskStore.psm1
+++ b/workflows/default/systems/mcp/modules/TaskStore.psm1
@@ -446,6 +446,15 @@ function Update-TaskRecord {
     }
 }
 
+function Get-TaskSlug {
+    param([string]$TaskName)
+    $slug = $TaskName.ToLower()
+    $slug = $slug -replace '[^a-z0-9]+', '-'
+    $slug = $slug -replace '^-|-$', ''
+    if ($slug.Length -gt 50) { $slug = $slug.Substring(0, 50) -replace '-$', '' }
+    return $slug
+}
+
 # ---------------------------------------------------------------------------
 # Exports
 # ---------------------------------------------------------------------------
@@ -461,5 +470,6 @@ Export-ModuleMember -Function @(
     'Get-StatusDir',
     'Get-TodoDirectories',
     'Ensure-TodoDirectories',
-    'Get-TodoTaskRecord'
+    'Get-TodoTaskRecord',
+    'Get-TaskSlug'
 )

--- a/workflows/default/systems/mcp/modules/TaskStore.psm1
+++ b/workflows/default/systems/mcp/modules/TaskStore.psm1
@@ -23,8 +23,103 @@ $script:ReservedFields = @('status', 'updated_at', 'id', 'created_at')
 # Helpers
 # ---------------------------------------------------------------------------
 
+function Get-DotbotProjectRoot {
+    if ($global:DotbotProjectRoot) {
+        return $global:DotbotProjectRoot
+    }
+
+    $cursor = $PSScriptRoot
+    while ($cursor) {
+        if ((Split-Path -Leaf $cursor) -eq ".bot") {
+            return (Split-Path -Parent $cursor)
+        }
+
+        $parent = Split-Path -Parent $cursor
+        if (-not $parent -or $parent -eq $cursor) {
+            break
+        }
+        $cursor = $parent
+    }
+
+    throw "Dotbot project root could not be resolved"
+}
+
 function Get-TasksBaseDir {
-    return (Join-Path $global:DotbotProjectRoot ".bot\workspace\tasks")
+    param(
+        [string]$TasksBaseDir
+    )
+
+    if ($TasksBaseDir) {
+        return $TasksBaseDir
+    }
+
+    $projectRoot = Get-DotbotProjectRoot
+    return (Join-Path $projectRoot ".bot\workspace\tasks")
+}
+
+function Get-TodoDirectories {
+    param(
+        [string]$TasksBaseDir
+    )
+
+    $resolvedBaseDir = Get-TasksBaseDir -TasksBaseDir $TasksBaseDir
+    $todoDir = Join-Path $resolvedBaseDir "todo"
+    $editedDir = Join-Path $todoDir "edited_tasks"
+    $deletedDir = Join-Path $todoDir "deleted_tasks"
+
+    return @{
+        TasksBaseDir = $resolvedBaseDir
+        TodoDir      = $todoDir
+        EditedDir    = $editedDir
+        DeletedDir   = $deletedDir
+    }
+}
+
+function Ensure-TodoDirectories {
+    param(
+        [string]$TasksBaseDir
+    )
+
+    $paths = Get-TodoDirectories -TasksBaseDir $TasksBaseDir
+    foreach ($dir in @($paths.TodoDir, $paths.EditedDir, $paths.DeletedDir)) {
+        if (-not (Test-Path $dir)) {
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+        }
+    }
+
+    return $paths
+}
+
+function Get-TodoTaskRecord {
+    param(
+        [Parameter(Mandatory)]
+        [string]$TaskId,
+        [string]$TasksBaseDir
+    )
+
+    $paths = Ensure-TodoDirectories -TasksBaseDir $TasksBaseDir
+    $files = Get-ChildItem -Path $paths.TodoDir -Filter "*.json" -File -ErrorAction SilentlyContinue
+
+    foreach ($file in $files) {
+        try {
+            $task = Get-Content -Path $file.FullName -Raw | ConvertFrom-Json
+            if ($task.id -eq $TaskId) {
+                return @{
+                    task           = $task
+                    path           = $file.FullName
+                    file_name      = $file.Name
+                    todo_dir       = $paths.TodoDir
+                    edited_dir     = $paths.EditedDir
+                    deleted_dir    = $paths.DeletedDir
+                    tasks_base_dir = $paths.TasksBaseDir
+                }
+            }
+        } catch {
+            Write-BotLog -Level Warn -Message "[TaskStore] Failed to read task file '$($file.FullName)'" -Exception $_
+        }
+    }
+
+    return $null
 }
 
 function Get-StatusDir {
@@ -363,5 +458,8 @@ Export-ModuleMember -Function @(
     'Find-TaskFileById',
     'Set-OrAddProperty',
     'Get-TasksBaseDir',
-    'Get-StatusDir'
+    'Get-StatusDir',
+    'Get-TodoDirectories',
+    'Ensure-TodoDirectories',
+    'Get-TodoTaskRecord'
 )

--- a/workflows/default/systems/mcp/modules/TaskStore.psm1
+++ b/workflows/default/systems/mcp/modules/TaskStore.psm1
@@ -97,7 +97,10 @@ function Get-TodoTaskRecord {
         [string]$TasksBaseDir
     )
 
-    $paths = Ensure-TodoDirectories -TasksBaseDir $TasksBaseDir
+    $paths = Get-TodoDirectories -TasksBaseDir $TasksBaseDir
+    if (-not (Test-Path -Path $paths.TodoDir -PathType Container)) {
+        return $null
+    }
     $files = Get-ChildItem -Path $paths.TodoDir -Filter "*.json" -File -ErrorAction SilentlyContinue
 
     foreach ($file in $files) {

--- a/workflows/default/systems/mcp/tools/decision-create/test.ps1
+++ b/workflows/default/systems/mcp/tools/decision-create/test.ps1
@@ -5,26 +5,7 @@ param(
 )
 
 . "$PSScriptRoot\..\..\dotbot-mcp-helpers.ps1"
-
-function Send-McpRequest {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Request,
-        [Parameter(Mandatory)]
-        [System.Diagnostics.Process]$Process
-    )
-
-    $json = $Request | ConvertTo-Json -Depth 10 -Compress
-    $Process.StandardInput.WriteLine($json)
-    $Process.StandardInput.Flush()
-    Start-Sleep -Milliseconds 100
-    $response = $Process.StandardOutput.ReadLine()
-
-    if ($response) {
-        return $response | ConvertFrom-Json
-    }
-    return $null
-}
+Import-Module "$PSScriptRoot\..\..\..\..\..\..\tests\Test-Helpers.psm1" -Force
 
 # ── Test 1: Create a basic Decision ──
 Write-Host "Test: Create a basic Decision" -ForegroundColor Yellow

--- a/workflows/default/systems/mcp/tools/decision-get/test.ps1
+++ b/workflows/default/systems/mcp/tools/decision-get/test.ps1
@@ -5,26 +5,7 @@ param(
 )
 
 . "$PSScriptRoot\..\..\dotbot-mcp-helpers.ps1"
-
-function Send-McpRequest {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Request,
-        [Parameter(Mandatory)]
-        [System.Diagnostics.Process]$Process
-    )
-
-    $json = $Request | ConvertTo-Json -Depth 10 -Compress
-    $Process.StandardInput.WriteLine($json)
-    $Process.StandardInput.Flush()
-    Start-Sleep -Milliseconds 100
-    $response = $Process.StandardOutput.ReadLine()
-
-    if ($response) {
-        return $response | ConvertFrom-Json
-    }
-    return $null
-}
+Import-Module "$PSScriptRoot\..\..\..\..\..\..\tests\Test-Helpers.psm1" -Force
 
 # ── Setup: Create a Decision to test against ──
 Write-Host "Setup: Creating test Decision" -ForegroundColor DarkGray

--- a/workflows/default/systems/mcp/tools/decision-list/test.ps1
+++ b/workflows/default/systems/mcp/tools/decision-list/test.ps1
@@ -5,26 +5,7 @@ param(
 )
 
 . "$PSScriptRoot\..\..\dotbot-mcp-helpers.ps1"
-
-function Send-McpRequest {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Request,
-        [Parameter(Mandatory)]
-        [System.Diagnostics.Process]$Process
-    )
-
-    $json = $Request | ConvertTo-Json -Depth 10 -Compress
-    $Process.StandardInput.WriteLine($json)
-    $Process.StandardInput.Flush()
-    Start-Sleep -Milliseconds 100
-    $response = $Process.StandardOutput.ReadLine()
-
-    if ($response) {
-        return $response | ConvertFrom-Json
-    }
-    return $null
-}
+Import-Module "$PSScriptRoot\..\..\..\..\..\..\tests\Test-Helpers.psm1" -Force
 
 # ── Setup: Create Decisions in different states ──
 Write-Host "Setup: Creating test Decisions" -ForegroundColor DarkGray

--- a/workflows/default/systems/mcp/tools/decision-mark-accepted/test.ps1
+++ b/workflows/default/systems/mcp/tools/decision-mark-accepted/test.ps1
@@ -5,26 +5,7 @@ param(
 )
 
 . "$PSScriptRoot\..\..\dotbot-mcp-helpers.ps1"
-
-function Send-McpRequest {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Request,
-        [Parameter(Mandatory)]
-        [System.Diagnostics.Process]$Process
-    )
-
-    $json = $Request | ConvertTo-Json -Depth 10 -Compress
-    $Process.StandardInput.WriteLine($json)
-    $Process.StandardInput.Flush()
-    Start-Sleep -Milliseconds 100
-    $response = $Process.StandardOutput.ReadLine()
-
-    if ($response) {
-        return $response | ConvertFrom-Json
-    }
-    return $null
-}
+Import-Module "$PSScriptRoot\..\..\..\..\..\..\tests\Test-Helpers.psm1" -Force
 
 # ── Setup: Create a proposed Decision ──
 Write-Host "Setup: Creating proposed Decision for acceptance test" -ForegroundColor DarkGray

--- a/workflows/default/systems/mcp/tools/decision-mark-deprecated/test.ps1
+++ b/workflows/default/systems/mcp/tools/decision-mark-deprecated/test.ps1
@@ -5,26 +5,7 @@ param(
 )
 
 . "$PSScriptRoot\..\..\dotbot-mcp-helpers.ps1"
-
-function Send-McpRequest {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Request,
-        [Parameter(Mandatory)]
-        [System.Diagnostics.Process]$Process
-    )
-
-    $json = $Request | ConvertTo-Json -Depth 10 -Compress
-    $Process.StandardInput.WriteLine($json)
-    $Process.StandardInput.Flush()
-    Start-Sleep -Milliseconds 100
-    $response = $Process.StandardOutput.ReadLine()
-
-    if ($response) {
-        return $response | ConvertFrom-Json
-    }
-    return $null
-}
+Import-Module "$PSScriptRoot\..\..\..\..\..\..\tests\Test-Helpers.psm1" -Force
 
 # ── Setup: Create a proposed Decision ──
 Write-Host "Setup: Creating proposed Decision for deprecation test" -ForegroundColor DarkGray

--- a/workflows/default/systems/mcp/tools/decision-mark-superseded/test.ps1
+++ b/workflows/default/systems/mcp/tools/decision-mark-superseded/test.ps1
@@ -5,26 +5,7 @@ param(
 )
 
 . "$PSScriptRoot\..\..\dotbot-mcp-helpers.ps1"
-
-function Send-McpRequest {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Request,
-        [Parameter(Mandatory)]
-        [System.Diagnostics.Process]$Process
-    )
-
-    $json = $Request | ConvertTo-Json -Depth 10 -Compress
-    $Process.StandardInput.WriteLine($json)
-    $Process.StandardInput.Flush()
-    Start-Sleep -Milliseconds 100
-    $response = $Process.StandardOutput.ReadLine()
-
-    if ($response) {
-        return $response | ConvertFrom-Json
-    }
-    return $null
-}
+Import-Module "$PSScriptRoot\..\..\..\..\..\..\tests\Test-Helpers.psm1" -Force
 
 # ── Setup: Create two Decisions (one to supersede, one as replacement) ──
 Write-Host "Setup: Creating Decisions for supersede test" -ForegroundColor DarkGray

--- a/workflows/default/systems/mcp/tools/decision-update/test.ps1
+++ b/workflows/default/systems/mcp/tools/decision-update/test.ps1
@@ -5,26 +5,7 @@ param(
 )
 
 . "$PSScriptRoot\..\..\dotbot-mcp-helpers.ps1"
-
-function Send-McpRequest {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Request,
-        [Parameter(Mandatory)]
-        [System.Diagnostics.Process]$Process
-    )
-
-    $json = $Request | ConvertTo-Json -Depth 10 -Compress
-    $Process.StandardInput.WriteLine($json)
-    $Process.StandardInput.Flush()
-    Start-Sleep -Milliseconds 100
-    $response = $Process.StandardOutput.ReadLine()
-
-    if ($response) {
-        return $response | ConvertFrom-Json
-    }
-    return $null
-}
+Import-Module "$PSScriptRoot\..\..\..\..\..\..\tests\Test-Helpers.psm1" -Force
 
 # ── Setup: Create a Decision to update ──
 Write-Host "Setup: Creating test Decision for update tests" -ForegroundColor DarkGray

--- a/workflows/default/systems/mcp/tools/task-answer-question/test.ps1
+++ b/workflows/default/systems/mcp/tools/task-answer-question/test.ps1
@@ -5,26 +5,7 @@ param(
 )
 
 . "$PSScriptRoot\..\..\dotbot-mcp-helpers.ps1"
-
-function Send-McpRequest {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Request,
-        [Parameter(Mandatory)]
-        [System.Diagnostics.Process]$Process
-    )
-
-    $json = $Request | ConvertTo-Json -Depth 10 -Compress
-    $Process.StandardInput.WriteLine($json)
-    $Process.StandardInput.Flush()
-    Start-Sleep -Milliseconds 100
-    $response = $Process.StandardOutput.ReadLine()
-
-    if ($response) {
-        return $response | ConvertFrom-Json
-    }
-    return $null
-}
+Import-Module "$PSScriptRoot\..\..\..\..\..\..\tests\Test-Helpers.psm1" -Force
 
 # ── Setup: create a task in needs-input with a pending question ──────────────
 $testTaskId = "test-$(New-Guid)"

--- a/workflows/default/systems/mcp/tools/task-create-bulk/test.ps1
+++ b/workflows/default/systems/mcp/tools/task-create-bulk/test.ps1
@@ -5,26 +5,7 @@ param(
 )
 
 . "$PSScriptRoot\..\..\dotbot-mcp-helpers.ps1"
-
-function Send-McpRequest {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Request,
-        [Parameter(Mandatory)]
-        [System.Diagnostics.Process]$Process
-    )
-    
-    $json = $Request | ConvertTo-Json -Depth 10 -Compress
-    $Process.StandardInput.WriteLine($json)
-    $Process.StandardInput.Flush()
-    Start-Sleep -Milliseconds 100
-    $response = $Process.StandardOutput.ReadLine()
-    
-    if ($response) {
-        return $response | ConvertFrom-Json
-    }
-    return $null
-}
+Import-Module "$PSScriptRoot\..\..\..\..\..\..\tests\Test-Helpers.psm1" -Force
 
 Write-Host "Test: Create multiple features in bulk" -ForegroundColor Yellow
 $response = Send-McpRequest -Process $Process -Request @{

--- a/workflows/default/systems/mcp/tools/task-create/test.ps1
+++ b/workflows/default/systems/mcp/tools/task-create/test.ps1
@@ -5,26 +5,7 @@ param(
 )
 
 . "$PSScriptRoot\..\..\dotbot-mcp-helpers.ps1"
-
-function Send-McpRequest {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Request,
-        [Parameter(Mandatory)]
-        [System.Diagnostics.Process]$Process
-    )
-    
-    $json = $Request | ConvertTo-Json -Depth 10 -Compress
-    $Process.StandardInput.WriteLine($json)
-    $Process.StandardInput.Flush()
-    Start-Sleep -Milliseconds 100
-    $response = $Process.StandardOutput.ReadLine()
-    
-    if ($response) {
-        return $response | ConvertFrom-Json
-    }
-    return $null
-}
+Import-Module "$PSScriptRoot\..\..\..\..\..\..\tests\Test-Helpers.psm1" -Force
 
 Write-Host "Test: Create a new feature" -ForegroundColor Yellow
 $response = Send-McpRequest -Process $Process -Request @{

--- a/workflows/default/systems/mcp/tools/task-get-next/test.ps1
+++ b/workflows/default/systems/mcp/tools/task-get-next/test.ps1
@@ -5,26 +5,7 @@ param(
 )
 
 . "$PSScriptRoot\..\..\dotbot-mcp-helpers.ps1"
-
-function Send-McpRequest {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Request,
-        [Parameter(Mandatory)]
-        [System.Diagnostics.Process]$Process
-    )
-    
-    $json = $Request | ConvertTo-Json -Depth 10 -Compress
-    $Process.StandardInput.WriteLine($json)
-    $Process.StandardInput.Flush()
-    Start-Sleep -Milliseconds 100
-    $response = $Process.StandardOutput.ReadLine()
-    
-    if ($response) {
-        return $response | ConvertFrom-Json
-    }
-    return $null
-}
+Import-Module "$PSScriptRoot\..\..\..\..\..\..\tests\Test-Helpers.psm1" -Force
 
 Write-Host "Test: Get next feature to work on" -ForegroundColor Yellow
 $response = Send-McpRequest -Process $Process -Request @{

--- a/workflows/default/systems/mcp/tools/task-get-stats/test.ps1
+++ b/workflows/default/systems/mcp/tools/task-get-stats/test.ps1
@@ -5,26 +5,7 @@ param(
 )
 
 . "$PSScriptRoot\..\..\dotbot-mcp-helpers.ps1"
-
-function Send-McpRequest {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Request,
-        [Parameter(Mandatory)]
-        [System.Diagnostics.Process]$Process
-    )
-    
-    $json = $Request | ConvertTo-Json -Depth 10 -Compress
-    $Process.StandardInput.WriteLine($json)
-    $Process.StandardInput.Flush()
-    Start-Sleep -Milliseconds 100
-    $response = $Process.StandardOutput.ReadLine()
-    
-    if ($response) {
-        return $response | ConvertFrom-Json
-    }
-    return $null
-}
+Import-Module "$PSScriptRoot\..\..\..\..\..\..\tests\Test-Helpers.psm1" -Force
 
 Write-Host "Test: Get feature statistics" -ForegroundColor Yellow
 $response = Send-McpRequest -Process $Process -Request @{

--- a/workflows/default/systems/mcp/tools/task-list/test.ps1
+++ b/workflows/default/systems/mcp/tools/task-list/test.ps1
@@ -5,26 +5,7 @@ param(
 )
 
 . "$PSScriptRoot\..\..\dotbot-mcp-helpers.ps1"
-
-function Send-McpRequest {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Request,
-        [Parameter(Mandatory)]
-        [System.Diagnostics.Process]$Process
-    )
-    
-    $json = $Request | ConvertTo-Json -Depth 10 -Compress
-    $Process.StandardInput.WriteLine($json)
-    $Process.StandardInput.Flush()
-    Start-Sleep -Milliseconds 100
-    $response = $Process.StandardOutput.ReadLine()
-    
-    if ($response) {
-        return $response | ConvertFrom-Json
-    }
-    return $null
-}
+Import-Module "$PSScriptRoot\..\..\..\..\..\..\tests\Test-Helpers.psm1" -Force
 
 Write-Host "Test: List all features" -ForegroundColor Yellow
 $response = Send-McpRequest -Process $Process -Request @{

--- a/workflows/default/systems/mcp/tools/task-mark-done/test.ps1
+++ b/workflows/default/systems/mcp/tools/task-mark-done/test.ps1
@@ -5,26 +5,7 @@ param(
 )
 
 . "$PSScriptRoot\..\..\dotbot-mcp-helpers.ps1"
-
-function Send-McpRequest {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Request,
-        [Parameter(Mandatory)]
-        [System.Diagnostics.Process]$Process
-    )
-    
-    $json = $Request | ConvertTo-Json -Depth 10 -Compress
-    $Process.StandardInput.WriteLine($json)
-    $Process.StandardInput.Flush()
-    Start-Sleep -Milliseconds 100
-    $response = $Process.StandardOutput.ReadLine()
-    
-    if ($response) {
-        return $response | ConvertFrom-Json
-    }
-    return $null
-}
+Import-Module "$PSScriptRoot\..\..\..\..\..\..\tests\Test-Helpers.psm1" -Force
 
 Write-Host "Test: Create a test feature first" -ForegroundColor Yellow
 $createResponse = Send-McpRequest -Process $Process -Request @{

--- a/workflows/default/systems/mcp/tools/task-mark-in-progress/test.ps1
+++ b/workflows/default/systems/mcp/tools/task-mark-in-progress/test.ps1
@@ -5,26 +5,7 @@ param(
 )
 
 . "$PSScriptRoot\..\..\dotbot-mcp-helpers.ps1"
-
-function Send-McpRequest {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Request,
-        [Parameter(Mandatory)]
-        [System.Diagnostics.Process]$Process
-    )
-    
-    $json = $Request | ConvertTo-Json -Depth 10 -Compress
-    $Process.StandardInput.WriteLine($json)
-    $Process.StandardInput.Flush()
-    Start-Sleep -Milliseconds 100
-    $response = $Process.StandardOutput.ReadLine()
-    
-    if ($response) {
-        return $response | ConvertFrom-Json
-    }
-    return $null
-}
+Import-Module "$PSScriptRoot\..\..\..\..\..\..\tests\Test-Helpers.psm1" -Force
 
 # First get a feature to mark
 Write-Host "Test: Get next feature first" -ForegroundColor Yellow

--- a/workflows/default/systems/mcp/tools/task-mark-todo/test.ps1
+++ b/workflows/default/systems/mcp/tools/task-mark-todo/test.ps1
@@ -5,26 +5,7 @@ param(
 )
 
 . "$PSScriptRoot\..\..\dotbot-mcp-helpers.ps1"
-
-function Send-McpRequest {
-    param(
-        [Parameter(Mandatory)]
-        [object]$Request,
-        [Parameter(Mandatory)]
-        [System.Diagnostics.Process]$Process
-    )
-    
-    $json = $Request | ConvertTo-Json -Depth 10 -Compress
-    $Process.StandardInput.WriteLine($json)
-    $Process.StandardInput.Flush()
-    Start-Sleep -Milliseconds 100
-    $response = $Process.StandardOutput.ReadLine()
-    
-    if ($response) {
-        return $response | ConvertFrom-Json
-    }
-    return $null
-}
+Import-Module "$PSScriptRoot\..\..\..\..\..\..\tests\Test-Helpers.psm1" -Force
 
 Write-Host "Test: Create a test feature first" -ForegroundColor Yellow
 $createResponse = Send-McpRequest -Process $Process -Request @{

--- a/workflows/default/systems/runtime/modules/WorktreeManager.psm1
+++ b/workflows/default/systems/runtime/modules/WorktreeManager.psm1
@@ -23,6 +23,8 @@ Shared infrastructure via directory links (junctions on Windows, symlinks on mac
   .bot/settings/          -> settings defaults
 #>
 
+Import-Module (Join-Path $PSScriptRoot "..\..\mcp\modules\TaskStore.psm1") -Force
+
 # --- Internal State ---
 $script:WorktreeMapPath = $null
 
@@ -246,15 +248,6 @@ function Invoke-WorktreeMapLocked {
             }
         }
     }
-}
-
-function Get-TaskSlug {
-    param([string]$TaskName)
-    $slug = $TaskName.ToLower()
-    $slug = $slug -replace '[^a-z0-9]+', '-'
-    $slug = $slug -replace '^-|-$', ''
-    if ($slug.Length -gt 50) { $slug = $slug.Substring(0, 50) -replace '-$', '' }
-    return $slug
 }
 
 function Stop-WorktreeProcesses {

--- a/workflows/default/systems/ui/modules/ControlAPI.psm1
+++ b/workflows/default/systems/ui/modules/ControlAPI.psm1
@@ -219,7 +219,7 @@ function Set-ControlSignal {
     }
 }
 
-function Send-Whisper {
+function Send-WhisperToInstance {
     param(
         [string]$InstanceType,
         [string]$Message,
@@ -354,6 +354,6 @@ function Get-ActivityTail {
 Export-ModuleMember -Function @(
     'Initialize-ControlAPI',
     'Set-ControlSignal',
-    'Send-Whisper',
+    'Send-WhisperToInstance',
     'Get-ActivityTail'
 )

--- a/workflows/default/systems/ui/modules/StateBuilder.psm1
+++ b/workflows/default/systems/ui/modules/StateBuilder.psm1
@@ -16,6 +16,7 @@ $script:Config = @{
 }
 
 Import-Module (Join-Path $PSScriptRoot "..\..\runtime\modules\ConsoleSequenceSanitizer.psm1")
+Import-Module (Join-Path $PSScriptRoot "..\..\mcp\modules\TaskMutation.psm1") -Force
 
 function Initialize-StateBuilder {
     param(
@@ -26,50 +27,6 @@ function Initialize-StateBuilder {
     $script:Config.BotRoot = $BotRoot
     $script:Config.ControlDir = $ControlDir
     $script:Config.ProcessesDir = $ProcessesDir
-}
-
-function Get-RoadmapOverviewDependencyMap {
-    param(
-        [Parameter(Mandatory)]
-        [string]$BotRoot
-    )
-
-    $overviewPath = Join-Path $BotRoot "workspace\product\roadmap-overview.md"
-    $dependencyMap = @{}
-    if (-not (Test-Path $overviewPath)) {
-        return $dependencyMap
-    }
-
-    foreach ($line in @(Get-Content -Path $overviewPath -ErrorAction SilentlyContinue)) {
-        if ($line -notmatch '^\|\s*\d+\s*\|') {
-            continue
-        }
-
-        $cells = ($line.Trim().Trim('|') -split '\s*\|\s*')
-        if ($cells.Count -lt 5) {
-            continue
-        }
-
-        $methodologyMatch = [regex]::Match($cells[2], '`([^`]+)`')
-        if (-not $methodologyMatch.Success) {
-            continue
-        }
-
-        $methodologyKey = $methodologyMatch.Groups[1].Value.Trim().ToLower()
-        if (-not $methodologyKey) {
-            continue
-        }
-
-        $dependencyText = $cells[3].Trim()
-        if (-not $dependencyText -or $dependencyText -match '^(none|n/a)$') {
-            $dependencyMap[$methodologyKey] = @()
-            continue
-        }
-
-        $dependencyMap[$methodologyKey] = @($dependencyText)
-    }
-
-    return $dependencyMap
 }
 
 function Get-RoadmapTaskDependencies {
@@ -125,7 +82,7 @@ function Get-BotState {
 
     # Build fresh state
     $tasksDir = Join-Path $botRoot "workspace\tasks"
-    $roadmapDependencyMap = Get-RoadmapOverviewDependencyMap -BotRoot $botRoot
+    $roadmapDependencyMap = Get-RoadmapOverviewDependencyMap -TasksBaseDir $tasksDir
 
     # Count tasks (including new analysis statuses)
     $todoTasks = @(Get-ChildItem -Path (Join-Path $tasksDir "todo") -Filter "*.json" -ErrorAction SilentlyContinue)

--- a/workflows/default/systems/ui/modules/TaskAPI.psm1
+++ b/workflows/default/systems/ui/modules/TaskAPI.psm1
@@ -148,34 +148,6 @@ function ConvertTo-TaskApiValue {
     return $Value
 }
 
-function Get-TodoTaskRecord {
-    param(
-        [Parameter(Mandatory)] [string]$TaskId
-    )
-
-    $todoDir = Join-Path (Get-TasksBaseDir) "todo"
-    if (-not (Test-Path $todoDir)) {
-        return $null
-    }
-
-    foreach ($file in @(Get-ChildItem -Path $todoDir -Filter "*.json" -File -ErrorAction SilentlyContinue)) {
-        try {
-            $task = Get-Content -Path $file.FullName -Raw | ConvertFrom-Json
-            if ($task.id -eq $TaskId) {
-                return @{
-                    task = $task
-                    path = $file.FullName
-                    name = $file.Name
-                }
-            }
-        } catch {
-            # Ignore malformed files while scanning
-        }
-    }
-
-    return $null
-}
-
 function Get-DeletedArchiveVersions {
     param(
         [string]$TaskId

--- a/workflows/default/systems/ui/server.ps1
+++ b/workflows/default/systems/ui/server.ps1
@@ -1173,7 +1173,7 @@ $docContext
                             $reader = New-Object System.IO.StreamReader($request.InputStream)
                             $body = $reader.ReadToEnd() | ConvertFrom-Json
                             $reader.Close()
-                            $result = Send-Whisper -InstanceType $body.instance_type -Message $body.message -Priority $(if ($body.priority) { $body.priority } else { "normal" })
+                            $result = Send-WhisperToInstance -InstanceType $body.instance_type -Message $body.message -Priority $(if ($body.priority) { $body.priority } else { "normal" })
                             $content = $result | ConvertTo-Json -Compress
                         } catch {
                             $statusCode = 500


### PR DESCRIPTION
Closes #123

## Summary

- **`Send-McpRequest`** — removed 15 embedded copies from MCP tool `test.ps1` files and `README-NEWTOOL.md` template; each now imports `Test-Helpers.psm1` with unified parameter order `($Process, $Request)`
- **`Write-Status`** — removed from `Platform-Functions.psm1` (no `-Type` param). `DotBotTheme.psm1` is the single source of truth. All scripts now explicitly import it
- **`Send-Whisper`** — renamed to `Send-WhisperToSession` (steering.ps1) and `Send-WhisperToInstance` (ControlAPI.psm1) to disambiguate targeting
- **Task helpers** (`Get-TasksBaseDir`, `Get-TodoDirectories`, `Ensure-TodoDirectories`, `Get-TodoTaskRecord`) — consolidated into `TaskStore.psm1`. Duplicates removed from `TaskMutation.psm1` and `TaskAPI.psm1`
- **`Get-RoadmapOverviewDependencyMap`** — removed proxy function from `StateBuilder.psm1`; calls canonical version in `TaskMutation.psm1` directly
- **`Get-TaskSlug`** — consolidated into `TaskStore.psm1` using the stronger WorktreeManager algorithm (lowercase, collapse non-alphanumerics, trim edge dashes, 50-char cap)
- Dropped unnecessary `-Global` from module imports in TaskMutation, StateBuilder, and WorktreeManager

## Test plan

- [x] Layers 1–3 pass on all platforms (Windows, macOS, Linux)
- [x] `Write-Status -Type Info` works everywhere (no shadowing)
- [x] UI dashboard loads correctly (Overview tab renders, `/api/state` 200)
- [x] Regression tests in `Test-TaskActions.ps1` verify canonical exports and duplicate removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)