### PR TITLE
feat(task-runner): post-task clarification-questions HITL loop

### DIFF
--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1165,6 +1165,34 @@ Assert-True -Name "Interview case resolves user prompt from workflow-launch-prom
 Write-Host ""
 
 # ═══════════════════════════════════════════════════════════════════
+# TASK-RUNNER CLARIFICATION-QUESTIONS HITL LOOP (PR-3c, #221)
+# ═══════════════════════════════════════════════════════════════════
+# The task-runner now detects clarification-questions.json after a prompt
+# task and pauses the process for human input, then runs adjust-after-answers.
+
+Write-Host "  TASK-RUNNER CLARIFICATION HITL LOOP" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+Assert-True -Name "Invoke-WorkflowProcess defines Invoke-TaskClarificationLoopIfPresent" `
+    -Condition ($workflowSrc -match 'function\s+Invoke-TaskClarificationLoopIfPresent\b')
+Assert-True -Name "Clarification loop checks clarification-questions.json" `
+    -Condition ($workflowSrc -match 'clarification-questions\.json')
+Assert-True -Name "Clarification loop polls for clarification-answers.json" `
+    -Condition ($workflowSrc -match 'clarification-answers\.json')
+Assert-True -Name "Clarification loop sets process status to needs-input" `
+    -Condition ($workflowSrc -match "ProcessData\.status\s*=\s*'needs-input'")
+Assert-True -Name "Clarification loop runs adjust-after-answers prompt" `
+    -Condition ($workflowSrc -match 'adjust-after-answers\.md')
+Assert-True -Name "Clarification loop appends to interview-summary.md" `
+    -Condition ($workflowSrc -match 'interview-summary\.md.*Clarification Log' -or $workflowSrc -match 'Clarification Log')
+Assert-True -Name "Clarification loop is wired into prompt-task path" `
+    -Condition ($workflowSrc -match 'Invoke-TaskClarificationLoopIfPresent\s+-Task')
+Assert-True -Name "Clarification loop respects stop signal" `
+    -Condition ($workflowSrc -match 'Test-ProcessStopSignal[\s\S]{0,400}clarification')
+
+Write-Host ""
+
+# ═══════════════════════════════════════════════════════════════════
 # KICKSTART FRICTION FIXES (batch 1)
 # ═══════════════════════════════════════════════════════════════════
 # Regressions guarding the four fixes that came out of analysing a real

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -229,6 +229,7 @@ function Invoke-TaskClarificationLoopIfPresent {
         [Parameter(Mandatory)][string]$ProductDir,
         [Parameter(Mandatory)][hashtable]$ProcessData,
         [Parameter(Mandatory)][string]$ProcId,
+        [string]$ProjectRoot,
         [string]$ModelName,
         [bool]$ShowDebug,
         [bool]$ShowVerbose,
@@ -282,20 +283,44 @@ function Invoke-TaskClarificationLoopIfPresent {
         Start-Sleep -Seconds 2
     }
 
+    # The UI server writes clarification-answers.json via Set-Content (open/
+    # truncate/write — non-atomic). Reading it the moment the file appears can
+    # race against the writer. Retry parse a few times before deleting and
+    # escalating, so a partially-written file doesn't force the user to
+    # resubmit answers.
     $answersData = $null
-    try {
-        $answersData = (Get-Content $answersPath -Raw) | ConvertFrom-Json
-    } catch {
-        # Delete malformed file so next run doesn't loop on the same parse failure.
+    $lastParseError = $null
+    for ($attempt = 1; $attempt -le 5; $attempt++) {
+        try {
+            $answersData = (Get-Content $answersPath -Raw) | ConvertFrom-Json
+            $lastParseError = $null
+            break
+        } catch {
+            $lastParseError = $_.Exception.Message
+            if ($attempt -lt 5 -and (Test-Path $answersPath)) {
+                Start-Sleep -Milliseconds 300
+            }
+        }
+    }
+    if (-not $answersData) {
+        # Persistently malformed — delete so next run doesn't loop on the same parse failure.
         Remove-Item $answersPath -Force -ErrorAction SilentlyContinue
         Reset-ClarificationState -PD $ProcessData -Id $ProcId -TaskName $Task.name
-        return "Failed to parse clarification-answers.json: $($_.Exception.Message)"
+        return "Failed to parse clarification-answers.json: $lastParseError"
     }
 
     if ($answersData -and $answersData.skipped -eq $true) {
         Write-Status "User skipped clarification questions for $($Task.name)" -Type Info
         Write-ProcessActivity -Id $ProcId -ActivityType "text" -Message "User skipped clarification questions for $($Task.name)"
     } elseif ($answersData) {
+        # Validate answers are present and non-empty. An empty/missing answers
+        # array would silently discard the pending questions without applying
+        # anything, so escalate as a malformed payload.
+        if (-not $answersData.answers -or $answersData.answers.Count -eq 0) {
+            Remove-Item $answersPath -Force -ErrorAction SilentlyContinue
+            Reset-ClarificationState -PD $ProcessData -Id $ProcId -TaskName $Task.name
+            return "clarification-answers.json has no 'answers' array — pending questions cannot be applied"
+        }
         $summaryPath = Join-Path $ProductDir "interview-summary.md"
         $timestamp = (Get-Date).ToUniversalTime().ToString("o")
         $qaSection = "`n`n### Task: $($Task.name)`n"
@@ -368,8 +393,11 @@ Instructions:
             return "Post-answer adjustment failed for task '$($Task.name)': $adjustErr"
         } finally {
             if ($adjustSessionId) {
-                try { Remove-ProviderSession -SessionId $adjustSessionId -ProjectRoot $projectRoot | Out-Null }
-                catch { Write-BotLog -Level Debug -Message "Adjust session cleanup failed" -Exception $_ }
+                try {
+                    $removeArgs = @{ SessionId = $adjustSessionId }
+                    if ($ProjectRoot) { $removeArgs['ProjectRoot'] = $ProjectRoot }
+                    Remove-ProviderSession @removeArgs | Out-Null
+                } catch { Write-BotLog -Level Debug -Message "Adjust session cleanup failed" -Exception $_ }
             }
         }
     }
@@ -1585,6 +1613,7 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
         if ($taskSuccess) {
             $clarErr = Invoke-TaskClarificationLoopIfPresent -Task $task -BotRoot $botRoot `
                 -ProductDir $productDir -ProcessData $processData -ProcId $procId `
+                -ProjectRoot $projectRoot `
                 -ModelName $claudeModelName -ShowDebug $ShowDebug `
                 -ShowVerbose $ShowVerbose -PermissionMode $permissionMode
             if ($clarErr) {

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -344,7 +344,9 @@ function Invoke-TaskClarificationLoopIfPresent {
             Set-Content -Path $summaryPath -Value $newSummary -NoNewline
         }
 
-        $adjustPromptPath = Join-Path $BotRoot "recipes\includes\adjust-after-answers.md"
+        # Forward slashes for cross-platform Join-Path safety (post-script-runner.ps1
+        # uses the same normalisation — Windows accepts either separator, Unix does not).
+        $adjustPromptPath = Join-Path $BotRoot "recipes/includes/adjust-after-answers.md"
         if (-not (Test-Path $adjustPromptPath)) {
             # Escalate via the postScriptFailed path so the worktree merge is
             # blocked. Without the adjust prompt the answers cannot be applied
@@ -1425,6 +1427,9 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
         $taskSuccess = $false
         $postScriptFailed = $false
         $postScriptError = $null
+        # Distinguishes which post-task hook actually flipped postScriptFailed
+        # so escalation messaging accurately names the failure source.
+        $postScriptFailureSource = 'post_script'
         $attemptNumber = 0
 
         if ($worktreePath) { Push-Location $worktreePath }
@@ -1596,6 +1601,7 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
                 $taskSuccess = $false
                 $postScriptFailed = $true
                 $postScriptError = $clarErr
+                $postScriptFailureSource = 'clarification'
             }
         }
 
@@ -1616,6 +1622,7 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
                 $taskSuccess = $false
                 $postScriptFailed = $true
                 $postScriptError = $outputErr
+                $postScriptFailureSource = 'outputs'
             }
         }
 
@@ -1703,27 +1710,33 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
             Write-ProcessFile -Id $procId -Data $processData
             Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task completed (analyse+execute): $($task.name)"
         } elseif ($postScriptFailed) {
-            # post_script failed AFTER task_mark_done moved the task JSON to done/.
-            # Preserve the worktree (so the operator can inspect artefacts and re-run
-            # the post_script manually) and move the task to needs-input/ with a
-            # pending_question. Deliberately skip worktree destruction and the
-            # consecutive_failures bump — this is operator-recoverable, not an agent
-            # failure.
-            Write-Status "post_script failed for $($task.name) — escalating to needs-input" -Type Warn
-            Write-ProcessActivity -Id $procId -ActivityType "error" -Message "post_script failed for $($task.name): $postScriptError — worktree preserved at $worktreePath"
+            # A post-task hook (post_script, clarification loop, outputs validation,
+            # or front-matter injection) failed AFTER task_mark_done moved the task
+            # JSON to done/. Preserve the worktree and move the task to needs-input/
+            # with a source-specific pending_question. Skip worktree destruction
+            # and consecutive_failures bump — operator-recoverable, not agent failure.
+            $sourceLabel = switch ($postScriptFailureSource) {
+                'clarification' { 'clarification loop' }
+                'outputs'       { 'outputs validation' }
+                'front_matter'  { 'front-matter injection' }
+                default         { 'post_script' }
+            }
+            Write-Status "$sourceLabel failed for $($task.name) — escalating to needs-input" -Type Warn
+            Write-ProcessActivity -Id $procId -ActivityType "error" -Message "$sourceLabel failed for $($task.name): $postScriptError — worktree preserved at $worktreePath"
 
             try {
                 $moved = Invoke-PostScriptFailureEscalation -Task $task -TasksBaseDir $tasksBaseDir `
-                    -PostScriptError $postScriptError -WorktreePath $worktreePath
+                    -PostScriptError $postScriptError -WorktreePath $worktreePath `
+                    -FailureSource $postScriptFailureSource
                 if ($moved) {
-                    Write-Status "Task moved to needs-input for manual post_script resolution" -Type Warn
+                    Write-Status "Task moved to needs-input for manual $sourceLabel resolution" -Type Warn
                 } else {
-                    Write-Status "Could not locate task in done/ during post_script escalation — state may be inconsistent" -Type Error
-                    Write-ProcessActivity -Id $procId -ActivityType "error" -Message "Post-script escalation could not find $($task.name) in done/"
+                    Write-Status "Could not locate task in done/ during $sourceLabel escalation — state may be inconsistent" -Type Error
+                    Write-ProcessActivity -Id $procId -ActivityType "error" -Message "$sourceLabel escalation could not find $($task.name) in done/"
                 }
             } catch {
-                Write-Status "Post-script escalation failed: $($_.Exception.Message)" -Type Error
-                Write-ProcessActivity -Id $procId -ActivityType "error" -Message "Post-script escalation failed for $($task.name): $($_.Exception.Message)"
+                Write-Status "$sourceLabel escalation failed: $($_.Exception.Message)" -Type Error
+                Write-ProcessActivity -Id $procId -ActivityType "error" -Message "$sourceLabel escalation failed for $($task.name): $($_.Exception.Message)"
             }
         } else {
             Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task failed: $($task.name)"

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -239,10 +239,21 @@ function Invoke-TaskClarificationLoopIfPresent {
 
     $answersPath = Join-Path $ProductDir "clarification-answers.json"
 
+    # Reset process state on any error path. Without this, a parse failure
+    # leaves the JSON stuck in needs-input until something else overwrites it.
+    function Reset-ClarificationState {
+        param($PD, $Id, $TaskName)
+        $PD.status = 'running'
+        $PD.pending_questions = $null
+        $PD.heartbeat_status = "Running task: $TaskName"
+        Write-ProcessFile -Id $Id -Data $PD
+    }
+
     $questionsData = $null
     try {
         $questionsData = (Get-Content $questionsPath -Raw) | ConvertFrom-Json
     } catch {
+        Remove-Item $questionsPath -Force -ErrorAction SilentlyContinue
         return "Failed to parse clarification-questions.json: $($_.Exception.Message)"
     }
     if (-not $questionsData -or -not $questionsData.questions -or $questionsData.questions.Count -eq 0) {
@@ -275,6 +286,9 @@ function Invoke-TaskClarificationLoopIfPresent {
     try {
         $answersData = (Get-Content $answersPath -Raw) | ConvertFrom-Json
     } catch {
+        # Delete malformed file so next run doesn't loop on the same parse failure.
+        Remove-Item $answersPath -Force -ErrorAction SilentlyContinue
+        Reset-ClarificationState -PD $ProcessData -Id $ProcId -TaskName $Task.name
         return "Failed to parse clarification-answers.json: $($_.Exception.Message)"
     }
 
@@ -306,9 +320,15 @@ function Invoke-TaskClarificationLoopIfPresent {
         }
 
         $adjustPromptPath = Join-Path $BotRoot "recipes\includes\adjust-after-answers.md"
-        if (Test-Path $adjustPromptPath) {
-            $adjustContent = Get-Content $adjustPromptPath -Raw
-            $adjustPrompt = @"
+        if (-not (Test-Path $adjustPromptPath)) {
+            # Escalate via the postScriptFailed path so the worktree merge is
+            # blocked. Without the adjust prompt the answers cannot be applied
+            # to artifacts; merging would be incorrect.
+            Reset-ClarificationState -PD $ProcessData -Id $ProcId -TaskName $Task.name
+            return "Adjust prompt not found at $adjustPromptPath — cannot apply clarification answers"
+        }
+        $adjustContent = Get-Content $adjustPromptPath -Raw
+        $adjustPrompt = @"
 $adjustContent
 
 ## Context
@@ -323,8 +343,10 @@ Instructions:
 4. Enrich/correct any affected artifacts
 5. Fill in the Interpretation column for the new Q&A entries in interview-summary.md
 "@
-            Write-Status "Running post-answer adjustment for task $($Task.name)..." -Type Process
-            Write-ProcessActivity -Id $ProcId -ActivityType "text" -Message "Adjusting artifacts after answers for $($Task.name)"
+        Write-Status "Running post-answer adjustment for task $($Task.name)..." -Type Process
+        Write-ProcessActivity -Id $ProcId -ActivityType "text" -Message "Adjusting artifacts after answers for $($Task.name)"
+        $adjustSessionId = $null
+        try {
             $adjustSessionId = New-ProviderSession
             $adjustArgs = @{
                 Prompt         = $adjustPrompt
@@ -337,17 +359,24 @@ Instructions:
             if ($PermissionMode) { $adjustArgs['PermissionMode'] = $PermissionMode }
             Invoke-ProviderStream @adjustArgs
             Write-Status "Post-answer adjustment complete for $($Task.name)" -Type Complete
-        } else {
-            Write-Status "Adjust prompt not found at $adjustPromptPath — skipping adjustment" -Type Warn
+        } catch {
+            $adjustErr = $_.Exception.Message
+            if ([string]::IsNullOrWhiteSpace($adjustErr)) { $adjustErr = $_.ToString() }
+            Reset-ClarificationState -PD $ProcessData -Id $ProcId -TaskName $Task.name
+            Remove-Item $questionsPath -Force -ErrorAction SilentlyContinue
+            Remove-Item $answersPath -Force -ErrorAction SilentlyContinue
+            return "Post-answer adjustment failed for task '$($Task.name)': $adjustErr"
+        } finally {
+            if ($adjustSessionId) {
+                try { Remove-ProviderSession -SessionId $adjustSessionId -ProjectRoot $projectRoot | Out-Null }
+                catch { Write-BotLog -Level Debug -Message "Adjust session cleanup failed" -Exception $_ }
+            }
         }
     }
 
     Remove-Item $questionsPath -Force -ErrorAction SilentlyContinue
     Remove-Item $answersPath -Force -ErrorAction SilentlyContinue
-    $ProcessData.status = 'running'
-    $ProcessData.pending_questions = $null
-    $ProcessData.heartbeat_status = "Running task: $($Task.name)"
-    Write-ProcessFile -Id $ProcId -Data $ProcessData
+    Reset-ClarificationState -PD $ProcessData -Id $ProcId -TaskName $Task.name
     return $null
 }
 

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -1628,9 +1628,20 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
 
         # Front-matter injection (parity with kickstart engine). Final step
         # before merge — by here outputs are validated and the clarification
-        # adjust pass has settled artifact contents.
+        # adjust pass has settled artifact contents. Wrap in try/catch so an
+        # IO/Add-YamlFrontMatter failure routes through the post-task escalation
+        # path (worktree preserved, accurate pending_question) instead of
+        # bubbling to the surrounding execution catch which would treat it as
+        # an execution-phase failure and destroy the worktree.
         if ($taskSuccess) {
-            Add-TaskFrontMatter -Task $task -ProductDir $productDir -ProcId $procId -ModelName $claudeModelName
+            try {
+                Add-TaskFrontMatter -Task $task -ProductDir $productDir -ProcId $procId -ModelName $claudeModelName
+            } catch {
+                $taskSuccess = $false
+                $postScriptFailed = $true
+                $postScriptError = $_.Exception.Message
+                $postScriptFailureSource = 'front_matter'
+            }
         }
         } finally {
             # Final safety-net cleanup: kill any remaining worktree processes

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -212,6 +212,145 @@ function Add-TaskFrontMatter {
     }
 }
 
+# Post-task clarification-questions HITL loop. Parity with kickstart engine
+# at Invoke-KickstartProcess.ps1:382-622, adapted to task scope. Detects
+# clarification-questions.json written by the agent during task execution,
+# pauses the process for human input, polls for clarification-answers.json,
+# appends Q&A to interview-summary.md, and runs adjust-after-answers.md as a
+# separate provider session. Returns $null on success or skip, an error
+# message string on failure.
+#
+# This is the file-watch path only — Teams notification polling (kickstart's
+# parallel channel) is not yet ported and is tracked as follow-up work.
+function Invoke-TaskClarificationLoopIfPresent {
+    param(
+        [Parameter(Mandatory)]$Task,
+        [Parameter(Mandatory)][string]$BotRoot,
+        [Parameter(Mandatory)][string]$ProductDir,
+        [Parameter(Mandatory)][hashtable]$ProcessData,
+        [Parameter(Mandatory)][string]$ProcId,
+        [string]$ModelName,
+        [bool]$ShowDebug,
+        [bool]$ShowVerbose,
+        [string]$PermissionMode
+    )
+    $questionsPath = Join-Path $ProductDir "clarification-questions.json"
+    if (-not (Test-Path $questionsPath)) { return $null }
+
+    $answersPath = Join-Path $ProductDir "clarification-answers.json"
+
+    $questionsData = $null
+    try {
+        $questionsData = (Get-Content $questionsPath -Raw) | ConvertFrom-Json
+    } catch {
+        return "Failed to parse clarification-questions.json: $($_.Exception.Message)"
+    }
+    if (-not $questionsData -or -not $questionsData.questions -or $questionsData.questions.Count -eq 0) {
+        Remove-Item $questionsPath -Force -ErrorAction SilentlyContinue
+        return $null
+    }
+
+    Write-Status "Task $($Task.name): $($questionsData.questions.Count) clarification question(s) — waiting for user" -Type Info
+    Write-ProcessActivity -Id $ProcId -ActivityType "text" -Message "Task '$($Task.name)' has $($questionsData.questions.Count) clarification question(s)"
+
+    $ProcessData.status = 'needs-input'
+    $ProcessData.pending_questions = $questionsData
+    $ProcessData.heartbeat_status = "Waiting for answers (task: $($Task.name))"
+    Write-ProcessFile -Id $ProcId -Data $ProcessData
+
+    if (Test-Path $answersPath) { Remove-Item $answersPath -Force -ErrorAction SilentlyContinue }
+
+    while (-not (Test-Path $answersPath)) {
+        if (Test-ProcessStopSignal -Id $ProcId) {
+            $ProcessData.status = 'stopped'
+            $ProcessData.failed_at = (Get-Date).ToUniversalTime().ToString("o")
+            $ProcessData.pending_questions = $null
+            Write-ProcessFile -Id $ProcId -Data $ProcessData
+            return "Process stopped by user during clarification wait"
+        }
+        Start-Sleep -Seconds 2
+    }
+
+    $answersData = $null
+    try {
+        $answersData = (Get-Content $answersPath -Raw) | ConvertFrom-Json
+    } catch {
+        return "Failed to parse clarification-answers.json: $($_.Exception.Message)"
+    }
+
+    if ($answersData -and $answersData.skipped -eq $true) {
+        Write-Status "User skipped clarification questions for $($Task.name)" -Type Info
+        Write-ProcessActivity -Id $ProcId -ActivityType "text" -Message "User skipped clarification questions for $($Task.name)"
+    } elseif ($answersData) {
+        $summaryPath = Join-Path $ProductDir "interview-summary.md"
+        $timestamp = (Get-Date).ToUniversalTime().ToString("o")
+        $qaSection = "`n`n### Task: $($Task.name)`n"
+        $qaSection += "| # | Question | Answer (verbatim) | Interpretation | Timestamp |`n"
+        $qaSection += "|---|----------|--------------------|----------------|-----------|`n"
+        $qIdx = 0
+        foreach ($ans in $answersData.answers) {
+            $qIdx++
+            $qText = ($ans.question -replace '\|', '\|' -replace "`n", ' ')
+            $aText = ($ans.answer -replace '\|', '\|' -replace "`n", ' ')
+            $qaSection += "| q$qIdx | $qText | $aText | _pending_ | $timestamp |`n"
+        }
+        if (Test-Path $summaryPath) {
+            $existingContent = Get-Content $summaryPath -Raw
+            if ($existingContent -notmatch '## Clarification Log') {
+                $qaSection = "`n## Clarification Log`n" + $qaSection
+            }
+            Add-Content -Path $summaryPath -Value $qaSection -NoNewline
+        } else {
+            $newSummary = "# Interview Summary`n`n## Clarification Log`n" + $qaSection
+            Set-Content -Path $summaryPath -Value $newSummary -NoNewline
+        }
+
+        $adjustPromptPath = Join-Path $BotRoot "recipes\includes\adjust-after-answers.md"
+        if (Test-Path $adjustPromptPath) {
+            $adjustContent = Get-Content $adjustPromptPath -Raw
+            $adjustPrompt = @"
+$adjustContent
+
+## Context
+
+- **Task that generated questions**: $($Task.name)
+- **User's project description**: see workflow-launch-prompt.txt and any briefing files in .bot/workspace/product/briefing/
+
+Instructions:
+1. Read .bot/workspace/product/interview-summary.md for the full Q&A history including the new answers
+2. Read ALL existing product artifacts in .bot/workspace/product/
+3. Assess the impact of the new information across all artifacts
+4. Enrich/correct any affected artifacts
+5. Fill in the Interpretation column for the new Q&A entries in interview-summary.md
+"@
+            Write-Status "Running post-answer adjustment for task $($Task.name)..." -Type Process
+            Write-ProcessActivity -Id $ProcId -ActivityType "text" -Message "Adjusting artifacts after answers for $($Task.name)"
+            $adjustSessionId = New-ProviderSession
+            $adjustArgs = @{
+                Prompt         = $adjustPrompt
+                Model          = $ModelName
+                SessionId      = $adjustSessionId
+                PersistSession = $false
+            }
+            if ($ShowDebug) { $adjustArgs['ShowDebugJson'] = $true }
+            if ($ShowVerbose) { $adjustArgs['ShowVerbose'] = $true }
+            if ($PermissionMode) { $adjustArgs['PermissionMode'] = $PermissionMode }
+            Invoke-ProviderStream @adjustArgs
+            Write-Status "Post-answer adjustment complete for $($Task.name)" -Type Complete
+        } else {
+            Write-Status "Adjust prompt not found at $adjustPromptPath — skipping adjustment" -Type Warn
+        }
+    }
+
+    Remove-Item $questionsPath -Force -ErrorAction SilentlyContinue
+    Remove-Item $answersPath -Force -ErrorAction SilentlyContinue
+    $ProcessData.status = 'running'
+    $ProcessData.pending_questions = $null
+    $ProcessData.heartbeat_status = "Running task: $($Task.name)"
+    Write-ProcessFile -Id $ProcId -Data $ProcessData
+    return $null
+}
+
 # Build the briefing-file references and interview-summary context block that
 # gets appended to LLM prompts. Parity with kickstart-engine behaviour at
 # Invoke-KickstartProcess.ps1:145-168. Read fresh per task so that context
@@ -1407,6 +1546,23 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
         # success — by here the declared outputs exist.
         if ($taskSuccess) {
             Add-TaskFrontMatter -Task $task -ProductDir $productDir -ProcId $procId -ModelName $claudeModelName
+        }
+
+        # Post-task clarification-questions HITL loop (parity with kickstart
+        # engine). If the agent wrote clarification-questions.json during task
+        # execution, pause the process for human input, then run the
+        # adjust-after-answers pass. Failure escalates like a post-script
+        # failure so the worktree merge is held.
+        if ($taskSuccess) {
+            $clarErr = Invoke-TaskClarificationLoopIfPresent -Task $task -BotRoot $botRoot `
+                -ProductDir $productDir -ProcessData $processData -ProcId $procId `
+                -ModelName $claudeModelName -ShowDebug $ShowDebug `
+                -ShowVerbose $ShowVerbose -PermissionMode $permissionMode
+            if ($clarErr) {
+                $taskSuccess = $false
+                $postScriptFailed = $true
+                $postScriptError = $clarErr
+            }
         }
         } finally {
             # Final safety-net cleanup: kill any remaining worktree processes

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -1579,6 +1579,26 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
             }
         }
 
+        # Post-task clarification-questions HITL loop (parity with kickstart
+        # engine). Runs BEFORE outputs validation and front-matter injection
+        # because the adjust-after-answers pass can rewrite product artifacts —
+        # if it ran after, it could remove the YAML front-matter we just
+        # injected or invalidate already-validated outputs. By running first
+        # we settle artifact contents before the final checks. Failure
+        # escalates like a post-script failure so the worktree merge is held.
+        if ($taskSuccess) {
+            $clarErr = Invoke-TaskClarificationLoopIfPresent -Task $task -BotRoot $botRoot `
+                -ProductDir $productDir -ProcessData $processData -ProcId $procId `
+                -ProjectRoot $projectRoot `
+                -ModelName $claudeModelName -ShowDebug $ShowDebug `
+                -ShowVerbose $ShowVerbose -PermissionMode $permissionMode
+            if ($clarErr) {
+                $taskSuccess = $false
+                $postScriptFailed = $true
+                $postScriptError = $clarErr
+            }
+        }
+
         # Outputs validation (parity with kickstart engine). On failure, escalate
         # via the same path as a post-script failure — task is in done/ already
         # but we don't want to merge a task whose declared outputs are missing.
@@ -1599,28 +1619,11 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
             }
         }
 
-        # Front-matter injection (parity with kickstart engine). Runs only on
-        # success — by here the declared outputs exist.
+        # Front-matter injection (parity with kickstart engine). Final step
+        # before merge — by here outputs are validated and the clarification
+        # adjust pass has settled artifact contents.
         if ($taskSuccess) {
             Add-TaskFrontMatter -Task $task -ProductDir $productDir -ProcId $procId -ModelName $claudeModelName
-        }
-
-        # Post-task clarification-questions HITL loop (parity with kickstart
-        # engine). If the agent wrote clarification-questions.json during task
-        # execution, pause the process for human input, then run the
-        # adjust-after-answers pass. Failure escalates like a post-script
-        # failure so the worktree merge is held.
-        if ($taskSuccess) {
-            $clarErr = Invoke-TaskClarificationLoopIfPresent -Task $task -BotRoot $botRoot `
-                -ProductDir $productDir -ProcessData $processData -ProcId $procId `
-                -ProjectRoot $projectRoot `
-                -ModelName $claudeModelName -ShowDebug $ShowDebug `
-                -ShowVerbose $ShowVerbose -PermissionMode $permissionMode
-            if ($clarErr) {
-                $taskSuccess = $false
-                $postScriptFailed = $true
-                $postScriptError = $clarErr
-            }
         }
         } finally {
             # Final safety-net cleanup: kill any remaining worktree processes

--- a/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/workflows/default/systems/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -265,12 +265,16 @@ function Invoke-TaskClarificationLoopIfPresent {
     Write-Status "Task $($Task.name): $($questionsData.questions.Count) clarification question(s) — waiting for user" -Type Info
     Write-ProcessActivity -Id $ProcId -ActivityType "text" -Message "Task '$($Task.name)' has $($questionsData.questions.Count) clarification question(s)"
 
+    # Delete any stale answers file BEFORE flipping status to needs-input.
+    # If we deleted after, a fresh UI-supplied answers file written between
+    # the status flip and the deletion could be wiped, leaving the runner
+    # waiting indefinitely.
+    if (Test-Path $answersPath) { Remove-Item $answersPath -Force -ErrorAction SilentlyContinue }
+
     $ProcessData.status = 'needs-input'
     $ProcessData.pending_questions = $questionsData
     $ProcessData.heartbeat_status = "Waiting for answers (task: $($Task.name))"
     Write-ProcessFile -Id $ProcId -Data $ProcessData
-
-    if (Test-Path $answersPath) { Remove-Item $answersPath -Force -ErrorAction SilentlyContinue }
 
     while (-not (Test-Path $answersPath)) {
         if (Test-ProcessStopSignal -Id $ProcId) {
@@ -390,8 +394,9 @@ Instructions:
             $adjustErr = $_.Exception.Message
             if ([string]::IsNullOrWhiteSpace($adjustErr)) { $adjustErr = $_.ToString() }
             Reset-ClarificationState -PD $ProcessData -Id $ProcId -TaskName $Task.name
-            Remove-Item $questionsPath -Force -ErrorAction SilentlyContinue
-            Remove-Item $answersPath -Force -ErrorAction SilentlyContinue
+            # Preserve clarification-questions.json and clarification-answers.json on
+            # failure so the operator can inspect them during the needs-input
+            # escalation. The escalation pending_question text directs them here.
             return "Post-answer adjustment failed for task '$($Task.name)': $adjustErr"
         } finally {
             if ($adjustSessionId) {

--- a/workflows/default/systems/runtime/modules/post-script-runner.ps1
+++ b/workflows/default/systems/runtime/modules/post-script-runner.ps1
@@ -74,7 +74,14 @@ function Invoke-PostScriptFailureEscalation {
         [Parameter(Mandatory)]$Task,
         [Parameter(Mandatory)][string]$TasksBaseDir,
         [Parameter(Mandatory)][string]$PostScriptError,
-        [AllowEmptyString()][string]$WorktreePath = ""
+        [AllowEmptyString()][string]$WorktreePath = "",
+        # Source of the failure controls the user-facing pending_question text.
+        # 'post_script'    — real post_script hook failure (default; back-compat).
+        # 'clarification'  — clarification HITL loop failure or operator stop.
+        # 'outputs'        — task-declared outputs missing after completion.
+        # 'front_matter'   — YAML front-matter injection failure.
+        [ValidateSet('post_script', 'clarification', 'outputs', 'front_matter')]
+        [string]$FailureSource = 'post_script'
     )
 
     $doneDir = Join-Path $TasksBaseDir "done"
@@ -111,12 +118,49 @@ function Invoke-PostScriptFailureEscalation {
         "Error: $PostScriptError"
     }
 
+    # Pick user-facing strings based on failure source. Default ('post_script')
+    # preserves prior behavior for back-compat with existing tests/assertions.
+    $sourceMessaging = switch ($FailureSource) {
+        'clarification' {
+            @{
+                id       = "clarification-failure"
+                question = "Clarification loop failed during task completion"
+                fixLabel = "Inspect clarification-questions/answers and retry manually"
+                fixRat   = "Review the questions/answers in the worktree and resolve before retry"
+            }
+        }
+        'outputs' {
+            @{
+                id       = "outputs-validation-failure"
+                question = "Task outputs validation failed"
+                fixLabel = "Produce the missing outputs and retry manually"
+                fixRat   = "Inspect the worktree to see which declared outputs are missing"
+            }
+        }
+        'front_matter' {
+            @{
+                id       = "front-matter-failure"
+                question = "YAML front-matter injection failed"
+                fixLabel = "Repair the affected document and retry manually"
+                fixRat   = "Inspect the worktree document(s) and fix front-matter blockers"
+            }
+        }
+        default {
+            @{
+                id       = "post-script-failure"
+                question = "post_script failed during task completion"
+                fixLabel = "Fix the post_script and retry manually"
+                fixRat   = "Inspect the worktree, repair the post_script, then retry the task"
+            }
+        }
+    }
+
     $taskContent.pending_question = @{
-        id             = "post-script-failure"
-        question       = "post_script failed during task completion"
+        id             = $sourceMessaging.id
+        question       = $sourceMessaging.question
         context        = $contextText
         options        = @(
-            @{ key = "A"; label = "Fix the post_script and retry manually"; rationale = "Inspect the worktree, repair the post_script, then retry the task" }
+            @{ key = "A"; label = $sourceMessaging.fixLabel; rationale = $sourceMessaging.fixRat }
             @{ key = "B"; label = "Discard task changes"; rationale = "Remove worktree and abandon this task's changes" }
         )
         recommendation = "A"


### PR DESCRIPTION
Closes #221. PR-3c of the rework-roadmap PR-3 split.

## Summary

Detects `clarification-questions.json` written by the agent during a prompt task and runs the same Generate -> Ask -> Adjust loop the kickstart engine implements at the phase level.

**Flow:**
1. After post-script success and outputs validation, before squash-merge, check for `.bot/workspace/product/clarification-questions.json`.
2. If present: set process to `needs-input` with pending_questions, poll for `clarification-answers.json` (or stop signal).
3. When answers arrive: append to `interview-summary.md` (creating the `Clarification Log` section if missing), then run `adjust-after-answers.md` as a separate provider session so the agent can revise existing product artifacts in light of the new answers.
4. Reset process to `running` and continue the merge path.

**Stop-signal aware:** process status correctly sets to `stopped` if the user kills mid-poll, with `pending_questions` cleared.

**Failure escalation:** any failure (parse error, stop, missing adjust prompt) goes through the existing `postScriptFailed` path — task does not merge.

## Scope

This is the file-watch path. **Teams notification polling** (the kickstart engine's parallel channel for clarification questions) is tracked as a follow-up. The dotbot Teams integration writes notifications at task-creation time today; extending it to clarification-questions JSON requires `NotificationClient.psm1` plumbing that's deferred.

## Test plan

- [x] Layer 1 (Test-WorkflowManifest 333 passed, Test-Compilation 275 passed): green
- [ ] Full layer 1-3 suite — running on the deletion PR (PR-3) per the agreed dev cadence

## Stack

- PR-3a (#338) — context injection + outputs validation + front-matter
- PR-3b (#339) — interview task type
- **PR-3c** (this one) — clarification-questions HITL loop
- PR-3 — deletion of legacy engines + UI cleanup (next)