### PR TITLE
fix: route UI settings writes to .control overrides

### DIFF
--- a/core/ui/modules/SettingsAPI.psm1
+++ b/core/ui/modules/SettingsAPI.psm1
@@ -28,6 +28,62 @@ function Initialize-SettingsAPI {
     $script:Config.StaticRoot = $StaticRoot
 }
 
+# Internal: load .control/settings.json as a hashtable (empty if missing/malformed).
+function Get-OverridesHashtable {
+    $overridesFile = Join-Path $script:Config.ControlDir "settings.json"
+    $h = @{}
+    if (Test-Path $overridesFile) {
+        try {
+            $existing = Get-Content $overridesFile -Raw | ConvertFrom-Json
+            foreach ($prop in $existing.PSObject.Properties) {
+                $h[$prop.Name] = $prop.Value
+            }
+        } catch { Write-BotLog -Level Debug -Message "Failed to parse overrides" -Exception $_ }
+    }
+    return $h
+}
+
+# Internal: persist a hashtable back to .control/settings.json.
+function Save-OverridesHashtable {
+    param([Parameter(Mandatory)] [hashtable]$Overrides)
+    if (-not (Test-Path $script:Config.ControlDir)) {
+        New-Item -ItemType Directory -Path $script:Config.ControlDir -Force | Out-Null
+    }
+    $overridesFile = Join-Path $script:Config.ControlDir "settings.json"
+    $Overrides | ConvertTo-Json -Depth 10 | Set-Content $overridesFile -Force
+}
+
+# Internal: merge a partial section (or top-level scalars) into .control/settings.json.
+# - $Key is the section name (e.g. 'analysis', 'mothership'). When $null, $Patch keys are
+#   merged at the top level (used for scalars like 'provider').
+# - $Patch is a hashtable of fields to set/replace.
+function Save-OverrideSection {
+    param(
+        [string]$Key,
+        [Parameter(Mandatory)] [hashtable]$Patch
+    )
+    $overrides = Get-OverridesHashtable
+    if ($Key) {
+        $existingSection = if ($overrides.ContainsKey($Key)) { $overrides[$Key] } else { @{} }
+        # Normalize PSCustomObject section to hashtable so Merge-DeepSettings can iterate.
+        if ($existingSection -is [PSCustomObject]) {
+            $h = @{}
+            foreach ($p in $existingSection.PSObject.Properties) { $h[$p.Name] = $p.Value }
+            $existingSection = $h
+        }
+        $merged = Merge-DeepSettings $existingSection $Patch
+        # Merge-DeepSettings returns an [ordered] dict; convert to plain hashtable for ConvertTo-Json fidelity.
+        $sectionHash = @{}
+        foreach ($k in $merged.Keys) { $sectionHash[$k] = $merged[$k] }
+        $overrides[$Key] = $sectionHash
+    } else {
+        foreach ($k in $Patch.Keys) {
+            $overrides[$k] = $Patch[$k]
+        }
+    }
+    Save-OverridesHashtable -Overrides $overrides
+}
+
 function Get-Theme {
     $themePath = Join-Path $script:Config.StaticRoot "theme-config.json"
     $settingsFile = Join-Path $script:Config.ControlDir "ui-settings.json"
@@ -232,41 +288,32 @@ function Set-AnalysisConfig {
     param(
         [Parameter(Mandatory)] $Body
     )
-    $settingsDefaultFile = Join-Path $script:Config.BotRoot "settings\settings.default.json"
-
-    $settingsData = Get-Content $settingsDefaultFile -Raw | ConvertFrom-Json
-    if (-not $settingsData.analysis) {
-        $settingsData | Add-Member -NotePropertyName "analysis" -NotePropertyValue @{
-            auto_approve_splits = $false
-            split_threshold_effort = "XL"
-            question_timeout_hours = $null
-            mode = "on-demand"
-        }
-    }
+    $patch = @{}
 
     if ($null -ne $Body.auto_approve_splits) {
-        $settingsData.analysis.auto_approve_splits = [bool]$Body.auto_approve_splits
+        $patch.auto_approve_splits = [bool]$Body.auto_approve_splits
     }
     if ($null -ne $Body.split_threshold_effort) {
-        $settingsData.analysis.split_threshold_effort = [string]$Body.split_threshold_effort
+        $patch.split_threshold_effort = [string]$Body.split_threshold_effort
     }
     if ($Body.PSObject.Properties.Name -contains 'question_timeout_hours') {
         if ($null -eq $Body.question_timeout_hours) {
-            $settingsData.analysis.question_timeout_hours = $null
+            $patch.question_timeout_hours = $null
         } else {
-            $settingsData.analysis.question_timeout_hours = [int]$Body.question_timeout_hours
+            $patch.question_timeout_hours = [int]$Body.question_timeout_hours
         }
     }
     if ($null -ne $Body.mode) {
-        $settingsData.analysis.mode = [string]$Body.mode
+        $patch.mode = [string]$Body.mode
     }
 
-    $settingsData | ConvertTo-Json -Depth 5 | Set-Content $settingsDefaultFile -Force
+    Save-OverrideSection -Key 'analysis' -Patch $patch
     Write-Status "Analysis config updated" -Type Success
 
+    $merged = Get-MergedSettings -BotRoot $script:Config.BotRoot
     return @{
         success = $true
-        analysis = $settingsData.analysis
+        analysis = $merged.analysis
     }
 }
 
@@ -324,36 +371,28 @@ function Set-CostConfig {
     param(
         [Parameter(Mandatory)] $Body
     )
-    $settingsDefaultFile = Join-Path $script:Config.BotRoot "settings\settings.default.json"
-
-    $settingsData = Get-Content $settingsDefaultFile -Raw | ConvertFrom-Json
-    if (-not $settingsData.costs) {
-        $settingsData | Add-Member -NotePropertyName "costs" -NotePropertyValue @{
-            hourly_rate = 50
-            ai_speedup_factor = 10
-            currency = "USD"
-        }
-    }
+    $patch = @{}
 
     if ($null -ne $Body.hourly_rate) {
-        $settingsData.costs.hourly_rate = [decimal]$Body.hourly_rate
+        $patch.hourly_rate = [decimal]$Body.hourly_rate
     }
     if ($null -ne $Body.ai_cost_per_task) {
-        $settingsData.costs.ai_cost_per_task = [decimal]$Body.ai_cost_per_task
+        $patch.ai_cost_per_task = [decimal]$Body.ai_cost_per_task
     }
     if ($null -ne $Body.ai_speedup_factor) {
-        $settingsData.costs.ai_speedup_factor = [decimal]$Body.ai_speedup_factor
+        $patch.ai_speedup_factor = [decimal]$Body.ai_speedup_factor
     }
     if ($null -ne $Body.currency) {
-        $settingsData.costs.currency = [string]$Body.currency
+        $patch.currency = [string]$Body.currency
     }
 
-    $settingsData | ConvertTo-Json -Depth 5 | Set-Content $settingsDefaultFile -Force
+    Save-OverrideSection -Key 'costs' -Patch $patch
     Write-Status "Cost config updated" -Type Success
 
+    $merged = Get-MergedSettings -BotRoot $script:Config.BotRoot
     return @{
         success = $true
-        costs = $settingsData.costs
+        costs = $merged.costs
     }
 }
 
@@ -446,20 +485,7 @@ function Set-EditorConfig {
     param(
         [Parameter(Mandatory)] $Body
     )
-    $settingsDefaultFile = Join-Path $script:Config.BotRoot "settings\settings.default.json"
-
-    if (-not (Test-Path $settingsDefaultFile)) {
-        # Create a minimal settings file if it doesn't exist
-        @{ editor = @{ name = 'off'; custom_command = '' } } | ConvertTo-Json -Depth 5 | Set-Content $settingsDefaultFile -Force
-    }
-
-    $settingsData = Get-Content $settingsDefaultFile -Raw | ConvertFrom-Json
-    if (-not $settingsData.editor) {
-        $settingsData | Add-Member -NotePropertyName "editor" -NotePropertyValue ([PSCustomObject]@{
-            name = 'off'
-            custom_command = ''
-        })
-    }
+    $patch = @{}
 
     if ($null -ne $Body.name) {
         # Validate against allowlist
@@ -480,7 +506,7 @@ function Set-EditorConfig {
                 }
             }
         }
-        $settingsData.editor.name = $requestedName
+        $patch.name = $requestedName
     }
     if ($null -ne $Body.custom_command) {
         $customCommand = [string]$Body.custom_command
@@ -492,15 +518,16 @@ function Set-EditorConfig {
                 error       = "custom_command exceeds maximum length of $maxCustomCommandLength characters."
             }
         }
-        $settingsData.editor.custom_command = $customCommand
+        $patch.custom_command = $customCommand
     }
 
-    $settingsData | ConvertTo-Json -Depth 5 | Set-Content $settingsDefaultFile -Force
-    Write-Status "Editor config updated: $($settingsData.editor.name)" -Type Success
+    Save-OverrideSection -Key 'editor' -Patch $patch
+    $merged = Get-MergedSettings -BotRoot $script:Config.BotRoot
+    Write-Status "Editor config updated: $($merged.editor.name)" -Type Success
 
     return @{
         success = $true
-        editor = $settingsData.editor
+        editor = $merged.editor
     }
 }
 
@@ -690,7 +717,6 @@ function Set-ActiveProvider {
     param(
         [Parameter(Mandatory)] $Body
     )
-    $settingsDefaultFile = Join-Path $script:Config.BotRoot "settings\settings.default.json"
     $providersDir = Join-Path $script:Config.BotRoot "settings\providers"
 
     $providerName = $Body.provider
@@ -707,25 +733,8 @@ function Set-ActiveProvider {
         return @{ _statusCode = 400; success = $false; error = "Unknown provider: $providerName" }
     }
 
-    # Update settings
-    if (-not (Test-Path $settingsDefaultFile)) {
-        @{ provider = $providerName } | ConvertTo-Json -Depth 5 | Set-Content $settingsDefaultFile -Force
-    }
-
     try {
-        $settingsData = Get-Content $settingsDefaultFile -Raw | ConvertFrom-Json
-    } catch {
-        return @{ _statusCode = 500; success = $false; error = "Failed to parse settings file: $($_.Exception.Message)" }
-    }
-
-    if ($settingsData.PSObject.Properties.Name -contains 'provider') {
-        $settingsData.provider = $providerName
-    } else {
-        $settingsData | Add-Member -NotePropertyName "provider" -NotePropertyValue $providerName
-    }
-
-    try {
-        $settingsData | ConvertTo-Json -Depth 5 | Set-Content $settingsDefaultFile -Force
+        Save-OverrideSection -Key $null -Patch @{ provider = $providerName }
     } catch {
         return @{ _statusCode = 500; success = $false; error = "Failed to write settings file: $($_.Exception.Message)" }
     }
@@ -828,128 +837,59 @@ function Set-MothershipConfig {
     param(
         [Parameter(Mandatory)] $Body
     )
-    $settingsDefaultFile = Join-Path $script:Config.BotRoot "settings\settings.default.json"
-    $overridesFile = Join-Path $script:Config.ControlDir "settings.json"
     $uiSettingsFile = Join-Path $script:Config.ControlDir "ui-settings.json"
 
-    # Non-secret settings go in settings.default.json
-    $settingsData = if (Test-Path $settingsDefaultFile) {
-        Get-Content $settingsDefaultFile -Raw | ConvertFrom-Json
-    } else {
-        [PSCustomObject]@{}
-    }
-
-    # Migrate legacy 'notifications' key to 'mothership'
-    if ($settingsData.PSObject.Properties['notifications'] -and -not $settingsData.PSObject.Properties['mothership']) {
-        $settingsData | Add-Member -NotePropertyName "mothership" -NotePropertyValue $settingsData.notifications
-        $settingsData.PSObject.Properties.Remove('notifications')
-        $settingsChanged = $true
-    }
-
-    if (-not $settingsData.PSObject.Properties['mothership']) {
-        $settingsData | Add-Member -NotePropertyName "mothership" -NotePropertyValue ([PSCustomObject]@{
-            enabled               = $false
-            server_url            = ""
-            api_key               = ""
-            channel               = "teams"
-            recipients            = @()
-            project_name          = ""
-            project_description   = ""
-            poll_interval_seconds = 30
-            sync_tasks            = $true
-            sync_questions        = $true
-        })
-    }
-
-    $notif = $settingsData.mothership
-    $settingsChanged = $false
+    # Build patch for the mothership section in .control/settings.json (gitignored overrides).
+    $patch = @{}
     $legacySoundEnabled = $null
 
-    if ($notif.PSObject.Properties['sound_enabled']) {
-        $legacySoundEnabled = [bool]$notif.sound_enabled
-        [void]$notif.PSObject.Properties.Remove('sound_enabled')
-        $settingsChanged = $true
-    }
-
-    if ($null -ne $Body.enabled) {
-        $notif.enabled = [bool]$Body.enabled
-        $settingsChanged = $true
-    }
-    if ($null -ne $Body.server_url) {
-        $notif.server_url = [string]$Body.server_url
-        $settingsChanged = $true
-    }
-    if ($null -ne $Body.channel) {
-        $validChannels = @("teams", "email", "jira", "slack")
-        if ($Body.channel -in $validChannels) {
-            $notif.channel = [string]$Body.channel
-            $settingsChanged = $true
-        }
-    }
-    if ($null -ne $Body.recipients) {
-        $notif.recipients = @($Body.recipients)
-        $settingsChanged = $true
-    }
-    if ($null -ne $Body.project_name) {
-        $notif.project_name = [string]$Body.project_name
-        $settingsChanged = $true
-    }
-    if ($null -ne $Body.project_description) {
-        $notif.project_description = [string]$Body.project_description
-        $settingsChanged = $true
-    }
-    if ($null -ne $Body.poll_interval_seconds) {
-        $interval = [int]$Body.poll_interval_seconds
-        if ($interval -lt 5) { $interval = 5 }
-        $notif.poll_interval_seconds = $interval
-        $settingsChanged = $true
-    }
-    if ($null -ne $Body.sync_tasks) {
-        $notif | Add-Member -NotePropertyName 'sync_tasks' -NotePropertyValue ([bool]$Body.sync_tasks) -Force
-        $settingsChanged = $true
-    }
-    if ($null -ne $Body.sync_questions) {
-        $notif | Add-Member -NotePropertyName 'sync_questions' -NotePropertyValue ([bool]$Body.sync_questions) -Force
-        $settingsChanged = $true
-    }
-
-    if ($settingsChanged) {
-        $settingsData | ConvertTo-Json -Depth 5 | Set-Content $settingsDefaultFile -Force
-    }
-
-    # API key goes in the gitignored overrides file
-    $overrides = @{}
-    $overridesChanged = $false
-    if (Test-Path $overridesFile) {
-        try {
-            $existing = Get-Content $overridesFile -Raw | ConvertFrom-Json
-            foreach ($prop in $existing.PSObject.Properties) {
-                $overrides[$prop.Name] = $prop.Value
-            }
-        } catch { Write-BotLog -Level Debug -Message "Failed to parse data" -Exception $_ }
-    }
-
-    # Migrate legacy 'notifications' key to 'mothership' in overrides
+    # Pre-load existing overrides so we can detect & strip legacy sound_enabled placement,
+    # and support legacy 'notifications' → 'mothership' migration.
+    $overrides = Get-OverridesHashtable
+    $overridesDirty = $false
     if ($overrides.ContainsKey('notifications') -and -not $overrides.ContainsKey('mothership')) {
         $overrides['mothership'] = $overrides['notifications']
         $overrides.Remove('notifications')
-        $overridesChanged = $true
+        $overridesDirty = $true
     }
-
     if ($overrides.ContainsKey('mothership') -and $overrides['mothership'] -is [PSCustomObject]) {
-        $hash = @{}
-        foreach ($p in $overrides['mothership'].PSObject.Properties) { $hash[$p.Name] = $p.Value }
-        $overrides['mothership'] = $hash
+        $h = @{}
+        foreach ($p in $overrides['mothership'].PSObject.Properties) { $h[$p.Name] = $p.Value }
+        $overrides['mothership'] = $h
+        $overridesDirty = $true
     }
-
     if ($overrides.ContainsKey('mothership') -and $overrides['mothership'].ContainsKey('sound_enabled')) {
-        if ($null -eq $legacySoundEnabled) {
-            $legacySoundEnabled = [bool]$overrides['mothership']['sound_enabled']
-        }
+        $legacySoundEnabled = [bool]$overrides['mothership']['sound_enabled']
         $overrides['mothership'].Remove('sound_enabled')
-        $overridesChanged = $true
+        $overridesDirty = $true
+    }
+    if ($overridesDirty) {
+        Save-OverridesHashtable -Overrides $overrides
     }
 
+    if ($null -ne $Body.enabled) { $patch.enabled = [bool]$Body.enabled }
+    if ($null -ne $Body.server_url) { $patch.server_url = [string]$Body.server_url }
+    if ($null -ne $Body.channel) {
+        $validChannels = @("teams", "email", "jira", "slack")
+        if ($Body.channel -in $validChannels) { $patch.channel = [string]$Body.channel }
+    }
+    if ($null -ne $Body.recipients) { $patch.recipients = @($Body.recipients) }
+    if ($null -ne $Body.project_name) { $patch.project_name = [string]$Body.project_name }
+    if ($null -ne $Body.project_description) { $patch.project_description = [string]$Body.project_description }
+    if ($null -ne $Body.poll_interval_seconds) {
+        $interval = [int]$Body.poll_interval_seconds
+        if ($interval -lt 5) { $interval = 5 }
+        $patch.poll_interval_seconds = $interval
+    }
+    if ($null -ne $Body.sync_tasks) { $patch.sync_tasks = [bool]$Body.sync_tasks }
+    if ($null -ne $Body.sync_questions) { $patch.sync_questions = [bool]$Body.sync_questions }
+    if ($null -ne $Body.api_key -and $Body.api_key -ne '') { $patch.api_key = [string]$Body.api_key }
+
+    if ($patch.Count -gt 0) {
+        Save-OverrideSection -Key 'mothership' -Patch $patch
+    }
+
+    # ui-settings.json: notification sound is a UI-only preference, not a merged setting.
     $uiSettings = @{
         showDebug = $false
         showVerbose = $false
@@ -980,18 +920,6 @@ function Set-MothershipConfig {
 
     if ($uiSettingsChanged) {
         $uiSettings | ConvertTo-Json -Depth 5 | Set-Content $uiSettingsFile -Force
-    }
-
-    if ($null -ne $Body.api_key -and $Body.api_key -ne '') {
-        if (-not $overrides.ContainsKey('mothership')) {
-            $overrides['mothership'] = @{}
-        }
-        $overrides['mothership']['api_key'] = [string]$Body.api_key
-        $overridesChanged = $true
-    }
-
-    if ($overridesChanged) {
-        $overrides | ConvertTo-Json -Depth 5 | Set-Content $overridesFile -Force
     }
 
     Write-Status "Mothership config updated" -Type Success

--- a/core/ui/modules/SettingsAPI.psm1
+++ b/core/ui/modules/SettingsAPI.psm1
@@ -69,11 +69,22 @@ function Save-OverrideSection {
     $overrides = Get-OverridesHashtable
     if ($Key) {
         $existingSection = if ($overrides.ContainsKey($Key)) { $overrides[$Key] } else { @{} }
-        # Normalize PSCustomObject section to hashtable so Merge-DeepSettings can iterate.
-        if ($existingSection -is [PSCustomObject]) {
+        # Normalize persisted section values to a hashtable so Merge-DeepSettings only receives
+        # object-like data. Treat $null and scalar/array values as an empty section.
+        if ($null -eq $existingSection) {
+            $existingSection = @{}
+        } elseif ($existingSection -is [hashtable]) {
+            # Already normalized.
+        } elseif ($existingSection -is [System.Collections.IDictionary]) {
+            $h = @{}
+            foreach ($k in $existingSection.Keys) { $h[$k] = $existingSection[$k] }
+            $existingSection = $h
+        } elseif ($existingSection -is [PSCustomObject]) {
             $h = @{}
             foreach ($p in $existingSection.PSObject.Properties) { $h[$p.Name] = $p.Value }
             $existingSection = $h
+        } else {
+            $existingSection = @{}
         }
         $merged = Merge-DeepSettings $existingSection $Patch
         # Merge-DeepSettings returns an [ordered] dict; convert to plain hashtable for ConvertTo-Json fidelity.

--- a/core/ui/modules/SettingsAPI.psm1
+++ b/core/ui/modules/SettingsAPI.psm1
@@ -873,7 +873,18 @@ function Set-MothershipConfig {
         $validChannels = @("teams", "email", "jira", "slack")
         if ($Body.channel -in $validChannels) { $patch.channel = [string]$Body.channel }
     }
-    if ($null -ne $Body.recipients) { $patch.recipients = @($Body.recipients) }
+    if ($null -ne $Body.recipients) {
+        # recipients must REPLACE, not merge -- Merge-DeepSettings concat+dedups scalar arrays.
+        $ov = Get-OverridesHashtable
+        if (-not $ov.ContainsKey('mothership')) { $ov['mothership'] = @{} }
+        if ($ov['mothership'] -is [PSCustomObject]) {
+            $h = @{}
+            foreach ($p in $ov['mothership'].PSObject.Properties) { $h[$p.Name] = $p.Value }
+            $ov['mothership'] = $h
+        }
+        $ov['mothership']['recipients'] = @($Body.recipients)
+        Save-OverridesHashtable -Overrides $ov
+    }
     if ($null -ne $Body.project_name) { $patch.project_name = [string]$Body.project_name }
     if ($null -ne $Body.project_description) { $patch.project_description = [string]$Body.project_description }
     if ($null -ne $Body.poll_interval_seconds) {

--- a/core/ui/modules/SettingsAPI.psm1
+++ b/core/ui/modules/SettingsAPI.psm1
@@ -41,8 +41,6 @@ function Get-OverridesHashtable {
         } catch {
             if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
                 Write-BotLog -Level Debug -Message "Failed to parse overrides" -Exception $_
-            } else {
-                Write-Verbose ("Failed to parse overrides: {0}" -f $_.Exception.Message)
             }
         }
     }

--- a/core/ui/modules/SettingsAPI.psm1
+++ b/core/ui/modules/SettingsAPI.psm1
@@ -38,7 +38,13 @@ function Get-OverridesHashtable {
             foreach ($prop in $existing.PSObject.Properties) {
                 $h[$prop.Name] = $prop.Value
             }
-        } catch { Write-BotLog -Level Debug -Message "Failed to parse overrides" -Exception $_ }
+        } catch {
+            if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
+                Write-BotLog -Level Debug -Message "Failed to parse overrides" -Exception $_
+            } else {
+                Write-Verbose ("Failed to parse overrides: {0}" -f $_.Exception.Message)
+            }
+        }
     }
     return $h
 }
@@ -50,7 +56,7 @@ function Save-OverridesHashtable {
         New-Item -ItemType Directory -Path $script:Config.ControlDir -Force | Out-Null
     }
     $overridesFile = Join-Path $script:Config.ControlDir "settings.json"
-    $Overrides | ConvertTo-Json -Depth 10 | Set-Content $overridesFile -Force
+    $Overrides | ConvertTo-Json -Depth 10 | Set-Content $overridesFile -Force -Encoding utf8NoBOM
 }
 
 # Internal: merge a partial section (or top-level scalars) into .control/settings.json.
@@ -839,65 +845,59 @@ function Set-MothershipConfig {
     )
     $uiSettingsFile = Join-Path $script:Config.ControlDir "ui-settings.json"
 
-    # Build patch for the mothership section in .control/settings.json (gitignored overrides).
-    $patch = @{}
     $legacySoundEnabled = $null
 
-    # Pre-load existing overrides so we can detect & strip legacy sound_enabled placement,
-    # and support legacy 'notifications' → 'mothership' migration.
+    # Single read of .control/settings.json; mutate in-memory; single save at end.
     $overrides = Get-OverridesHashtable
-    $overridesDirty = $false
+    $dirty = $false
+
+    # Legacy 'notifications' -> 'mothership' migration.
     if ($overrides.ContainsKey('notifications') -and -not $overrides.ContainsKey('mothership')) {
         $overrides['mothership'] = $overrides['notifications']
         $overrides.Remove('notifications')
-        $overridesDirty = $true
+        $dirty = $true
     }
-    if ($overrides.ContainsKey('mothership') -and $overrides['mothership'] -is [PSCustomObject]) {
+
+    # Ensure mothership section is a mutable hashtable.
+    if (-not $overrides.ContainsKey('mothership')) {
+        $overrides['mothership'] = @{}
+    } elseif ($overrides['mothership'] -is [PSCustomObject]) {
         $h = @{}
         foreach ($p in $overrides['mothership'].PSObject.Properties) { $h[$p.Name] = $p.Value }
         $overrides['mothership'] = $h
-        $overridesDirty = $true
+        $dirty = $true
     }
-    if ($overrides.ContainsKey('mothership') -and $overrides['mothership'].ContainsKey('sound_enabled')) {
-        $legacySoundEnabled = [bool]$overrides['mothership']['sound_enabled']
-        $overrides['mothership'].Remove('sound_enabled')
-        $overridesDirty = $true
-    }
-    if ($overridesDirty) {
-        Save-OverridesHashtable -Overrides $overrides
+    $section = $overrides['mothership']
+
+    # Strip legacy sound_enabled (now lives in ui-settings.json, handled below).
+    if ($section.ContainsKey('sound_enabled')) {
+        $legacySoundEnabled = [bool]$section['sound_enabled']
+        $section.Remove('sound_enabled')
+        $dirty = $true
     }
 
-    if ($null -ne $Body.enabled) { $patch.enabled = [bool]$Body.enabled }
-    if ($null -ne $Body.server_url) { $patch.server_url = [string]$Body.server_url }
+    if ($null -ne $Body.enabled)    { $section['enabled']    = [bool]$Body.enabled;      $dirty = $true }
+    if ($null -ne $Body.server_url) { $section['server_url'] = [string]$Body.server_url; $dirty = $true }
     if ($null -ne $Body.channel) {
         $validChannels = @("teams", "email", "jira", "slack")
-        if ($Body.channel -in $validChannels) { $patch.channel = [string]$Body.channel }
+        if ($Body.channel -in $validChannels) { $section['channel'] = [string]$Body.channel; $dirty = $true }
     }
-    if ($null -ne $Body.recipients) {
-        # recipients must REPLACE, not merge -- Merge-DeepSettings concat+dedups scalar arrays.
-        $ov = Get-OverridesHashtable
-        if (-not $ov.ContainsKey('mothership')) { $ov['mothership'] = @{} }
-        if ($ov['mothership'] -is [PSCustomObject]) {
-            $h = @{}
-            foreach ($p in $ov['mothership'].PSObject.Properties) { $h[$p.Name] = $p.Value }
-            $ov['mothership'] = $h
-        }
-        $ov['mothership']['recipients'] = @($Body.recipients)
-        Save-OverridesHashtable -Overrides $ov
-    }
-    if ($null -ne $Body.project_name) { $patch.project_name = [string]$Body.project_name }
-    if ($null -ne $Body.project_description) { $patch.project_description = [string]$Body.project_description }
+    # recipients REPLACE (not merge) -- Merge-DeepSettings concat+dedups scalar arrays.
+    if ($null -ne $Body.recipients) { $section['recipients'] = @($Body.recipients); $dirty = $true }
+    if ($null -ne $Body.project_name)        { $section['project_name']        = [string]$Body.project_name;        $dirty = $true }
+    if ($null -ne $Body.project_description) { $section['project_description'] = [string]$Body.project_description; $dirty = $true }
     if ($null -ne $Body.poll_interval_seconds) {
         $interval = [int]$Body.poll_interval_seconds
         if ($interval -lt 5) { $interval = 5 }
-        $patch.poll_interval_seconds = $interval
+        $section['poll_interval_seconds'] = $interval
+        $dirty = $true
     }
-    if ($null -ne $Body.sync_tasks) { $patch.sync_tasks = [bool]$Body.sync_tasks }
-    if ($null -ne $Body.sync_questions) { $patch.sync_questions = [bool]$Body.sync_questions }
-    if ($null -ne $Body.api_key -and $Body.api_key -ne '') { $patch.api_key = [string]$Body.api_key }
+    if ($null -ne $Body.sync_tasks)     { $section['sync_tasks']     = [bool]$Body.sync_tasks;     $dirty = $true }
+    if ($null -ne $Body.sync_questions) { $section['sync_questions'] = [bool]$Body.sync_questions; $dirty = $true }
+    if ($null -ne $Body.api_key -and $Body.api_key -ne '') { $section['api_key'] = [string]$Body.api_key; $dirty = $true }
 
-    if ($patch.Count -gt 0) {
-        Save-OverrideSection -Key 'mothership' -Patch $patch
+    if ($dirty) {
+        Save-OverridesHashtable -Overrides $overrides
     }
 
     # ui-settings.json: notification sound is a UI-only preference, not a merged setting.

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2550,6 +2550,122 @@ if (Test-Path $settingsLoaderModule) {
 }
 
 # ═══════════════════════════════════════════════════════════════════
+# SETTINGS API WRITERS — issue #309 regression
+# UI Set-* writers must NOT touch settings.default.json (framework-protected).
+# Writes go to .control/settings.json (gitignored overrides).
+# ═══════════════════════════════════════════════════════════════════
+Write-Host ""
+Write-Host "--- SettingsAPI Writers (issue #309) ---" -ForegroundColor Cyan
+
+$settingsApiModule = Join-Path $botDir "core/ui/modules/SettingsAPI.psm1"
+
+if (Test-Path $settingsApiModule) {
+    # Need DotBotLog for Write-BotLog/Write-Status used inside SettingsAPI.
+    $logModule = Join-Path $botDir "core/runtime/modules/DotBotLog.psm1"
+    if (Test-Path $logModule) { Import-Module $logModule -Force -DisableNameChecking -Global }
+    $themeModule = Join-Path $botDir "core/runtime/modules/DotBotTheme.psm1"
+    if (Test-Path $themeModule) { Import-Module $themeModule -Force -DisableNameChecking -Global }
+    Import-Module $settingsApiModule -Force -DisableNameChecking
+
+    $apiFixture = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-test-api-$([guid]::NewGuid().ToString().Substring(0,8))"
+    $apiBotDir = Join-Path $apiFixture ".bot"
+    $apiSettingsDir = Join-Path $apiBotDir "settings"
+    $apiControlDir = Join-Path $apiBotDir ".control"
+    $apiProvidersDir = Join-Path $apiSettingsDir "providers"
+    $apiStaticRoot = Join-Path $apiBotDir "ui\static"
+    New-Item -ItemType Directory -Path $apiSettingsDir -Force | Out-Null
+    New-Item -ItemType Directory -Path $apiControlDir -Force | Out-Null
+    New-Item -ItemType Directory -Path $apiProvidersDir -Force | Out-Null
+    New-Item -ItemType Directory -Path $apiStaticRoot -Force | Out-Null
+
+    # Back up real ~/dotbot/user-settings.json (merge chain layer 2)
+    $apiUserSettings = Join-Path $HOME "dotbot" "user-settings.json"
+    $apiUserExisted = Test-Path $apiUserSettings
+    $apiUserBackup = if ($apiUserExisted) { Get-Content $apiUserSettings -Raw } else { $null }
+
+    try {
+        # Seed shipped defaults — values that should NEVER be mutated by the UI writers.
+        $defaults = @{
+            provider = "claude"
+            analysis = @{ auto_approve_splits = $false; split_threshold_effort = "XL"; question_timeout_hours = $null; mode = "on-demand" }
+            costs    = @{ hourly_rate = 50; ai_speedup_factor = 10; currency = "USD" }
+            editor   = @{ name = "off"; custom_command = "" }
+            mothership = @{ enabled = $false; server_url = ""; api_key = ""; channel = "teams"; recipients = @(); project_name = ""; project_description = ""; poll_interval_seconds = 30; sync_tasks = $true; sync_questions = $true }
+        }
+        $defaultsFile = Join-Path $apiSettingsDir "settings.default.json"
+        $defaults | ConvertTo-Json -Depth 10 | Set-Content $defaultsFile -Force
+        $defaultsHashBefore = (Get-FileHash $defaultsFile -Algorithm SHA256).Hash
+
+        # Stub claude provider so Set-ActiveProvider validation passes.
+        @{ name = "claude"; display_name = "Claude"; executable = "claude"; models = @{} } | ConvertTo-Json -Depth 5 | Set-Content (Join-Path $apiProvidersDir "claude.json") -Force
+
+        if (Test-Path $apiUserSettings) { Remove-Item $apiUserSettings -Force }
+
+        Initialize-SettingsAPI -ControlDir $apiControlDir -BotRoot $apiBotDir -StaticRoot $apiStaticRoot
+
+        $overridesFile = Join-Path $apiControlDir "settings.json"
+
+        function Get-OverridesJson { Get-Content $overridesFile -Raw | ConvertFrom-Json }
+
+        # --- Set-AnalysisConfig ---
+        $r = Set-AnalysisConfig -Body ([PSCustomObject]@{ auto_approve_splits = $true; mode = "auto" })
+        Assert-True -Name "#309: Set-AnalysisConfig success" -Condition ($r.success -eq $true)
+        Assert-Equal -Name "#309: AnalysisConfig writes to .control overrides" -Expected $true -Actual ((Get-OverridesJson).analysis.auto_approve_splits)
+        Assert-Equal -Name "#309: AnalysisConfig mode persisted" -Expected "auto" -Actual ((Get-OverridesJson).analysis.mode)
+        Assert-Equal -Name "#309: AnalysisConfig merged read returns override" -Expected $true -Actual (Get-AnalysisConfig).auto_approve_splits
+
+        # --- Set-CostConfig ---
+        $r = Set-CostConfig -Body ([PSCustomObject]@{ hourly_rate = 99; currency = "EUR" })
+        Assert-True -Name "#309: Set-CostConfig success" -Condition ($r.success -eq $true)
+        Assert-Equal -Name "#309: CostConfig writes to .control overrides" -Expected 99 -Actual ([int](Get-OverridesJson).costs.hourly_rate)
+        Assert-Equal -Name "#309: CostConfig currency persisted" -Expected "EUR" -Actual (Get-OverridesJson).costs.currency
+
+        # --- Set-EditorConfig ---
+        $r = Set-EditorConfig -Body ([PSCustomObject]@{ name = "custom"; custom_command = "vi {path}" })
+        Assert-True -Name "#309: Set-EditorConfig success" -Condition ($r.success -eq $true)
+        Assert-Equal -Name "#309: EditorConfig writes to .control overrides" -Expected "custom" -Actual (Get-OverridesJson).editor.name
+        Assert-Equal -Name "#309: EditorConfig custom_command persisted" -Expected "vi {path}" -Actual (Get-OverridesJson).editor.custom_command
+
+        # --- Set-ActiveProvider (top-level scalar) ---
+        $r = Set-ActiveProvider -Body ([PSCustomObject]@{ provider = "claude" })
+        Assert-Equal -Name "#309: ActiveProvider writes to .control overrides" -Expected "claude" -Actual (Get-OverridesJson).provider
+
+        # --- Set-MothershipConfig (mix of non-secret + secret) ---
+        $r = Set-MothershipConfig -Body ([PSCustomObject]@{
+            enabled = $true
+            server_url = "http://localhost:5048"
+            channel = "slack"
+            recipients = @("U123","U456")
+            project_name = "demo"
+            api_key = "secret-key-xyz"
+        })
+        Assert-True -Name "#309: Set-MothershipConfig success" -Condition ($r.success -eq $true)
+        $ov = Get-OverridesJson
+        Assert-Equal -Name "#309: Mothership.enabled in .control" -Expected $true -Actual $ov.mothership.enabled
+        Assert-Equal -Name "#309: Mothership.channel=slack in .control" -Expected "slack" -Actual $ov.mothership.channel
+        Assert-Equal -Name "#309: Mothership.api_key co-located in .control" -Expected "secret-key-xyz" -Actual $ov.mothership.api_key
+        Assert-Equal -Name "#309: Mothership.server_url in .control" -Expected "http://localhost:5048" -Actual $ov.mothership.server_url
+        Assert-Equal -Name "#309: Mothership.recipients length" -Expected 2 -Actual @($ov.mothership.recipients).Count
+
+        # --- The critical assertion: settings.default.json bytes UNCHANGED ---
+        $defaultsHashAfter = (Get-FileHash $defaultsFile -Algorithm SHA256).Hash
+        Assert-Equal -Name "#309: settings.default.json untouched by ALL UI writers" -Expected $defaultsHashBefore -Actual $defaultsHashAfter
+
+        # --- Merged read returns override values, defaults survive elsewhere ---
+        $merged = Get-MothershipConfig
+        Assert-Equal -Name "#309: Get-MothershipConfig returns merged enabled=true" -Expected $true -Actual $merged.enabled
+        Assert-Equal -Name "#309: Get-MothershipConfig returns merged channel=slack" -Expected "slack" -Actual $merged.channel
+        Assert-True -Name "#309: Get-MothershipConfig api_key_set" -Condition ($merged.api_key_set -eq $true)
+    } finally {
+        if (Test-Path $apiUserSettings) { Remove-Item $apiUserSettings -Force }
+        if ($apiUserExisted -and $null -ne $apiUserBackup) { Set-Content $apiUserSettings $apiUserBackup }
+        Remove-Item $apiFixture -Recurse -Force -ErrorAction SilentlyContinue
+    }
+} else {
+    Write-TestResult -Name "SettingsAPI module exists" -Status Fail -Message "Module not found at $settingsApiModule"
+}
+
+# ═══════════════════════════════════════════════════════════════════
 # MERGE CONFLICT ESCALATION MODULE TESTS (issue #224)
 # ═══════════════════════════════════════════════════════════════════
 Write-Host ""

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2647,6 +2647,20 @@ if (Test-Path $settingsApiModule) {
         Assert-Equal -Name "#309: Mothership.server_url in .control" -Expected "http://localhost:5048" -Actual $ov.mothership.server_url
         Assert-Equal -Name "#309: Mothership.recipients length" -Expected 2 -Actual @($ov.mothership.recipients).Count
 
+        # Regression: recipients must REPLACE, not concat+dedup (issue #309 follow-up).
+        $r = Set-MothershipConfig -Body ([PSCustomObject]@{ recipients = @("U123") })
+        $ov = Get-OverridesJson
+        Assert-Equal -Name "#309: Mothership.recipients shrinks on replace" -Expected 1 -Actual @($ov.mothership.recipients).Count
+        Assert-Equal -Name "#309: Mothership.recipients keeps remaining" -Expected "U123" -Actual @($ov.mothership.recipients)[0]
+
+        # Regression: empty recipients clears the list.
+        $r = Set-MothershipConfig -Body ([PSCustomObject]@{ recipients = @() })
+        $ov = Get-OverridesJson
+        Assert-Equal -Name "#309: Mothership.recipients can clear to empty" -Expected 0 -Actual @($ov.mothership.recipients).Count
+
+        # Restore recipients for downstream merged-read assertions.
+        $null = Set-MothershipConfig -Body ([PSCustomObject]@{ recipients = @("U123","U456") })
+
         # --- The critical assertion: settings.default.json bytes UNCHANGED ---
         $defaultsHashAfter = (Get-FileHash $defaultsFile -Algorithm SHA256).Hash
         Assert-Equal -Name "#309: settings.default.json untouched by ALL UI writers" -Expected $defaultsHashBefore -Actual $defaultsHashAfter

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2572,7 +2572,7 @@ if (Test-Path $settingsApiModule) {
     $apiSettingsDir = Join-Path $apiBotDir "settings"
     $apiControlDir = Join-Path $apiBotDir ".control"
     $apiProvidersDir = Join-Path $apiSettingsDir "providers"
-    $apiStaticRoot = Join-Path (Join-Path $apiBotDir "ui") "static"
+    $apiStaticRoot = Join-Path $apiBotDir "ui/static"
     New-Item -ItemType Directory -Path $apiSettingsDir -Force | Out-Null
     New-Item -ItemType Directory -Path $apiControlDir -Force | Out-Null
     New-Item -ItemType Directory -Path $apiProvidersDir -Force | Out-Null

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2572,7 +2572,7 @@ if (Test-Path $settingsApiModule) {
     $apiSettingsDir = Join-Path $apiBotDir "settings"
     $apiControlDir = Join-Path $apiBotDir ".control"
     $apiProvidersDir = Join-Path $apiSettingsDir "providers"
-    $apiStaticRoot = Join-Path $apiBotDir "ui\static"
+    $apiStaticRoot = Join-Path (Join-Path $apiBotDir "ui") "static"
     New-Item -ItemType Directory -Path $apiSettingsDir -Force | Out-Null
     New-Item -ItemType Directory -Path $apiControlDir -Force | Out-Null
     New-Item -ItemType Directory -Path $apiProvidersDir -Force | Out-Null
@@ -2581,7 +2581,11 @@ if (Test-Path $settingsApiModule) {
     # Back up real ~/dotbot/user-settings.json (merge chain layer 2)
     $apiUserSettings = Join-Path $HOME "dotbot" "user-settings.json"
     $apiUserExisted = Test-Path $apiUserSettings
-    $apiUserBackup = if ($apiUserExisted) { Get-Content $apiUserSettings -Raw } else { $null }
+    $apiUserBackupPath = if ($apiUserExisted) {
+        $p = [System.IO.Path]::GetTempFileName()
+        Copy-Item $apiUserSettings $p -Force
+        $p
+    } else { $null }
 
     try {
         # Seed shipped defaults — values that should NEVER be mutated by the UI writers.
@@ -2672,7 +2676,10 @@ if (Test-Path $settingsApiModule) {
         Assert-True -Name "#309: Get-MothershipConfig api_key_set" -Condition ($merged.api_key_set -eq $true)
     } finally {
         if (Test-Path $apiUserSettings) { Remove-Item $apiUserSettings -Force }
-        if ($apiUserExisted -and $null -ne $apiUserBackup) { Set-Content $apiUserSettings $apiUserBackup }
+        if ($apiUserExisted -and $apiUserBackupPath) {
+            Copy-Item $apiUserBackupPath $apiUserSettings -Force
+            Remove-Item $apiUserBackupPath -Force -ErrorAction SilentlyContinue
+        }
         Remove-Item $apiFixture -Recurse -Force -ErrorAction SilentlyContinue
     }
 } else {


### PR DESCRIPTION
## Linked issue

Closes #309

## Summary of changes

UI Settings writers (`Set-AnalysisConfig`, `Set-CostConfig`, `Set-EditorConfig`, `Set-ActiveProvider`, `Set-MothershipConfig`) persisted non-secret config into `.bot/settings/settings.default.json`. That file is framework-protected by `FrameworkIntegrity.psm1`, so the next workflow run rejected `task_mark_analysing`. Claude then reverted the file per `CLAUDE.md` guidance, wiping user config (Slack channel, recipients, `enabled` flag) and breaking notification dispatch end-to-end.

This PR routes all five writers to `.bot/.control/settings.json` (the gitignored overrides layer) via a new internal helper `Save-OverrideSection` that uses `Merge-DeepSettings` from `SettingsLoader.psm1`. Readers were already going through `Get-MergedSettings`, so the three-tier merge chain (`default → ~/dotbot/user-settings → .control`, last wins) surfaces the saved values without further changes. Legacy `notifications` → `mothership` migration and the `sound_enabled` → `ui-settings.json` move are preserved.

`mothership.recipients` is written directly to `.control/settings.json` (bypassing `Save-OverrideSection`) because `Merge-DeepSettings` concats+dedups arrays of scalars — going through the merge would make recipients append-only and prevent the UI from removing or clearing entries.

Net effect:
- `settings.default.json` stays clean → `FrameworkIntegrity` guard stays green.
- User-saved values take effect (merge chain prefers `.control`).
- `dotbot init --force` no longer overwrites UI choices.
- Mothership/Slack delivery now works when configured via UI.
- UI can shrink or clear `mothership.recipients` (replace semantics, not merge).

## Testing notes

- New Layer-2 regression block `--- SettingsAPI Writers (issue #309) ---` in `tests/Test-Components.ps1` exercises all five setters in an isolated fixture and asserts:
  - Writes land in `.control/settings.json` under the expected key.
  - `settings.default.json` bytes (SHA256) are unchanged after every writer runs.
  - `Get-*Config` returns the override values via the merge chain.
  - `mothership.api_key` (secret) co-locates with `enabled`/`channel`/`recipients` in `.control` (no split across files).
  - `mothership.recipients` shrinks on replace and clears on empty array (regression for the merge-vs-replace bug).

Run:
```
pwsh install.ps1
pwsh tests/Run-Tests.ps1
```
## Checklist

- [x] Tests added or updated
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)