### PR TITLE
feat(task-runner): interview task type

### DIFF
--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1144,6 +1144,27 @@ Assert-True -Name "Add-TaskFrontMatter sets generator to dotbot-task-runner" `
 Write-Host ""
 
 # ═══════════════════════════════════════════════════════════════════
+# TASK-RUNNER INTERVIEW TASK TYPE (PR-3b, #220)
+# ═══════════════════════════════════════════════════════════════════
+# The task-runner now handles type:interview tasks by wrapping
+# Invoke-InterviewLoop. Regression guard against the dispatch case
+# being removed once the kickstart engine is deleted.
+
+Write-Host "  TASK-RUNNER INTERVIEW TASK TYPE" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+Assert-True -Name "Invoke-WorkflowProcess dot-sources InterviewLoop.ps1" `
+    -Condition ($workflowSrc -match 'InterviewLoop\.ps1')
+Assert-True -Name "Invoke-WorkflowProcess has 'interview' case in task-type switch" `
+    -Condition ($workflowSrc -match "'interview'\s*\{")
+Assert-True -Name "Invoke-WorkflowProcess interview case calls Invoke-InterviewLoop" `
+    -Condition ($workflowSrc -match 'Invoke-InterviewLoop')
+Assert-True -Name "Interview case resolves user prompt from workflow-launch-prompt.txt" `
+    -Condition ($workflowSrc -match 'workflow-launch-prompt\.txt')
+
+Write-Host ""
+
+# ═══════════════════════════════════════════════════════════════════
 # KICKSTART FRICTION FIXES (batch 1)
 # ═══════════════════════════════════════════════════════════════════
 # Regressions guarding the four fixes that came out of analysing a real

--- a/workflows/default/systems/runtime/modules/InterviewLoop.ps1
+++ b/workflows/default/systems/runtime/modules/InterviewLoop.ps1
@@ -16,7 +16,9 @@ function Invoke-InterviewLoop {
         [string]$UserPrompt,
         [switch]$ShowDebugJson,
         [switch]$ShowVerboseOutput,
-        [string]$PermissionMode
+        [string]$PermissionMode,
+        [string]$Generator = 'dotbot-kickstart',
+        [string]$TaskId
     )
 
     $processData = $ProcessData
@@ -103,11 +105,12 @@ Review all context above. Decide whether to write clarification-questions.json (
             # Add YAML front matter to interview summary
             $meta = @{
                 generated_at = (Get-Date).ToUniversalTime().ToString("o")
-                model = $interviewModel
-                process_id = $ProcessId
-                phase = "interview"
-                generator = "dotbot-kickstart"
+                model        = $interviewModel
+                process_id   = $ProcessId
+                phase        = "interview"
+                generator    = $Generator
             }
+            if ($TaskId) { $meta['task'] = "task-$TaskId" }
             Add-YamlFrontMatter -FilePath $summaryPath -Metadata $meta
 
             # Clean up any leftover question/answer files now that the interview is fully analysed

--- a/workflows/default/systems/runtime/modules/InterviewLoop.ps1
+++ b/workflows/default/systems/runtime/modules/InterviewLoop.ps1
@@ -149,8 +149,16 @@ Review all context above. Decide whether to write clarification-questions.json (
                     Import-Module $notifModule -Force
                     $interviewNotifSettings = Get-NotificationSettings -BotRoot $BotRoot
                     if ($interviewNotifSettings.enabled) {
+                        # Notification label reflects the calling engine: kickstart for the
+                        # legacy synthetic Phase-0 interview, task-runner for type:interview tasks.
+                        $notifNamePrefix = if ($Generator -eq 'dotbot-task-runner') {
+                            if ($TaskId) { "Interview (task $TaskId)" } else { "Interview" }
+                        } else {
+                            "Kickstart Interview"
+                        }
+                        $notifId = if ($TaskId) { "$ProcessId-interview-$TaskId" } else { "$ProcessId-interview" }
                         foreach ($q in $questions) {
-                            $fakeTask = @{ id = "$ProcessId-interview"; name = "Kickstart Interview Round $interviewRound" }
+                            $fakeTask = @{ id = $notifId; name = "$notifNamePrefix Round $interviewRound" }
                             $pendingQ = @{
                                 id = "$($q.id)-r$interviewRound"
                                 question = $q.question

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -769,7 +769,18 @@ try {
                             -ShowDebugJson:$ShowDebug -ShowVerboseOutput:$ShowVerbose `
                             -PermissionMode $permissionMode `
                             -Generator 'dotbot-task-runner' -TaskId $interviewTaskId
-                        $typeSuccess = $true
+                        # Verify the interview produced its required artifact. Invoke-InterviewLoop
+                        # can exit early without writing interview-summary.md (parse failures, etc.)
+                        # and downstream prompt tasks need this file as context.
+                        $interviewSummaryPath = Join-Path $productDir "interview-summary.md"
+                        if (Test-Path -LiteralPath $interviewSummaryPath -PathType Leaf -ErrorAction SilentlyContinue) {
+                            $typeSuccess = $true
+                        } else {
+                            $typeSuccess = $false
+                            $typeError = "Interview loop completed without producing $interviewSummaryPath"
+                            Write-Status $typeError -Type Error
+                            Write-ProcessActivity -Id $procId -ActivityType "error" -Message "$($task.name): $typeError"
+                        }
                     }
                 }
             } catch {

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -703,19 +703,37 @@ try {
                         $typeSuccess = $true
                     }
                     'interview' {
-                        # Resolve user prompt: task.prompt > workflow-launch-prompt.txt > task.description
-                        $userPrompt = if ($task.prompt) { $task.prompt }
-                            elseif (Test-Path (Join-Path $botRoot ".control\launchers\workflow-launch-prompt.txt")) {
-                                Get-Content (Join-Path $botRoot ".control\launchers\workflow-launch-prompt.txt") -Raw
-                            } elseif ($task.description) { $task.description }
-                            else { "" }
+                        # Resolve user prompt. task.prompt may be either a path
+                        # to a prompt file or inline text — try the path forms
+                        # first (relative to scriptBase, then botRoot, then as
+                        # given), fall back to inline text. This supports both
+                        # conventions seen in workflow.yaml today.
+                        $userPrompt = ""
+                        if ($task.prompt) {
+                            $resolvedPromptPath = $null
+                            $promptCandidates = @(
+                                (Join-Path $scriptBase $task.prompt),
+                                (Join-Path $botRoot $task.prompt),
+                                $task.prompt
+                            ) | Where-Object { $_ } | Select-Object -Unique
+                            foreach ($c in $promptCandidates) {
+                                if (Test-Path $c -PathType Leaf) { $resolvedPromptPath = $c; break }
+                            }
+                            $userPrompt = if ($resolvedPromptPath) { Get-Content $resolvedPromptPath -Raw } else { $task.prompt }
+                        } elseif (Test-Path (Join-Path $botRoot ".control\launchers\workflow-launch-prompt.txt")) {
+                            $userPrompt = Get-Content (Join-Path $botRoot ".control\launchers\workflow-launch-prompt.txt") -Raw
+                        } elseif ($task.description) {
+                            $userPrompt = $task.description
+                        }
                         Write-Status "Interview: $($task.name)" -Type Process
                         Write-ProcessActivity -Id $procId -ActivityType "init" -Message "Interview task: $($task.name)"
                         Write-Header "Interview"
+                        $interviewTaskId = if ($task -is [System.Collections.IDictionary]) { $task['id'] } else { $task.id }
                         Invoke-InterviewLoop -ProcessId $procId -ProcessData $processData `
                             -BotRoot $botRoot -ProductDir $productDir -UserPrompt $userPrompt `
                             -ShowDebugJson:$ShowDebug -ShowVerboseOutput:$ShowVerbose `
-                            -PermissionMode $permissionMode
+                            -PermissionMode $permissionMode `
+                            -Generator 'dotbot-task-runner' -TaskId $interviewTaskId
                         $typeSuccess = $true
                     }
                 }

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -273,6 +273,8 @@ $entityModel = if (Test-Path (Join-Path $productDir "entity-model.md")) { "Read 
 . (Join-Path $botRoot "systems\runtime\modules\task-reset.ps1")
 # Post-script runner (shared helper)
 . (Join-Path $botRoot "systems\runtime\modules\post-script-runner.ps1")
+# Interview loop (used by 'interview' task type)
+. (Join-Path $botRoot "systems\runtime\modules\InterviewLoop.ps1")
 $tasksBaseDir = Join-Path $botRoot "workspace\tasks"
 
 # Recover orphaned tasks
@@ -698,6 +700,22 @@ try {
                     'barrier' {
                         Write-Status "Barrier: $($task.name) — synchronization point" -Type Process
                         Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Barrier reached: $($task.name)"
+                        $typeSuccess = $true
+                    }
+                    'interview' {
+                        # Resolve user prompt: task.prompt > workflow-launch-prompt.txt > task.description
+                        $userPrompt = if ($task.prompt) { $task.prompt }
+                            elseif (Test-Path (Join-Path $botRoot ".control\launchers\workflow-launch-prompt.txt")) {
+                                Get-Content (Join-Path $botRoot ".control\launchers\workflow-launch-prompt.txt") -Raw
+                            } elseif ($task.description) { $task.description }
+                            else { "" }
+                        Write-Status "Interview: $($task.name)" -Type Process
+                        Write-ProcessActivity -Id $procId -ActivityType "init" -Message "Interview task: $($task.name)"
+                        Write-Header "Interview"
+                        Invoke-InterviewLoop -ProcessId $procId -ProcessData $processData `
+                            -BotRoot $botRoot -ProductDir $productDir -UserPrompt $userPrompt `
+                            -ShowDebugJson:$ShowDebug -ShowVerboseOutput:$ShowVerbose `
+                            -PermissionMode $permissionMode
                         $typeSuccess = $true
                     }
                 }

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -704,26 +704,56 @@ try {
                     }
                     'interview' {
                         # Resolve user prompt. task.prompt may be either a path
-                        # to a prompt file or inline text — try the path forms
-                        # first (relative to scriptBase, then botRoot, then as
-                        # given), fall back to inline text. This supports both
-                        # conventions seen in workflow.yaml today.
+                        # to a prompt file or inline text. Only try path
+                        # resolution when the value LOOKS like a path (no
+                        # newlines, has a separator or extension or starts
+                        # with a dot/slash). Inline text containing wildcard
+                        # characters would otherwise cause Test-Path to
+                        # interpret them as glob patterns and throw under
+                        # StrictMode. Use -LiteralPath + try/catch so any
+                        # remaining edge cases fall back to inline text.
                         $userPrompt = ""
                         if ($task.prompt) {
+                            $promptValue = [string]$task.prompt
+                            $looksLikePath = -not [string]::IsNullOrWhiteSpace($promptValue) -and `
+                                ($promptValue -notmatch "[`r`n]") -and `
+                                ($promptValue.Length -lt 260) -and `
+                                (
+                                    [System.IO.Path]::IsPathRooted($promptValue) -or
+                                    $promptValue -match '[\\/]' -or
+                                    $promptValue -match '^\.\.?(?:[\\/]|$)' -or
+                                    $promptValue -match '\.[A-Za-z0-9]+$'
+                                )
                             $resolvedPromptPath = $null
-                            $promptCandidates = @(
-                                (Join-Path $scriptBase $task.prompt),
-                                (Join-Path $botRoot $task.prompt),
-                                $task.prompt
-                            ) | Where-Object { $_ } | Select-Object -Unique
-                            foreach ($c in $promptCandidates) {
-                                if (Test-Path $c -PathType Leaf) { $resolvedPromptPath = $c; break }
+                            if ($looksLikePath) {
+                                $promptCandidates = @(
+                                    (Join-Path $scriptBase $promptValue),
+                                    (Join-Path $botRoot $promptValue),
+                                    $promptValue
+                                ) | Where-Object { $_ } | Select-Object -Unique
+                                foreach ($c in $promptCandidates) {
+                                    try {
+                                        if (Test-Path -LiteralPath $c -PathType Leaf -ErrorAction SilentlyContinue) {
+                                            $resolvedPromptPath = $c
+                                            break
+                                        }
+                                    } catch { Write-BotLog -Level Debug -Message "prompt path probe failed" -Exception $_ }
+                                }
                             }
-                            $userPrompt = if ($resolvedPromptPath) { Get-Content $resolvedPromptPath -Raw } else { $task.prompt }
-                        } elseif (Test-Path (Join-Path $botRoot ".control\launchers\workflow-launch-prompt.txt")) {
-                            $userPrompt = Get-Content (Join-Path $botRoot ".control\launchers\workflow-launch-prompt.txt") -Raw
-                        } elseif ($task.description) {
-                            $userPrompt = $task.description
+                            if ($resolvedPromptPath) {
+                                try { $userPrompt = Get-Content -LiteralPath $resolvedPromptPath -Raw -ErrorAction Stop }
+                                catch { $userPrompt = $promptValue }
+                            } else {
+                                $userPrompt = $promptValue
+                            }
+                        } else {
+                            $defaultPromptPath = Join-Path $botRoot ".control\launchers\workflow-launch-prompt.txt"
+                            if (Test-Path -LiteralPath $defaultPromptPath -PathType Leaf -ErrorAction SilentlyContinue) {
+                                try { $userPrompt = Get-Content -LiteralPath $defaultPromptPath -Raw -ErrorAction Stop }
+                                catch { $userPrompt = "" }
+                            } elseif ($task.description) {
+                                $userPrompt = $task.description
+                            }
                         }
                         Write-Status "Interview: $($task.name)" -Type Process
                         Write-ProcessActivity -Id $procId -ActivityType "init" -Message "Interview task: $($task.name)"

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -750,7 +750,12 @@ try {
                             $defaultPromptPath = Join-Path $botRoot ".control\launchers\workflow-launch-prompt.txt"
                             if (Test-Path -LiteralPath $defaultPromptPath -PathType Leaf -ErrorAction SilentlyContinue) {
                                 try { $userPrompt = Get-Content -LiteralPath $defaultPromptPath -Raw -ErrorAction Stop }
-                                catch { $userPrompt = "" }
+                                catch {
+                                    # Read failure (perms, encoding, transient IO): fall back
+                                    # to task.description so the documented prompt-resolution
+                                    # order (file > description > empty) still holds.
+                                    if ($task.description) { $userPrompt = $task.description } else { $userPrompt = "" }
+                                }
                             } elseif ($task.description) {
                                 $userPrompt = $task.description
                             }


### PR DESCRIPTION
Closes #220. PR-3b of the rework-roadmap PR-3 split.

## Summary

Adds an `interview` case to the task-type dispatch switch in `Invoke-WorkflowProcess.ps1`. A task with `type: interview` runs `Invoke-InterviewLoop`, producing `interview-summary.md` that subsequent prompt tasks consume via the context injection landed in PR-3a (#338).

User-prompt resolution order:
1. `task.prompt` (explicit override in workflow.yaml)
2. `.bot/.control/launchers/workflow-launch-prompt.txt` (canonical location)
3. `task.description` (fallback)

`InterviewLoop.ps1` is now dot-sourced from `Invoke-WorkflowProcess.ps1`, so the existing `launch-process.ps1` dot-source remains a no-op for the kickstart engine until PR-3 deletes the engine.

`Test-WorkflowManifest.ps1` gains 4 static assertions guarding the wiring.

## Test plan

- [x] Layer 1 (Test-WorkflowManifest, Test-Compilation): green
- [ ] Full layer 1-3 suite — running on the deletion PR (PR-3) per the agreed dev cadence to avoid burning ~12 minutes per intermediate stack PR

## Stack

- PR-3a (#338) — context injection + outputs validation + front-matter (parent of this PR)
- **PR-3b** (this one) — interview task type
- PR-3c — clarification-questions HITL loop (next)
- PR-3 — deletion of legacy engines + UI cleanup