### PR TITLE
Add Slack channel support to Send-DotbotQuestion.ps1

### DIFF
--- a/server/Send-DotbotQuestion.ps1
+++ b/server/Send-DotbotQuestion.ps1
@@ -114,7 +114,7 @@ param(
 
     [string]$QuestionId = ([guid]::NewGuid().ToString()),
 
-    [ValidateSet("teams", "email", "jira")]
+    [ValidateSet("teams", "email", "jira", "slack")]
     [string]$Channel = "teams",
 
     [string]$JiraIssueKey = "",
@@ -233,6 +233,8 @@ $instanceReq = @{
 # Route user to the right recipient field
 if ($User -match '@') {
     $instanceReq.recipients.emails = @($User)
+} elseif ($Channel -eq 'slack') {
+    $instanceReq.recipients.slackUserIds = @($User)
 } else {
     $instanceReq.recipients.userObjectIds = @($User)
 }

--- a/server/Send-DotbotQuestion.ps1
+++ b/server/Send-DotbotQuestion.ps1
@@ -44,7 +44,7 @@
     A unique identifier for the question. Defaults to auto-generated GUID.
 
 .PARAMETER Channel
-    Delivery channel: "teams", "email", or "jira". Default: "teams".
+    Delivery channel: "teams", "email", "jira", or "slack". Default: "teams".
 
 .PARAMETER JiraIssueKey
     Required when -Channel is "jira". The Jira issue key to post the comment to.
@@ -231,10 +231,13 @@ $instanceReq = @{
 }
 
 # Route user to the right recipient field
-if ($User -match '@') {
-    $instanceReq.recipients.emails = @($User)
-} elseif ($Channel -eq 'slack') {
+if ($Channel -eq 'slack') {
+    if ($User -match '@') {
+        throw "Slack delivery requires a Slack user ID in -User, not an email address."
+    }
     $instanceReq.recipients.slackUserIds = @($User)
+} elseif ($User -match '@') {
+    $instanceReq.recipients.emails = @($User)
 } else {
     $instanceReq.recipients.userObjectIds = @($User)
 }


### PR DESCRIPTION
## Linked issue

Closes #294 

## Summary of changes

`Send-DotbotQuestion.ps1` now accepts `-Channel slack` and routes non-email IDs to `recipients.slackUserIds` when the channel is Slack. Teams and email paths unchanged.

Two edits in `server/Send-DotbotQuestion.ps1`:
- Added `"slack"` to the `-Channel` `ValidateSet`
- Added `elseif ($Channel -eq 'slack')` branch that maps `$User` to `slackUserIds`

This closes the gap in the manual test script.

## Testing notes

Requires local Q&A server + Slack app setup

.\Send-DotbotQuestion.ps1 
    -BotUrl http://localhost:5048 \`
    -User "U012AB3CD" \`
    -Channel slack \`
    -Question "Which database?" \`
    -Options @(@{key="A";label="PostgreSQL";rationale="Mature"}) \`
    -Wait

Expect: Slack DM card appears. No ValidateSet error.

## Checklist

- [ ] Tests added or updated
- [ ] Docs updated (if behaviour changed)
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
