### PR TITLE
test: parallelize independent init-project.ps1 calls (#328)

### DIFF
--- a/tests/Test-Structure.ps1
+++ b/tests/Test-Structure.ps1
@@ -185,31 +185,66 @@ if (-not $dotbotInstalled) {
         # No -Force: if the runspace already has the module loaded, this is a
         # no-op; otherwise it loads once. -Force would re-execute the module
         # script on every iteration in a reused runspace.
-        Import-Module "$using:PSScriptRoot\Test-Helpers.psm1" -DisableNameChecking
-        foreach ($rel in $spec.Required) {
-            if (-not (Test-Path (Join-Path $using:dotbotDir $rel))) {
-                return [pscustomobject]@{ Key = $spec.Key; Project = $null; Output = ''; Skipped = $true; MissingRequired = $rel }
+        Import-Module (Join-Path $using:PSScriptRoot 'Test-Helpers.psm1') -DisableNameChecking
+
+        $project         = $null
+        $output          = ''
+        $skipped         = $true
+        $missingRequired = 'init worker did not emit a result'
+        $locationPushed  = $false
+
+        try {
+            $missing = $spec.Required | Where-Object { -not (Test-Path (Join-Path $using:dotbotDir $_)) } | Select-Object -First 1
+            if ($missing) {
+                $missingRequired = "required path missing: $missing"
+            } else {
+                $project = New-TestProject
+                Push-Location $project
+                $locationPushed = $true
+
+                # Only the alias spec inspects stdout (deprecation warning).
+                # Discard output for the other five so we don't materialise
+                # large strings we'll never read.
+                if ($spec.Key -eq 'alias') {
+                    $output = & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $using:dotbotDir 'scripts\init-project.ps1') @($spec.Args) 2>&1 | Out-String
+                } else {
+                    & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $using:dotbotDir 'scripts\init-project.ps1') @($spec.Args) 2>&1 | Out-Null
+                }
+
+                $skipped = $false
+                $missingRequired = $null
             }
+        } catch {
+            $missingRequired = "init worker failed: $($_.Exception.Message)"
+            if ($project) {
+                # Worker created the temp project but failed afterwards. Clean
+                # up here rather than handing back a half-broken project to
+                # Phase B. Phase B's outer finally will skip it because we
+                # null the field below.
+                Remove-TestProject -Path $project
+                $project = $null
+            }
+        } finally {
+            if ($locationPushed) { Pop-Location }
         }
-        $project = New-TestProject
-        Push-Location $project
-        # Only the alias spec inspects stdout (deprecation warning check).
-        # Discard output for the other five so we don't materialise large
-        # strings we'll never read.
-        if ($spec.Key -eq 'alias') {
-            $output = & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $using:dotbotDir 'scripts\init-project.ps1') @($spec.Args) 2>&1 | Out-String
-        } else {
-            & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $using:dotbotDir 'scripts\init-project.ps1') @($spec.Args) 2>&1 | Out-Null
-            $output = ''
+
+        [pscustomobject]@{
+            Key             = $spec.Key
+            Project         = $project
+            Output          = $output
+            Skipped         = $skipped
+            MissingRequired = $missingRequired
         }
-        Pop-Location
-        [pscustomobject]@{ Key = $spec.Key; Project = $project; Output = $output; Skipped = $false; MissingRequired = $null }
     } -ThrottleLimit 6 | ForEach-Object { $initResults[$_.Key] = $_ }
 
   try {
     # --- Phase B: run assertions per section against the pre-built projects.
 
-    $testProject = $initResults['basic'].Project
+    $basicInit = $initResults['basic']
+    if ($basicInit.Skipped -or -not $basicInit.Project) {
+        Write-TestResult -Name "Project init tests" -Status Skip -Message $basicInit.MissingRequired
+    } else {
+    $testProject = $basicInit.Project
     try {
         $botDir = Join-Path $testProject ".bot"
         Assert-PathExists -Name ".bot directory created" -Path $botDir
@@ -344,6 +379,7 @@ if (-not $dotbotInstalled) {
     } finally {
         Remove-TestProject -Path $testProject
     }
+    }
 
     # --- Init with -Stack dotnet ---
     Write-Host ""
@@ -376,7 +412,7 @@ if (-not $dotbotInstalled) {
             Remove-TestProject -Path $testProject3
         }
     } else {
-        Write-TestResult -Name "-Stack dotnet tests" -Status Skip -Message "dotnet profile not found at $dotnetProfile"
+        Write-TestResult -Name "-Stack dotnet tests" -Status Skip -Message $dotnetInit.MissingRequired
     }
 
 
@@ -428,7 +464,7 @@ if (-not $dotbotInstalled) {
             Remove-TestProject -Path $testProjectCombo
         }
     } else {
-        Write-TestResult -Name "Combo profile tests" -Status Skip -Message "Required profiles not found"
+        Write-TestResult -Name "Combo profile tests" -Status Skip -Message $comboInit.MissingRequired
     }
 
     # --- Init with -Workflow kickstart-via-jira ---
@@ -580,7 +616,7 @@ if (-not $dotbotInstalled) {
             Remove-TestProject -Path $testProject4
         }
     } else {
-        Write-TestResult -Name "-Workflow kickstart-via-jira tests" -Status Skip -Message "kickstart-via-jira profile not found at $kickstartViaJiraProfile"
+        Write-TestResult -Name "-Workflow kickstart-via-jira tests" -Status Skip -Message $jiraInit.MissingRequired
     }
 
     # --- Init with -Workflow kickstart-via-pr ---
@@ -649,7 +685,7 @@ if (-not $dotbotInstalled) {
             Remove-TestProject -Path $testProjectPr
         }
     } else {
-        Write-TestResult -Name "-Workflow kickstart-via-pr tests" -Status Skip -Message "kickstart-via-pr profile not found at $kickstartViaPrProfile"
+        Write-TestResult -Name "-Workflow kickstart-via-pr tests" -Status Skip -Message $prInit.MissingRequired
     }
     # --- Deprecated alias: -Workflow multi-repo ---
     Write-Host ""
@@ -678,7 +714,7 @@ if (-not $dotbotInstalled) {
             Remove-TestProject -Path $testProjectAlias
         }
     } else {
-        Write-TestResult -Name "-- alias tests" -Status Skip -Message "kickstart-via-jira profile not found at $kickstartViaJiraProfile"
+        Write-TestResult -Name "-- alias tests" -Status Skip -Message $aliasInit.MissingRequired
     }
   } finally {
     # Belt-and-braces cleanup. Each section's own try/finally already removes

--- a/tests/Test-Structure.ps1
+++ b/tests/Test-Structure.ps1
@@ -171,10 +171,21 @@ if (-not $dotbotInstalled) {
         @{ Key = 'alias';  Args = @('-Workflow','multi-repo');                                                           Required = @('workflows\kickstart-via-jira') }
     )
 
+    # Pre-populate with Skipped placeholders so a worker that throws before
+    # emitting its result still leaves a usable entry — the section's
+    # `if (-not $xInit.Skipped)` check then routes to the existing skip path
+    # instead of dereferencing $null.
     $initResults = @{}
+    foreach ($spec in $initSpecs) {
+        $initResults[$spec.Key] = [pscustomobject]@{ Key = $spec.Key; Project = $null; Output = ''; Skipped = $true; MissingRequired = 'init worker did not emit a result' }
+    }
+
     $initSpecs | ForEach-Object -Parallel {
         $spec = $_
-        Import-Module "$using:PSScriptRoot\Test-Helpers.psm1" -Force -DisableNameChecking
+        # No -Force: if the runspace already has the module loaded, this is a
+        # no-op; otherwise it loads once. -Force would re-execute the module
+        # script on every iteration in a reused runspace.
+        Import-Module "$using:PSScriptRoot\Test-Helpers.psm1" -DisableNameChecking
         foreach ($rel in $spec.Required) {
             if (-not (Test-Path (Join-Path $using:dotbotDir $rel))) {
                 return [pscustomobject]@{ Key = $spec.Key; Project = $null; Output = ''; Skipped = $true; MissingRequired = $rel }
@@ -182,11 +193,20 @@ if (-not $dotbotInstalled) {
         }
         $project = New-TestProject
         Push-Location $project
-        $output = & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $using:dotbotDir 'scripts\init-project.ps1') @($spec.Args) 2>&1
+        # Only the alias spec inspects stdout (deprecation warning check).
+        # Discard output for the other five so we don't materialise large
+        # strings we'll never read.
+        if ($spec.Key -eq 'alias') {
+            $output = & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $using:dotbotDir 'scripts\init-project.ps1') @($spec.Args) 2>&1 | Out-String
+        } else {
+            & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $using:dotbotDir 'scripts\init-project.ps1') @($spec.Args) 2>&1 | Out-Null
+            $output = ''
+        }
         Pop-Location
-        [pscustomobject]@{ Key = $spec.Key; Project = $project; Output = ($output | Out-String); Skipped = $false; MissingRequired = $null }
+        [pscustomobject]@{ Key = $spec.Key; Project = $project; Output = $output; Skipped = $false; MissingRequired = $null }
     } -ThrottleLimit 6 | ForEach-Object { $initResults[$_.Key] = $_ }
 
+  try {
     # --- Phase B: run assertions per section against the pre-built projects.
 
     $testProject = $initResults['basic'].Project
@@ -660,6 +680,17 @@ if (-not $dotbotInstalled) {
     } else {
         Write-TestResult -Name "-- alias tests" -Status Skip -Message "kickstart-via-jira profile not found at $kickstartViaJiraProfile"
     }
+  } finally {
+    # Belt-and-braces cleanup. Each section's own try/finally already removes
+    # its temp project on the happy path; this catches anything that survives
+    # a terminating error in Phase B before its section's finally ran.
+    # Remove-TestProject is idempotent (path-existence + *dotbot-test* guard).
+    foreach ($r in $initResults.Values) {
+        if ($r -and $r.Project) {
+            Remove-TestProject -Path $r.Project
+        }
+    }
+  }
 }
 
 Write-Host ""

--- a/tests/Test-Structure.ps1
+++ b/tests/Test-Structure.ps1
@@ -159,13 +159,38 @@ $dotbotInstalled = Test-Path (Join-Path $dotbotDir "workflows\default")
 if (-not $dotbotInstalled) {
     Write-TestResult -Name "Project init tests" -Status Skip -Message "dotbot not installed globally — run install.ps1 first"
 } else {
-    $testProject = New-TestProject
-    try {
-        # Run init
-        Push-Location $testProject
-        & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
-        Pop-Location
+    # --- Phase A: fan out the six independent profile/workflow inits in parallel.
+    # Each writes to its own throwaway temp project (no shared state), so the wall
+    # time compresses to roughly the slowest single init instead of the sum.
+    $initSpecs = @(
+        @{ Key = 'basic';  Args = @();                                                                                   Required = @() }
+        @{ Key = 'dotnet'; Args = @('-Stack','dotnet');                                                                  Required = @('stacks\dotnet') }
+        @{ Key = 'combo';  Args = @('-Workflow','kickstart-via-jira','-Stack','dotnet-blazor');                          Required = @('workflows\kickstart-via-jira','stacks\dotnet-blazor') }
+        @{ Key = 'jira';   Args = @('-Workflow','kickstart-via-jira');                                                   Required = @('workflows\kickstart-via-jira') }
+        @{ Key = 'pr';     Args = @('-Workflow','kickstart-via-pr');                                                     Required = @('workflows\kickstart-via-pr') }
+        @{ Key = 'alias';  Args = @('-Workflow','multi-repo');                                                           Required = @('workflows\kickstart-via-jira') }
+    )
 
+    $initResults = @{}
+    $initSpecs | ForEach-Object -Parallel {
+        $spec = $_
+        Import-Module "$using:PSScriptRoot\Test-Helpers.psm1" -Force -DisableNameChecking
+        foreach ($rel in $spec.Required) {
+            if (-not (Test-Path (Join-Path $using:dotbotDir $rel))) {
+                return [pscustomobject]@{ Key = $spec.Key; Project = $null; Output = ''; Skipped = $true; MissingRequired = $rel }
+            }
+        }
+        $project = New-TestProject
+        Push-Location $project
+        $output = & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $using:dotbotDir 'scripts\init-project.ps1') @($spec.Args) 2>&1
+        Pop-Location
+        [pscustomobject]@{ Key = $spec.Key; Project = $project; Output = ($output | Out-String); Skipped = $false; MissingRequired = $null }
+    } -ThrottleLimit 6 | ForEach-Object { $initResults[$_.Key] = $_ }
+
+    # --- Phase B: run assertions per section against the pre-built projects.
+
+    $testProject = $initResults['basic'].Project
+    try {
         $botDir = Join-Path $testProject ".bot"
         Assert-PathExists -Name ".bot directory created" -Path $botDir
 
@@ -306,13 +331,10 @@ if (-not $dotbotInstalled) {
     Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
 
     $dotnetProfile = Join-Path $dotbotDir "stacks\dotnet"
-    if (Test-Path $dotnetProfile) {
-        $testProject3 = New-TestProject
+    $dotnetInit = $initResults['dotnet']
+    if (-not $dotnetInit.Skipped) {
+        $testProject3 = $dotnetInit.Project
         try {
-            Push-Location $testProject3
-            & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") -Stack dotnet 2>&1 | Out-Null
-            Pop-Location
-
             $botDir3 = Join-Path $testProject3 ".bot"
             Assert-PathExists -Name "--: .bot created with dotnet profile" -Path $botDir3
 
@@ -337,6 +359,7 @@ if (-not $dotbotInstalled) {
         Write-TestResult -Name "-Stack dotnet tests" -Status Skip -Message "dotnet profile not found at $dotnetProfile"
     }
 
+
     # --- Init with -Workflow kickstart-via-jira -Stack dotnet-blazor (taxonomy + extends) ---
     Write-Host ""
     Write-Host "  INIT --WORKFLOW + --STACK (with extends)" -ForegroundColor Cyan
@@ -344,13 +367,10 @@ if (-not $dotbotInstalled) {
 
     $kickstartViaJiraProfile = Join-Path $dotbotDir "workflows\kickstart-via-jira"
     $dotnetBlazorProfile = Join-Path $dotbotDir "stacks\dotnet-blazor"
-    if ((Test-Path $kickstartViaJiraProfile) -and (Test-Path $dotnetBlazorProfile)) {
-        $testProjectCombo = New-TestProject
+    $comboInit = $initResults['combo']
+    if (-not $comboInit.Skipped) {
+        $testProjectCombo = $comboInit.Project
         try {
-            Push-Location $testProjectCombo
-            & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") -Workflow kickstart-via-jira -Stack dotnet-blazor 2>&1 | Out-Null
-            Pop-Location
-
             $botDirCombo = Join-Path $testProjectCombo ".bot"
             Assert-PathExists -Name "Combo: .bot created" -Path $botDirCombo
 
@@ -397,13 +417,10 @@ if (-not $dotbotInstalled) {
     Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
 
     $kickstartViaJiraProfile = Join-Path $dotbotDir "workflows\kickstart-via-jira"
-    if (Test-Path $kickstartViaJiraProfile) {
-        $testProject4 = New-TestProject
+    $jiraInit = $initResults['jira']
+    if (-not $jiraInit.Skipped) {
+        $testProject4 = $jiraInit.Project
         try {
-            Push-Location $testProject4
-            & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") -Workflow kickstart-via-jira 2>&1 | Out-Null
-            Pop-Location
-
             $botDir4 = Join-Path $testProject4 ".bot"
             Assert-PathExists -Name "-- kickstart-via-jira: .bot created" -Path $botDir4
 
@@ -553,13 +570,10 @@ if (-not $dotbotInstalled) {
 
     $kickstartViaPrProfile = Join-Path $dotbotDir "workflows\kickstart-via-pr"
     Assert-PathExists -Name "-- kickstart-via-pr: source profile exists" -Path $kickstartViaPrProfile
-    if (Test-Path $kickstartViaPrProfile) {
-        $testProjectPr = New-TestProject
+    $prInit = $initResults['pr']
+    if (-not $prInit.Skipped) {
+        $testProjectPr = $prInit.Project
         try {
-            Push-Location $testProjectPr
-            & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") -Workflow kickstart-via-pr 2>&1 | Out-Null
-            Pop-Location
-
             $botDirPr = Join-Path $testProjectPr ".bot"
             Assert-PathExists -Name "-- kickstart-via-pr: .bot created" -Path $botDirPr
             Assert-PathExists -Name "-- kickstart-via-pr: .env.local created" -Path (Join-Path $testProjectPr ".env.local")
@@ -622,13 +636,10 @@ if (-not $dotbotInstalled) {
     Write-Host "  INIT DEPRECATED ALIAS" -ForegroundColor Cyan
     Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
 
-    if (Test-Path $kickstartViaJiraProfile) {
-        $testProjectAlias = New-TestProject
+    $aliasInit = $initResults['alias']
+    if (-not $aliasInit.Skipped) {
+        $testProjectAlias = $aliasInit.Project
         try {
-            Push-Location $testProjectAlias
-            $aliasOutput = & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") -Workflow multi-repo 2>&1
-            Pop-Location
-
             $aliasBotDir = Join-Path $testProjectAlias ".bot"
             Assert-PathExists -Name "-- alias multi-repo: .bot created" -Path $aliasBotDir
 
@@ -639,7 +650,7 @@ if (-not $dotbotInstalled) {
                     -Expected "kickstart-via-jira" -Actual $aliasSettings.workflow
             }
 
-            $aliasOutputText = $aliasOutput | Out-String
+            $aliasOutputText = $aliasInit.Output
             Assert-True -Name "-- alias multi-repo shows deprecation warning" `
                 -Condition ($aliasOutputText -match "deprecated" -and $aliasOutputText -match "kickstart-via-jira") `
                 -Message "Expected deprecation warning for multi-repo alias"


### PR DESCRIPTION
## Summary

- Fan out the six independent `init-project.ps1` calls in `Test-Structure.ps1` into `ForEach-Object -Parallel`. Each call writes to its own throwaway temp project (no shared state), so they're safe to run concurrently.
- Phase A (top of the dotbot-installed branch) creates the six projects in parallel and returns a hashtable keyed by name. Phase B (the existing six sections) runs assertions against the pre-built projects — no assertion logic was touched.
- The `-Force` re-init in the basic section stays serial because it depends on the basic init having already run.

## Result on my machine

| | Test-Structure.ps1 | Same assertions? |
|---|---|---|
| Baseline (post-#327) | 308.9s | 292 / 0 / 0 |
| With this change | 152.9s | 292 / 0 / 0 |

50.5% faster (156s saved). With the inline-timing leaderboard from #327, the parallel batch shows up as a single ~59s tick on `.bot directory created` (the first assertion after Phase A) — that's the slowest single init in the batch, which is the correct attribution. The previously-30-50s `--: .bot created`, `-- kickstart-via-jira: .bot created`, etc. are all now sub-second because the projects were pre-built.

## Test plan

- [x] AST parse-check
- [x] `pwsh tests/Test-Structure.ps1` standalone — 292/0/0 in 152.9s
- [x] `git diff origin/main` — +47/-36 lines, single file
- [ ] Layers 1-3 CI on Windows / macOS / Linux must all pass — that's the OS-specific safety net for the runspace concurrency

Closes #328