### PR TITLE
Fix init prompt paths, unapproved verbs, and analysis loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,9 +101,12 @@ Always do both steps before considering a dev cycle complete. Do not skip tests.
 
 **Test output efficiency:** Run the test suite once and capture output, then analyze the file — never re-run the full suite just to grep for different patterns.
 
-```bash
-pwsh tests/Run-Tests.ps1 2>&1 | tee /tmp/test-results.txt
-# Then use Read/Grep on /tmp/test-results.txt as many times as needed
+Always prefix the output filename with the current branch so parallel worktrees and sessions do not overwrite each other's results. Replace forward slashes in branch names so the path stays filesystem-safe:
+
+```powershell
+$branch = (git rev-parse --abbrev-ref HEAD) -replace '[\\/]', '-'
+pwsh tests/Run-Tests.ps1 2>&1 | Tee-Object -FilePath "/tmp/test-results-$branch.txt"
+# Then use Read/Grep on the same file as many times as needed.
 ```
 
 If the code hasn't changed since the last run, re-read the output file instead of re-running. For targeted iteration, run only the specific test file (e.g., `pwsh tests/Test-Structure.ps1`). Run the full suite once at the end.

--- a/core/mcp/modules/PathSanitizer.psm1
+++ b/core/mcp/modules/PathSanitizer.psm1
@@ -40,7 +40,7 @@ function Remove-AbsolutePaths {
 
     # --- Phase 1: Replace known project root with '.' ---
     if ($ProjectRoot) {
-        # JSON-escaped double-backslash variant (e.g. C:\\Users\\andre\\repos\\project)
+        # JSON-escaped double-backslash variant (e.g. C:\\Users\\<user>\\repos\\project)
         # In -replace, '\\' as regex matches one literal '\'; '\\' as replacement outputs '\\'
         # (backslash is not special in .NET replacement strings, only $ is)
         $doubleEscaped = $ProjectRoot -replace '\\', '\\'
@@ -48,10 +48,10 @@ function Remove-AbsolutePaths {
             $Text = $Text -replace [regex]::Escape($doubleEscaped), '.'
         }
 
-        # Native backslash variant (e.g. C:\Users\andre\repos\project)
+        # Native backslash variant (e.g. C:\Users\<user>\repos\project)
         $Text = $Text -replace [regex]::Escape($ProjectRoot), '.'
 
-        # Forward-slash variant (e.g. /c/Users/andre/repos/project or C:/Users/andre/repos/project)
+        # Forward-slash variant (e.g. /c/Users/<user>/repos/project or C:/Users/<user>/repos/project)
         $forwardSlash = $ProjectRoot -replace '\\', '/'
         if ($forwardSlash -ne $ProjectRoot) {
             $Text = $Text -replace [regex]::Escape($forwardSlash), '.'
@@ -66,13 +66,13 @@ function Remove-AbsolutePaths {
     }
 
     # --- Phase 2: Safety net — redact any remaining user-home paths ---
-    # Windows:  C:\Users\username  or  C:\\Users\\username  or  C:/Users/username
+    # Windows:  C:\Users\<user>  or  C:\\Users\\<user>  or  C:/Users/<user>
     $Text = $Text -replace '[A-Za-z]:[/\\]+Users[/\\]+\w+', '<REDACTED>'
 
-    # Linux:    /home/username
+    # Linux:    /home/<user>
     $Text = $Text -replace '/home/\w+', '<REDACTED>'
 
-    # macOS:    /Users/username
+    # macOS:    /Users/<user>
     $Text = $Text -replace '/Users/\w+', '<REDACTED>'
 
     return $Text

--- a/core/mcp/modules/TaskMutation.psm1
+++ b/core/mcp/modules/TaskMutation.psm1
@@ -354,7 +354,7 @@ function Get-TodoTaskLookup {
         [string]$TasksBaseDir
     )
 
-    $paths = Ensure-TodoDirectories -TasksBaseDir $TasksBaseDir
+    $paths = Initialize-TodoDirectories -TasksBaseDir $TasksBaseDir
     $lookup = @{}
     $referenceMap = @{}
     $orderedTasks = [System.Collections.Generic.List[object]]::new()
@@ -713,7 +713,7 @@ function Get-TaskVersionHistory {
         [string]$TasksBaseDir
     )
 
-    $paths = Ensure-TodoDirectories -TasksBaseDir $TasksBaseDir
+    $paths = Initialize-TodoDirectories -TasksBaseDir $TasksBaseDir
 
     return @{
         success = $true
@@ -735,7 +735,7 @@ function Restore-TaskVersion {
 
     $actorName = Get-ArchiveActor -Actor $Actor
     $auditUser = Get-AuditUsername
-    $paths = Ensure-TodoDirectories -TasksBaseDir $TasksBaseDir
+    $paths = Initialize-TodoDirectories -TasksBaseDir $TasksBaseDir
     $history = Get-TaskVersionHistory -TaskId $TaskId -TasksBaseDir $paths.TasksBaseDir
     $archiveVersion = @($history.edited_versions + $history.deleted_versions) |
         Where-Object { $_.version_id -eq $VersionId } |

--- a/core/mcp/modules/TaskStore.psm1
+++ b/core/mcp/modules/TaskStore.psm1
@@ -3,7 +3,7 @@
 Centralised task store — atomic state transitions and CRUD operations.
 
 .DESCRIPTION
-Provides Move-TaskState (atomic, validated), Get-TaskByIdOrSlug (unified lookup),
+Provides Set-TaskState (atomic, validated), Get-TaskByIdOrSlug (unified lookup),
 New-TaskRecord (create with defaults), and Update-TaskRecord (merge-update).
 TaskIndexCache.psm1 remains the read-only query layer.
 #>
@@ -75,7 +75,7 @@ function Get-TodoDirectories {
     }
 }
 
-function Ensure-TodoDirectories {
+function Initialize-TodoDirectories {
     param(
         [string]$TasksBaseDir
     )
@@ -189,10 +189,10 @@ function Assert-ValidStatus {
 }
 
 # ---------------------------------------------------------------------------
-# Move-TaskState
+# Set-TaskState
 # ---------------------------------------------------------------------------
 
-function Move-TaskState {
+function Set-TaskState {
     <#
     .SYNOPSIS
     Atomic, validated task state transition.
@@ -219,7 +219,7 @@ function Move-TaskState {
     # Block reserved fields in Updates
     foreach ($key in @($Updates.Keys)) {
         if ($key -in $script:ReservedFields) {
-            throw "Cannot override reserved field '$key' via -Updates. Use Move-TaskState parameters instead."
+            throw "Cannot override reserved field '$key' via -Updates. Use Set-TaskState parameters instead."
         }
     }
 
@@ -404,7 +404,7 @@ function Update-TaskRecord {
     <#
     .SYNOPSIS
     Merge-updates a task's properties in place. Cannot change status — use
-    Move-TaskState for that.
+    Set-TaskState for that.
     #>
     param(
         [Parameter(Mandatory)][string]$TaskId,
@@ -413,7 +413,7 @@ function Update-TaskRecord {
 
     # Block status changes
     if ($Updates.ContainsKey('status')) {
-        throw "Cannot update 'status' via Update-TaskRecord. Use Move-TaskState instead."
+        throw "Cannot update 'status' via Update-TaskRecord. Use Set-TaskState instead."
     }
 
     # Block other reserved fields
@@ -463,7 +463,7 @@ function Get-TaskSlug {
 # ---------------------------------------------------------------------------
 
 Export-ModuleMember -Function @(
-    'Move-TaskState',
+    'Set-TaskState',
     'Get-TaskByIdOrSlug',
     'New-TaskRecord',
     'Update-TaskRecord',
@@ -472,7 +472,7 @@ Export-ModuleMember -Function @(
     'Get-TasksBaseDir',
     'Get-StatusDir',
     'Get-TodoDirectories',
-    'Ensure-TodoDirectories',
+    'Initialize-TodoDirectories',
     'Get-TodoTaskRecord',
     'Get-TaskSlug'
 )

--- a/core/mcp/tools/task-get-next/script.ps1
+++ b/core/mcp/tools/task-get-next/script.ps1
@@ -4,7 +4,7 @@ if (-not (Get-Module TaskIndexCache)) {
     Import-Module $indexModule -Force
 }
 
-# Import task store (for Move-TaskState when skipping condition-unmet tasks)
+# Import task store (for Set-TaskState when skipping condition-unmet tasks)
 $taskStoreModule = Join-Path $global:DotbotProjectRoot ".bot/core/mcp/modules/TaskStore.psm1"
 if (-not (Get-Module TaskStore)) {
     Import-Module $taskStoreModule -Force
@@ -57,7 +57,7 @@ function Invoke-TaskGetNext {
     $maxIterations = [Math]::Max(50, $candidatePoolSize + 10)
 
     # Track IDs we've already considered in this invocation. Acts as a safety net
-    # against re-picking a task whose Move-TaskState failed (so the index still
+    # against re-picking a task whose Set-TaskState failed (so the index still
     # lists it as todo/analysed on subsequent Update-TaskIndex calls).
     $seenIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 
@@ -101,7 +101,7 @@ function Invoke-TaskGetNext {
                 $conditionText = if ($candidate.condition -is [array]) { ($candidate.condition -join ', ') } else { "$($candidate.condition)" }
                 Write-BotLog -Level Info -Message "[task-get-next] Skipped task '$($candidate.name)' ($($candidate.id)): condition not met ($conditionText)"
                 try {
-                    Move-TaskState -TaskId $candidate.id `
+                    Set-TaskState -TaskId $candidate.id `
                         -FromStates @($candidateStatus) `
                         -ToState 'skipped' `
                         -Updates @{
@@ -151,7 +151,7 @@ function Invoke-TaskGetNext {
             $statusMessage += " $conditionSkipCount task(s) skipped (condition not met)."
         }
         if ($moveFailures.Count -gt 0) {
-            $statusMessage += " WARNING: $($moveFailures.Count) task(s) stuck (Move-TaskState failed): $($moveFailures -join ', '). Inspect logs and .bot/workspace/tasks/."
+            $statusMessage += " WARNING: $($moveFailures.Count) task(s) stuck (Set-TaskState failed): $($moveFailures -join ', '). Inspect logs and .bot/workspace/tasks/."
         }
 
         Write-BotLog -Level Debug -Message "[task-get-next] No eligible tasks found"

--- a/core/mcp/tools/task-mark-analysed/script.ps1
+++ b/core/mcp/tools/task-mark-analysed/script.ps1
@@ -63,7 +63,7 @@ function Invoke-TaskMarkAnalysed {
         pending_question      = $null
     }
 
-    $result = Move-TaskState -TaskId $taskId `
+    $result = Set-TaskState -TaskId $taskId `
         -FromStates @('analysing', 'needs-input', 'analysed') `
         -ToState 'analysed' `
         -Updates $updates

--- a/core/mcp/tools/task-mark-analysing/script.ps1
+++ b/core/mcp/tools/task-mark-analysing/script.ps1
@@ -22,7 +22,7 @@ function Invoke-TaskMarkAnalysing {
     }
 
     # Perform atomic state transition
-    $result = Move-TaskState -TaskId $taskId -FromStates @('todo', 'analysing') -ToState 'analysing' -Updates $updates
+    $result = Set-TaskState -TaskId $taskId -FromStates @('todo', 'analysing') -ToState 'analysing' -Updates $updates
 
     # Track Claude session for conversation continuity (only on actual transition)
     if (-not $result.already_in_state) {

--- a/core/mcp/tools/task-mark-done/script.ps1
+++ b/core/mcp/tools/task-mark-done/script.ps1
@@ -206,7 +206,7 @@ function Invoke-TaskMarkDone {
     foreach ($key in $commitUpdates.Keys) { $updates[$key] = $commitUpdates[$key] }
     if ($executionActivities.Count -gt 0) { $updates['execution_activity_log'] = $executionActivities }
 
-    $result = Move-TaskState -TaskId $taskId `
+    $result = Set-TaskState -TaskId $taskId `
         -FromStates @('todo', 'analysing', 'analysed', 'in-progress', 'done') `
         -ToState 'done' `
         -Updates $updates

--- a/core/mcp/tools/task-mark-in-progress/script.ps1
+++ b/core/mcp/tools/task-mark-in-progress/script.ps1
@@ -48,7 +48,7 @@ function Invoke-TaskMarkInProgress {
         $updates['started_at'] = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
     }
 
-    $result = Move-TaskState -TaskId $taskId `
+    $result = Set-TaskState -TaskId $taskId `
         -FromStates @('analysed', 'todo', 'in-progress') `
         -ToState 'in-progress' `
         -Updates $updates

--- a/core/mcp/tools/task-mark-needs-input/script.ps1
+++ b/core/mcp/tools/task-mark-needs-input/script.ps1
@@ -100,7 +100,7 @@ function Invoke-TaskMarkNeedsInput {
         $updates['pending_question'] = $null
     }
 
-    $result = Move-TaskState -TaskId $taskId `
+    $result = Set-TaskState -TaskId $taskId `
         -FromStates @('analysing', 'in-progress', 'needs-input') `
         -ToState 'needs-input' `
         -Updates $updates

--- a/core/mcp/tools/task-mark-skipped/script.ps1
+++ b/core/mcp/tools/task-mark-skipped/script.ps1
@@ -16,7 +16,7 @@ function Invoke-TaskMarkSkipped {
         throw "Invalid skip reason. Must be one of: $($validReasons -join ', ')"
     }
 
-    # We need to read the task first to build skip_history, because Move-TaskState
+    # We need to read the task first to build skip_history, because Set-TaskState
     # won't apply updates on idempotent (already_in_state) returns.
     $found = Find-TaskFileById -TaskId $taskId
     if (-not $found) { throw "Task with ID '$taskId' not found" }
@@ -41,12 +41,12 @@ function Invoke-TaskMarkSkipped {
 
     $allStatuses = @('todo', 'analysing', 'needs-input', 'analysed', 'in-progress', 'done', 'skipped', 'split', 'cancelled')
 
-    $result = Move-TaskState -TaskId $taskId `
+    $result = Set-TaskState -TaskId $taskId `
         -FromStates $allStatuses `
         -ToState 'skipped' `
         -Updates @{ skip_history = $skipHistory }
 
-    # If already in skipped state, Move-TaskState returns early without applying updates.
+    # If already in skipped state, Set-TaskState returns early without applying updates.
     # Persist skip_history manually in that case.
     if ($result.already_in_state) {
         Set-OrAddProperty -Object $result.task_content -Name 'skip_history' -Value $skipHistory

--- a/core/mcp/tools/task-mark-todo/script.ps1
+++ b/core/mcp/tools/task-mark-todo/script.ps1
@@ -8,10 +8,20 @@ function Invoke-TaskMarkTodo {
     $taskId = $Arguments['task_id']
     if (-not $taskId) { throw "Task ID is required" }
 
-    # Clear completion timestamps when reverting to todo
+    # Clear completion timestamps and any leftover question state when
+    # reverting to todo. Other transitions out of needs-input
+    # (task-mark-analysed, task-answer-question) already clear
+    # pending_question; without the same here, a singular question left
+    # over from an escalation is migrated back into pending_questions[]
+    # by task-mark-needs-input on the next failure (see
+    # task-mark-needs-input/script.ps1: "Migrate legacy single
+    # pending_question into pending_questions"), resurfacing a stale
+    # question to the operator.
     $updates = @{
-        completed_at = $null
-        started_at   = $null
+        completed_at      = $null
+        started_at        = $null
+        pending_question  = $null
+        pending_questions = @()
     }
 
     $previousState = Find-TaskFileById -TaskId $taskId

--- a/core/mcp/tools/task-mark-todo/script.ps1
+++ b/core/mcp/tools/task-mark-todo/script.ps1
@@ -18,7 +18,7 @@ function Invoke-TaskMarkTodo {
     if (-not $previousState) {
         throw "Task with ID '$taskId' not found"
     }
-    $result = Move-TaskState -TaskId $taskId `
+    $result = Set-TaskState -TaskId $taskId `
         -FromStates @('todo', 'in-progress', 'done', 'skipped') `
         -ToState 'todo' `
         -Updates $updates

--- a/core/mcp/tools/task-mark-todo/script.ps1
+++ b/core/mcp/tools/task-mark-todo/script.ps1
@@ -19,7 +19,7 @@ function Invoke-TaskMarkTodo {
         throw "Task with ID '$taskId' not found"
     }
     $result = Set-TaskState -TaskId $taskId `
-        -FromStates @('todo', 'in-progress', 'done', 'skipped') `
+        -FromStates @('todo', 'in-progress', 'done', 'skipped', 'needs-input') `
         -ToState 'todo' `
         -Updates $updates
 

--- a/core/runtime/launch-process.ps1
+++ b/core/runtime/launch-process.ps1
@@ -278,7 +278,7 @@ if (-not $preflight.passed) {
 }
 
 # --- Single-instance guard (slot-aware) ---
-if (-not (Acquire-ProcessLock -LockType $lockKey)) {
+if (-not (Request-ProcessLock -LockType $lockKey)) {
     $lockPath = Join-Path $controlDir "launch-$lockKey.lock"
     $existingPid = if (Test-Path $lockPath) { (Get-Content $lockPath -Raw -ErrorAction SilentlyContinue)?.Trim() } else { "unknown" }
     Write-BotLog -Level Warn -Message "Another $lockKey process is already running (PID $existingPid). Exiting."

--- a/core/runtime/modules/MergeConflictEscalation.psm1
+++ b/core/runtime/modules/MergeConflictEscalation.psm1
@@ -55,7 +55,7 @@ function Move-TaskToMergeConflictNeedsInput {
         }
     }
 
-    # TODO(#224): delegate to Move-TaskState once it accepts `done` as a FromState.
+    # TODO(#224): delegate to Set-TaskState once it accepts `done` as a FromState.
     $taskContent = Get-Content $taskFile.FullName -Raw | ConvertFrom-Json
     $taskContent.status = 'needs-input'
     $taskContent.updated_at = (Get-Date).ToUniversalTime().ToString("o")

--- a/core/runtime/modules/MergeConflictEscalation.psm1
+++ b/core/runtime/modules/MergeConflictEscalation.psm1
@@ -55,7 +55,12 @@ function Move-TaskToMergeConflictNeedsInput {
         }
     }
 
-    # TODO(#224): delegate to Set-TaskState once it accepts `done` as a FromState.
+    # Inline transition rather than Set-TaskState: this path runs AFTER
+    # task_mark_done has already moved the task to done/, and the merge-conflict
+    # escalation needs to preserve the worktree, set a structured pending_question,
+    # and close the open execution session in one cohesive block. Refactor to
+    # Set-TaskState is tracked under #224 once those concerns are extracted into
+    # the broader transition helper.
     $taskContent = Get-Content $taskFile.FullName -Raw | ConvertFrom-Json
     $taskContent.status = 'needs-input'
     $taskContent.updated_at = (Get-Date).ToUniversalTime().ToString("o")

--- a/core/runtime/modules/ProcessRegistry.psm1
+++ b/core/runtime/modules/ProcessRegistry.psm1
@@ -104,18 +104,13 @@ function Test-ProcessStopSignal {
     Test-Path $stopFile
 }
 
-function Acquire-ProcessLock {
+function Request-ProcessLock {
     <#
     .SYNOPSIS
     Atomically acquire a process lock using FileMode.CreateNew.
     Returns $true if lock acquired, $false if another live process holds it.
     Automatically cleans stale locks (dead PIDs).
     #>
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
-        'PSUseApprovedVerbs',
-        '',
-        Justification = 'Acquire communicates lock semantics more clearly than the approved alternatives for this exported command.'
-    )]
     param([string]$LockType)
     $lockPath = Join-Path $script:ControlDir "launch-$LockType.lock"
 
@@ -458,7 +453,7 @@ Export-ModuleMember -Function @(
     'Write-ProcessFile',
     'Write-ProcessActivity',
     'Test-ProcessStopSignal',
-    'Acquire-ProcessLock',
+    'Request-ProcessLock',
     'Test-ProcessLock',
     'Set-ProcessLock',
     'Remove-ProcessLock',

--- a/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -1728,8 +1728,19 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
                 if (-not (Test-Path $needsInputDir)) {
                     New-Item -ItemType Directory -Path $needsInputDir -Force | Out-Null
                 }
+                # Build a safe filename-prefix to find the task file:
+                # task IDs are not guaranteed to be 8+ chars (test fixtures
+                # use short IDs like 'notif001'), and may legitimately
+                # contain regex metacharacters. Substring(0,8) on a short
+                # ID throws and would crash the catch block itself,
+                # leaving the task stuck in in-progress and re-picked.
+                $taskIdPrefix = $null
+                if (-not [string]::IsNullOrEmpty($task.id)) {
+                    $prefixLength = [Math]::Min(8, $task.id.Length)
+                    $taskIdPrefix = [regex]::Escape($task.id.Substring(0, $prefixLength))
+                }
                 $taskFile = Get-ChildItem -Path $inProgressDir -Filter "*.json" -File -ErrorAction SilentlyContinue |
-                    Where-Object { $_.Name -match $task.id.Substring(0,8) } | Select-Object -First 1
+                    Where-Object { $taskIdPrefix -and $_.Name -match $taskIdPrefix } | Select-Object -First 1
                 if ($taskFile) {
                     $taskData = Get-Content $taskFile.FullName -Raw | ConvertFrom-Json
                     $taskData.status = 'needs-input'
@@ -1922,10 +1933,19 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
                 if (-not (Test-Path $needsInputDir)) {
                     New-Item -ItemType Directory -Path $needsInputDir -Force | Out-Null
                 }
+                # Same safe filename-prefix as the execution-phase
+                # escalation above: short or regex-metachar task IDs
+                # would otherwise crash this catch and trap the task in
+                # analysing/ or in-progress/.
+                $taskIdPrefix = $null
+                if (-not [string]::IsNullOrEmpty($task.id)) {
+                    $prefixLength = [Math]::Min(8, $task.id.Length)
+                    $taskIdPrefix = [regex]::Escape($task.id.Substring(0, $prefixLength))
+                }
                 foreach ($searchDir in @('analysing', 'in-progress')) {
                     $dir = Join-Path $tasksBaseDir $searchDir
                     $found = Get-ChildItem -Path $dir -Filter "*.json" -File -ErrorAction SilentlyContinue |
-                        Where-Object { $_.Name -match $task.id.Substring(0,8) } | Select-Object -First 1
+                        Where-Object { $taskIdPrefix -and $_.Name -match $taskIdPrefix } | Select-Object -First 1
                     if ($found) {
                         $taskData = Get-Content $found.FullName -Raw | ConvertFrom-Json
                         $taskData.status = 'needs-input'

--- a/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -461,8 +461,8 @@ if ($sessionResult.success) {
 Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Workflow child started (session: $sessionId, PID: $PID)"
 
 # Load both prompt templates
-$analysisTemplateFile = Join-Path $botRoot "recipes\prompts\98-analyse-task.md"
-$executionTemplateFile = Join-Path $botRoot "recipes\prompts\99-autonomous-task.md"
+$analysisTemplateFile = Join-Path $botRoot "core\prompts\98-analyse-task.md"
+$executionTemplateFile = Join-Path $botRoot "core\prompts\99-autonomous-task.md"
 $analysisPromptTemplate = Get-Content $analysisTemplateFile -Raw
 $executionPromptTemplate = Get-Content $executionTemplateFile -Raw
 

--- a/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -734,6 +734,15 @@ try {
 
         try {   # Per-task try/catch — catches failures in BOTH analysis and execution phases
 
+        # Defensive per-iteration init: the post-task hook flags are set on the
+        # success path further down (around the execution-phase init block).
+        # Set them here too so that any exception escaping before that block
+        # (e.g. a Build-TaskPrompt failure) cannot leave the elseif at the
+        # post-loop branch reading an unset variable under StrictMode.
+        $postScriptFailed = $false
+        $postScriptError = $null
+        $postScriptFailureSource = 'post_script'
+
         # --- Task type dispatch (script / mcp / task_gen bypass Claude entirely) ---
         $taskTypeVal = if ($task.type) { $task.type } else { 'prompt' }
         # prompt_template uses Claude but with a workflow-specific prompt file
@@ -1678,23 +1687,33 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
         try { Remove-ProviderSession -SessionId $executionSessionId -ProjectRoot $projectRoot | Out-Null } catch { Write-BotLog -Level Debug -Message "Cleanup: failed to stop process" -Exception $_ }
 
         } catch {
-            # Execution phase setup/run failed — log and recover the task
-            Write-Diag "Execution EXCEPTION: $($_.Exception.Message)"
-            Write-Status "Execution failed: $($_.Exception.Message)" -Type Error
-            Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Execution failed for $($task.name): $($_.Exception.Message)"
+            # Execution phase setup/run failed — escalate to needs-input so the
+            # task picker stops re-selecting the same task and looping. The
+            # operator can inspect pending_question on the task record.
+            $execErrorMessage = $_.Exception.Message
+            Write-Diag "Execution EXCEPTION: $execErrorMessage"
+            Write-Status "Execution failed: $execErrorMessage" -Type Error
+            Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Execution failed for $($task.name): $execErrorMessage"
             try {
                 $inProgressDir = Join-Path $tasksBaseDir "in-progress"
-                $todoDir = Join-Path $tasksBaseDir "todo"
+                $needsInputDir = Join-Path $tasksBaseDir "needs-input"
+                if (-not (Test-Path $needsInputDir)) {
+                    New-Item -ItemType Directory -Path $needsInputDir -Force | Out-Null
+                }
                 $taskFile = Get-ChildItem -Path $inProgressDir -Filter "*.json" -File -ErrorAction SilentlyContinue |
                     Where-Object { $_.Name -match $task.id.Substring(0,8) } | Select-Object -First 1
                 if ($taskFile) {
                     $taskData = Get-Content $taskFile.FullName -Raw | ConvertFrom-Json
-                    $taskData.status = 'todo'
-                    $taskData | ConvertTo-Json -Depth 20 | Set-Content (Join-Path $todoDir $taskFile.Name) -Encoding UTF8
+                    $taskData.status = 'needs-input'
+                    if (-not ($taskData.PSObject.Properties.Name -contains 'pending_question')) {
+                        $taskData | Add-Member -NotePropertyName pending_question -NotePropertyValue $null -Force
+                    }
+                    $taskData.pending_question = "Execution failed: $execErrorMessage"
+                    $taskData | ConvertTo-Json -Depth 20 | Set-Content (Join-Path $needsInputDir $taskFile.Name) -Encoding UTF8
                     Remove-Item $taskFile.FullName -Force
-                    Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Recovered task $($task.name) back to todo"
+                    Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Escalated task $($task.name) to needs-input after execution failure"
                 }
-            } catch { Write-BotLog -Level Warn -Message "Failed to recover task" -Exception $_ }
+            } catch { Write-BotLog -Level Warn -Message "Failed to escalate task" -Exception $_ }
             $taskSuccess = $false
         }
 
@@ -1837,23 +1856,32 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
             Write-Status "Task failed unexpectedly: $($_.Exception.Message)" -Type Error
             Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task $($task.name) failed: $($_.Exception.Message)"
 
-            # Recover task: move from whatever state back to todo
+            # Recover task: escalate from whatever state to needs-input so the
+            # task picker stops re-selecting the same task and looping.
+            $perTaskErrorMessage = $_.Exception.Message
             try {
+                $needsInputDir = Join-Path $tasksBaseDir "needs-input"
+                if (-not (Test-Path $needsInputDir)) {
+                    New-Item -ItemType Directory -Path $needsInputDir -Force | Out-Null
+                }
                 foreach ($searchDir in @('analysing', 'in-progress')) {
                     $dir = Join-Path $tasksBaseDir $searchDir
                     $found = Get-ChildItem -Path $dir -Filter "*.json" -File -ErrorAction SilentlyContinue |
                         Where-Object { $_.Name -match $task.id.Substring(0,8) } | Select-Object -First 1
                     if ($found) {
                         $taskData = Get-Content $found.FullName -Raw | ConvertFrom-Json
-                        $taskData.status = 'todo'
-                        $todoDir = Join-Path $tasksBaseDir "todo"
-                        $taskData | ConvertTo-Json -Depth 20 | Set-Content (Join-Path $todoDir $found.Name) -Encoding UTF8
+                        $taskData.status = 'needs-input'
+                        if (-not ($taskData.PSObject.Properties.Name -contains 'pending_question')) {
+                            $taskData | Add-Member -NotePropertyName pending_question -NotePropertyValue $null -Force
+                        }
+                        $taskData.pending_question = "Per-task failure: $perTaskErrorMessage"
+                        $taskData | ConvertTo-Json -Depth 20 | Set-Content (Join-Path $needsInputDir $found.Name) -Encoding UTF8
                         Remove-Item $found.FullName -Force
-                        Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Recovered task $($task.name) back to todo"
+                        Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Escalated task $($task.name) to needs-input after per-task failure"
                         break
                     }
                 }
-            } catch { Write-BotLog -Level Warn -Message "Failed to recover task" -Exception $_ }
+            } catch { Write-BotLog -Level Warn -Message "Failed to escalate task" -Exception $_ }
         }
 
         # Continue to next task?

--- a/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -1710,7 +1710,15 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
             # Execution phase setup/run failed — escalate to needs-input so the
             # task picker stops re-selecting the same task and looping. The
             # operator can inspect pending_question on the task record.
+            # Some exceptions surface with an empty .Message; fall back to the
+            # full error record so operators always see actionable context.
             $execErrorMessage = $_.Exception.Message
+            if ([string]::IsNullOrWhiteSpace($execErrorMessage)) {
+                $execErrorMessage = $_.ToString()
+            }
+            if ([string]::IsNullOrWhiteSpace($execErrorMessage)) {
+                $execErrorMessage = '<no error details available>'
+            }
             Write-Diag "Execution EXCEPTION: $execErrorMessage"
             Write-Status "Execution failed: $execErrorMessage" -Type Error
             Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Execution failed for $($task.name): $execErrorMessage"
@@ -1900,7 +1908,15 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
 
             # Recover task: escalate from whatever state to needs-input so the
             # task picker stops re-selecting the same task and looping.
+            # Some exceptions surface with an empty .Message; fall back to the
+            # full error record so operators always see actionable context.
             $perTaskErrorMessage = $_.Exception.Message
+            if ([string]::IsNullOrWhiteSpace($perTaskErrorMessage)) {
+                $perTaskErrorMessage = $_.ToString()
+            }
+            if ([string]::IsNullOrWhiteSpace($perTaskErrorMessage)) {
+                $perTaskErrorMessage = '<no error details available>'
+            }
             try {
                 $needsInputDir = Join-Path $tasksBaseDir "needs-input"
                 if (-not (Test-Path $needsInputDir)) {

--- a/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -460,11 +460,31 @@ if ($sessionResult.success) {
 }
 Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Workflow child started (session: $sessionId, PID: $PID)"
 
-# Load both prompt templates
-$analysisTemplateFile = Join-Path $botRoot "core\prompts\98-analyse-task.md"
-$executionTemplateFile = Join-Path $botRoot "core\prompts\99-autonomous-task.md"
-$analysisPromptTemplate = Get-Content $analysisTemplateFile -Raw
-$executionPromptTemplate = Get-Content $executionTemplateFile -Raw
+# Load both prompt templates. Use multi-segment Join-Path to avoid embedding
+# backslashes that break on macOS/Linux, and make the reads terminating with
+# an explicit non-empty check so a missing or empty template fails fast at
+# startup instead of cascading into a parameter-binding error in the
+# execution phase.
+$analysisTemplateFile = Join-Path $botRoot 'core' 'prompts' '98-analyse-task.md'
+$executionTemplateFile = Join-Path $botRoot 'core' 'prompts' '99-autonomous-task.md'
+
+try {
+    $analysisPromptTemplate = Get-Content -Path $analysisTemplateFile -Raw -ErrorAction Stop
+} catch {
+    throw "Failed to load analysis prompt template '$analysisTemplateFile'. Ensure the file exists and is readable. $($_.Exception.Message)"
+}
+if ([string]::IsNullOrWhiteSpace($analysisPromptTemplate)) {
+    throw "Analysis prompt template '$analysisTemplateFile' is empty. A non-empty prompt template is required."
+}
+
+try {
+    $executionPromptTemplate = Get-Content -Path $executionTemplateFile -Raw -ErrorAction Stop
+} catch {
+    throw "Failed to load execution prompt template '$executionTemplateFile'. Ensure the file exists and is readable. $($_.Exception.Message)"
+}
+if ([string]::IsNullOrWhiteSpace($executionPromptTemplate)) {
+    throw "Execution prompt template '$executionTemplateFile' is empty. A non-empty prompt template is required."
+}
 
 $processData.workflow = "workflow (analyse + execute)"
 
@@ -1705,10 +1725,32 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
                 if ($taskFile) {
                     $taskData = Get-Content $taskFile.FullName -Raw | ConvertFrom-Json
                     $taskData.status = 'needs-input'
-                    if (-not ($taskData.PSObject.Properties.Name -contains 'pending_question')) {
-                        $taskData | Add-Member -NotePropertyName pending_question -NotePropertyValue $null -Force
+                    $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
+                    # Match the canonical pending_question schema used by other
+                    # needs-input escalations (e.g. MergeConflictEscalation) so
+                    # NotificationPoller, task-answer-question, and the UI all
+                    # see a structured object instead of a bare string.
+                    $pendingQuestion = @{
+                        id             = "execution-failure-$($task.id)"
+                        question       = "Execution failed for task '$($task.name)'"
+                        context        = "Execution-phase exception: $execErrorMessage"
+                        options        = @(
+                            @{ key = "A"; label = "Investigate logs and retry"; rationale = "Inspect the worktree, fix the underlying issue, then move the task back to todo" }
+                            @{ key = "B"; label = "Skip this task"; rationale = "Mark the task skipped and continue with the rest of the workflow" }
+                        )
+                        recommendation = "A"
+                        asked_at       = $timestamp
                     }
-                    $taskData.pending_question = "Execution failed: $execErrorMessage"
+                    if (-not ($taskData.PSObject.Properties.Name -contains 'pending_question')) {
+                        $taskData | Add-Member -NotePropertyName pending_question -NotePropertyValue $pendingQuestion -Force
+                    } else {
+                        $taskData.pending_question = $pendingQuestion
+                    }
+                    if (-not ($taskData.PSObject.Properties.Name -contains 'updated_at')) {
+                        $taskData | Add-Member -NotePropertyName updated_at -NotePropertyValue $timestamp -Force
+                    } else {
+                        $taskData.updated_at = $timestamp
+                    }
                     $taskData | ConvertTo-Json -Depth 20 | Set-Content (Join-Path $needsInputDir $taskFile.Name) -Encoding UTF8
                     Remove-Item $taskFile.FullName -Force
                     Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Escalated task $($task.name) to needs-input after execution failure"
@@ -1871,10 +1913,30 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
                     if ($found) {
                         $taskData = Get-Content $found.FullName -Raw | ConvertFrom-Json
                         $taskData.status = 'needs-input'
-                        if (-not ($taskData.PSObject.Properties.Name -contains 'pending_question')) {
-                            $taskData | Add-Member -NotePropertyName pending_question -NotePropertyValue $null -Force
+                        $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
+                        # Same canonical pending_question shape as the
+                        # execution-phase escalation above.
+                        $pendingQuestion = @{
+                            id             = "per-task-failure-$($task.id)"
+                            question       = "Per-task failure for '$($task.name)'"
+                            context        = "Per-task exception: $perTaskErrorMessage"
+                            options        = @(
+                                @{ key = "A"; label = "Investigate logs and retry"; rationale = "Inspect the failure context, fix the underlying issue, then move the task back to todo" }
+                                @{ key = "B"; label = "Skip this task"; rationale = "Mark the task skipped and continue with the rest of the workflow" }
+                            )
+                            recommendation = "A"
+                            asked_at       = $timestamp
                         }
-                        $taskData.pending_question = "Per-task failure: $perTaskErrorMessage"
+                        if (-not ($taskData.PSObject.Properties.Name -contains 'pending_question')) {
+                            $taskData | Add-Member -NotePropertyName pending_question -NotePropertyValue $pendingQuestion -Force
+                        } else {
+                            $taskData.pending_question = $pendingQuestion
+                        }
+                        if (-not ($taskData.PSObject.Properties.Name -contains 'updated_at')) {
+                            $taskData | Add-Member -NotePropertyName updated_at -NotePropertyValue $timestamp -Force
+                        } else {
+                            $taskData.updated_at = $timestamp
+                        }
                         $taskData | ConvertTo-Json -Depth 20 | Set-Content (Join-Path $needsInputDir $found.Name) -Encoding UTF8
                         Remove-Item $found.FullName -Force
                         Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Escalated task $($task.name) to needs-input after per-task failure"

--- a/tests/Test-ProcessRegistry.ps1
+++ b/tests/Test-ProcessRegistry.ps1
@@ -175,18 +175,18 @@ Write-Host "  --------------------------------------------" -ForegroundColor Dar
 # Start clean
 Remove-ProcessLock -LockType "test-lock"
 
-$acquired = Acquire-ProcessLock -LockType "test-lock"
-Assert-True -Name "Acquire-ProcessLock succeeds on fresh lock" `
+$acquired = Request-ProcessLock -LockType "test-lock"
+Assert-True -Name "Request-ProcessLock succeeds on fresh lock" `
     -Condition ($acquired -eq $true) `
     -Message "Failed to acquire lock"
 
 $lockFile = Join-Path $testControlDir "launch-test-lock.lock"
-Assert-True -Name "Acquire-ProcessLock creates lock file" `
+Assert-True -Name "Request-ProcessLock creates lock file" `
     -Condition (Test-Path $lockFile) `
     -Message "Lock file not found"
 
 $lockContent = (Get-Content $lockFile -Raw).Trim()
-Assert-True -Name "Acquire-ProcessLock writes current PID" `
+Assert-True -Name "Request-ProcessLock writes current PID" `
     -Condition ($lockContent -eq $PID.ToString()) `
     -Message "Expected PID $PID, got: $lockContent"
 
@@ -210,8 +210,8 @@ Set-ProcessLock -LockType "stale-test"
 $staleLockFile = Join-Path $testControlDir "launch-stale-test.lock"
 # Write a PID that doesn't exist (use a high number unlikely to be a real process)
 "99999" | Set-Content $staleLockFile -NoNewline -Encoding utf8NoBOM
-$acquiredStale = Acquire-ProcessLock -LockType "stale-test"
-Assert-True -Name "Acquire-ProcessLock cleans stale lock (dead PID)" `
+$acquiredStale = Request-ProcessLock -LockType "stale-test"
+Assert-True -Name "Request-ProcessLock cleans stale lock (dead PID)" `
     -Condition ($acquiredStale -eq $true) `
     -Message "Failed to acquire lock after stale cleanup"
 Remove-ProcessLock -LockType "stale-test"

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -213,9 +213,9 @@ try {
     Assert-True -Name "TaskStore exports Get-TodoDirectories" `
         -Condition ($null -ne (Get-Command Get-TodoDirectories -ErrorAction SilentlyContinue)) `
         -Message "Expected Get-TodoDirectories to be exported from TaskStore"
-    Assert-True -Name "TaskStore exports Ensure-TodoDirectories" `
-        -Condition ($null -ne (Get-Command Ensure-TodoDirectories -ErrorAction SilentlyContinue)) `
-        -Message "Expected Ensure-TodoDirectories to be exported from TaskStore"
+    Assert-True -Name "TaskStore exports Initialize-TodoDirectories" `
+        -Condition ($null -ne (Get-Command Initialize-TodoDirectories -ErrorAction SilentlyContinue)) `
+        -Message "Expected Initialize-TodoDirectories to be exported from TaskStore"
     Assert-True -Name "TaskStore exports Get-TodoTaskRecord" `
         -Condition ($null -ne (Get-Command Get-TodoTaskRecord -ErrorAction SilentlyContinue)) `
         -Message "Expected Get-TodoTaskRecord to be exported from TaskStore"
@@ -1012,7 +1012,7 @@ try {
     Assert-PathExists -Name "Analysed task with unmet condition moved to skipped/" -Path $analysedSkipDest
     Assert-True -Name "Analysed-skip task no longer in analysed/" `
         -Condition (-not (Test-Path $analysedSkipPath)) `
-        -Message "Expected analysed/ source file to be removed after Move-TaskState"
+        -Message "Expected analysed/ source file to be removed after Set-TaskState"
     $analysedSkipped = Get-Content $analysedSkipDest -Raw | ConvertFrom-Json
     Assert-Equal -Name "Analysed→skipped task records skip_reason=condition-not-met" `
         -Expected "condition-not-met" `


### PR DESCRIPTION
## Linked issue

Closes #351

## Summary of changes

Five commits on `fix/init-prompt-paths-verbs-and-loop`:

1. **`fix(init):`** read autonomous-task prompts from `core/prompts/`, not `recipes/prompts/`. The framework prompts ship at `core/prompts/` and `dotbot init` lays them down at `.bot/core/prompts/`; the lookup at `Invoke-WorkflowProcess.ps1:464-465` was looking in the wrong place and `Get-Content` was failing silently, leaving `$executionPromptTemplate` empty.
2. **`refactor(modules):`** rename `Move-TaskState` → `Set-TaskState`, `Ensure-TodoDirectories` → `Initialize-TodoDirectories`, `Acquire-ProcessLock` → `Request-ProcessLock`, and drop the now-unnecessary `PSUseApprovedVerbs` suppression. All callers updated; historical roadmap docs left as-is.
3. **`fix(workflow):`** escalate failed execution to `needs-input` instead of resetting to `todo`. Adds `pending_question` carrying the exception message. Initialize `$postScriptFailed`, `$postScriptError`, `$postScriptFailureSource` defensively at the top of the per-task try so the post-loop `elseif` branch never reads an unset variable under StrictMode.
4. **`docs(CLAUDE):`** branch-prefix the documented test-output filename so parallel worktrees and sessions do not collide on `/tmp/test-results.txt`.
5. **`fix(privacy):`** redact PathSanitizer comment examples to `<user>`. The privacy scan was self-tripping on `core/mcp/modules/PathSanitizer.psm1` because the file's own comments documented the patterns it scrubs using a real username (`andre`) and the placeholder `username` (which `\w+` matches). Switching to `<user>` (the leading `<` is not `\w`) closes both the leak and the self-match. Surfaced by the same SlashOps dogfood loop that produced commits 1-4 — `task_mark_done` for "Product Documents" was paused into `needs-input` because verification could not clear the framework file.

Full root-cause analysis is in the linked issue (#351).

## Testing notes

Local runs on this branch:

- `tests/Test-WorkflowManifest.ps1` (reads source directly): **358 passed, 0 failed, 0 skipped**.
- `pwsh install.ps1` then `pwsh tests/Run-Tests.ps1`: layers 1-3 pass locally (capture-once log on file).
- PathSanitizer fix verified end-to-end: `00-privacy-scan.ps1` against the SlashOps target now returns `success=True`, and an empty test commit clears gitleaks + privacy + reference checks before being reset.
- End-to-end repro: re-run `dotbot init -Force` against the dogfood target and re-trigger `start-from-prompt`. Expect:
  - No `unapproved verbs` warnings on `TaskStore` or `ProcessRegistry` import.
  - Task-runner does not crash on `98-analyse-task.md` / `99-autonomous-task.md` reads.
  - If execution does fail for any other reason, the task lands in `tasks/needs-input/` (with a populated `pending_question`) rather than spinning back to `todo` and re-running analysis.
  - No `'$postScriptFailed' cannot be retrieved` StrictMode error in the activity JSONL.
  - `task_mark_done` no longer trips on `PathSanitizer.psm1` self-documentation.

CI (`test.yml`) will run the same pyramid across Windows / macOS / Linux — cherry-pick `Test-WorkflowManifest.ps1`, `Test-ProcessRegistry.ps1`, `Test-TaskActions.ps1` from the run log when reviewing.

## Out of scope

PSScriptAnalyzer reports four more `PSUseApprovedVerbs` hits in modules outside the import path that triggered this issue (`Rotate-DotBotLog`, `Delete-RoadmapTask`, `Parse-Reference`, `Ensure-ManifestTaskIds`, `Parse-StreamLine` × 3). Listed in #351 for a follow-up PR.

The dotbot source repo itself has 32 other privacy-scan violations across `tests/Test-PathSanitizer.ps1` (deliberate test fixtures), `server/docs/TEAMS-SETUP.md`, `server/terraform/*`, and one `workflows/start-from-jira/` recipe doc. Out of scope for this PR — the framework comment self-match was the only one blocking dogfood targets.

## Checklist

- [x] Tests added or updated — existing `Test-WorkflowManifest.ps1` and module unit tests still cover behaviour; rename callers updated in `Test-ProcessRegistry.ps1` and `Test-TaskActions.ps1`. Commit 5 is comments-only so existing PathSanitizer unit tests remain valid.
- [x] Docs updated (if behaviour changed) — `CLAUDE.md` capture-once recipe.
- [x] Linked issue exists — #351.
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md).