### PR TITLE
feat: Set kickstart modal title from workflow name

### DIFF
--- a/workflows/default/systems/ui/static/index.html
+++ b/workflows/default/systems/ui/static/index.html
@@ -1459,7 +1459,7 @@
     <div class="modal-overlay" id="kickstart-modal">
         <div class="modal modal-wide">
             <div class="modal-header">
-                <span class="modal-title">◈ Kickstart Project</span>
+                <span class="modal-title">◈ <span id="kickstart-modal-title">Kickstart Project</span></span>
                 <button class="modal-close" id="kickstart-modal-close"><!-- Close icon loaded dynamically --></button>
             </div>
             <div class="modal-body">

--- a/workflows/default/systems/ui/static/modules/kickstart.js
+++ b/workflows/default/systems/ui/static/modules/kickstart.js
@@ -501,6 +501,16 @@ async function openKickstartModal(workflowName, options) {
         setTimeout(() => textarea?.focus(), 100);
     }
 
+    // Set title from workflow name immediately so it's correct before the
+    // async form fetch completes. Falls back to generic label when no name.
+    const titleEl = document.getElementById('kickstart-modal-title');
+    if (titleEl) {
+        const displayName = workflowName
+            ? workflowName.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+            : 'Kickstart Project';
+        titleEl.textContent = displayName;
+    }
+
     if (!workflowName) return;
 
     // Re-fetch this workflow's form config so the modal reflects the


### PR DESCRIPTION
## Linked issue 

<!-- Every PR should close an issue. Replace the number below. -->
<!-- PRs without a linked issue will be sent back unless they're trivial. -->

Closes #276 

## Summary of changes

- Add a dedicated #kickstart-modal-title span in the modal header (index.html:1462) and update openKickstartModal in kickstart.js to set the title immediately on open from workflowName. 
- The name is formatted by replacing hyphens with spaces and capitalizing each word (e.g. kickstart-via-jira → Kickstart Via Jira), with a fallback to Kickstart Project if no workflow name is available. 
- Title is set before the async /api/workflows/{name}/form fetch completes, so the correct workflow is always reflected the moment the modal appears.


## Screenshots / recordings

<img width="1224" height="849" alt="image" src="https://github.com/user-attachments/assets/579d4722-97d8-44ff-8224-da0e8a88e170" />


## Testing notes

1. Install dotbot with multiple kickstart workflows (e.g. kickstart-from-scratch + kickstart-via-jira)
2. Click Run on each workflow card
3. Verify the modal title reflects the selected workflow name (Kickstart From Scratch, Kickstart Via Jira, etc.)
4. Verify fallback: if workflow name is unavailable, header shows Kickstart Project
5. Layers 1–3 tests pass


## Checklist

- [ ] Tests added or updated
- [ ] Docs updated (if behaviour changed)
- [ ] Linked issue exists
- [ ] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
