### PR TITLE
fix:mcp tool invocation fails on Turkish Windows locale — culture-dep…

### DIFF
--- a/tests/Test-Structure.ps1
+++ b/tests/Test-Structure.ps1
@@ -1251,6 +1251,68 @@ if ($themeViolations.Count -eq 0) {
 Write-Host ""
 
 # ═══════════════════════════════════════════════════════════════════
+# CULTURE-INVARIANT CASING HYGIENE
+# ═══════════════════════════════════════════════════════════════════
+
+Write-Host "  CULTURE-INVARIANT CASING HYGIENE" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+# Scans workflows/ for bare .ToLower() / .ToUpper() calls. Culture-dependent
+# casing breaks on Turkish/Azerbaijani locales where "i".ToUpper() returns "İ"
+# (U+0130) instead of "I", causing MCP function dispatch to fail and slug
+# filenames to contain non-ASCII characters. See issue #280.
+#
+# Use .ToLowerInvariant() / .ToUpperInvariant() for identifiers, slugs,
+# filenames, dispatcher lookups, and any ASCII key matching. Exempt files
+# are those that legitimately display user-provided text, where locale
+# casing is arguably correct.
+
+$workflowsDir = Join-Path $repoRoot "workflows"
+$invariantTargetFiles = @()
+if (Test-Path $workflowsDir) {
+    $invariantTargetFiles += @(Get-ChildItem -Path $workflowsDir -Recurse -Include "*.ps1", "*.psm1" -File)
+}
+
+# Exempt: files that format user-provided display text where locale casing
+# is arguably correct (not identifiers, not persisted to disk, not dispatched).
+$invariantExemptPaths = @(
+    'DotBotTheme.psm1'  # Write-Header letter-spacing formatter; takes user titles
+)
+
+$invariantForbiddenPatterns = @(
+    @{ Pattern = '\.ToLower\(\)';  Name = '.ToLower()';  Fix = '.ToLowerInvariant()' }
+    @{ Pattern = '\.ToUpper\(\)';  Name = '.ToUpper()';  Fix = '.ToUpperInvariant()' }
+)
+
+$invariantViolations = @()
+foreach ($file in $invariantTargetFiles) {
+    if ($file.Name -in $invariantExemptPaths) { continue }
+
+    $lines = Get-Content $file.FullName
+    for ($lineNum = 0; $lineNum -lt $lines.Count; $lineNum++) {
+        $line = $lines[$lineNum]
+        if ($line.TrimStart() -match '^\s*#') { continue }
+        foreach ($fp in $invariantForbiddenPatterns) {
+            if ($line -match $fp.Pattern) {
+                $relPath = $file.FullName.Substring($repoRoot.Length + 1)
+                $invariantViolations += "${relPath}:$($lineNum + 1) uses $($fp.Name) — use $($fp.Fix)"
+            }
+        }
+    }
+}
+
+if ($invariantViolations.Count -eq 0) {
+    Write-TestResult -Name "No bare .ToLower()/.ToUpper() in workflows/ (locale-safe dispatch/slugs)" -Status Pass
+} else {
+    $sample = ($invariantViolations | Select-Object -First 15) -join "`n  "
+    $extra = if ($invariantViolations.Count -gt 15) { "`n  ... and $($invariantViolations.Count - 15) more" } else { "" }
+    Write-TestResult -Name "No bare .ToLower()/.ToUpper() in workflows/ (locale-safe dispatch/slugs)" -Status Fail `
+        -Message "Found $($invariantViolations.Count) violation(s). Use .ToLowerInvariant()/.ToUpperInvariant() for identifiers, slugs, and dispatch lookups. See issue #280.`n  $sample$extra"
+}
+
+Write-Host ""
+
+# ═══════════════════════════════════════════════════════════════════
 # FRAMEWORK FILE PROTECTION
 # ═══════════════════════════════════════════════════════════════════
 

--- a/workflows/default/systems/mcp/dotbot-mcp.ps1
+++ b/workflows/default/systems/mcp/dotbot-mcp.ps1
@@ -215,9 +215,10 @@ function Invoke-CallTool {
     
     try {
         # Convert tool name to function name: get_current_datetime -> Invoke-GetCurrentDateTime
+        # ToUpperInvariant ensures Turkish/Azerbaijani locales don't fold "i" -> "İ".
         $parts = $Name -split '_'
         $capitalizedParts = foreach ($part in $parts) {
-            $part.Substring(0,1).ToUpper() + $part.Substring(1)
+            $part.Substring(0,1).ToUpperInvariant() + $part.Substring(1)
         }
         $functionName = 'Invoke-' + ($capitalizedParts -join '')
         

--- a/workflows/default/systems/mcp/modules/NotificationClient.psm1
+++ b/workflows/default/systems/mcp/modules/NotificationClient.psm1
@@ -195,7 +195,7 @@ function Send-ServerNotification {
         }
     }
     if (-not $projectId) {
-        $projectId = ($projectName.ToLower() -replace '[^a-z0-9]+', '-').Trim('-')
+        $projectId = ($projectName.ToLowerInvariant() -replace '[^a-z0-9]+', '-').Trim('-')
     }
 
     # Deterministic UUIDv5-style GUID from composite key for idempotent retries
@@ -449,7 +449,7 @@ function Get-TaskNotificationResponse {
         }
         if (-not $projectId) {
             $projectName = if ($Settings.project_name) { $Settings.project_name } else { "dotbot" }
-            $projectId = ($projectName.ToLower() -replace '[^a-z0-9]+', '-').Trim('-')
+            $projectId = ($projectName.ToLowerInvariant() -replace '[^a-z0-9]+', '-').Trim('-')
         }
     }
 

--- a/workflows/default/systems/mcp/modules/PathSanitizer.psm1
+++ b/workflows/default/systems/mcp/modules/PathSanitizer.psm1
@@ -59,7 +59,7 @@ function Remove-AbsolutePaths {
 
         # Git-bash style lowercase drive letter (e.g. /c/Users/... from C:\Users\...)
         if ($ProjectRoot -match '^([A-Za-z]):\\') {
-            $driveLetter = $Matches[1].ToLower()
+            $driveLetter = $Matches[1].ToLowerInvariant()
             $gitBashPath = '/' + $driveLetter + ($ProjectRoot.Substring(2) -replace '\\', '/')
             $Text = $Text -replace [regex]::Escape($gitBashPath), '.'
         }

--- a/workflows/default/systems/mcp/modules/TaskIndexCache.psm1
+++ b/workflows/default/systems/mcp/modules/TaskIndexCache.psm1
@@ -68,7 +68,7 @@ function Add-IgnoreReferenceAlias {
         return
     }
 
-    $normalizedAlias = "$Alias".Trim().ToLower()
+    $normalizedAlias = "$Alias".Trim().ToLowerInvariant()
     if (-not $normalizedAlias) {
         return
     }
@@ -101,7 +101,7 @@ function Get-IgnoreDependencyTokens {
             return
         }
 
-        $normalizedValue = $Value.Trim().ToLower()
+        $normalizedValue = $Value.Trim().ToLowerInvariant()
         if ($normalizedValue -and -not $tokens.Contains($normalizedValue)) {
             $null = $tokens.Add($normalizedValue)
         }
@@ -161,7 +161,7 @@ function Get-IgnoreRoadmapDependencyMap {
             continue
         }
 
-        $methodologyKey = $methodologyMatch.Groups[1].Value.Trim().ToLower()
+        $methodologyKey = $methodologyMatch.Groups[1].Value.Trim().ToLowerInvariant()
         if (-not $methodologyKey) {
             continue
         }
@@ -191,7 +191,7 @@ function Get-ResolvedIgnoreDependencies {
         return $explicitDependencies
     }
 
-    $researchPrompt = "$($Task.research_prompt)".Trim().ToLower()
+    $researchPrompt = "$($Task.research_prompt)".Trim().ToLowerInvariant()
     if ($researchPrompt -and $RoadmapDependencyMap.ContainsKey($researchPrompt)) {
         return @($RoadmapDependencyMap[$researchPrompt])
     }
@@ -245,7 +245,7 @@ function Get-TaskIgnoreLookup {
         $position += 1
         Add-IgnoreReferenceAlias -ReferenceMap $references -TaskId $task.id -Alias $task.id
         Add-IgnoreReferenceAlias -ReferenceMap $references -TaskId $task.id -Alias $task.name
-        $slug = (($task.name -replace '[^a-zA-Z0-9\s-]', '' -replace '\s+', '-').ToLower())
+        $slug = (($task.name -replace '[^a-zA-Z0-9\s-]', '' -replace '\s+', '-').ToLowerInvariant())
         if ($slug) {
             Add-IgnoreReferenceAlias -ReferenceMap $references -TaskId $task.id -Alias $slug
         }
@@ -448,7 +448,7 @@ function Update-TaskIndex {
                         $script:TaskIndex.DoneIds += $content.id
                         $script:TaskIndex.DoneNames += $content.name
                         # Also store slug version of name for dependency matching
-                        $slug = ($content.name -replace '[^a-zA-Z0-9\s-]', '' -replace '\s+', '-').ToLower()
+                        $slug = ($content.name -replace '[^a-zA-Z0-9\s-]', '' -replace '\s+', '-').ToLowerInvariant()
                         $script:TaskIndex.DoneSlugs += $slug
                     }
                     'split' {
@@ -456,7 +456,7 @@ function Update-TaskIndex {
                         # Split tasks satisfy dependencies — work delegated to sub-tasks
                         $script:TaskIndex.DoneIds += $content.id
                         $script:TaskIndex.DoneNames += $content.name
-                        $slug = ($content.name -replace '[^a-zA-Z0-9\s-]', '' -replace '\s+', '-').ToLower()
+                        $slug = ($content.name -replace '[^a-zA-Z0-9\s-]', '' -replace '\s+', '-').ToLowerInvariant()
                         $script:TaskIndex.DoneSlugs += $slug
                     }
                     'skipped' { $script:TaskIndex.Skipped[$content.id] = $entry }
@@ -687,7 +687,7 @@ function Test-DependencyMet {
         [array]$DoneIds
     )
     
-    $depLower = $Dependency.ToLower()
+    $depLower = $Dependency.ToLowerInvariant()
     
     # Exact match on ID
     if ($Dependency -in $DoneIds) { return $true }
@@ -801,7 +801,7 @@ function Get-DeadlockedTasks {
     foreach ($t in $index.Skipped.Values) {
         $skippedLookup.Add($t.id)   | Out-Null
         $skippedLookup.Add($t.name) | Out-Null
-        $slug = ($t.name -replace '[^a-zA-Z0-9\s-]', '' -replace '\s+', '-').ToLower()
+        $slug = ($t.name -replace '[^a-zA-Z0-9\s-]', '' -replace '\s+', '-').ToLowerInvariant()
         $skippedLookup.Add($slug)   | Out-Null
         $skippedNameMap[$t.id]   = $t.name
         $skippedNameMap[$t.name] = $t.name

--- a/workflows/default/systems/mcp/modules/TaskMutation.psm1
+++ b/workflows/default/systems/mcp/modules/TaskMutation.psm1
@@ -136,7 +136,7 @@ function Add-TaskReferenceAlias {
         return
     }
 
-    $normalizedAlias = "$Alias".Trim().ToLower()
+    $normalizedAlias = "$Alias".Trim().ToLowerInvariant()
     if (-not $normalizedAlias) {
         return
     }
@@ -169,7 +169,7 @@ function Get-TaskDependencyReferenceTokens {
             return
         }
 
-        $normalizedValue = $Value.Trim().ToLower()
+        $normalizedValue = $Value.Trim().ToLowerInvariant()
         if ($normalizedValue -and -not $tokens.Contains($normalizedValue)) {
             $null = $tokens.Add($normalizedValue)
         }
@@ -230,7 +230,7 @@ function Get-RoadmapOverviewDependencyMap {
             continue
         }
 
-        $methodologyKey = $methodologyMatch.Groups[1].Value.Trim().ToLower()
+        $methodologyKey = $methodologyMatch.Groups[1].Value.Trim().ToLowerInvariant()
         if (-not $methodologyKey) {
             continue
         }
@@ -260,7 +260,7 @@ function Get-ResolvedTaskDependencies {
         return $explicitDependencies
     }
 
-    $researchPrompt = "$($Task.research_prompt)".Trim().ToLower()
+    $researchPrompt = "$($Task.research_prompt)".Trim().ToLowerInvariant()
     if ($researchPrompt -and $RoadmapDependencyMap.ContainsKey($researchPrompt)) {
         return @($RoadmapDependencyMap[$researchPrompt])
     }

--- a/workflows/default/systems/mcp/modules/TaskStore.psm1
+++ b/workflows/default/systems/mcp/modules/TaskStore.psm1
@@ -378,7 +378,7 @@ function New-TaskRecord {
     }
 
     # Build filename
-    $safeName = ( ($task.name -replace '[^a-zA-Z0-9\s-]', '') -replace '\s+', '-' ).ToLower()
+    $safeName = ( ($task.name -replace '[^a-zA-Z0-9\s-]', '') -replace '\s+', '-' ).ToLowerInvariant()
     if ($safeName.Length -gt 50) { $safeName = $safeName.Substring(0, 50) }
     if ([string]::IsNullOrEmpty($safeName)) { $safeName = 'task' }
     $shortId  = $id.Substring(0, [Math]::Min(8, $id.Length))
@@ -451,7 +451,7 @@ function Update-TaskRecord {
 
 function Get-TaskSlug {
     param([string]$TaskName)
-    $slug = $TaskName.ToLower()
+    $slug = $TaskName.ToLowerInvariant()
     $slug = $slug -replace '[^a-z0-9]+', '-'
     $slug = $slug -replace '^-|-$', ''
     if ($slug.Length -gt 50) { $slug = $slug.Substring(0, 50) -replace '-$', '' }

--- a/workflows/default/systems/mcp/tools/decision-create/script.ps1
+++ b/workflows/default/systems/mcp/tools/decision-create/script.ps1
@@ -41,7 +41,7 @@ function Invoke-DecisionCreate {
     $id = "dec-" + ([guid]::NewGuid().ToString('N').Substring(0, 8))
     $date = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd")
 
-    $slug = ($title -replace '[^\w\s-]', '' -replace '\s+', '-').ToLower()
+    $slug = ($title -replace '[^\w\s-]', '' -replace '\s+', '-').ToLowerInvariant()
     if ($slug.Length -gt 60) { $slug = $slug.Substring(0, 60).TrimEnd('-') }
 
     $decisionsBaseDir = Join-Path $global:DotbotProjectRoot ".bot\workspace\decisions"

--- a/workflows/default/systems/mcp/tools/task-answer-question/script.ps1
+++ b/workflows/default/systems/mcp/tools/task-answer-question/script.ps1
@@ -101,8 +101,8 @@ function Invoke-TaskAnswerQuestion {
         $resolvedAnswer = $answer
         $answerType = "custom"
         $validKeys = @("A", "B", "C", "D", "E")
-        if ($answer.ToUpper() -in $validKeys) {
-            $answerKey = $answer.ToUpper()
+        if ($answer.ToUpperInvariant() -in $validKeys) {
+            $answerKey = $answer.ToUpperInvariant()
             $answerType = "option"
             $matchingOption = $targetQuestion.options | Where-Object { $_.key -eq $answerKey } | Select-Object -First 1
             if ($matchingOption) {
@@ -256,8 +256,8 @@ function Invoke-TaskAnswerQuestion {
 
     # Check if answer is an option key
     $validKeys = @("A", "B", "C", "D", "E")
-    if ($answer.ToUpper() -in $validKeys) {
-        $answerKey = $answer.ToUpper()
+    if ($answer.ToUpperInvariant() -in $validKeys) {
+        $answerKey = $answer.ToUpperInvariant()
         $answerType = "option"
 
         # Find the matching option

--- a/workflows/default/systems/mcp/tools/task-create-bulk/script.ps1
+++ b/workflows/default/systems/mcp/tools/task-create-bulk/script.ps1
@@ -99,7 +99,7 @@ function Invoke-TaskCreateBulk {
             if ($dependencies -and $dependencies.Count -gt 0) {
                 $invalidDeps = @()
                 foreach ($dep in $dependencies) {
-                    $depLower = $dep.ToLower()
+                    $depLower = $dep.ToLowerInvariant()
                     $found = $false
                     
                     # Check all existing tasks
@@ -107,7 +107,7 @@ function Invoke-TaskCreateBulk {
                     
                     # Also check previously created tasks in this batch
                     $allTasks += $createdTasks | ForEach-Object {
-                        $taskSlug = ($_.name -replace '[^\w\s-]', '' -replace '\s+', '-').ToLower()
+                        $taskSlug = ($_.name -replace '[^\w\s-]', '' -replace '\s+', '-').ToLowerInvariant()
                         [PSCustomObject]@{
                             id = $_.id
                             name = $_.name
@@ -123,7 +123,7 @@ function Invoke-TaskCreateBulk {
                         if ($t.name -eq $dep) { $found = $true; break }
                         
                         # Check slug match
-                        $taskSlug = if ($t.slug) { $t.slug } else { ($t.name -replace '[^\w\s-]', '' -replace '\s+', '-').ToLower() }
+                        $taskSlug = if ($t.slug) { $t.slug } else { ($t.name -replace '[^\w\s-]', '' -replace '\s+', '-').ToLowerInvariant() }
                         if ($taskSlug -eq $depLower) { $found = $true; break }
                         
                         # Fuzzy match
@@ -180,7 +180,7 @@ function Invoke-TaskCreateBulk {
             }
 
             # Create filename from name (sanitized)
-            $fileName = ($task.name -replace '[^\w\s-]', '' -replace '\s+', '-').ToLower()
+            $fileName = ($task.name -replace '[^\w\s-]', '' -replace '\s+', '-').ToLowerInvariant()
             if ($fileName.Length -gt 50) {
                 $fileName = $fileName.Substring(0, 50)
             }

--- a/workflows/default/systems/mcp/tools/task-create/script.ps1
+++ b/workflows/default/systems/mcp/tools/task-create/script.ps1
@@ -103,7 +103,7 @@ function Invoke-TaskCreate {
         
         $invalidDeps = @()
         foreach ($dep in $dependencies) {
-            $depLower = $dep.ToLower()
+            $depLower = $dep.ToLowerInvariant()
             $found = $false
             
             # Check all tasks (todo, in-progress, done)
@@ -117,7 +117,7 @@ function Invoke-TaskCreate {
                 if ($task.name -eq $dep) { $found = $true; break }
                 
                 # Check slug match (generated from name)
-                $taskSlug = ($task.name -replace '[^\w\s-]', '' -replace '\s+', '-').ToLower()
+                $taskSlug = ($task.name -replace '[^\w\s-]', '' -replace '\s+', '-').ToLowerInvariant()
                 if ($taskSlug -eq $depLower) { $found = $true; break }
                 
                 # Fuzzy match
@@ -198,7 +198,7 @@ function Invoke-TaskCreate {
     }
     
     # Create filename from name (sanitized)
-    $fileName = ($name -replace '[^\w\s-]', '' -replace '\s+', '-').ToLower()
+    $fileName = ($name -replace '[^\w\s-]', '' -replace '\s+', '-').ToLowerInvariant()
     if ($fileName.Length -gt 50) {
         $fileName = $fileName.Substring(0, 50)
     }

--- a/workflows/default/systems/runtime/launch-process.ps1
+++ b/workflows/default/systems/runtime/launch-process.ps1
@@ -336,7 +336,7 @@ $procFilePath = Join-Path $processesDir "$procId.json"
 Write-Diag "Process file exists: $(Test-Path $procFilePath) at $procFilePath"
 
 # Banner
-Write-Card -Title "PROCESS: $($Type.ToUpper())" -Width 50 -BorderStyle Rounded -BorderColor Label -TitleColor Label -Lines @(
+Write-Card -Title "PROCESS: $($Type.ToUpperInvariant())" -Width 50 -BorderStyle Rounded -BorderColor Label -TitleColor Label -Lines @(
     "$($t.Label)ID:$($t.Reset)    $($t.Cyan)$procId$($t.Reset)"
     "$($t.Label)Model:$($t.Reset) $($t.Purple)$Model$($t.Reset)"
     "$($t.Label)Type:$($t.Reset)  $($t.Amber)$Type$($t.Reset)"

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-ExecutionProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-ExecutionProcess.ps1
@@ -150,7 +150,7 @@ try {
                     }
                     'mcp' {
                         $toolFuncParts = $task.mcp_tool -split '_'
-                        $capitalParts = foreach ($p in $toolFuncParts) { $p.Substring(0,1).ToUpper() + $p.Substring(1) }
+                        $capitalParts = foreach ($p in $toolFuncParts) { $p.Substring(0,1).ToUpperInvariant() + $p.Substring(1) }
                         $toolFunc = 'Invoke-' + ($capitalParts -join '')
                         $toolArgs = if ($task.mcp_args) { $task.mcp_args } else { @{} }
                         Write-Status "Calling MCP tool: $($task.mcp_tool)" -Type Process

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-KickstartProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-KickstartProcess.ps1
@@ -221,7 +221,7 @@ An interview-summary.md file exists in .bot/workspace/product/ containing the us
         }
         $processData.heartbeat_status = "Phase ${phaseNum}: $phaseName"
         Write-ProcessFile -Id $procId -Data $processData
-        Write-ProcessActivity -Id $procId -ActivityType "init" -Message "Phase $phaseNum — $($phaseName.ToLower())..."
+        Write-ProcessActivity -Id $procId -ActivityType "init" -Message "Phase $phaseNum — $($phaseName.ToLowerInvariant())..."
         Write-Header "Phase ${phaseNum}: $phaseName"
 
         if ($phaseType -eq "barrier") {
@@ -636,7 +636,7 @@ Instructions:
         $commitPaths = if ($phase.commit -and $phase.commit.paths) { $phase.commit.paths } else { $phase.commit_paths }
         $commitMsg = if ($phase.commit -and $phase.commit.message) { $phase.commit.message }
                      elseif ($phase.commit_message) { $phase.commit_message }
-                     else { "chore(kickstart): phase $phaseNum — $($phaseName.ToLower())" }
+                     else { "chore(kickstart): phase $phaseNum — $($phaseName.ToLowerInvariant())" }
         if ($commitPaths) {
             Write-Status "Committing phase $phaseNum artifacts..." -Type Info
             foreach ($cp in $commitPaths) {
@@ -706,7 +706,7 @@ Instructions:
             Write-ProcessFile -Id $procId -Data $processData
         }
 
-        Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Phase $phaseNum complete — $($phaseName.ToLower())"
+        Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Phase $phaseNum complete — $($phaseName.ToLowerInvariant())"
         $phaseNum++
     }
 

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -449,7 +449,7 @@ try {
                     }
                     'mcp' {
                         $toolFuncParts = $task.mcp_tool -split '_'
-                        $capitalParts = foreach ($p in $toolFuncParts) { $p.Substring(0,1).ToUpper() + $p.Substring(1) }
+                        $capitalParts = foreach ($p in $toolFuncParts) { $p.Substring(0,1).ToUpperInvariant() + $p.Substring(1) }
                         $toolFunc = 'Invoke-' + ($capitalParts -join '')
                         $toolArgs = if ($task.mcp_args) { $task.mcp_args } else { @{} }
                         Write-Status "Calling MCP tool: $($task.mcp_tool)" -Type Process

--- a/workflows/default/systems/runtime/modules/WorktreeManager.psm1
+++ b/workflows/default/systems/runtime/modules/WorktreeManager.psm1
@@ -273,7 +273,7 @@ function Stop-WorktreeProcesses {
             $escapedOriginal = [regex]::Escape($WorktreePath)
             $forwardSlash = $WorktreePath -replace '\\', '/'
             $escapedForward = [regex]::Escape($forwardSlash)
-            $gitBashStyle = $forwardSlash -replace '^([A-Za-z]):', { '/' + $_.Groups[1].Value.ToLower() }
+            $gitBashStyle = $forwardSlash -replace '^([A-Za-z]):', { '/' + $_.Groups[1].Value.ToLowerInvariant() }
             $escapedGitBash = [regex]::Escape($gitBashStyle)
 
             $candidates = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |

--- a/workflows/default/systems/runtime/modules/rate-limit-handler.ps1
+++ b/workflows/default/systems/runtime/modules/rate-limit-handler.ps1
@@ -18,7 +18,7 @@ function Get-RateLimitResetTime {
     if ($Message -match "resets?\s+(\d{1,2}):?(\d{2})?\s*(am|pm)\s*\(([^)]+)\)") {
         $hour = [int]$matches[1]
         $minute = if ($matches[2]) { [int]$matches[2] } else { 0 }
-        $ampm = $matches[3].ToLower()
+        $ampm = $matches[3].ToLowerInvariant()
         $timezone = $matches[4]
         
         # Convert to 24-hour format

--- a/workflows/default/systems/runtime/modules/workflow-manifest.ps1
+++ b/workflows/default/systems/runtime/modules/workflow-manifest.ps1
@@ -198,7 +198,7 @@ function Ensure-ManifestTaskIds {
         $existingId = if ($t -is [System.Collections.IDictionary]) { $t['id'] } else { $t.id }
         if (-not $existingId) {
             $taskName = if ($t -is [System.Collections.IDictionary]) { $t['name'] } else { $t.name }
-            $genId = ($taskName -replace '[^\w\s-]', '' -replace '\s+', '-').ToLower()
+            $genId = ($taskName -replace '[^\w\s-]', '' -replace '\s+', '-').ToLowerInvariant()
             if ($t -is [System.Collections.IDictionary]) { $t['id'] = $genId }
             else { $t | Add-Member -NotePropertyName 'id' -NotePropertyValue $genId -Force }
         }
@@ -339,7 +339,7 @@ function New-WorkflowTask {
     if ($TaskDef['env'])                       { $task["env"] = $TaskDef['env'] }
     if ($TaskDef['post_script'])               { $task["post_script"] = $TaskDef['post_script'] }
 
-    $slug = ($name -replace '[^\w\s-]', '' -replace '\s+', '-').ToLower()
+    $slug = ($name -replace '[^\w\s-]', '' -replace '\s+', '-').ToLowerInvariant()
     if ($slug.Length -gt 50) { $slug = $slug.Substring(0, 50) }
     $fileName = "$slug-$($id.Split('-')[0]).json"
     $filePath = Join-Path $tasksDir $fileName

--- a/workflows/default/systems/ui/modules/DecisionAPI.psm1
+++ b/workflows/default/systems/ui/modules/DecisionAPI.psm1
@@ -138,7 +138,7 @@ function New-Decision {
     }
 
     $id   = "dec-" + ([guid]::NewGuid().ToString('N').Substring(0, 8))
-    $slug = ($title -replace '[^\w\s-]', '' -replace '\s+', '-').ToLower()
+    $slug = ($title -replace '[^\w\s-]', '' -replace '\s+', '-').ToLowerInvariant()
     if ($slug.Length -gt 60) { $slug = $slug.Substring(0, 60).TrimEnd('-') }
     $date = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd")
 

--- a/workflows/default/systems/ui/modules/NotificationPoller.psm1
+++ b/workflows/default/systems/ui/modules/NotificationPoller.psm1
@@ -235,8 +235,8 @@ function Invoke-TaskTransitionFromNotification {
     $answerType = "custom"
 
     $validKeys = @("A", "B", "C", "D", "E")
-    if ($Answer.ToUpper() -in $validKeys) {
-        $answerKey = $Answer.ToUpper()
+    if ($Answer.ToUpperInvariant() -in $validKeys) {
+        $answerKey = $Answer.ToUpperInvariant()
         $answerType = "option"
         $matchingOption = $pendingQuestion.options | Where-Object { $_.key -eq $answerKey } | Select-Object -First 1
         if ($matchingOption) {
@@ -434,8 +434,8 @@ function Invoke-BatchQuestionTransitionFromNotification {
     $resolvedAnswer = $Answer
     $answerType     = "custom"
     $validKeys      = @("A", "B", "C", "D", "E")
-    if ($Answer.ToUpper() -in $validKeys) {
-        $answerKey = $Answer.ToUpper()
+    if ($Answer.ToUpperInvariant() -in $validKeys) {
+        $answerKey = $Answer.ToUpperInvariant()
         $answerType = "option"
         $matchingOption = $Question.options | Where-Object { $_.key -eq $answerKey } | Select-Object -First 1
         $resolvedAnswer = if ($matchingOption) { "$answerKey - $($matchingOption.label)" } else { $answerKey }

--- a/workflows/default/systems/ui/modules/ProductAPI.psm1
+++ b/workflows/default/systems/ui/modules/ProductAPI.psm1
@@ -30,7 +30,7 @@ function Resolve-ProductDocumentInfo {
     )
 
     $relativePath = [System.IO.Path]::GetRelativePath($ProductDir, $File.FullName) -replace '\\', '/'
-    $ext = $File.Extension.ToLower()
+    $ext = $File.Extension.ToLowerInvariant()
     $isMd = $ext -eq '.md'
     $isJson = $ext -eq '.json'
     $isTxt = $ext -eq '.txt'
@@ -288,7 +288,7 @@ function Get-ProductDocumentRaw {
         return @{ Found = $false }
     }
 
-    $ext = [System.IO.Path]::GetExtension($resolvedDoc.FullPath).ToLower()
+    $ext = [System.IO.Path]::GetExtension($resolvedDoc.FullPath).ToLowerInvariant()
     $mimeType = switch ($ext) {
         '.png'  { 'image/png' }
         '.jpg'  { 'image/jpeg' }

--- a/workflows/default/systems/ui/modules/StateBuilder.psm1
+++ b/workflows/default/systems/ui/modules/StateBuilder.psm1
@@ -42,7 +42,7 @@ function Get-RoadmapTaskDependencies {
         return $explicitDependencies
     }
 
-    $researchPrompt = "$($Task.research_prompt)".Trim().ToLower()
+    $researchPrompt = "$($Task.research_prompt)".Trim().ToLowerInvariant()
     if ($researchPrompt -and $DependencyMap.ContainsKey($researchPrompt)) {
         return @($DependencyMap[$researchPrompt])
     }

--- a/workflows/default/systems/ui/modules/TaskAPI.psm1
+++ b/workflows/default/systems/ui/modules/TaskAPI.psm1
@@ -404,7 +404,7 @@ function Submit-TaskAnswer {
 
             foreach ($att in @($Attachments)) {
                 $safeName = [System.IO.Path]::GetFileName($att.name)
-                $ext = [System.IO.Path]::GetExtension($safeName).ToLower()
+                $ext = [System.IO.Path]::GetExtension($safeName).ToLowerInvariant()
                 if ($ext -notin $allowedExtensions) {
                     Write-DotbotWarning "Skipping attachment '$safeName': unsupported extension '$ext'"
                     continue

--- a/workflows/default/systems/ui/server.ps1
+++ b/workflows/default/systems/ui/server.ps1
@@ -1634,7 +1634,7 @@ $docContext
                                             }
                                             foreach ($att in @($ans.attachments)) {
                                                 $safeName = [System.IO.Path]::GetFileName($att.name)
-                                                $ext = [System.IO.Path]::GetExtension($safeName).ToLower()
+                                                $ext = [System.IO.Path]::GetExtension($safeName).ToLowerInvariant()
                                                 if ($ext -notin $allowedAttachExtensions) { continue }
                                                 try {
                                                     $bytes = [System.Convert]::FromBase64String($att.content)

--- a/workflows/kickstart-via-jira/systems/mcp/tools/atlassian-download/script.ps1
+++ b/workflows/kickstart-via-jira/systems/mcp/tools/atlassian-download/script.ps1
@@ -89,7 +89,7 @@ function Invoke-AtlassianDownload {
                 original_name = $FileName
                 source        = $Source
                 size          = $fileInfo.Length
-                content_type  = switch -Wildcard ([System.IO.Path]::GetExtension($destPath).ToLower()) {
+                content_type  = switch -Wildcard ([System.IO.Path]::GetExtension($destPath).ToLowerInvariant()) {
                     '.pdf'  { 'application/pdf' }   '.png'  { 'image/png' }
                     '.jpg'  { 'image/jpeg' }        '.jpeg' { 'image/jpeg' }
                     '.gif'  { 'image/gif' }         '.svg'  { 'image/svg+xml' }


### PR DESCRIPTION
## Summary

Closes #280 — MCP tool invocation and task slug generation fail on Turkish (`tr-TR`) Windows locale due to culture-dependent casing.

On `tr-TR`, `"i".ToUpper()` returns `İ` (U+0130) and `"I".ToLower()` returns `ı` (U+0131). This broke:

- **MCP dispatcher**: `task_mark_in_progress` dispatched to non-existent `Invoke-TaskMarkİnProgress`, causing every `mcp__dotbot__*` call to fail and first task to hit max-retries → dependency deadlock.
- **Slug / filename generation**: task and decision filenames contained `ı`/`İ` (e.g. `configure-ıssue-driven-*.json`).
- **Dependency / alias matching**: case-folded lookups missed their own entries.
- **Commit messages**: kickstart phase names rendered with dotless `ı` in git history.

## Changes

Replaced bare `.ToLower()` / `.ToUpper()` with culture-invariant `.ToLowerInvariant()` / `.ToUpperInvariant()` across **25 files**:

**Dispatchers (the original bug):**
- `workflows/default/systems/mcp/dotbot-mcp.ps1` — MCP tool name → function name
- `workflows/default/systems/runtime/modules/ProcessTypes/Invoke-ExecutionProcess.ps1`
- `workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1`

**Slug / filename generation:**
- `task-create`, `task-create-bulk`, `decision-create` (tool scripts)
- `TaskStore.psm1`, `TaskIndexCache.psm1`, `NotificationClient.psm1` (modules)
- `workflow-manifest.ps1`, `DecisionAPI.psm1`

**Alias / dependency normalization:**
- `TaskIndexCache.psm1`, `TaskMutation.psm1`, `StateBuilder.psm1`

**Other ASCII-input sites (extensions, drive letters, am/pm, answer keys, phase names):**
- `task-answer-question`, `NotificationPoller.psm1`, `ProductAPI.psm1`, `TaskAPI.psm1`, `ui/server.ps1`
- `PathSanitizer.psm1`, `WorktreeManager.psm1`, `rate-limit-handler.ps1`
- `launch-process.ps1`, `Invoke-KickstartProcess.ps1`
- `kickstart-via-jira/.../atlassian-download/script.ps1`

**Intentionally exempt:** `DotBotTheme.psm1` (letter-spacing formatter for user-provided titles where locale casing is arguably correct).

## Regression guard

Added Layer 1 Pester check in `tests/Test-Structure.ps1` that scans `workflows/**/*.ps1` and `*.psm1` for bare `.ToLower()` / `.ToUpper()` calls and fails with an actionable message pointing to `.ToLowerInvariant()` / `.ToUpperInvariant()`. `DotBotTheme.psm1` is explicitly allowlisted.

## Test plan

- [ ] CI passes on Linux/macOS/Windows (Layer 1–3) — baseline: all dispatch/slug code paths still work on `en-US`.
- [ ] Manual verification on Turkish locale:
  - Set `[Threading.Thread]::CurrentThread.CurrentCulture = 'tr-TR'` in a PowerShell session.
  - Run `pwsh install.ps1`.
  - In a test project: `dotbot init --workflow issue-driven`, launch dashboard, click **Run** on the first task.
  - Confirm: first task reaches `done` (not `skipped`), task filenames are ASCII (`configure-issue-driven-*.json`), no `Invoke-TaskMarkİnProgress` errors in `proc-*.activity.jsonl`.
- [ ] Verify new Pester guard fires: introduce a `.ToLower()` somewhere under `workflows/`, confirm Layer 1 fails with a pointer to the file and line.