### PR TITLE
Add README.md for kickstart-via-jira workflow

### DIFF
--- a/workflows/kickstart-via-jira/README.md
+++ b/workflows/kickstart-via-jira/README.md
@@ -72,7 +72,7 @@ claude mcp add sourcebot -s user -- npx -y @sourcebot/mcp@latest
 
 ## Running a kickstart
 
-1. **Product tab** → click **RUN WORKFLOW**
+1. Run the workflow from the Overview tab
 2. Paste a Jira epic key (e.g. `ABC-1234`) into the prompt field
 3. Click **Kickstart**
 

--- a/workflows/kickstart-via-jira/README.md
+++ b/workflows/kickstart-via-jira/README.md
@@ -50,12 +50,18 @@ Edit `.env.local` in the project root:
 claude mcp add atlassian -s user npx -- @anthropic/mcp-atlassian
 ```
 
-### 5. Register Sourcebot (optional)
+### 5. Register Sourcebot
 
-Skip if your org does not run Sourcebot. The workflow degrades gracefully — repo discovery uses briefing docs instead.
+If your org runs a self-hosted Sourcebot instance:
 
 ```powershell
-claude mcp add sourcebot https://YOUR_SOURCEBOT_URL/mcp
+claude mcp add --transport http sourcebot -s user https://YOUR_SOURCEBOT_URL/mcp
+```
+
+Alternatively, use the npm package:
+
+```powershell
+claude mcp add sourcebot -s user -- npx -y @sourcebot/mcp@latest
 ```
 
 ### 6. Launch the web UI

--- a/workflows/kickstart-via-jira/README.md
+++ b/workflows/kickstart-via-jira/README.md
@@ -1,0 +1,126 @@
+# kickstart-via-jira
+
+Research-driven initiative workflow. Fetches Jira/Confluence context, runs multi-source research across internet, Atlassian, and org repositories, synthesises findings, plans implementation across multiple repos, and produces handoff documents and draft PRs.
+
+## Prerequisites
+
+**CLI tools** (must be on PATH):
+- [PowerShell 7+](https://aka.ms/powershell)
+- [git](https://git-scm.com/downloads)
+- [Azure CLI](https://aka.ms/installazurecliwindows) (`az`)
+- [Claude CLI](https://docs.anthropic.com/en/docs/claude-code)
+
+**MCP servers** (register before init):
+- `atlassian` — required for Jira + Confluence access
+- `sourcebot` — optional; only needed if your org runs [Sourcebot](https://sourcebot.dev) for cross-repo code search
+
+## Setup
+
+### 1. Create a project directory
+
+```powershell
+mkdir my-initiative
+cd my-initiative
+git init
+```
+
+### 2. Initialise dotbot with this workflow
+
+```powershell
+dotbot init -Workflow kickstart-via-jira
+```
+
+This creates `.bot/`, scaffolds `.env.local`, registers the dotbot MCP server, and creates a `repos/` directory for cloned repositories.
+
+### 3. Configure environment variables
+
+Edit `.env.local` in the project root:
+
+| Variable | Value | Where to get it |
+|----------|-------|----------------|
+| `ATLASSIAN_EMAIL` | Your Atlassian login email | Your Atlassian account |
+| `ATLASSIAN_API_TOKEN` | API token | [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens) → Create API token |
+| `ATLASSIAN_CLOUD_ID` | Your Jira site URL | Open Jira in browser — copy `https://yourcompany.atlassian.net` |
+| `AZURE_DEVOPS_PAT` | Personal Access Token | `https://dev.azure.com/YOUR_ORG/_usersSettings/tokens` — scopes: Code (Read & Write) + Packaging (Read) |
+| `AZURE_DEVOPS_ORG_URL` | Org URL | `https://dev.azure.com/YOUR_ORG` |
+
+### 4. Register the Atlassian MCP server
+
+```powershell
+claude mcp add atlassian npx @anthropic/mcp-atlassian
+```
+
+### 5. Register Sourcebot (optional)
+
+Skip if your org does not run Sourcebot. The workflow degrades gracefully — repo discovery uses briefing docs instead.
+
+```powershell
+claude mcp add sourcebot https://YOUR_SOURCEBOT_URL/mcp
+```
+
+### 6. Launch the web UI
+
+```powershell
+.bot\go.ps1          # opens http://localhost:8686
+```
+
+## Running a kickstart
+
+1. **Product tab** → click **RUN WORKFLOW**
+2. Paste a Jira epic key (e.g. `ABC-1234`) into the prompt field
+3. Click **Kickstart**
+
+### Finding a Jira key
+
+Open any epic in Jira. The key is shown top-left of the issue and in the URL:
+`https://yourcompany.atlassian.net/browse/ABC-1234` → key is `ABC-1234`
+
+Use a parent epic, not a subtask. The workflow fetches the epic and all its children automatically.
+
+### Clarifying questions
+
+At certain phases, the workflow may pause and show an **◈ Action Required** widget (bottom-right of UI). Answer the questions and the workflow resumes automatically.
+
+## Pipeline phases
+
+| # | Phase | What happens | External writes? |
+|---|-------|-------------|-----------------|
+| 0 | Fetch Jira Context | Reads Jira issue, child issues, Confluence pages | No |
+| 0.5 | Generate Product Documents | Writes `mission.md`, `roadmap-overview.md` locally | No |
+| 1a | Plan Internet Research | Creates internet research task | No |
+| 1b | Plan Atlassian Research | Creates Atlassian research task | No |
+| 1c | Plan Sourcebot Research | Creates Sourcebot research task (skipped if no Sourcebot) | No |
+| — | Execute Research | Waits for all research tasks to complete | No |
+| 2a | Create Deep-Dive Tasks | Creates one per-repo analysis task per affected repo | No |
+| — | Execute Deep Dives | Waits for all deep-dive tasks to complete | No |
+| 3 | Synthesise Research | Merges all research into a summary locally | No |
+| 3b | Publish to Jira | Creates child Jira issue, posts research as comments | **Yes** |
+| 4 | Research Repositories | Synthesises deep dives into implementation guide locally | No |
+| 5 | Refine Dependencies | Writes cross-repo dependency map locally | No |
+| 6 | Generate Implementation Plans | Writes per-repo code-level plans locally | No |
+| 7 | Create Implementation Tasks | Creates per-repo implementation tasks locally | No |
+| — | Execute Implementation | Waits for all implementation tasks to complete | No |
+| 9 | Remediate Builds | Fixes build/test failures in local cloned repos | No |
+| 10 | Draft Handoff & PRs | Pushes branches, creates draft PRs in Azure DevOps | **Yes** |
+
+Phases with **Yes** are visible to your team. All others are local-only — safe to run freely.
+
+## Outputs
+
+All outputs land in `.bot/workspace/product/`:
+
+| File | Created by |
+|------|-----------|
+| `briefing/jira-context.md` | Fetch Jira Context |
+| `mission.md` | Generate Product Documents |
+| `roadmap-overview.md` | Generate Product Documents |
+| `research-internet.md` | Internet research task |
+| `research-documents.md` | Atlassian research task |
+| `research-repos.md` | Sourcebot research task (or seeded from briefing) |
+| `research-summary.md` | Synthesise Research |
+| `briefing/04_IMPLEMENTATION_RESEARCH.md` | Research Repositories |
+| `briefing/05_DEPENDENCY_MAP.md` | Refine Dependencies |
+| `repos/{RepoName}/.bot/workspace/product/{RepoName}_Plan.md` | Generate Implementation Plans |
+| `repos/{RepoName}/.bot/workspace/product/{RepoName}_Outcomes.md` | Execute Implementation |
+| `repos/{RepoName}/.bot/workspace/product/{RepoName}_Remediation.md` | Remediate Builds |
+| `repos/{RepoName}/.bot/workspace/product/{RepoName}-handoff.md` | Draft Handoff & PRs |

--- a/workflows/kickstart-via-jira/README.md
+++ b/workflows/kickstart-via-jira/README.md
@@ -47,7 +47,7 @@ Edit `.env.local` in the project root:
 ### 4. Register the Atlassian MCP server
 
 ```powershell
-claude mcp add atlassian npx @anthropic/mcp-atlassian
+claude mcp add atlassian -s user npx -- @anthropic/mcp-atlassian
 ```
 
 ### 5. Register Sourcebot (optional)

--- a/workflows/kickstart-via-jira/README.md
+++ b/workflows/kickstart-via-jira/README.md
@@ -12,7 +12,7 @@ Research-driven initiative workflow. Fetches Jira/Confluence context, runs multi
 
 **MCP servers** (register before init):
 - `atlassian` — required for Jira + Confluence access
-- `sourcebot` — optional; only needed if your org runs [Sourcebot](https://sourcebot.dev) for cross-repo code search
+- `sourcebot` — required by this workflow's preflight checks in the UI; used for cross-repo code search if your org runs [Sourcebot](https://sourcebot.dev)
 
 ## Setup
 
@@ -90,16 +90,16 @@ At certain phases, the workflow may pause and show an **◈ Action Required** wi
 | 1a | Plan Internet Research | Creates internet research task | No |
 | 1b | Plan Atlassian Research | Creates Atlassian research task | No |
 | 1c | Plan Sourcebot Research | Creates Sourcebot research task (skipped if no Sourcebot) | No |
-| — | Execute Research | Waits for all research tasks to complete | No |
+| — | Execute Research | Barrier — sync point between research task creation and deep-dive planning | No |
 | 2a | Create Deep-Dive Tasks | Creates one per-repo analysis task per affected repo | No |
-| — | Execute Deep Dives | Waits for all deep-dive tasks to complete | No |
+| — | Execute Deep Dives | Barrier — sync point between deep-dive task creation and research synthesis | No |
 | 3 | Synthesise Research | Merges all research into a summary locally | No |
 | 3b | Publish to Jira | Creates child Jira issue, posts research as comments | **Yes** |
 | 4 | Research Repositories | Synthesises deep dives into implementation guide locally | No |
 | 5 | Refine Dependencies | Writes cross-repo dependency map locally | No |
 | 6 | Generate Implementation Plans | Writes per-repo code-level plans locally | No |
 | 7 | Create Implementation Tasks | Creates per-repo implementation tasks locally | No |
-| — | Execute Implementation | Waits for all implementation tasks to complete | No |
+| — | Execute Implementation | Barrier — sync point between implementation task creation and remediation | No |
 | 9 | Remediate Builds | Fixes build/test failures in local cloned repos | No |
 | 10 | Draft Handoff & PRs | Pushes branches, creates draft PRs in Azure DevOps | **Yes** |
 
@@ -107,7 +107,7 @@ Phases with **Yes** are visible to your team. All others are local-only — safe
 
 ## Outputs
 
-All outputs land in `.bot/workspace/product/`:
+Initiative-level outputs land in `.bot/workspace/product/`. Per-repo outputs land inside each cloned repository under `repos/{RepoName}/.bot/workspace/product/`.
 
 | File | Created by |
 |------|-----------|


### PR DESCRIPTION
## Linked issue

Closes #278

## Summary of changes

Adds `workflows/kickstart-via-jira/README.md` — a setup and usage guide for the kickstart-via-jira workflow. Covers prerequisites, environment variables, MCP server registration, launching the UI, running a kickstart, pipeline phases with external-write visibility, and output file locations.

No behaviour changed — docs only.

## Testing notes

1. Follow the setup steps in the README against a real Jira epic
2. Verify all commands are copy-pasteable and produce expected results
3. Confirm phase names match the Workflows tab in the UI
4. Confirm output file paths match what the workflow actually produces

## Checklist

- [ ] Tests added or updated
- [x] Docs updated (if behaviour changed)
- [ ] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
