### PR TITLE
fix(ui): empty checkbox row in Kickstart from scratch modal (#275)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ Thumbs.db
 # Claude Code
 .claude/agents/
 .claude/settings.local.json
+.claude/worktrees/
 .claude/skills/*
 !.claude/skills/dotbot-code-review/
 !.claude/skills/design-system/

--- a/workflows/default/systems/ui/static/index.html
+++ b/workflows/default/systems/ui/static/index.html
@@ -1500,9 +1500,9 @@
                         <div class="form-option">
                             <label class="form-checkbox-label">
                                 <input type="checkbox" id="kickstart-interview" checked>
-                                <span class="form-checkbox-text" id="kickstart-interview-label">Interview me to clarify requirements</span>
+                                <span class="form-checkbox-text" id="kickstart-interview-label" data-default="Interview me to clarify requirements"></span>
                             </label>
-                            <div class="form-option-hint" id="kickstart-interview-hint">Dotbot will ask clarifying questions before creating product documents</div>
+                            <div class="form-option-hint" id="kickstart-interview-hint" data-default="Dotbot will ask clarifying questions before creating product documents"></div>
                         </div>
                         <div class="form-option">
                             <label class="form-checkbox-label">

--- a/workflows/default/systems/ui/static/modules/kickstart.js
+++ b/workflows/default/systems/ui/static/modules/kickstart.js
@@ -3,19 +3,6 @@
  * Handles new project detection and kickstart flow
  */
 
-// Default label and hint for the interview checkbox row.
-// These exist because server.ps1 defaults `show_interview` to `true` whenever
-// a workflow mode does not set it explicitly (e.g. the `has_docs` mode in
-// kickstart-from-scratch/workflow.yaml). When that happens the dialog arrives
-// with `show_interview: true` but no `interview_label` / `interview_hint`,
-// which previously rendered as a blank mystery checkbox
-// (bug-kickstart-from-scratch). These constants are used as fallbacks in the
-// reset phase so the row always carries meaningful text, and match the
-// default wording baked into index.html for #kickstart-interview-label and
-// #kickstart-interview-hint.
-const KICKSTART_DEFAULT_INTERVIEW_LABEL = 'Interview me to clarify requirements';
-const KICKSTART_DEFAULT_INTERVIEW_HINT = 'Dotbot will ask clarifying questions before creating product documents';
-
 // State
 let isNewProject = false;
 let kickstartInProgress = false;
@@ -334,8 +321,12 @@ function applyKickstartDialog(dialog, phases, mode) {
     // Reset dialog-controlled content before applying new values so a workflow
     // that omits a field does not inherit the previous workflow's text (#235).
     if (descEl) descEl.textContent = '';
-    if (labelEl) labelEl.textContent = KICKSTART_DEFAULT_INTERVIEW_LABEL;
-    if (hintEl) hintEl.textContent = KICKSTART_DEFAULT_INTERVIEW_HINT;
+    // Fall back to data-default attributes defined in index.html — the
+    // workflow-configured interview_label/interview_hint can be empty when
+    // the server defaults show_interview to true without supplying text
+    // (e.g. a mode that omits show_interview in its form block).
+    if (labelEl) labelEl.textContent = labelEl.dataset.default || '';
+    if (hintEl) hintEl.textContent = hintEl.dataset.default || '';
     if (promptEl) promptEl.placeholder = '';
 
     // Remove any auto-detect button injected on a previous apply so repeated

--- a/workflows/default/systems/ui/static/modules/kickstart.js
+++ b/workflows/default/systems/ui/static/modules/kickstart.js
@@ -23,6 +23,14 @@ let kickstartSubmitting = false; // in-flight guard against double submit
  * Checks if this is a new project and sets up event handlers
  */
 async function initKickstart() {
+    // Seed elements that carry a data-default with the default text so the
+    // modal never briefly renders with an empty label before the dialog
+    // config arrives. data-default stays the single source of truth (see
+    // #kickstart-interview-label / #kickstart-interview-hint in index.html).
+    document.querySelectorAll('[data-default]').forEach(el => {
+        if (!el.textContent) el.textContent = el.dataset.default;
+    });
+
     try {
         const response = await fetch(`${API_BASE}/api/product/list`);
         if (response.ok) {

--- a/workflows/default/systems/ui/static/modules/kickstart.js
+++ b/workflows/default/systems/ui/static/modules/kickstart.js
@@ -3,6 +3,19 @@
  * Handles new project detection and kickstart flow
  */
 
+// Default label and hint for the interview checkbox row.
+// These exist because server.ps1 defaults `show_interview` to `true` whenever
+// a workflow mode does not set it explicitly (e.g. the `has_docs` mode in
+// kickstart-from-scratch/workflow.yaml). When that happens the dialog arrives
+// with `show_interview: true` but no `interview_label` / `interview_hint`,
+// which previously rendered as a blank mystery checkbox
+// (bug-kickstart-from-scratch). These constants are used as fallbacks in the
+// reset phase so the row always carries meaningful text, and match the
+// default wording baked into index.html for #kickstart-interview-label and
+// #kickstart-interview-hint.
+const KICKSTART_DEFAULT_INTERVIEW_LABEL = 'Interview me to clarify requirements';
+const KICKSTART_DEFAULT_INTERVIEW_HINT = 'Dotbot will ask clarifying questions before creating product documents';
+
 // State
 let isNewProject = false;
 let kickstartInProgress = false;
@@ -321,8 +334,8 @@ function applyKickstartDialog(dialog, phases, mode) {
     // Reset dialog-controlled content before applying new values so a workflow
     // that omits a field does not inherit the previous workflow's text (#235).
     if (descEl) descEl.textContent = '';
-    if (labelEl) labelEl.textContent = '';
-    if (hintEl) hintEl.textContent = '';
+    if (labelEl) labelEl.textContent = KICKSTART_DEFAULT_INTERVIEW_LABEL;
+    if (hintEl) hintEl.textContent = KICKSTART_DEFAULT_INTERVIEW_HINT;
     if (promptEl) promptEl.placeholder = '';
 
     // Remove any auto-detect button injected on a previous apply so repeated


### PR DESCRIPTION
Fixes #275

## Summary

- Fixes the blank, unlabeled interview checkbox that appears at the bottom of the **Kickstart Project** modal when running the `kickstart-from-scratch` workflow in a project that already has `mission.md` (spec: `specs/bug-kickstart-from-scratch.md`).
- **Root cause:** the active form mode (`has_docs` in `kickstart-from-scratch/workflow.yaml`) does not set `show_interview`, so the server defaults it to `true` and returns no `interview_label` / `interview_hint`. The reset phase cleared the DOM label to an empty string, producing a mystery checkbox.
- **Fix:** store the default interview label/hint in `data-default` attributes on `#kickstart-interview-label` / `#kickstart-interview-hint` in `index.html` — the single source of truth. `initKickstart` seeds element `textContent` from `data-default` at page load (so the modal never renders an empty label), and `applyKickstartDialog` falls back to `data-default` when the dialog omits the text. The `show_interview` visibility logic is unchanged — when a workflow explicitly sets `show_interview: false`, the row is still hidden.

## Known limitation (out of scope for this PR)

When the kickstart modal is reopened, the dialog-controlled content (description, interview label/hint, prompt placeholder) briefly shows the previous workflow's text until `/api/workflows/{name}/form` responds and `applyKickstartDialog` repopulates the DOM. This is pre-existing behaviour — the modal is intentionally shown before the fetch completes so the click feels responsive. The modal header title itself is static HTML and is not affected.

## Test plan

- [x] Open the UI in a project with an existing `mission.md` → click **Run** on **Kickstart from scratch** → interview row shows the default label and hint text (no blank checkbox).
- [x] Open the UI in a fresh project (no `mission.md`) → click **Kickstart from scratch** → interview row is hidden (the `new_project` mode has `show_interview: false`).
- [x] `pwsh tests/Run-Tests.ps1 -Layer 2` passes locally.