### PR TITLE
Added Karpathy-inspired Claude Code behavioral guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,3 +147,69 @@ These files are exempt from the output hygiene test because they define the them
 - Runtime state lives in `.bot/.control/` (gitignored) and `.bot/workspace/` (version-controlled)
 - Settings merge: `.bot/settings/settings.default.json` (checked in) + `.bot/.control/settings.json` (user overrides)
 - The steering protocol (`steering-heartbeat`) allows operator "whisper" interrupts during autonomous execution
+
+## Karpathy's Guidelines
+
+Behavioural guidelines to reduce common LLM coding mistakes.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.


### PR DESCRIPTION
## What this does
Adds Karpathy-inspired behavioral guidelines to CLAUDE.md to improve Claude Code's reasoning discipline when operating inside dotbot's autonomous workflow.

## Why
Without behavioral guardrails, Claude Code inside dotbot might:
- Make wrong assumptions silently rather than surfacing ambiguity
- Overcomplicate generated tools and scripts
- Touch code adjacent to the task as side effects
- Use weak success criteria that can't drive autonomous verification loops

## Source
Derived from Andrej Karpathy's observations on LLM coding pitfalls.
Implemented by: https://github.com/multica-ai/andrej-karpathy-skills

## Linked issue

-- PR does not have a linked issue and falls under the category of trivial.

## Summary of changes

--Only appended text to existing CLAUDE.md

## Testing notes
Not yet verified in a live dotbot session. Submitting for maintainer 
review and feedback. Happy to run specific scenarios if the maintainer 
can suggest a reference task to test against.