### PR TITLE
test: golden-snapshot fixtures for .bot/ to cut Layer 1-3 setup time

### DIFF
--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -58,8 +58,10 @@ Write-Host ""
 $devDir = Split-Path $PSScriptRoot -Parent  # repo root
 $installDir = Join-Path $HOME "dotbot"
 if ((Test-Path $installDir) -and (2 -in $layersToRun -or 3 -in $layersToRun -or 4 -in $layersToRun)) {
-    $devNewest = (Get-ChildItem "$devDir\workflows","$devDir\stacks" -Recurse -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1).LastWriteTime
-    $installNewest = (Get-ChildItem "$installDir\workflows","$installDir\stacks" -Recurse -File -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -First 1).LastWriteTime
+    # scripts/ is included so changes to init-project.ps1 / Platform-Functions.psm1
+    # / etc. trigger an auto-reinstall (and downstream golden rebuild).
+    $devNewest = (Get-ChildItem "$devDir\workflows","$devDir\stacks","$devDir\scripts" -Recurse -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1).LastWriteTime
+    $installNewest = (Get-ChildItem "$installDir\workflows","$installDir\stacks","$installDir\scripts" -Recurse -File -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -First 1).LastWriteTime
     if ($devNewest -gt $installNewest) {
         Write-Host "  ⚠ Installed dotbot is stale (dev source is newer)" -ForegroundColor Yellow
         Write-Host "  → Auto-installing from dev source..." -ForegroundColor Yellow

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -80,6 +80,12 @@ if ((Test-Path $installDir) -and (2 -in $layersToRun -or 3 -in $layersToRun -or 
 # .bot/ once per workflow flavor here and tests clone the matching golden
 # instead of paying the 30s init cost per section.
 if (2 -in $layersToRun -or 3 -in $layersToRun) {
+    if (-not (Test-Path $installDir)) {
+        Write-Host "  ✗ dotbot is not installed at $installDir" -ForegroundColor Red
+        Write-Host "  → Run: pwsh install.ps1" -ForegroundColor Yellow
+        Write-Host ""
+        exit 1
+    }
     Import-Module "$PSScriptRoot\Test-Helpers.psm1" -DisableNameChecking
     try {
         Initialize-GoldenSnapshots -Flavors @('default', 'start-from-jira', 'start-from-pr', 'start-from-repo') | Out-Null

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -83,9 +83,11 @@ if (2 -in $layersToRun -or 3 -in $layersToRun) {
         Initialize-GoldenSnapshots -Flavors @('default', 'start-from-jira', 'start-from-pr', 'start-from-repo') | Out-Null
         Write-Host ""
     } catch {
+        # Layer 2/3 hard-depends on goldens. Continuing would only produce
+        # noisy downstream failures, so fail fast here.
         Write-Host "  ✗ Golden snapshot build failed: $($_.Exception.Message)" -ForegroundColor Red
-        Write-Host "  Tests that depend on goldens will fail; tests that call init directly will still run." -ForegroundColor DarkYellow
         Write-Host ""
+        exit 1
     }
 }
 

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -73,6 +73,22 @@ if ((Test-Path $installDir) -and (2 -in $layersToRun -or 3 -in $layersToRun -or 
     }
 }
 
+# ── Golden snapshot fixtures ─────────────────────────────────────────────
+# Most Layer 2+ tests just need a ready .bot/, not a fresh init. We build
+# .bot/ once per workflow flavor here and tests clone the matching golden
+# instead of paying the 30s init cost per section.
+if (2 -in $layersToRun -or 3 -in $layersToRun) {
+    Import-Module "$PSScriptRoot\Test-Helpers.psm1" -DisableNameChecking
+    try {
+        Initialize-GoldenSnapshots -Flavors @('default', 'start-from-jira', 'start-from-pr', 'start-from-repo') | Out-Null
+        Write-Host ""
+    } catch {
+        Write-Host "  ✗ Golden snapshot build failed: $($_.Exception.Message)" -ForegroundColor Red
+        Write-Host "  Tests that depend on goldens will fail; tests that call init directly will still run." -ForegroundColor DarkYellow
+        Write-Host ""
+    }
+}
+
 $overallFailed = $false
 $layerResults = @{}
 $layerTimings = @{}

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -40,16 +40,10 @@ if (-not $yamlModule) {
     exit 1
 }
 
-# Create a test project with .bot initialized
-$testProject = New-TestProject
-$botDir = Join-Path $testProject ".bot"
-
-Push-Location $testProject
-& pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
-
-& git add -A 2>&1 | Out-Null
-& git commit -m "dotbot init" --quiet 2>&1 | Out-Null
-Pop-Location
+# Create a test project with .bot pre-populated from the default golden snapshot
+$layer2Proj = New-TestProjectFromGolden -Flavor 'default'
+$testProject = $layer2Proj.ProjectRoot
+$botDir = $layer2Proj.BotDir
 
 # Strip verify config to only include scripts that actually exist in the test project
 $verifyConfigPath = Join-Path $botDir "hooks\verify\config.json"
@@ -3059,14 +3053,9 @@ Write-Host "  ──────────────────────
 
 $kickstartViaJiraProfile = Join-Path $dotbotDir "workflows\start-from-jira"
 if (Test-Path $kickstartViaJiraProfile) {
-    $mrTestProject = New-TestProject
-    $mrBotDir = Join-Path $mrTestProject ".bot"
-
-    Push-Location $mrTestProject
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") -Workflow start-from-jira 2>&1 | Out-Null
-    & git add -A 2>&1 | Out-Null
-    & git commit -m "dotbot init start-from-jira" --quiet 2>&1 | Out-Null
-    Pop-Location
+    $mrProj = New-TestProjectFromGolden -Flavor 'start-from-jira'
+    $mrTestProject = $mrProj.ProjectRoot
+    $mrBotDir = $mrProj.BotDir
 
     # Strip verify config to only include scripts that actually exist in the test project
     $mrVerifyConfig = Join-Path $mrBotDir "hooks\verify\config.json"
@@ -3256,14 +3245,9 @@ Write-Host "  ──────────────────────
 $kickstartViaPrProfile = Join-Path $dotbotDir "workflows\start-from-pr"
 Assert-PathExists -Name "start-from-pr profile source exists" -Path $kickstartViaPrProfile
 if (Test-Path $kickstartViaPrProfile) {
-    $prTestProject = New-TestProject
-    $prBotDir = Join-Path $prTestProject ".bot"
-
-    Push-Location $prTestProject
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") -Workflow start-from-pr 2>&1 | Out-Null
-    & git add -A 2>&1 | Out-Null
-    & git commit -m "dotbot init start-from-pr" --quiet 2>&1 | Out-Null
-    Pop-Location
+    $prProj = New-TestProjectFromGolden -Flavor 'start-from-pr'
+    $prTestProject = $prProj.ProjectRoot
+    $prBotDir = $prProj.BotDir
 
     $prVerifyConfig = Join-Path $prBotDir "hooks\verify\config.json"
     if (Test-Path $prVerifyConfig) {

--- a/tests/Test-Helpers.psm1
+++ b/tests/Test-Helpers.psm1
@@ -458,7 +458,13 @@ function Initialize-GoldenSnapshots {
             continue
         }
         if ($sourceNewest) {
-            $goldenNewest = (Get-ChildItem $goldenBot -Recurse -File -ErrorAction SilentlyContinue |
+            # Scan the whole golden tree, not just .bot/ — init writes root
+            # files (.gitignore, .mcp.json, .claude/, etc.) that the golden
+            # captures, and scripts/ aren't copied under .bot/ at all. Limiting
+            # to .bot/ would (a) miss stale root files and (b) trigger
+            # constant rebuilds when ~/dotbot/scripts has a newer mtime than
+            # any .bot file.
+            $goldenNewest = (Get-ChildItem $goldenDir -Recurse -File -ErrorAction SilentlyContinue |
                 Sort-Object LastWriteTime -Descending | Select-Object -First 1).LastWriteTime
             if (-not $goldenNewest -or $sourceNewest -gt $goldenNewest) {
                 $needRebuild += $flavor

--- a/tests/Test-Helpers.psm1
+++ b/tests/Test-Helpers.psm1
@@ -438,7 +438,10 @@ function Initialize-GoldenSnapshots {
         }
     }
 
-    $sourcePaths = @("$dotbotDir\workflows", "$dotbotDir\stacks") | Where-Object { Test-Path $_ }
+    # scripts/ is included so a change to init-project.ps1 (or anything else
+    # init-project loads) invalidates the golden — workflows/ and stacks/ alone
+    # would miss script-only updates. Mirrors the stale-install check in Run-Tests.ps1.
+    $sourcePaths = @("$dotbotDir\workflows", "$dotbotDir\stacks", "$dotbotDir\scripts") | Where-Object { Test-Path $_ }
     $sourceNewest = $null
     if ($sourcePaths) {
         $sourceNewest = (Get-ChildItem $sourcePaths -Recurse -File -ErrorAction SilentlyContinue |

--- a/tests/Test-Helpers.psm1
+++ b/tests/Test-Helpers.psm1
@@ -350,6 +350,249 @@ function Initialize-TestBotProject {
     }
 }
 
+# --- Golden Snapshot Fixtures ---
+#
+# Each Layer 2+ test that needs a ready .bot/ used to call init-project.ps1
+# (~30s on Windows). We instead build the post-init project once per workflow
+# flavor at suite start and clone it via robocopy (Windows) or cp -a (Unix)
+# per test. Tests that exist to verify init behaviour still call
+# Initialize-TestBotProject directly. Set DOTBOT_REBUILD_GOLDENS=1 to force
+# a rebuild.
+#
+# A "golden" captures the full post-init project root (sans .git/), not just
+# .bot/. init-project.ps1 also creates .gitignore, .mcp.json, .claude/,
+# .codex/, .gemini/, AGENTS.md, CLAUDE.md, GEMINI.md, etc. Tests that read
+# any of these (e.g. Get-GitignoredCopyPaths reads .gitignore) need the
+# whole tree.
+
+function Get-GoldenSnapshotsRoot {
+    return Join-Path ([System.IO.Path]::GetTempPath()) 'dotbot-test-goldens'
+}
+
+function Copy-DirectoryTree {
+    <#
+    .SYNOPSIS
+        Cross-platform recursive directory copy. Source contents into Destination.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$Source,
+        [Parameter(Mandatory)][string]$Destination
+    )
+
+    if (-not (Test-Path $Destination)) {
+        New-Item -ItemType Directory -Path $Destination -Force | Out-Null
+    }
+
+    if ($IsWindows) {
+        # /MIR mirrors; /XD .git keeps the destination's own git repo intact.
+        # Exit codes 0-7 are success; >=8 is a real failure.
+        & robocopy $Source $Destination /MIR /XD .git /MT:8 /NJS /NFL /NDL /NP /NC 2>&1 | Out-Null
+        if ($LASTEXITCODE -ge 8) {
+            $code = $LASTEXITCODE
+            $global:LASTEXITCODE = 0
+            throw "robocopy failed (exit $code) copying $Source -> $Destination"
+        }
+        $global:LASTEXITCODE = 0
+    } else {
+        # cp -a preserves attributes; trailing /. copies contents not dir.
+        & cp -a "$Source/." $Destination
+        if ($LASTEXITCODE -ne 0) {
+            throw "cp -a failed (exit $LASTEXITCODE) copying $Source -> $Destination"
+        }
+    }
+}
+
+function Initialize-GoldenSnapshots {
+    <#
+    .SYNOPSIS
+        Build per-flavor golden .bot/ snapshots once for the test run.
+    .DESCRIPTION
+        Each flavor's golden lives at <temp>\dotbot-test-goldens\<flavor>\.bot\.
+        Rebuilds any flavor whose golden is missing, older than the installed
+        dotbot source, or when $env:DOTBOT_REBUILD_GOLDENS = '1'. Builds all
+        stale flavors in parallel via ForEach-Object -Parallel (mirroring the
+        pattern in Test-Structure.ps1).
+        Returns a hashtable mapping flavor -> .bot/ path.
+    #>
+    param([Parameter(Mandatory)][string[]]$Flavors)
+
+    $dotbotDir = Get-DotbotInstallDir
+    $goldensRoot = Get-GoldenSnapshotsRoot
+    if (-not (Test-Path $goldensRoot)) {
+        New-Item -ItemType Directory -Path $goldensRoot -Force | Out-Null
+    }
+
+    $argsMap = @{
+        'default'         = @()
+        'start-from-jira' = @('-Workflow', 'start-from-jira')
+        'start-from-pr'   = @('-Workflow', 'start-from-pr')
+        'start-from-repo' = @('-Workflow', 'start-from-repo')
+    }
+
+    foreach ($flavor in $Flavors) {
+        if (-not $argsMap.ContainsKey($flavor)) {
+            throw "Unknown golden flavor: $flavor"
+        }
+    }
+
+    $sourcePaths = @("$dotbotDir\workflows", "$dotbotDir\stacks") | Where-Object { Test-Path $_ }
+    $sourceNewest = $null
+    if ($sourcePaths) {
+        $sourceNewest = (Get-ChildItem $sourcePaths -Recurse -File -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTime -Descending | Select-Object -First 1).LastWriteTime
+    }
+
+    $forceRebuild = $env:DOTBOT_REBUILD_GOLDENS -eq '1'
+    $needRebuild = @()
+    foreach ($flavor in $Flavors) {
+        $goldenDir = Join-Path $goldensRoot $flavor
+        $goldenBot = Join-Path $goldenDir '.bot'
+        if ($forceRebuild -or -not (Test-Path $goldenBot)) {
+            $needRebuild += $flavor
+            continue
+        }
+        if ($sourceNewest) {
+            $goldenNewest = (Get-ChildItem $goldenBot -Recurse -File -ErrorAction SilentlyContinue |
+                Sort-Object LastWriteTime -Descending | Select-Object -First 1).LastWriteTime
+            if (-not $goldenNewest -or $sourceNewest -gt $goldenNewest) {
+                $needRebuild += $flavor
+            }
+        }
+    }
+
+    if ($needRebuild.Count -gt 0) {
+        Write-Host "  → Building golden snapshots for: $($needRebuild -join ', ')" -ForegroundColor Cyan
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+
+        # Resolve args per-flavor in the outer scope; ForEach-Object -Parallel
+        # rejects subscripted $using: expressions like $using:argsMap[$flavor].
+        $buildSpecs = $needRebuild | ForEach-Object {
+            [pscustomobject]@{ Flavor = $_; Args = $argsMap[$_] }
+        }
+
+        $buildResults = $buildSpecs | ForEach-Object -Parallel {
+            $spec = $_
+            $flavor = $spec.Flavor
+            $goldenFlavorDir = Join-Path $using:goldensRoot $flavor
+            $buildError = $null
+            $tempProject = $null
+
+            try {
+                if (Test-Path $goldenFlavorDir) {
+                    Remove-Item -Path $goldenFlavorDir -Recurse -Force -ErrorAction SilentlyContinue
+                }
+                New-Item -ItemType Directory -Path $goldenFlavorDir -Force | Out-Null
+
+                Import-Module (Join-Path $using:PSScriptRoot 'Test-Helpers.psm1') -DisableNameChecking
+                $tempProject = New-TestProject -Prefix 'dotbot-golden-build'
+
+                Push-Location $tempProject
+                if ($spec.Args.Count -eq 0) {
+                    & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $using:dotbotDir 'scripts\init-project.ps1') 2>&1 | Out-Null
+                } else {
+                    & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $using:dotbotDir 'scripts\init-project.ps1') @($spec.Args) 2>&1 | Out-Null
+                }
+                Pop-Location
+
+                if (-not (Test-Path (Join-Path $tempProject '.bot'))) {
+                    throw "init-project.ps1 did not create .bot for flavor $flavor"
+                }
+                # Capture entire post-init project (sans .git/) — init creates
+                # .gitignore, .mcp.json, .claude/, .codex/, .gemini/, AGENTS.md,
+                # CLAUDE.md, GEMINI.md alongside .bot/, and downstream tests
+                # (e.g. Get-GitignoredCopyPaths) read these.
+                Copy-DirectoryTree -Source $tempProject -Destination $goldenFlavorDir
+            } catch {
+                $buildError = $_.Exception.Message
+            } finally {
+                if ($tempProject) {
+                    Remove-TestProject -Path $tempProject
+                }
+            }
+
+            [pscustomobject]@{ Flavor = $flavor; Error = $buildError }
+        } -ThrottleLimit 6
+
+        $failures = $buildResults | Where-Object { $_.Error }
+        if ($failures) {
+            $msg = ($failures | ForEach-Object { "$($_.Flavor): $($_.Error)" }) -join '; '
+            throw "Golden snapshot build failed: $msg"
+        }
+
+        $sw.Stop()
+        Write-Host "  ✓ Goldens built in $([math]::Round($sw.Elapsed.TotalSeconds, 1))s" -ForegroundColor Green
+    }
+
+    $result = @{}
+    foreach ($flavor in $Flavors) {
+        $result[$flavor] = Join-Path $goldensRoot "$flavor\.bot"
+    }
+    return $result
+}
+
+function New-TestProjectFromGolden {
+    <#
+    .SYNOPSIS
+        Create a test project by cloning a pre-built post-init golden snapshot.
+    .DESCRIPTION
+        Returns the same shape as Initialize-TestBotProject but ~10-30x faster
+        because it skips init-project.ps1. Initialize-GoldenSnapshots must have
+        been called first (Run-Tests.ps1 does this once before Layer 2). The
+        returned project is fully isolated: regenerating instance_id ensures
+        clones don't share workspace identity with the golden or each other.
+
+        Copies the entire golden tree (.bot/, .gitignore, .mcp.json, .claude/,
+        .codex/, .gemini/, *.md memory files) into the new test project. The
+        new project's .git/ is preserved (Copy-DirectoryTree excludes .git).
+    #>
+    param(
+        [Parameter(Mandatory)][string]$Flavor,
+        [string]$Prefix = 'dotbot-test'
+    )
+
+    $goldensRoot = Get-GoldenSnapshotsRoot
+    $goldenDir = Join-Path $goldensRoot $Flavor
+    if (-not (Test-Path (Join-Path $goldenDir '.bot'))) {
+        throw "Golden snapshot for flavor '$Flavor' not found at $goldenDir. Initialize-GoldenSnapshots must run before this function (Run-Tests.ps1 calls it before Layer 2)."
+    }
+
+    $project = New-TestProject -Prefix $Prefix
+    Copy-DirectoryTree -Source $goldenDir -Destination $project
+
+    $destBot = Join-Path $project '.bot'
+
+    # Regenerate instance_id so each clone has its own workspace identity.
+    $settingsPath = Join-Path $destBot 'settings\settings.default.json'
+    if (Test-Path $settingsPath) {
+        try {
+            $settings = Get-Content $settingsPath -Raw | ConvertFrom-Json
+            $newId = [guid]::NewGuid().ToString()
+            if ($settings.PSObject.Properties['instance_id']) {
+                $settings.instance_id = $newId
+            } else {
+                $settings | Add-Member -NotePropertyName instance_id -NotePropertyValue $newId -Force
+            }
+            $settings | ConvertTo-Json -Depth 10 | Set-Content -Path $settingsPath -Encoding UTF8
+        } catch { Write-Verbose "instance_id regen skipped: $_" }
+    }
+
+    $controlDir = Join-Path $destBot '.control'
+    if (-not (Test-Path $controlDir)) {
+        New-Item -Path $controlDir -ItemType Directory -Force | Out-Null
+    }
+
+    Push-Location $project
+    & git add -A 2>&1 | Out-Null
+    & git commit -m "dotbot init" --quiet 2>&1 | Out-Null
+    Pop-Location
+
+    return @{
+        ProjectRoot = $project
+        BotDir      = $destBot
+        ControlDir  = $controlDir
+    }
+}
+
 # --- MCP Server Helpers ---
 
 function Start-McpServer {
@@ -495,6 +738,10 @@ Export-ModuleMember -Function @(
     'New-TestProject'
     'Remove-TestProject'
     'Initialize-TestBotProject'
+    'Get-GoldenSnapshotsRoot'
+    'Copy-DirectoryTree'
+    'Initialize-GoldenSnapshots'
+    'New-TestProjectFromGolden'
     'Start-McpServer'
     'Stop-McpServer'
     'Send-McpRequest'

--- a/tests/Test-Helpers.psm1
+++ b/tests/Test-Helpers.psm1
@@ -501,16 +501,25 @@ function Initialize-GoldenSnapshots {
                 $tempProject = New-TestProject -Prefix 'dotbot-test-golden-build'
 
                 Push-Location $tempProject
-                if ($spec.Args.Count -eq 0) {
-                    & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $using:dotbotDir 'scripts\init-project.ps1') 2>&1 | Out-Null
+                $initOutput = if ($spec.Args.Count -eq 0) {
+                    & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $using:dotbotDir 'scripts\init-project.ps1') 2>&1
                 } else {
-                    & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $using:dotbotDir 'scripts\init-project.ps1') @($spec.Args) 2>&1 | Out-Null
+                    & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $using:dotbotDir 'scripts\init-project.ps1') @($spec.Args) 2>&1
                 }
                 $initExitCode = $LASTEXITCODE
                 Pop-Location
 
                 if ($initExitCode -ne 0) {
-                    throw "init-project.ps1 failed for flavor $flavor (exit $initExitCode)"
+                    # Surface init-project.ps1's own output — without it, "exit 1"
+                    # alone is hard to debug. Trim and tail to keep errors readable.
+                    $initText = (($initOutput | ForEach-Object { "$_" }) -join [Environment]::NewLine).Trim()
+                    if ($initText.Length -gt 4000) {
+                        $initText = '...' + $initText.Substring($initText.Length - 3997)
+                    }
+                    if ([string]::IsNullOrWhiteSpace($initText)) {
+                        throw "init-project.ps1 failed for flavor $flavor (exit $initExitCode)"
+                    }
+                    throw "init-project.ps1 failed for flavor $flavor (exit $initExitCode):$([Environment]::NewLine)$initText"
                 }
                 if (-not (Test-Path (Join-Path $tempProject '.bot'))) {
                     throw "init-project.ps1 did not create .bot for flavor $flavor"

--- a/tests/Test-Helpers.psm1
+++ b/tests/Test-Helpers.psm1
@@ -394,10 +394,13 @@ function Copy-DirectoryTree {
         }
         $global:LASTEXITCODE = 0
     } else {
-        # cp -a preserves attributes; trailing /. copies contents not dir.
-        & cp -a "$Source/." $Destination
-        if ($LASTEXITCODE -ne 0) {
-            throw "cp -a failed (exit $LASTEXITCODE) copying $Source -> $Destination"
+        # Match Windows behaviour by excluding .git so the destination repo stays
+        # intact (and so goldens captured on Unix don't bake a stale .git in).
+        Get-ChildItem -LiteralPath $Source -Force | Where-Object { $_.Name -ne '.git' } | ForEach-Object {
+            & cp -a $_.FullName $Destination
+            if ($LASTEXITCODE -ne 0) {
+                throw "cp -a failed (exit $LASTEXITCODE) copying $($_.FullName) -> $Destination"
+            }
         }
     }
 }
@@ -484,7 +487,9 @@ function Initialize-GoldenSnapshots {
                 New-Item -ItemType Directory -Path $goldenFlavorDir -Force | Out-Null
 
                 Import-Module (Join-Path $using:PSScriptRoot 'Test-Helpers.psm1') -DisableNameChecking
-                $tempProject = New-TestProject -Prefix 'dotbot-golden-build'
+                # Prefix must contain "dotbot-test" so Remove-TestProject's
+                # safety allowlist (`$Path -like "*dotbot-test*"`) cleans it up.
+                $tempProject = New-TestProject -Prefix 'dotbot-test-golden-build'
 
                 Push-Location $tempProject
                 if ($spec.Args.Count -eq 0) {
@@ -492,8 +497,12 @@ function Initialize-GoldenSnapshots {
                 } else {
                     & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $using:dotbotDir 'scripts\init-project.ps1') @($spec.Args) 2>&1 | Out-Null
                 }
+                $initExitCode = $LASTEXITCODE
                 Pop-Location
 
+                if ($initExitCode -ne 0) {
+                    throw "init-project.ps1 failed for flavor $flavor (exit $initExitCode)"
+                }
                 if (-not (Test-Path (Join-Path $tempProject '.bot'))) {
                     throw "init-project.ps1 did not create .bot for flavor $flavor"
                 }
@@ -553,7 +562,10 @@ function New-TestProjectFromGolden {
     $goldensRoot = Get-GoldenSnapshotsRoot
     $goldenDir = Join-Path $goldensRoot $Flavor
     if (-not (Test-Path (Join-Path $goldenDir '.bot'))) {
-        throw "Golden snapshot for flavor '$Flavor' not found at $goldenDir. Initialize-GoldenSnapshots must run before this function (Run-Tests.ps1 calls it before Layer 2)."
+        # Standalone test-file runs (e.g. `pwsh tests/Test-Components.ps1`) skip
+        # the suite-level build. Lazily build the missing flavor here so each
+        # test file remains runnable on its own.
+        Initialize-GoldenSnapshots -Flavors @($Flavor) | Out-Null
     }
 
     $project = New-TestProject -Prefix $Prefix

--- a/tests/Test-ServerStartup.ps1
+++ b/tests/Test-ServerStartup.ps1
@@ -141,26 +141,14 @@ function Stop-UiServer {
 function Initialize-TestBotProject {
     <#
     .SYNOPSIS
-        Create a temp project and run dotbot init.
+        Create a temp project from the default golden .bot/ snapshot.
+    .DESCRIPTION
+        Local override that delegates to New-TestProjectFromGolden so each
+        Test-ServerStartup section gets a ready .bot/ in ~1-3s instead of
+        paying the 30s init cost. The HTTP server tests don't depend on
+        having a freshly-initialised .bot/, only a clean one.
     #>
-    $project = New-TestProject
-    Push-Location $project
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
-    & git add -A 2>&1 | Out-Null
-    & git commit -m "dotbot init" --quiet 2>&1 | Out-Null
-    Pop-Location
-
-    $botDir = Join-Path $project ".bot"
-    $controlDir = Join-Path $botDir ".control"
-    if (-not (Test-Path $controlDir)) {
-        New-Item -Path $controlDir -ItemType Directory -Force | Out-Null
-    }
-
-    return @{
-        ProjectRoot = $project
-        BotDir      = $botDir
-        ControlDir  = $controlDir
-    }
+    return New-TestProjectFromGolden -Flavor 'default'
 }
 
 # ═══════════════════════════════════════════════════════════════════

--- a/tests/Test-ToolLocal.ps1
+++ b/tests/Test-ToolLocal.ps1
@@ -39,12 +39,9 @@ if (-not $dotbotInstalled) {
 
 # --- Default workflow tools (need an initialized project) ---
 
-$testProject = New-TestProject
-$botDir = Join-Path $testProject ".bot"
-
-Push-Location $testProject
-& pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
-Pop-Location
+$toolLocalProj = New-TestProjectFromGolden -Flavor 'default'
+$testProject = $toolLocalProj.ProjectRoot
+$botDir = $toolLocalProj.BotDir
 
 $toolsDir = Join-Path $botDir "systems\mcp\tools"
 $defaultTests = Get-ChildItem -Path $toolsDir -Filter "test.ps1" -Recurse -File -ErrorAction SilentlyContinue |

--- a/tests/Test-WorkflowIntegration.ps1
+++ b/tests/Test-WorkflowIntegration.ps1
@@ -197,13 +197,10 @@ Write-Host ""
 Write-Host "  GET-ACTIVEWORKFLOWMANIFEST" -ForegroundColor Cyan
 Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
 
-$testProjectManifest = New-TestProject
+$manifestProj = New-TestProjectFromGolden -Flavor 'default'
+$testProjectManifest = $manifestProj.ProjectRoot
 try {
-    Push-Location $testProjectManifest
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
-    Pop-Location
-
-    $botDirManifest = Join-Path $testProjectManifest ".bot"
+    $botDirManifest = $manifestProj.BotDir
 
     # Dot-source the workflow manifest module from the installed bot
     . (Join-Path $botDirManifest "systems\runtime\modules\workflow-manifest.ps1")
@@ -268,13 +265,10 @@ Write-Host ""
 Write-Host "  FORM.MODES CONDITIONS" -ForegroundColor Cyan
 Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
 
-$testProjectModes = New-TestProject
+$modesProj = New-TestProjectFromGolden -Flavor 'default'
+$testProjectModes = $modesProj.ProjectRoot
 try {
-    Push-Location $testProjectModes
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
-    Pop-Location
-
-    $botDirModes = Join-Path $testProjectModes ".bot"
+    $botDirModes = $modesProj.BotDir
 
     # Dot-source workflow manifest module
     . (Join-Path $botDirModes "systems\runtime\modules\workflow-manifest.ps1")
@@ -346,13 +340,10 @@ Write-Host "  MANIFEST PREFLIGHT CHECKS" -ForegroundColor Cyan
 Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
 
 if (Test-Path $kickstartViaJiraProfile) {
-    $testProjectPreflight = New-TestProject
+    $preflightProj = New-TestProjectFromGolden -Flavor 'start-from-jira'
+    $testProjectPreflight = $preflightProj.ProjectRoot
     try {
-        Push-Location $testProjectPreflight
-        & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") -Workflow start-from-jira 2>&1 | Out-Null
-        Pop-Location
-
-        $botDirPreflight = Join-Path $testProjectPreflight ".bot"
+        $botDirPreflight = $preflightProj.BotDir
 
         # Dot-source modules
         . (Join-Path $botDirPreflight "systems\runtime\modules\workflow-manifest.ps1")
@@ -398,13 +389,10 @@ if (Test-Path $kickstartViaJiraProfile) {
 }
 
 # Default profile should have empty/minimal preflight
-$testProjectDefaultPreflight = New-TestProject
+$defaultPreflightProj = New-TestProjectFromGolden -Flavor 'default'
+$testProjectDefaultPreflight = $defaultPreflightProj.ProjectRoot
 try {
-    Push-Location $testProjectDefaultPreflight
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
-    Pop-Location
-
-    $botDirDefaultPreflight = Join-Path $testProjectDefaultPreflight ".bot"
+    $botDirDefaultPreflight = $defaultPreflightProj.BotDir
     . (Join-Path $botDirDefaultPreflight "systems\runtime\modules\workflow-manifest.ps1")
 
     $defaultManifest = Get-ActiveWorkflowManifest -BotRoot $botDirDefaultPreflight
@@ -428,13 +416,10 @@ Write-Host ""
 Write-Host "  MANIFEST TASKS → PHASES" -ForegroundColor Cyan
 Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
 
-$testProjectPhases = New-TestProject
+$phasesProj = New-TestProjectFromGolden -Flavor 'default'
+$testProjectPhases = $phasesProj.ProjectRoot
 try {
-    Push-Location $testProjectPhases
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
-    Pop-Location
-
-    $botDirPhases = Join-Path $testProjectPhases ".bot"
+    $botDirPhases = $phasesProj.BotDir
     . (Join-Path $botDirPhases "systems\runtime\modules\workflow-manifest.ps1")
 
     $manifest = Get-ActiveWorkflowManifest -BotRoot $botDirPhases
@@ -477,13 +462,10 @@ Write-Host ""
 Write-Host "  TASK CONDITIONS IN PIPELINE" -ForegroundColor Cyan
 Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
 
-$testProjectConditions = New-TestProject
+$conditionsProj = New-TestProjectFromGolden -Flavor 'default'
+$testProjectConditions = $conditionsProj.ProjectRoot
 try {
-    Push-Location $testProjectConditions
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
-    Pop-Location
-
-    $botDirCond = Join-Path $testProjectConditions ".bot"
+    $botDirCond = $conditionsProj.BotDir
     . (Join-Path $botDirCond "systems\runtime\modules\workflow-manifest.ps1")
 
     $manifest = Get-ActiveWorkflowManifest -BotRoot $botDirCond
@@ -531,15 +513,9 @@ Write-Host "  ──────────────────────
 $cliScript = Join-Path $dotbotDir "bin\dotbot.ps1"
 $kickstartWf = Join-Path $dotbotDir "workflows\start-from-prompt"
 if ((Test-Path $cliScript) -and (Test-Path $kickstartWf)) {
-    $testProjectCli = New-TestProject
+    $cliProj = New-TestProjectFromGolden -Flavor 'default'
+    $testProjectCli = $cliProj.ProjectRoot
     try {
-        Push-Location $testProjectCli
-        try {
-            & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
-        } finally {
-            Pop-Location
-        }
-
         # Test: workflow add with no extra args (the failing scenario)
         $addOutput = & pwsh -NoProfile -ExecutionPolicy Bypass -Command "Set-Location '$testProjectCli'; & '$cliScript' workflow add start-from-prompt" 2>&1
         $addFailed = $addOutput | Where-Object { $_ -match 'positional parameter cannot be found' -or $_ -match 'cannot be found that accepts argument' }
@@ -587,13 +563,10 @@ $kickstartFromScratchDir = Join-Path $dotbotDir "workflows\start-from-prompt"
 
 if ((Test-Path $wfAddScript) -and (Test-Path $kickstartFromScratchDir)) {
     # --- Test: basic add creates expected directory structure ---
-    $testProjectAdd = New-TestProject
+    $addProj = New-TestProjectFromGolden -Flavor 'default'
+    $testProjectAdd = $addProj.ProjectRoot
     try {
-        Push-Location $testProjectAdd
-        & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
-        Pop-Location
-
-        $botDir = Join-Path $testProjectAdd ".bot"
+        $botDir = $addProj.BotDir
         $wfTarget = Join-Path $botDir "workflows\start-from-prompt"
 
         & pwsh -NoProfile -ExecutionPolicy Bypass -Command "Set-Location '$testProjectAdd'; & '$wfAddScript' start-from-prompt" 2>&1 | Out-Null
@@ -631,12 +604,9 @@ if ((Test-Path $wfAddScript) -and (Test-Path $kickstartFromScratchDir)) {
     }
 
     # --- Test: duplicate add without --Force is rejected ---
-    $testProjectDup = New-TestProject
+    $dupProj = New-TestProjectFromGolden -Flavor 'default'
+    $testProjectDup = $dupProj.ProjectRoot
     try {
-        Push-Location $testProjectDup
-        & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
-        Pop-Location
-
         # First add
         & pwsh -NoProfile -ExecutionPolicy Bypass -Command "Set-Location '$testProjectDup'; & '$wfAddScript' start-from-prompt" 2>&1 | Out-Null
 
@@ -652,12 +622,9 @@ if ((Test-Path $wfAddScript) -and (Test-Path $kickstartFromScratchDir)) {
     }
 
     # --- Test: duplicate add with --Force succeeds ---
-    $testProjectForce = New-TestProject
+    $forceProj = New-TestProjectFromGolden -Flavor 'default'
+    $testProjectForce = $forceProj.ProjectRoot
     try {
-        Push-Location $testProjectForce
-        & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
-        Pop-Location
-
         # First add
         & pwsh -NoProfile -ExecutionPolicy Bypass -Command "Set-Location '$testProjectForce'; & '$wfAddScript' start-from-prompt" 2>&1 | Out-Null
 
@@ -677,12 +644,9 @@ if ((Test-Path $wfAddScript) -and (Test-Path $kickstartFromScratchDir)) {
     }
 
     # --- Test: adding non-existent workflow fails ---
-    $testProjectBad = New-TestProject
+    $badProj = New-TestProjectFromGolden -Flavor 'default'
+    $testProjectBad = $badProj.ProjectRoot
     try {
-        Push-Location $testProjectBad
-        & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
-        Pop-Location
-
         $badOutput = & pwsh -NoProfile -ExecutionPolicy Bypass -Command "Set-Location '$testProjectBad'; & '$wfAddScript' nonexistent-workflow-xyz" 2>&1
         $notFound = $badOutput | Where-Object { $_ -match 'not found' }
         Assert-True -Name "workflow add: non-existent workflow fails with error" `
@@ -699,12 +663,9 @@ if ((Test-Path $wfAddScript) -and (Test-Path $kickstartFromScratchDir)) {
     # --- Test: task_categories merged from workflow manifest ---
     $jiraWfDir = Join-Path $dotbotDir "workflows\start-from-jira"
     if (Test-Path $jiraWfDir) {
-        $testProjectCats = New-TestProject
+        $catsProj = New-TestProjectFromGolden -Flavor 'default'
+        $testProjectCats = $catsProj.ProjectRoot
         try {
-            Push-Location $testProjectCats
-            & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
-            Pop-Location
-
             & pwsh -NoProfile -ExecutionPolicy Bypass -Command "Set-Location '$testProjectCats'; & '$wfAddScript' start-from-jira" 2>&1 | Out-Null
 
             $settingsPath = Join-Path $testProjectCats ".bot\settings\settings.default.json"
@@ -745,13 +706,10 @@ if ((Test-Path $wfAddScript) -and (Test-Path $kickstartFromScratchDir)) {
     }
 
     # --- Test: add then remove round-trip ---
-    $testProjectRoundTrip = New-TestProject
+    $roundTripProj = New-TestProjectFromGolden -Flavor 'default'
+    $testProjectRoundTrip = $roundTripProj.ProjectRoot
     try {
-        Push-Location $testProjectRoundTrip
-        & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
-        Pop-Location
-
-        $botDir = Join-Path $testProjectRoundTrip ".bot"
+        $botDir = $roundTripProj.BotDir
         $wfDir = Join-Path $botDir "workflows\start-from-prompt"
 
         # Add
@@ -1007,7 +965,7 @@ if ($userSettingsExisted) {
 
 try {
     # --- Test 1: ~/dotbot/user-settings.json supplies values when .control is absent ---
-    $testProjectUserOnly = Initialize-TestBotProject
+    $testProjectUserOnly = New-TestProjectFromGolden -Flavor 'default'
     try {
         @'
 {
@@ -1027,7 +985,7 @@ try {
     }
 
     # --- Test 2: .control/settings.json overrides ~/dotbot/user-settings.json ---
-    $testProjectPrecedence = Initialize-TestBotProject
+    $testProjectPrecedence = New-TestProjectFromGolden -Flavor 'default'
     try {
         @'
 {
@@ -1056,7 +1014,7 @@ try {
     }
 
     # --- Test 3: missing ~/dotbot/user-settings.json is a silent no-op ---
-    $testProjectMissing = Initialize-TestBotProject
+    $testProjectMissing = New-TestProjectFromGolden -Flavor 'default'
     try {
         if (Test-Path $userSettingsFile) {
             Remove-Item $userSettingsFile -Force
@@ -1072,7 +1030,7 @@ try {
     }
 
     # --- Test 4: malformed ~/dotbot/user-settings.json does not break resolution ---
-    $testProjectMalformed = Initialize-TestBotProject
+    $testProjectMalformed = New-TestProjectFromGolden -Flavor 'default'
     try {
         "{ this is not valid json !!!" | Set-Content $userSettingsFile
 


### PR DESCRIPTION
Closes #331. Refs #325.

## Summary

Most Layer 2+ tests just need a ready `.bot/`, not a fresh init. We now build `.bot/` once per workflow flavor at suite start in `$env:TEMP/dotbot-test-goldens`, and tests clone the matching golden via `robocopy` (Windows) or `cp -a` (Unix) instead of paying the 30s `init-project.ps1` cost per test section.

Tests that exist to verify init behaviour itself keep calling `init-project.ps1` directly:
- All of `Test-Structure.ps1` (it is the source of truth for what a freshly-initialised `.bot/` looks like).
- The "WORKFLOW.YAML AFTER INIT" section in `Test-WorkflowIntegration.ps1` (4 first-init checks, one per flavor).
- The user-settings no-leak regression (Test 5 in the user-settings cascade).

## Implementation

`tests/Test-Helpers.psm1` adds two new exports:
- `Initialize-GoldenSnapshots -Flavors <names>` — builds any stale or missing goldens in parallel using the same `ForEach-Object -Parallel -ThrottleLimit 6` pattern PR #330 introduced. Idempotent.
- `New-TestProjectFromGolden -Flavor <name>` — creates a fresh git-init'd temp project, clones the golden tree in, regenerates `instance_id` so each clone has its own workspace identity, and commits. Returns the same shape as `Initialize-TestBotProject`.

`tests/Run-Tests.ps1` calls `Initialize-GoldenSnapshots` once before Layer 2+, after the existing stale-install check.

Goldens capture the entire post-init project tree (sans `.git/`), not just `.bot/` — `init-project.ps1` also creates `.gitignore`, `.mcp.json`, `.claude/`, `.codex/`, `.gemini/`, and provider memory files that downstream tests read (e.g. `Get-GitignoredCopyPaths` reads `.gitignore`).

Cache invalidation mirrors the existing stale-install check: rebuild when any file under `~/dotbot/workflows/` or `~/dotbot/stacks/` is newer than the golden. Set `DOTBOT_REBUILD_GOLDENS=1` to force rebuild for debugging.

## Results (Windows, single run)

| Layer | Baseline | After | Saved |
|---|---|---|---|
| Layer 1 | 3m 45s | 2m 12s | 1m 33s |
| Layer 2 | 26m 16s | 15m 50s | **~10m** |
| Layer 3 | 5.8s | 6.5s | -1s |

Most-affected files in Layer 2:
- `Test-WorkflowIntegration.ps1`: 15m 59s -> 7m 59s
- `Test-Components.ps1`: 5m 49s -> 3m 0s
- `Test-ServerStartup.ps1`: 3m 57s -> 28.5s

Goldens build in ~45s upfront on a cold cache. Subsequent runs against unchanged source hit the cache (no rebuild).

## Out of scope

Proposal B (server pooling for HTTP-backed tests, ~2-4 min additional saving) is a separate follow-up issue per the suggested order of work in #331. To be opened after this PR merges.

## Test plan

- [x] All Layer 1-3 assertions pass on Windows (412/412 in Test-Components, 120/120 in Test-WorkflowIntegration, 49/49 in Test-ServerStartup).
- [x] Re-run with goldens cached -> no rebuild, no "Building golden snapshots" message.
- [x] Force-rebuild via `DOTBOT_REBUILD_GOLDENS=1` works.
- [ ] CI passes on Windows, macOS, Linux.