### PR TITLE
ui: remove global analyze-execute controls (#103)

### DIFF
--- a/workflows/default/systems/ui/static/index.html
+++ b/workflows/default/systems/ui/static/index.html
@@ -94,18 +94,6 @@
                             <div class="control-buttons" id="controls">
                                 <!-- Dynamic workflow controls (populated by JS when workflows are installed) -->
                                 <div id="workflow-controls-container"></div>
-                                <!-- Execute Tasks: launches workflow process to execute pending tasks -->
-                                <div class="process-control-row" id="generic-workflow-control">
-                                    <div class="process-control-header">
-                                        <span class="led off" id="workflow-loop-led"></span>
-                                        <span class="process-control-label">Execute Tasks</span>
-                                    </div>
-                                    <div class="process-control-actions">
-                                        <button class="ctrl-btn-xs primary" data-action="start-workflow" title="Execute pending tasks (todo/analysed)">Start</button>
-                                        <button class="ctrl-btn-xs" data-action="stop-workflow" title="Graceful stop: finish current task then end" disabled>Stop</button>
-                                        <button class="ctrl-btn-xs danger" data-action="kill-workflow" title="Immediate: terminate process via PID" disabled>Kill</button>
-                                    </div>
-                                </div>
                             </div>
                             <div class="signal-feedback" id="signal-status"></div>
                         </div>

--- a/workflows/default/systems/ui/static/modules/controls.js
+++ b/workflows/default/systems/ui/static/modules/controls.js
@@ -551,15 +551,6 @@ function initControlButtons() {
         if (!action) return;
 
         switch (action) {
-            case 'start-workflow':
-                await launchWorkflow();
-                break;
-            case 'stop-workflow':
-                await stopProcessesByType('task-runner');
-                break;
-            case 'kill-workflow':
-                await killProcessesByType('task-runner');
-                break;
             // Legacy actions kept for backward compat
             case 'start-analysis':
                 await launchProcessFromOverview('analysis');
@@ -645,7 +636,7 @@ async function launchProcessFromOverview(type) {
 
 /**
  * Render per-workflow control rows from installed workflows data.
- * The generic workflow control row is hidden; per-workflow controls replace it.
+ * Per-workflow controls are the sole entry point for running workflows.
  * @param {Array} workflows - Array of workflow objects from /api/workflows/installed
  */
 function renderWorkflowControls(workflows) {
@@ -822,34 +813,6 @@ function updateWorkflowControlStates(workflowsState) {
         if (runBtn) runBtn.disabled = isAlive;
         if (stopBtn) stopBtn.disabled = !isAlive;
     });
-}
-
-/**
- * Launch a unified workflow process (analyse then execute per task)
- */
-async function launchWorkflow() {
-    try {
-        const response = await fetch(`${API_BASE}/api/process/launch`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ type: 'task-runner', continue: true })
-        });
-
-        const data = await response.json();
-
-        if (data.success) {
-            showSignalFeedback(`Launched workflow: ${data.process_id}`);
-            showToast('Workflow process launched', 'success');
-        } else {
-            showSignalFeedback(`Error: ${data.error || 'Launch failed'}`);
-        }
-
-        await pollState();
-
-    } catch (error) {
-        console.error('Launch workflow error:', error);
-        showSignalFeedback(`Error: ${error.message}`);
-    }
 }
 
 /**

--- a/workflows/default/systems/ui/static/modules/ui-updates.js
+++ b/workflows/default/systems/ui/static/modules/ui-updates.js
@@ -219,8 +219,6 @@ function updateRunningStatus(session, control, analysis, loops) {
     const agentState = document.getElementById('agent-state');
 
     // Update loop status LEDs
-    const workflowLed = document.getElementById('workflow-loop-led');
-    const workflowActive = loops?.workflow_alive ?? false;
     // Legacy LEDs (kept for backward compat if old HTML is cached)
     const analysisLed = document.getElementById('analysis-loop-led');
     const executionLed = document.getElementById('execution-loop-led');
@@ -228,10 +226,6 @@ function updateRunningStatus(session, control, analysis, loops) {
     // Use loops.analysis_alive if available (PID-validated), fall back to signal file check
     const analysisActive = loops?.analysis_alive ?? analysis?.running;
     const executionActive = loops?.execution_alive ?? control?.running;
-
-    if (workflowLed) {
-        workflowLed.className = workflowActive ? 'led pulse' : 'led off';
-    }
 
     if (analysisLed) {
         analysisLed.className = analysisActive ? 'led pulse' : 'led off';
@@ -616,10 +610,6 @@ function updateControlButtonStates(session, control, loops) {
     const anyAlive = loops?.any_alive ?? false;
 
     const btnMap = [
-        // Unified workflow controls
-        { action: 'start-workflow', enabled: !workflowAlive && !analysisAlive && !executionAlive },
-        { action: 'stop-workflow', enabled: workflowAlive },
-        { action: 'kill-workflow', enabled: workflowAlive },
         // Legacy controls (kept for backward compat)
         { action: 'start-analysis', enabled: !analysisAlive && !workflowAlive },
         { action: 'stop-analysis', enabled: analysisAlive },


### PR DESCRIPTION
## Summary

Closes #103

The Overview tab's control panel was showing both the legacy global **Execute Tasks** row (Start / Stop / Kill) **and** the per-workflow Run/Stop rows at the same time. The global row predates named workflows and is redundant — the **Resume** button in the right-side workflow panel already covers the same functionality in a workflow-scoped way.

This PR deletes the global row and all dead code tied to it, leaving per-workflow controls as the sole entry point.

## Why the global row is redundant

The removed global **Start** button and the per-workflow **Resume** button hit the exact same backend endpoint with the same `continue: true` flag — the only difference is scope:

| Button | Endpoint | Body |
|---|---|---|
| Global **Start** (removed) | `POST /api/process/launch` | `{ type: 'task-runner', continue: true }` |
| **Resume** (per workflow) | `POST /api/process/launch` | `{ type: 'task-runner', continue: true, workflow_name: <name> }` |

Without `workflow_name` the task-runner just continued whichever pending tasks it found first, which is exactly the ambiguity #103 flags. **Resume** is the workflow-scoped replacement and is already wired up.

The per-workflow **Run** button is a separate code path (`POST /api/workflows/{name}/run`) that creates new tasks from the workflow definition — not affected by this change.

## Changes

- **`workflows/default/systems/ui/static/index.html`** — remove the `#generic-workflow-control` block (Start/Stop/Kill buttons + `#workflow-loop-led`). `#workflow-controls-container` above it stays; per-workflow rows are injected there.
- **`workflows/default/systems/ui/static/modules/controls.js`**
  - Drop the `start-workflow` / `stop-workflow` / `kill-workflow` cases from the control click handler.
  - Remove the now-orphaned `launchWorkflow()` function (grep confirmed no other callers).
  - Update the `renderWorkflowControls()` jsdoc — the old comment referenced the generic row which no longer exists.
- **`workflows/default/systems/ui/static/modules/ui-updates.js`**
  - Remove `#workflow-loop-led` lookup and class updates from `updateRunningStatus()`.
  - Remove the three workflow entries from the `btnMap` in `updateControlButtonStates()`.
  - Keep `workflowAlive` — the legacy analysis/execution/both entries still use it to disable themselves when a task-runner workflow is running.

Repo-wide grep after the change: zero remaining references to `generic-workflow-control`, `workflow-loop-led`, `launchWorkflow`, or the three `*-workflow` action names.

## Test plan

- [ ] `pwsh install.ps1` (succeeds locally)
- [ ] `pwsh tests/Run-Tests.ps1` — layers 1–3 pass
- [ ] `.bot\go.ps1` — open the Overview tab
  - [ ] Global **Execute Tasks** row is gone
  - [ ] Installed workflows still render a Run/Stop row each
  - [ ] Click **Run** on a named workflow → task-runner process launches, LED pulses, **Stop** works
  - [ ] Click **Resume** on a workflow with pending tasks → task-runner resumes the workflow's pending tasks (the behavior the global Start button used to offer, just scoped)
  - [ ] DevTools console: no `ReferenceError`, no missing-element warnings
- [ ] Hard refresh to bypass cached HTML — removed row does not reappear