### PR TITLE
test: show elapsed time on every test result (#326)

### DIFF
--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -75,23 +75,47 @@ if ((Test-Path $installDir) -and (2 -in $layersToRun -or 3 -in $layersToRun -or 
 
 $overallFailed = $false
 $layerResults = @{}
+$layerTimings = @{}
+
+function Invoke-TestFile {
+    param(
+        [Parameter(Mandatory)][string]$Layer,
+        [Parameter(Mandatory)][string]$FileName
+    )
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\$FileName"
+    $code = $LASTEXITCODE
+    $sw.Stop()
+
+    if (-not $layerTimings.ContainsKey($Layer)) { $layerTimings[$Layer] = @() }
+    $layerTimings[$Layer] += [pscustomobject]@{
+        File      = $FileName
+        ElapsedMs = $sw.ElapsedMilliseconds
+        ExitCode  = $code
+    }
+
+    return $code
+}
+
+function Format-Duration {
+    param([int64]$Ms)
+    $totalSeconds = [math]::Round($Ms / 1000.0, 1)
+    if ($totalSeconds -lt 60) {
+        return ("{0}s" -f $totalSeconds)
+    }
+    $minutes = [math]::Floor($totalSeconds / 60)
+    $seconds = [int]([math]::Round($totalSeconds - ($minutes * 60)))
+    return ("{0}m {1}s" -f $minutes, $seconds)
+}
 
 # Layer 1: Structure + Compilation
 if (1 -in $layersToRun) {
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-Structure.ps1"
-    $structureCode = $LASTEXITCODE
-
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-Compilation.ps1"
-    $compilationCode = $LASTEXITCODE
-
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-WorkflowManifest.ps1"
-    $workflowManifestCode = $LASTEXITCODE
-
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-MdRefs.ps1"
-    $mdRefsCode = $LASTEXITCODE
-
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-SkillCodeReview.ps1"
-    $skillCodeReviewCode = $LASTEXITCODE
+    $structureCode       = Invoke-TestFile -Layer '1' -FileName 'Test-Structure.ps1'
+    $compilationCode     = Invoke-TestFile -Layer '1' -FileName 'Test-Compilation.ps1'
+    $workflowManifestCode = Invoke-TestFile -Layer '1' -FileName 'Test-WorkflowManifest.ps1'
+    $mdRefsCode          = Invoke-TestFile -Layer '1' -FileName 'Test-MdRefs.ps1'
+    $skillCodeReviewCode = Invoke-TestFile -Layer '1' -FileName 'Test-SkillCodeReview.ps1'
 
     $exitCode = if ($structureCode -ne 0 -or $compilationCode -ne 0 -or $workflowManifestCode -ne 0 -or $mdRefsCode -ne 0 -or $skillCodeReviewCode -ne 0) { 1 } else { 0 }
     $layerResults["1"] = ($exitCode -eq 0)
@@ -100,35 +124,16 @@ if (1 -in $layersToRun) {
 
 # Layer 2: Components
 if (2 -in $layersToRun) {
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-Components.ps1"
-    $componentsCode = $LASTEXITCODE
-
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-TaskActions.ps1"
-    $taskActionsCode = $LASTEXITCODE
-
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-ServerStartup.ps1"
-    $serverStartupCode = $LASTEXITCODE
-
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-WorkflowIntegration.ps1"
-    $workflowIntegrationCode = $LASTEXITCODE
-
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-ProcessRegistry.ps1"
-    $processRegistryCode = $LASTEXITCODE
-
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-ProcessDispatch.ps1"
-    $processDispatchCode = $LASTEXITCODE
-
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-StudioAPI.ps1"
-    $studioAPICode = $LASTEXITCODE
-
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-GoScript.ps1"
-    $goScriptCode = $LASTEXITCODE
-
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-KickstartLauncher.ps1"
-    $kickstartLauncherCode = $LASTEXITCODE
-
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-ToolLocal.ps1"
-    $toolLocalCode = $LASTEXITCODE
+    $componentsCode          = Invoke-TestFile -Layer '2' -FileName 'Test-Components.ps1'
+    $taskActionsCode         = Invoke-TestFile -Layer '2' -FileName 'Test-TaskActions.ps1'
+    $serverStartupCode       = Invoke-TestFile -Layer '2' -FileName 'Test-ServerStartup.ps1'
+    $workflowIntegrationCode = Invoke-TestFile -Layer '2' -FileName 'Test-WorkflowIntegration.ps1'
+    $processRegistryCode     = Invoke-TestFile -Layer '2' -FileName 'Test-ProcessRegistry.ps1'
+    $processDispatchCode     = Invoke-TestFile -Layer '2' -FileName 'Test-ProcessDispatch.ps1'
+    $studioAPICode           = Invoke-TestFile -Layer '2' -FileName 'Test-StudioAPI.ps1'
+    $goScriptCode            = Invoke-TestFile -Layer '2' -FileName 'Test-GoScript.ps1'
+    $kickstartLauncherCode   = Invoke-TestFile -Layer '2' -FileName 'Test-KickstartLauncher.ps1'
+    $toolLocalCode           = Invoke-TestFile -Layer '2' -FileName 'Test-ToolLocal.ps1'
 
     $exitCode = if ($componentsCode -ne 0 -or $taskActionsCode -ne 0 -or $serverStartupCode -ne 0 -or $workflowIntegrationCode -ne 0 -or $processRegistryCode -ne 0 -or $processDispatchCode -ne 0 -or $studioAPICode -ne 0 -or $goScriptCode -ne 0 -or $kickstartLauncherCode -ne 0 -or $toolLocalCode -ne 0) { 1 } else { 0 }
     $layerResults["2"] = ($exitCode -eq 0)
@@ -136,25 +141,17 @@ if (2 -in $layersToRun) {
 }
 # Layer 3: Mock Claude
 if (3 -in $layersToRun) {
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-MockClaude.ps1"
-    $exitCode = $LASTEXITCODE
+    $exitCode = Invoke-TestFile -Layer '3' -FileName 'Test-MockClaude.ps1'
     $layerResults["3"] = ($exitCode -eq 0)
     if ($exitCode -ne 0) { $overallFailed = $true }
 }
 
 # Layer 4: E2E Claude + Teams Q&A + Email Q&A + Jira Q&A
 if (4 -in $layersToRun) {
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-E2E-Claude.ps1"
-    $claudeExit = $LASTEXITCODE
-
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-E2E-Teams-QA.ps1"
-    $teamsExit = $LASTEXITCODE
-
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-E2E-Email-QA.ps1"
-    $emailExit = $LASTEXITCODE
-
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\Test-E2E-Jira-QA.ps1"
-    $jiraExit = $LASTEXITCODE
+    $claudeExit = Invoke-TestFile -Layer '4' -FileName 'Test-E2E-Claude.ps1'
+    $teamsExit  = Invoke-TestFile -Layer '4' -FileName 'Test-E2E-Teams-QA.ps1'
+    $emailExit  = Invoke-TestFile -Layer '4' -FileName 'Test-E2E-Email-QA.ps1'
+    $jiraExit   = Invoke-TestFile -Layer '4' -FileName 'Test-E2E-Jira-QA.ps1'
 
     $layerResults["4"] = ($claudeExit -eq 0 -and $teamsExit -eq 0 -and $emailExit -eq 0 -and $jiraExit -eq 0)
     if ($claudeExit -ne 0 -or $teamsExit -ne 0 -or $emailExit -ne 0 -or $jiraExit -ne 0) { $overallFailed = $true }
@@ -171,7 +168,17 @@ foreach ($layer in $layersToRun) {
     $key = "$layer"
     $status = if ($layerResults[$key]) { "✓ PASSED" } else { "✗ FAILED" }
     $color = if ($layerResults[$key]) { "Green" } else { "Red" }
-    Write-Host "  Layer $layer : $status" -ForegroundColor $color
+    $files = $layerTimings[$key]
+    $layerTotalMs = if ($files) { ($files | Measure-Object -Property ElapsedMs -Sum).Sum } else { 0 }
+    Write-Host "  Layer $layer : $status " -NoNewline -ForegroundColor $color
+    Write-Host ("({0})" -f (Format-Duration -Ms $layerTotalMs)) -ForegroundColor DarkGray
+    if ($files) {
+        $maxNameLen = ($files | Measure-Object -Property { $_.File.Length } -Maximum).Maximum
+        foreach ($f in ($files | Sort-Object -Property ElapsedMs -Descending)) {
+            $padded = $f.File.PadRight($maxNameLen)
+            Write-Host ("            {0}  {1}" -f $padded, (Format-Duration -Ms $f.ElapsedMs)) -ForegroundColor DarkGray
+        }
+    }
 }
 
 Write-Host ""

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -84,7 +84,12 @@ function Invoke-TestFile {
     )
 
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\$FileName"
+    # Pipe to Out-Host so the child's stdout goes to the terminal / CI log
+    # directly. Without this, the function's success stream captures every
+    # line into the caller's `$code = Invoke-TestFile ...` assignment, which
+    # both swallows the test output and turns $code into an Object[] instead
+    # of an int.
+    & pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\$FileName" | Out-Host
     $code = $LASTEXITCODE
     $sw.Stop()
 

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -100,12 +100,13 @@ function Invoke-TestFile {
 
 function Format-Duration {
     param([int64]$Ms)
-    $totalSeconds = [math]::Round($Ms / 1000.0, 1)
-    if ($totalSeconds -lt 60) {
-        return ("{0}s" -f $totalSeconds)
+    $duration = [TimeSpan]::FromMilliseconds($Ms)
+    if ($duration.TotalSeconds -lt 60) {
+        return ("{0}s" -f [math]::Round($duration.TotalSeconds, 1))
     }
-    $minutes = [math]::Floor($totalSeconds / 60)
-    $seconds = [int]([math]::Round($totalSeconds - ($minutes * 60)))
+    $totalSeconds = [int64][math]::Round($duration.TotalSeconds)
+    $minutes = [int64]($totalSeconds / 60)
+    $seconds = $totalSeconds % 60
     return ("{0}m {1}s" -f $minutes, $seconds)
 }
 
@@ -173,7 +174,7 @@ foreach ($layer in $layersToRun) {
     Write-Host "  Layer $layer : $status " -NoNewline -ForegroundColor $color
     Write-Host ("({0})" -f (Format-Duration -Ms $layerTotalMs)) -ForegroundColor DarkGray
     if ($files) {
-        $maxNameLen = ($files | Measure-Object -Property { $_.File.Length } -Maximum).Maximum
+        $maxNameLen = ($files | ForEach-Object { $_.File.Length } | Measure-Object -Maximum).Maximum
         foreach ($f in ($files | Sort-Object -Property ElapsedMs -Descending)) {
             $padded = $f.File.PadRight($maxNameLen)
             Write-Host ("            {0}  {1}" -f $padded, (Format-Duration -Ms $f.ElapsedMs)) -ForegroundColor DarkGray

--- a/tests/Test-Helpers.psm1
+++ b/tests/Test-Helpers.psm1
@@ -16,6 +16,12 @@ $script:TestResults = @{
     Errors  = [System.Collections.ArrayList]::new()
 }
 
+# Stopwatch reset on each result so each line shows time since the previous result.
+# This attributes setup cost (Initialize-TestBotProject, Start-McpServer, Start-Sleep)
+# to the first assertion that follows it — exactly what we want to triage slow tests.
+$script:LastResultStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+$script:TotalElapsedMs = [int64]0
+
 function Reset-TestResults {
     $script:TestResults = @{
         Passed  = 0
@@ -23,10 +29,17 @@ function Reset-TestResults {
         Skipped = 0
         Errors  = [System.Collections.ArrayList]::new()
     }
+    $script:TotalElapsedMs = [int64]0
+    $script:LastResultStopwatch.Restart()
 }
 
 function Get-TestResults {
     return $script:TestResults
+}
+
+function Format-TestElapsed {
+    param([int64]$Ms)
+    return "({0}ms)" -f $Ms
 }
 
 function Write-TestResult {
@@ -39,22 +52,30 @@ function Write-TestResult {
         [string]$Message = ""
     )
 
+    $elapsedMs = $script:LastResultStopwatch.ElapsedMilliseconds
+    $script:LastResultStopwatch.Restart()
+    $script:TotalElapsedMs += $elapsedMs
+    $elapsedTag = Format-TestElapsed -Ms $elapsedMs
+
     switch ($Status) {
         'Pass' {
             $script:TestResults.Passed++
-            Write-Host "  ✓ $Name" -ForegroundColor Green
+            Write-Host "  ✓ $Name " -NoNewline -ForegroundColor Green
+            Write-Host $elapsedTag -ForegroundColor DarkGray
         }
         'Fail' {
             $script:TestResults.Failed++
             [void]$script:TestResults.Errors.Add("${Name}: ${Message}")
-            Write-Host "  ✗ $Name" -ForegroundColor Red
+            Write-Host "  ✗ $Name " -NoNewline -ForegroundColor Red
+            Write-Host $elapsedTag -ForegroundColor DarkGray
             if ($Message) {
                 Write-Host "    $Message" -ForegroundColor DarkRed
             }
         }
         'Skip' {
             $script:TestResults.Skipped++
-            Write-Host "  ○ $Name (skipped)" -ForegroundColor Yellow
+            Write-Host "  ○ $Name (skipped) " -NoNewline -ForegroundColor Yellow
+            Write-Host $elapsedTag -ForegroundColor DarkGray
             if ($Message) {
                 Write-Host "    $Message" -ForegroundColor DarkYellow
             }
@@ -67,6 +88,7 @@ function Write-TestSummary {
 
     $r = $script:TestResults
     $total = $r.Passed + $r.Failed + $r.Skipped
+    $totalSeconds = [math]::Round($script:TotalElapsedMs / 1000.0, 1)
 
     Write-Host ""
     Write-Host "  ─────────────────────────────────────────" -ForegroundColor DarkGray
@@ -76,7 +98,8 @@ function Write-TestSummary {
     Write-Host "$($r.Failed) failed" -NoNewline -ForegroundColor $(if ($r.Failed -gt 0) { "Red" } else { "Green" })
     Write-Host ", " -NoNewline
     Write-Host "$($r.Skipped) skipped" -NoNewline -ForegroundColor Yellow
-    Write-Host " / $total total"
+    Write-Host " / $total total " -NoNewline
+    Write-Host "(${totalSeconds}s)" -ForegroundColor DarkGray
 
     if ($r.Errors.Count -gt 0) {
         Write-Host ""

--- a/tests/Test-Helpers.psm1
+++ b/tests/Test-Helpers.psm1
@@ -20,7 +20,9 @@ $script:TestResults = @{
 # This attributes setup cost (Initialize-TestBotProject, Start-McpServer, Start-Sleep)
 # to the first assertion that follows it — exactly what we want to triage slow tests.
 $script:LastResultStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-$script:TotalElapsedMs = [int64]0
+# Suite-wide stopwatch — used in Write-TestSummary so the displayed total includes
+# any time spent after the final result (teardown, finally blocks, MCP shutdown).
+$script:SuiteStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
 function Reset-TestResults {
     $script:TestResults = @{
@@ -29,8 +31,8 @@ function Reset-TestResults {
         Skipped = 0
         Errors  = [System.Collections.ArrayList]::new()
     }
-    $script:TotalElapsedMs = [int64]0
     $script:LastResultStopwatch.Restart()
+    $script:SuiteStopwatch.Restart()
 }
 
 function Get-TestResults {
@@ -54,7 +56,6 @@ function Write-TestResult {
 
     $elapsedMs = $script:LastResultStopwatch.ElapsedMilliseconds
     $script:LastResultStopwatch.Restart()
-    $script:TotalElapsedMs += $elapsedMs
     $elapsedTag = Format-TestElapsed -Ms $elapsedMs
 
     switch ($Status) {
@@ -88,7 +89,7 @@ function Write-TestSummary {
 
     $r = $script:TestResults
     $total = $r.Passed + $r.Failed + $r.Skipped
-    $totalSeconds = [math]::Round($script:TotalElapsedMs / 1000.0, 1)
+    $totalSeconds = [math]::Round($script:SuiteStopwatch.Elapsed.TotalSeconds, 1)
 
     Write-Host ""
     Write-Host "  ─────────────────────────────────────────" -ForegroundColor DarkGray

--- a/tests/Test-Structure.ps1
+++ b/tests/Test-Structure.ps1
@@ -494,7 +494,7 @@ if (-not $dotbotInstalled) {
                 $briefingDir = Join-Path $botDir4 "workspace\product\briefing"
                 $productDir = Join-Path $botDir4 "workspace\product"
 
-                # Scenario 1: No artifacts → exit 1 (missing initiative.md)
+                # Scenario 1: No artifacts → exit 1 (missing briefing/jira-context.md)
                 $result1 = & pwsh -NoProfile -ExecutionPolicy Bypass -Command "
                     `$global:DotbotProjectRoot = '$($testProject4 -replace "'","''")'
                     & '$($hookCopy -replace "'","''")'

--- a/tests/Test-Structure.ps1
+++ b/tests/Test-Structure.ps1
@@ -252,40 +252,27 @@ if (-not $dotbotInstalled) {
                 -Message "Expected valid GUID in settings.instance_id"
         }
 
-    } finally {
-        Remove-TestProject -Path $testProject
-    }
-
-    # --- Init with -Force (preserves workspace data) ---
-    Write-Host ""
-    Write-Host "  INIT -FORCE" -ForegroundColor Cyan
-    Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
-
-    $testProject2 = New-TestProject
-    try {
-        # First init
-        Push-Location $testProject2
-        & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
-        Pop-Location
-
-        $botDir2 = Join-Path $testProject2 ".bot"
+        # --- Init with -Force (preserves workspace data) ---
+        # Reuses the basic project from PROJECT INIT above to avoid a redundant init.
+        Write-Host ""
+        Write-Host "  INIT -FORCE" -ForegroundColor Cyan
+        Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
 
         # Create a dummy file in workspace to verify preservation
-        $dummyFile = Join-Path $botDir2 "workspace\tasks\todo\test-task.json"
+        $dummyFile = Join-Path $botDir "workspace\tasks\todo\test-task.json"
         @{ id = "test-123"; name = "Dummy task" } | ConvertTo-Json | Set-Content -Path $dummyFile
 
         # Create a dummy settings file in .control to verify preservation
-        $controlDir = Join-Path $botDir2 ".control"
+        $controlDir = Join-Path $botDir ".control"
         if (-not (Test-Path $controlDir)) { New-Item -Path $controlDir -ItemType Directory -Force | Out-Null }
         $dummySettings = Join-Path $controlDir "settings.json"
         @{ anthropic_api_key = "sk-test-dummy" } | ConvertTo-Json | Set-Content -Path $dummySettings
 
         # Capture instance_id before re-init; it must be preserved on -Force
-        $settingsPath2 = Join-Path $botDir2 "settings\settings.default.json"
         $initialInstanceId = $null
-        if (Test-Path $settingsPath2) {
+        if (Test-Path $settingsDefault) {
             try {
-                $settingsBeforeForce = Get-Content $settingsPath2 -Raw | ConvertFrom-Json
+                $settingsBeforeForce = Get-Content $settingsDefault -Raw | ConvertFrom-Json
                 if ($settingsBeforeForce.PSObject.Properties['instance_id']) {
                     $initialInstanceId = "$($settingsBeforeForce.instance_id)"
                 }
@@ -293,24 +280,24 @@ if (-not $dotbotInstalled) {
         }
 
         # Re-init with -Force
-        Push-Location $testProject2
+        Push-Location $testProject
         & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") -Force 2>&1 | Out-Null
         Pop-Location
 
-        Assert-PathExists -Name "-Force: .bot still exists" -Path $botDir2
+        Assert-PathExists -Name "-Force: .bot still exists" -Path $botDir
         Assert-PathExists -Name "-Force: workspace task preserved" -Path $dummyFile
         Assert-PathExists -Name "-Force: .control/settings.json preserved" -Path $dummySettings
-        Assert-PathExists -Name "-Force: system files refreshed" -Path (Join-Path $botDir2 "systems\mcp\dotbot-mcp.ps1")
+        Assert-PathExists -Name "-Force: system files refreshed" -Path (Join-Path $botDir "systems\mcp\dotbot-mcp.ps1")
 
         if ($initialInstanceId) {
-            $settingsAfterForce = Get-Content $settingsPath2 -Raw | ConvertFrom-Json
+            $settingsAfterForce = Get-Content $settingsDefault -Raw | ConvertFrom-Json
             Assert-Equal -Name "-Force: preserves existing settings.instance_id" `
                 -Expected $initialInstanceId `
                 -Actual "$($settingsAfterForce.instance_id)"
         }
 
     } finally {
-        Remove-TestProject -Path $testProject2
+        Remove-TestProject -Path $testProject
     }
 
     # --- Init with -Stack dotnet ---
@@ -495,6 +482,63 @@ if (-not $dotbotInstalled) {
                 Assert-ValidPowerShell -Name "-- kickstart-via-jira: $relPathKey valid syntax" -Path $ps1.FullName
             }
 
+            # --- Verification Hook: 03-research-completeness.ps1 ---
+            # Reuses the kickstart-via-jira project above to avoid a redundant init.
+            Write-Host ""
+            Write-Host "  VERIFICATION HOOK" -ForegroundColor Cyan
+            Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+            $hookScript = Join-Path $dotbotDir "workflows\kickstart-via-jira\hooks\verify\03-research-completeness.ps1"
+            $hookCopy = Join-Path $botDir4 "hooks\verify\03-research-completeness.ps1"
+            if ((Test-Path $hookScript) -and (Test-Path $hookCopy)) {
+                $briefingDir = Join-Path $botDir4 "workspace\product\briefing"
+                $productDir = Join-Path $botDir4 "workspace\product"
+
+                # Scenario 1: No artifacts → exit 1 (missing initiative.md)
+                $result1 = & pwsh -NoProfile -ExecutionPolicy Bypass -Command "
+                    `$global:DotbotProjectRoot = '$($testProject4 -replace "'","''")'
+                    & '$($hookCopy -replace "'","''")'
+                " 2>&1
+                $exitCode1 = $LASTEXITCODE
+                Assert-Equal -Name "Hook: no artifacts -> exit 1" -Expected 1 -Actual $exitCode1 -Message "Output: $($result1 -join "`n")"
+
+                # Scenario 2: Only jira-context.md → exit 0 with warnings
+                New-Item -Path $briefingDir -ItemType Directory -Force | Out-Null
+                "# Jira Context" | Set-Content (Join-Path $briefingDir "jira-context.md")
+
+                $result2 = & pwsh -NoProfile -ExecutionPolicy Bypass -Command "
+                    `$global:DotbotProjectRoot = '$($testProject4 -replace "'","''")'
+                    & '$($hookCopy -replace "'","''")'
+                " 2>&1
+                $exitCode2 = $LASTEXITCODE
+                Assert-Equal -Name "Hook: only jira-context.md -> exit 0" -Expected 0 -Actual $exitCode2 -Message "Output: $($result2 -join "`n")"
+
+                # Scenario 3: All artifacts present → exit 0, success message
+                "# Interview" | Set-Content (Join-Path $productDir "interview-summary.md")
+                "# Mission" | Set-Content (Join-Path $productDir "mission.md")
+                "# Internet" | Set-Content (Join-Path $productDir "research-internet.md")
+                "# Documents" | Set-Content (Join-Path $productDir "research-documents.md")
+                "# Repos" | Set-Content (Join-Path $productDir "research-repos.md")
+                New-Item -Path (Join-Path $briefingDir "repos") -ItemType Directory -Force | Out-Null
+                "# Deep dive" | Set-Content (Join-Path $briefingDir "repos\FakeRepo.md")
+
+                $result3 = & pwsh -NoProfile -ExecutionPolicy Bypass -Command "
+                    `$global:DotbotProjectRoot = '$($testProject4 -replace "'","''")'
+                    & '$($hookCopy -replace "'","''")'
+                " 2>&1
+                $exitCode3 = $LASTEXITCODE
+                Assert-Equal -Name "Hook: all artifacts -> exit 0" -Expected 0 -Actual $exitCode3
+
+                $output3 = $result3 -join "`n"
+                Assert-True -Name "Hook: all artifacts -> success message" `
+                    -Condition ($output3 -match "All research artifacts present") `
+                    -Message "Expected 'All research artifacts present' in output"
+            } elseif (-not (Test-Path $hookScript)) {
+                Write-TestResult -Name "Verification hook tests" -Status Skip -Message "Hook script not found at $hookScript"
+            } else {
+                Write-TestResult -Name "Hook tests" -Status Skip -Message "Hook not copied to .bot/"
+            }
+
         } finally {
             Remove-TestProject -Path $testProject4
         }
@@ -604,76 +648,6 @@ if (-not $dotbotInstalled) {
         }
     } else {
         Write-TestResult -Name "-- alias tests" -Status Skip -Message "kickstart-via-jira profile not found at $kickstartViaJiraProfile"
-    }
-
-    # --- Verification Hook: 03-research-completeness.ps1 ---
-    Write-Host ""
-    Write-Host "  VERIFICATION HOOK" -ForegroundColor Cyan
-    Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
-
-    $hookScript = Join-Path $dotbotDir "workflows\kickstart-via-jira\hooks\verify\03-research-completeness.ps1"
-    if (Test-Path $hookScript) {
-        $testProject5 = New-TestProject
-        try {
-            # Init with kickstart-via-jira profile
-            Push-Location $testProject5
-            & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") -Workflow kickstart-via-jira 2>&1 | Out-Null
-            Pop-Location
-
-            $botDir5 = Join-Path $testProject5 ".bot"
-            $briefingDir5 = Join-Path $botDir5 "workspace\product\briefing"
-            $productDir5 = Join-Path $botDir5 "workspace\product"
-            $hookCopy5 = Join-Path $botDir5 "hooks\verify\03-research-completeness.ps1"
-
-            if (Test-Path $hookCopy5) {
-                # Scenario 1: No artifacts → exit 1 (missing initiative.md)
-                $result1 = & pwsh -NoProfile -ExecutionPolicy Bypass -Command "
-                    `$global:DotbotProjectRoot = '$($testProject5 -replace "'","''")'
-                    & '$($hookCopy5 -replace "'","''")'
-                " 2>&1
-                $exitCode1 = $LASTEXITCODE
-                Assert-Equal -Name "Hook: no artifacts -> exit 1" -Expected 1 -Actual $exitCode1 -Message "Output: $($result1 -join "`n")"
-
-                # Scenario 2: Only jira-context.md → exit 0 with warnings
-                New-Item -Path $briefingDir5 -ItemType Directory -Force | Out-Null
-                "# Jira Context" | Set-Content (Join-Path $briefingDir5 "jira-context.md")
-
-                $result2 = & pwsh -NoProfile -ExecutionPolicy Bypass -Command "
-                    `$global:DotbotProjectRoot = '$($testProject5 -replace "'","''")'
-                    & '$($hookCopy5 -replace "'","''")'
-                " 2>&1
-                $exitCode2 = $LASTEXITCODE
-                Assert-Equal -Name "Hook: only jira-context.md -> exit 0" -Expected 0 -Actual $exitCode2 -Message "Output: $($result2 -join "`n")"
-
-                # Scenario 3: All artifacts present → exit 0, success message
-                "# Interview" | Set-Content (Join-Path $productDir5 "interview-summary.md")
-                "# Mission" | Set-Content (Join-Path $productDir5 "mission.md")
-                "# Internet" | Set-Content (Join-Path $productDir5 "research-internet.md")
-                "# Documents" | Set-Content (Join-Path $productDir5 "research-documents.md")
-                "# Repos" | Set-Content (Join-Path $productDir5 "research-repos.md")
-                New-Item -Path (Join-Path $briefingDir5 "repos") -ItemType Directory -Force | Out-Null
-                "# Deep dive" | Set-Content (Join-Path $briefingDir5 "repos\FakeRepo.md")
-
-                $result3 = & pwsh -NoProfile -ExecutionPolicy Bypass -Command "
-                    `$global:DotbotProjectRoot = '$($testProject5 -replace "'","''")'
-                    & '$($hookCopy5 -replace "'","''")'
-                " 2>&1
-                $exitCode3 = $LASTEXITCODE
-                Assert-Equal -Name "Hook: all artifacts -> exit 0" -Expected 0 -Actual $exitCode3
-
-                $output3 = $result3 -join "`n"
-                Assert-True -Name "Hook: all artifacts -> success message" `
-                    -Condition ($output3 -match "All research artifacts present") `
-                    -Message "Expected 'All research artifacts present' in output"
-            } else {
-                Write-TestResult -Name "Hook tests" -Status Skip -Message "Hook not copied to .bot/"
-            }
-
-        } finally {
-            Remove-TestProject -Path $testProject5
-        }
-    } else {
-        Write-TestResult -Name "Verification hook tests" -Status Skip -Message "Hook script not found at $hookScript"
     }
 }
 


### PR DESCRIPTION
## Summary

- Inline `(NNms)` timing on every assertion produced by `Write-TestResult` in `tests/Test-Helpers.psm1`.
- Total wall time appended to each layer summary line, e.g. `Layer 1 Summary: 292 passed, 0 failed, 0 skipped / 292 total (308.9s)`.
- Per-file leaderboard at the end of `tests/Run-Tests.ps1`, sorted by elapsed time, e.g.
  ```
  Layer 2 : ✓ PASSED (3m 14s)
            Test-Components.ps1           1m 52s
            Test-WorkflowIntegration.ps1  38s
            ...
  ```
- Acted on the new visibility: consolidated two redundant `init-project.ps1` calls in `Test-Structure.ps1` (PROJECT INIT shares its project with INIT -FORCE; INIT --WORKFLOW kickstart-via-jira shares its project with VERIFICATION HOOK). Layer 1 drops from 434.3s to 308.9s on my machine — ~29% faster, same 292 passing assertions.

The "elapsed since previous result" measurement attributes setup cost (`Initialize-TestBotProject`, `Start-McpServer`, `Start-Sleep`) to the first assertion that follows it, which is exactly what surfaces slow fixtures.

No flag. No new files. No changes to any individual `Test-*.ps1` (they all go through `Write-TestResult`).

## Follow-up

The bigger win — parallelizing the six remaining independent `init-project.ps1` calls in Test-Structure.ps1 via `ForEach-Object -Parallel` — is tracked in #328.

## Test plan

- [x] AST parse-check both files clean
- [x] Run `pwsh tests/Test-Structure.ps1` standalone — 292 passed, 0 failed in 308.9s (down from 434.3s baseline)
- [x] Run `pwsh tests/Run-Tests.ps1 -Layer 3` — leaderboard format renders correctly (single-entry case)
- [x] Dry-run multi-entry leaderboard formatting — sorts and pads as expected
- [ ] First real full Layer 1-3 run on `main` after merge: confirm green and capture leaderboard data for #328 / Layer 2 follow-ups

Closes #326
Refs #328