### PR TITLE
chore: drop residual .serena worktree-exclusion references

### DIFF
--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -125,10 +125,10 @@ $worktreeManagerModule = Join-Path $botDir "systems\runtime\modules\WorktreeMana
 if (Test-Path $worktreeManagerModule) {
     Import-Module $worktreeManagerModule -Force
 
-    Add-Content -Path (Join-Path $testProject ".gitignore") -Value ".serena/"
-    $serenaCacheDir = Join-Path $testProject ".serena\cache"
-    New-Item -Path $serenaCacheDir -ItemType Directory -Force | Out-Null
-    Set-Content -Path (Join-Path $serenaCacheDir "index.json") -Value '{"cache":true}'
+    Add-Content -Path (Join-Path $testProject ".gitignore") -Value ".idea/"
+    $noiseCacheDir = Join-Path $testProject ".idea\cache"
+    New-Item -Path $noiseCacheDir -ItemType Directory -Force | Out-Null
+    Set-Content -Path (Join-Path $noiseCacheDir "index.json") -Value '{"cache":true}'
     Set-Content -Path (Join-Path $testProject ".env") -Value "DOTBOT_TEST=1"
 
     $gitignoredCopyPaths = @(Get-GitignoredCopyPaths -ProjectRoot $testProject)
@@ -136,9 +136,9 @@ if (Test-Path $worktreeManagerModule) {
     Assert-True -Name "Get-GitignoredCopyPaths keeps ignored env files" `
         -Condition ($gitignoredCopyPaths -contains ".env") `
         -Message "Expected .env to be copied into worktrees"
-    Assert-True -Name "Get-GitignoredCopyPaths excludes legacy .serena caches" `
-        -Condition (-not ($gitignoredCopyPaths -contains ".serena/cache/index.json")) `
-        -Message "Legacy .serena cache contents should stay excluded from worktree copies"
+    Assert-True -Name "Get-GitignoredCopyPaths excludes noise dir caches" `
+        -Condition (-not ($gitignoredCopyPaths -contains ".idea/cache/index.json")) `
+        -Message "Noise directory cache contents should stay excluded from worktree copies"
 } else {
     Write-TestResult -Name "WorktreeManager module exists" -Status Fail -Message "Module not found at $worktreeManagerModule"
 }

--- a/workflows/default/systems/runtime/modules/WorktreeManager.psm1
+++ b/workflows/default/systems/runtime/modules/WorktreeManager.psm1
@@ -34,7 +34,7 @@ $script:NoiseDirectories = @(
     'Debug', 'Release', 'x64', 'x86',
     '.vs', '.idea', '.vscode',
     '__pycache__', '.mypy_cache',
-    '.git', '.control', '.serena',
+    '.git', '.control',
     'TestResults', 'test-results', 'playwright-report',
     'sessions'
 )


### PR DESCRIPTION
## Summary

- Removes `.serena` from `WorktreeManager.psm1`'s noise-directory exclusion list.
- Updates the `Test-Components.ps1` fixture to use `.idea/cache/` instead of `.serena/cache/`, preserving full coverage of the noise-exclusion logic without naming a no-longer-supported integration.

PR #182 removed Serena from `dotbot init` on 2026-04-08. Issue #184 tracked the follow-up to drop the defensive `.serena` exclusion after a stabilization window. That window has passed (18 days), and confirmed that all stale `.mcp.json` files predating PR #182 have been cleaned up locally.

The defensive assertions in `Test-Structure.ps1` (no `serena` server in fresh `.mcp.json`, no `.serena/` line in fresh `.gitignore`) are intentionally left in place as regression guards.

Closes #184

## Test plan

- [x] Layer 1 (Structure, Compilation, WorkflowManifest, MdRefs, SkillCodeReview): all green
- [x] Layer 2 (Components, TaskActions, ServerStartup, WorkflowIntegration, ProcessRegistry, ProcessDispatch, StudioAPI, GoScript, KickstartLauncher, ToolLocal): all green - including the rewritten `Get-GitignoredCopyPaths` assertion
- [x] Layer 3 (Mock Claude): all green
- [x] `pwsh install.ps1` succeeds