### PR TITLE
fix(kickstart-via-jira): correct Atlassian MCP registration command

### DIFF
--- a/workflows/kickstart-via-jira/README.md
+++ b/workflows/kickstart-via-jira/README.md
@@ -50,7 +50,7 @@ Edit `.env.local` in the project root:
 claude mcp add --transport http atlassian -s user https://mcp.atlassian.com/v1/mcp
 ```
 
-Then run `/mcp` in Claude Code → select `atlassian` → authenticate via OAuth browser flow.
+In a Claude Code session, run `/mcp` → select `atlassian` → authenticate via OAuth browser flow.
 
 ### 5. Register Sourcebot
 

--- a/workflows/kickstart-via-jira/README.md
+++ b/workflows/kickstart-via-jira/README.md
@@ -47,8 +47,10 @@ Edit `.env.local` in the project root:
 ### 4. Register the Atlassian MCP server
 
 ```powershell
-claude mcp add atlassian -s user npx -- @anthropic/mcp-atlassian
+claude mcp add --transport http atlassian -s user https://mcp.atlassian.com/v1/mcp
 ```
+
+Then run `/mcp` in Claude Code → select `atlassian` → authenticate via OAuth browser flow.
 
 ### 5. Register Sourcebot
 

--- a/workflows/kickstart-via-jira/on-install.ps1
+++ b/workflows/kickstart-via-jira/on-install.ps1
@@ -51,7 +51,7 @@ if (Test-Path $mcpJsonPath) {
         Write-Success "atlassian MCP server registered"
     } else {
         Write-DotbotWarning "atlassian MCP server not found -- Phase 0 will use graceful degradation"
-        Write-Status "  To add Atlassian MCP: npx @anthropic/mcp-atlassian (requires API token with Jira + Confluence scopes)"
+        Write-Status "  To add Atlassian MCP: claude mcp add --transport http atlassian -s user https://mcp.atlassian.com/v1/mcp (then /mcp -> authenticate)"
     }
 } else {
     Write-DotbotWarning ".mcp.json not found -- MCP servers will be configured during init"

--- a/workflows/kickstart-via-jira/workflow.yaml
+++ b/workflows/kickstart-via-jira/workflow.yaml
@@ -32,7 +32,7 @@ requires:
   mcp_servers:
     - name: atlassian
       message: "Atlassian MCP server must be registered"
-      hint: "Run 'claude mcp add atlassian' or 'dotbot init --force' to register it"
+      hint: "Run: claude mcp add --transport http atlassian -s user https://mcp.atlassian.com/v1/mcp -- then run /mcp and authenticate"
     - name: sourcebot
       message: "Sourcebot MCP server is required for repository code search"
       hint: "Run 'claude mcp add sourcebot' to register the Sourcebot server"


### PR DESCRIPTION
## Linked issue

<!-- Every PR should close an issue. Replace the number below. -->
<!-- PRs without a linked issue will be sent back unless they're trivial. -->

Closes #305 

## Summary of changes

- `workflows/kickstart-via-jira/README.md` — replace setup command with Atlassian's official remote MCP endpoint + OAuth auth step
- `workflows/kickstart-via-jira/on-install.ps1` — update post-install hint to match
- `workflows/kickstart-via-jira/workflow.yaml` — update preflight failure hint to match

The npm package `@anthropic/mcp-atlassian` referenced across docs and hints does not exist in the npm registry (verified via `https://registry.npmjs.org/@anthropic/mcp-atlassian` → 404). Users following the README hit `✗ Failed to connect`, and Phase 0 (Fetch Jira Context) falls back to direct `curl` with env-var credentials instead of using `mcp__atlassian__*` tools.

New command uses Atlassian's official remote MCP:
`claude mcp add --transport http atlassian -s user https://mcp.atlassian.com/v1/mcp`

## Testing notes

1. Run the old command → `claude mcp list` shows `atlassian: npx @anthropic/mcp-atlassian - ✗ Failed to connect`.
2. Remove and apply the new command from the updated README step 4.
3. Open Claude Code (`claude`) → type `/mcp` → select `atlassian` → complete OAuth browser flow.
4. `claude mcp list` shows `atlassian: https://mcp.atlassian.com/v1/mcp (HTTP) - ✓ Connected`.
5. Start kickstart — Phase 0 calls `mcp__atlassian__getJiraIssue` successfully against a real Jira key.

## Checklist

- [x] Docs updated (if behaviour changed)
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
