### PR TITLE
[PR-3/#29] NotificationSummary infrastructure

### DIFF
--- a/server/src/Dotbot.Server/Program.cs
+++ b/server/src/Dotbot.Server/Program.cs
@@ -117,6 +117,7 @@ try
     builder.Services.AddSingleton<JwtSigningKeyProvider>();
     builder.Services.AddSingleton<TokenStorageService>();
     builder.Services.AddSingleton<MagicLinkService>();
+    builder.Services.AddSingleton<NotificationSummaryBuilder>();
 
     // Delivery providers
     builder.Services.AddSingleton<IQuestionDeliveryProvider, TeamsDeliveryProvider>();

--- a/server/src/Dotbot.Server/Services/Delivery/IQuestionDeliveryProvider.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/IQuestionDeliveryProvider.cs
@@ -16,6 +16,10 @@ public class DeliveryContext
     public bool IsReminder { get; set; }
     public string? MagicLinkUrl { get; set; }
     public string? JiraIssueKey { get; set; }
+
+    // Set by DeliveryOrchestrator in PR-6/#287; null for legacy callers.
+    // Providers wired to render this in PR-4/#285 (Email+Jira) and PR-5/#286 (Teams+Slack).
+    public NotificationSummary? Summary { get; set; }
 }
 
 public class RecipientInfo

--- a/server/src/Dotbot.Server/Services/Delivery/NotificationSummary.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/NotificationSummary.cs
@@ -1,0 +1,52 @@
+namespace Dotbot.Server.Services.Delivery;
+
+public class NotificationSummary
+{
+    public required string QuestionTitle { get; set; }
+    public required string QuestionType { get; set; }
+    public required string ProjectName { get; set; }
+
+    public string? DeliverableSummary { get; set; }
+    public string? Context { get; set; }
+
+    // All questions in the current instance's batch, each with its state.
+    // Outpost groups questions when calling task-mark-needs-input; single-question
+    // instance → one entry. No cross-instance lookup.
+    public List<BatchQuestionRef> BatchQuestions { get; set; } = new();
+
+    public List<AttachmentRef> Attachments { get; set; } = new();
+    public List<ReviewLinkRef> ReviewLinks { get; set; } = new();
+
+    public required string RespondUrl { get; set; }
+    public DateTime? DueBy { get; set; }
+    public bool IsReminder { get; set; }
+}
+
+public class BatchQuestionRef
+{
+    public required Guid QuestionId { get; set; }
+    public required string Title { get; set; }
+    public required string Type { get; set; }
+
+    // Populated by the PR introducing multi-question batches (#289). Until then,
+    // builder leaves these at default — single-question instances never carry an
+    // already-answered question (reminders suppress those, see #290).
+    public bool IsAnswered { get; set; }
+    public string? AnsweredSummary { get; set; }
+}
+
+public class AttachmentRef
+{
+    public required string Name { get; set; }
+    public required string ContentType { get; set; }
+    public long? SizeBytes { get; set; }
+    // No DownloadUrl — channels never link to files. Downloads happen on the web
+    // form after the magic link is followed (PRD §4.2).
+}
+
+public class ReviewLinkRef
+{
+    public required string Title { get; set; }
+    public required string Url { get; set; }
+    public string? Type { get; set; }
+}

--- a/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
@@ -39,13 +39,13 @@ public class NotificationSummaryBuilder
                     // IsAnswered / AnsweredSummary populated when multi-question batches land (#289).
                 }
             },
-                    ContentType = string.IsNullOrEmpty(a.MediaType?.Trim())
-                        ? "application/octet-stream"
-                        : a.MediaType.Trim(),
+            Attachments = template.Attachments?
+                .Select(a => new AttachmentRef
+                {
                     Name = a.Name,
                     ContentType = string.IsNullOrWhiteSpace(a.MediaType)
                         ? "application/octet-stream"
-                        : a.MediaType,
+                        : a.MediaType.Trim(),
                     SizeBytes = a.SizeBytes,
                 })
                 .ToList() ?? new List<AttachmentRef>(),

--- a/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Dotbot.Server.Models;
 
 namespace Dotbot.Server.Services.Delivery;
@@ -14,8 +13,13 @@ public class NotificationSummaryBuilder
         ArgumentNullException.ThrowIfNull(template);
         ArgumentNullException.ThrowIfNull(instance);
         ArgumentNullException.ThrowIfNull(respondUrl);
-        Debug.Assert(instance.QuestionId == template.QuestionId,
-            $"Instance QuestionId {instance.QuestionId} does not match template QuestionId {template.QuestionId}.");
+
+        if (instance.QuestionId != template.QuestionId)
+        {
+            throw new ArgumentException(
+                $"Instance QuestionId {instance.QuestionId} does not match template QuestionId {template.QuestionId}.",
+                nameof(instance));
+        }
 
         return new NotificationSummary
         {

--- a/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
@@ -14,8 +14,13 @@ public class NotificationSummaryBuilder
         {
             QuestionTitle = template.Title,
             QuestionType = template.Type,
-            ProjectName = template.Project.Name ?? template.Project.ProjectId,
-            DeliverableSummary = template.DeliverableSummary ?? template.Description,
+            ProjectName = string.IsNullOrWhiteSpace(template.Project.Name)
+                ? template.Project.ProjectId
+                : template.Project.Name,
+            // Legacy singleChoice templates carry no DeliverableSummary; providers render
+            // Title + Context as before. Validator enforces non-empty for approval /
+            // documentReview, so this stays null only when intentional (PRD §8 line 651).
+            DeliverableSummary = template.DeliverableSummary,
             Context = template.Context,
             BatchQuestions = new List<BatchQuestionRef>
             {
@@ -31,7 +36,9 @@ public class NotificationSummaryBuilder
                 .Select(a => new AttachmentRef
                 {
                     Name = a.Name,
-                    ContentType = a.MediaType ?? "application/octet-stream",
+                    ContentType = string.IsNullOrWhiteSpace(a.MediaType)
+                        ? "application/octet-stream"
+                        : a.MediaType,
                     SizeBytes = a.SizeBytes,
                 })
                 .ToList() ?? new List<AttachmentRef>(),
@@ -43,9 +50,10 @@ public class NotificationSummaryBuilder
                 })
                 .ToList() ?? new List<ReviewLinkRef>(),
             RespondUrl = respondUrl,
-            DueBy = template.DeliveryDefaults?.EscalateAfterDays is int days
-                ? instance.CreatedAt.AddDays(days)
-                : null,
+            // DueBy is per-recipient: PRD §4.5 line 642 derives it from InstanceRecipient.SentAt,
+            // not instance.CreatedAt. Set by DeliveryOrchestrator in PR-6/#287 alongside
+            // RespondUrl personalisation.
+            DueBy = null,
             IsReminder = isReminder,
         };
     }

--- a/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
@@ -10,6 +10,9 @@ public class NotificationSummaryBuilder
         string respondUrl,
         bool isReminder)
     {
+        ArgumentNullException.ThrowIfNull(template);
+        ArgumentNullException.ThrowIfNull(instance);
+        ArgumentNullException.ThrowIfNull(respondUrl);
         return new NotificationSummary
         {
             QuestionTitle = template.Title,

--- a/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Dotbot.Server.Models;
 
 namespace Dotbot.Server.Services.Delivery;
@@ -10,6 +11,12 @@ public class NotificationSummaryBuilder
         string respondUrl,
         bool isReminder)
     {
+        ArgumentNullException.ThrowIfNull(template);
+        ArgumentNullException.ThrowIfNull(instance);
+        ArgumentNullException.ThrowIfNull(respondUrl);
+        Debug.Assert(instance.QuestionId == template.QuestionId,
+            $"Instance QuestionId {instance.QuestionId} does not match template QuestionId {template.QuestionId}.");
+
         return new NotificationSummary
         {
             QuestionTitle = template.Title,

--- a/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
@@ -1,0 +1,52 @@
+using Dotbot.Server.Models;
+
+namespace Dotbot.Server.Services.Delivery;
+
+public class NotificationSummaryBuilder
+{
+    public NotificationSummary Build(
+        QuestionTemplate template,
+        QuestionInstance instance,
+        string respondUrl,
+        bool isReminder)
+    {
+        return new NotificationSummary
+        {
+            QuestionTitle = template.Title,
+            QuestionType = template.Type,
+            ProjectName = template.Project.Name ?? template.Project.ProjectId,
+            DeliverableSummary = template.DeliverableSummary ?? template.Description,
+            Context = template.Context,
+            BatchQuestions = new List<BatchQuestionRef>
+            {
+                new()
+                {
+                    QuestionId = template.QuestionId,
+                    Title = template.Title,
+                    Type = template.Type,
+                    // IsAnswered / AnsweredSummary populated when multi-question batches land (#289).
+                }
+            },
+            Attachments = template.Attachments?
+                .Select(a => new AttachmentRef
+                {
+                    Name = a.Name,
+                    ContentType = a.MediaType ?? "application/octet-stream",
+                    SizeBytes = a.SizeBytes,
+                })
+                .ToList() ?? new List<AttachmentRef>(),
+            ReviewLinks = template.ReferenceLinks?
+                .Select(r => new ReviewLinkRef
+                {
+                    Title = r.Label,
+                    Url = r.Url,
+                })
+                .ToList() ?? new List<ReviewLinkRef>(),
+            RespondUrl = respondUrl,
+            DueBy = template.DeliveryDefaults?.EscalateAfterDays is int days
+                ? instance.CreatedAt.AddDays(days)
+                : null,
+            IsReminder = isReminder,
+        };
+    }
+}

--- a/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
@@ -39,9 +39,9 @@ public class NotificationSummaryBuilder
                     // IsAnswered / AnsweredSummary populated when multi-question batches land (#289).
                 }
             },
-            Attachments = template.Attachments?
-                .Select(a => new AttachmentRef
-                {
+                    ContentType = string.IsNullOrEmpty(a.MediaType?.Trim())
+                        ? "application/octet-stream"
+                        : a.MediaType.Trim(),
                     Name = a.Name,
                     ContentType = string.IsNullOrWhiteSpace(a.MediaType)
                         ? "application/octet-stream"

--- a/server/tests/Dotbot.Server.Tests/Unit/NotificationSummaryBuilderTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/NotificationSummaryBuilderTests.cs
@@ -15,6 +15,7 @@ public class NotificationSummaryBuilderTests
         string projectId = "proj-1",
         string? projectName = "Project One",
         string? description = null,
+        string? context = null,
         string? deliverableSummary = null,
         List<QuestionAttachment>? attachments = null,
         List<ReferenceLink>? referenceLinks = null,
@@ -26,6 +27,7 @@ public class NotificationSummaryBuilderTests
             Title = title,
             Type = type,
             Description = description,
+            Context = context,
             Options = [],
             Project = new ProjectRef { ProjectId = projectId, Name = projectName },
             DeliverableSummary = deliverableSummary,
@@ -80,6 +82,15 @@ public class NotificationSummaryBuilderTests
     {
         var s = Build(Template(deliverableSummary: summary, description: "ignored"));
         Assert.Equal(expected, s.DeliverableSummary);
+    }
+
+    [Theory]
+    [InlineData("longer background block", "longer background block")]
+    [InlineData(null, null)]
+    public void Context_PassesThroughOrStaysNull(string? context, string? expected)
+    {
+        var s = Build(Template(context: context));
+        Assert.Equal(expected, s.Context);
     }
 
     [Fact]

--- a/server/tests/Dotbot.Server.Tests/Unit/NotificationSummaryBuilderTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/NotificationSummaryBuilderTests.cs
@@ -1,0 +1,176 @@
+using Dotbot.Server.Models;
+using Dotbot.Server.Services.Delivery;
+
+namespace Dotbot.Server.Tests.Unit;
+
+public class NotificationSummaryBuilderTests
+{
+    private const string DefaultRespondUrl = "https://example/respond/abc";
+    private static readonly NotificationSummaryBuilder Builder = new();
+
+    private static QuestionTemplate Template(
+        Guid? questionId = null,
+        string title = "Approve architecture v2",
+        string type = "approval",
+        string projectId = "proj-1",
+        string? projectName = "Project One",
+        string? description = null,
+        string? deliverableSummary = null,
+        List<QuestionAttachment>? attachments = null,
+        List<ReferenceLink>? referenceLinks = null,
+        DeliveryDefaults? deliveryDefaults = null)
+        => new()
+        {
+            QuestionId = questionId ?? Guid.NewGuid(),
+            Version = 1,
+            Title = title,
+            Type = type,
+            Description = description,
+            Options = [],
+            Project = new ProjectRef { ProjectId = projectId, Name = projectName },
+            DeliverableSummary = deliverableSummary,
+            Attachments = attachments,
+            ReferenceLinks = referenceLinks,
+            DeliveryDefaults = deliveryDefaults,
+        };
+
+    private static QuestionInstance Instance(
+        Guid? questionId = null,
+        string projectId = "proj-1",
+        DateTime? createdAt = null)
+        => new()
+        {
+            InstanceId = Guid.NewGuid(),
+            QuestionId = questionId ?? Guid.NewGuid(),
+            QuestionVersion = 1,
+            ProjectId = projectId,
+            CreatedAt = createdAt ?? new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+        };
+
+    private static NotificationSummary Build(
+        QuestionTemplate template,
+        QuestionInstance? instance = null,
+        string respondUrl = DefaultRespondUrl,
+        bool isReminder = false)
+        => Builder.Build(template, instance ?? Instance(questionId: template.QuestionId), respondUrl, isReminder);
+
+    [Fact]
+    public void Header_TitleAndTypeRoundTrip()
+    {
+        var s = Build(Template(title: "Approve v2", type: "approval"));
+        Assert.Equal("Approve v2", s.QuestionTitle);
+        Assert.Equal("approval", s.QuestionType);
+    }
+
+    [Theory]
+    [InlineData("Acme", "proj-x", "Acme")]    // explicit name wins
+    [InlineData(null, "proj-x", "proj-x")]    // null name → projectId fallback
+    public void ProjectName_PrefersNameThenProjectId(string? name, string projectId, string expected)
+    {
+        var s = Build(Template(projectId: projectId, projectName: name));
+        Assert.Equal(expected, s.ProjectName);
+    }
+
+    [Theory]
+    [InlineData("summary", "ignored", "summary")]    // explicit summary wins
+    [InlineData(null, "legacy desc", "legacy desc")] // null summary → Description fallback
+    [InlineData(null, null, null)]                   // both null → null
+    public void DeliverableSummary_FallbackChain(string? summary, string? description, string? expected)
+    {
+        var s = Build(Template(deliverableSummary: summary, description: description));
+        Assert.Equal(expected, s.DeliverableSummary);
+    }
+
+    [Fact]
+    public void BatchQuestions_SingleEntryFromTemplate()
+    {
+        var qid = Guid.NewGuid();
+        var t = Template(questionId: qid, title: "Q1", type: "approval");
+        var bq = Assert.Single(Build(t).BatchQuestions);
+
+        Assert.Equal(qid, bq.QuestionId);
+        Assert.Equal("Q1", bq.Title);
+        Assert.Equal("approval", bq.Type);
+    }
+
+    [Fact]
+    public void BatchQuestions_AnsweredStateAtDefault()
+    {
+        // Locks the deferred-population contract — see #289.
+        var bq = Assert.Single(Build(Template()).BatchQuestions);
+        Assert.False(bq.IsAnswered);
+        Assert.Null(bq.AnsweredSummary);
+    }
+
+    [Fact]
+    public void Attachments_MappedWithMediaTypeFallback()
+    {
+        var t = Template(attachments: new List<QuestionAttachment>
+        {
+            new() { AttachmentId = Guid.NewGuid(), Name = "spec.pdf", MediaType = "application/pdf", SizeBytes = 1024 },
+            new() { AttachmentId = Guid.NewGuid(), Name = "blob.bin", MediaType = null, SizeBytes = null },
+        });
+
+        var atts = Build(t).Attachments;
+        Assert.Equal(2, atts.Count);
+
+        Assert.Equal("spec.pdf", atts[0].Name);
+        Assert.Equal("application/pdf", atts[0].ContentType);
+        Assert.Equal(1024, atts[0].SizeBytes);
+
+        Assert.Equal("blob.bin", atts[1].Name);
+        Assert.Equal("application/octet-stream", atts[1].ContentType);
+        Assert.Null(atts[1].SizeBytes);
+    }
+
+    [Fact]
+    public void ReferenceLinks_MappedToReviewLinkRefs()
+    {
+        var t = Template(referenceLinks: new List<ReferenceLink>
+        {
+            new() { Label = "ADR-007", Url = "https://example/adr/7" },
+        });
+
+        var link = Assert.Single(Build(t).ReviewLinks);
+        Assert.Equal("ADR-007", link.Title);
+        Assert.Equal("https://example/adr/7", link.Url);
+        Assert.Null(link.Type);
+    }
+
+    [Fact]
+    public void EmptyCollections_StayEmptyNotNull()
+    {
+        var s = Build(Template(attachments: null, referenceLinks: null));
+        Assert.Empty(s.Attachments);
+        Assert.Empty(s.ReviewLinks);
+    }
+
+    [Fact]
+    public void DueBy_ComputedFromEscalateAfterDays()
+    {
+        var created = new DateTime(2026, 1, 10, 9, 0, 0, DateTimeKind.Utc);
+        var t = Template(deliveryDefaults: new DeliveryDefaults { EscalateAfterDays = 3 });
+        var s = Build(t, instance: Instance(questionId: t.QuestionId, createdAt: created));
+
+        Assert.Equal(created.AddDays(3), s.DueBy);
+    }
+
+    [Theory]
+    [InlineData(false, null)]   // no DeliveryDefaults at all
+    [InlineData(true, null)]    // DeliveryDefaults set, EscalateAfterDays null
+    public void DueBy_NullWhenNoEscalation(bool hasDefaults, int? escalateAfterDays)
+    {
+        var t = Template(deliveryDefaults: hasDefaults
+            ? new DeliveryDefaults { EscalateAfterDays = escalateAfterDays }
+            : null);
+        Assert.Null(Build(t).DueBy);
+    }
+
+    [Fact]
+    public void Parameters_FlowThrough()
+    {
+        var s = Build(Template(), respondUrl: "https://m/respond/xyz", isReminder: true);
+        Assert.Equal("https://m/respond/xyz", s.RespondUrl);
+        Assert.True(s.IsReminder);
+    }
+}

--- a/server/tests/Dotbot.Server.Tests/Unit/NotificationSummaryBuilderTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/NotificationSummaryBuilderTests.cs
@@ -182,4 +182,15 @@ public class NotificationSummaryBuilderTests
         Assert.Equal("https://m/respond/xyz", s.RespondUrl);
         Assert.True(s.IsReminder);
     }
+
+    [Fact]
+    public void Build_ThrowsWhenInstanceQuestionIdDoesNotMatchTemplate()
+    {
+        // Runtime check (not Debug.Assert) so the contract holds in Release builds.
+        var template = Template(questionId: Guid.NewGuid());
+        var instance = Instance(questionId: Guid.NewGuid());
+        var ex = Assert.Throws<ArgumentException>(
+            () => Builder.Build(template, instance, DefaultRespondUrl, isReminder: false));
+        Assert.Equal("instance", ex.ParamName);
+    }
 }

--- a/server/tests/Dotbot.Server.Tests/Unit/NotificationSummaryBuilderTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/NotificationSummaryBuilderTests.cs
@@ -65,6 +65,8 @@ public class NotificationSummaryBuilderTests
     [Theory]
     [InlineData("Acme", "proj-x", "Acme")]    // explicit name wins
     [InlineData(null, "proj-x", "proj-x")]    // null name → projectId fallback
+    [InlineData("", "proj-x", "proj-x")]      // empty name → projectId fallback
+    [InlineData("   ", "proj-x", "proj-x")]   // whitespace name → projectId fallback
     public void ProjectName_PrefersNameThenProjectId(string? name, string projectId, string expected)
     {
         var s = Build(Template(projectId: projectId, projectName: name));
@@ -72,12 +74,11 @@ public class NotificationSummaryBuilderTests
     }
 
     [Theory]
-    [InlineData("summary", "ignored", "summary")]    // explicit summary wins
-    [InlineData(null, "legacy desc", "legacy desc")] // null summary → Description fallback
-    [InlineData(null, null, null)]                   // both null → null
-    public void DeliverableSummary_FallbackChain(string? summary, string? description, string? expected)
+    [InlineData("summary", "summary")]   // explicit value passes through
+    [InlineData(null, null)]             // null stays null — legacy templates render Context separately
+    public void DeliverableSummary_PassesThroughOrStaysNull(string? summary, string? expected)
     {
-        var s = Build(Template(deliverableSummary: summary, description: description));
+        var s = Build(Template(deliverableSummary: summary, description: "ignored"));
         Assert.Equal(expected, s.DeliverableSummary);
     }
 
@@ -109,10 +110,11 @@ public class NotificationSummaryBuilderTests
         {
             new() { AttachmentId = Guid.NewGuid(), Name = "spec.pdf", MediaType = "application/pdf", SizeBytes = 1024 },
             new() { AttachmentId = Guid.NewGuid(), Name = "blob.bin", MediaType = null, SizeBytes = null },
+            new() { AttachmentId = Guid.NewGuid(), Name = "blank.dat", MediaType = "   " },
         });
 
         var atts = Build(t).Attachments;
-        Assert.Equal(2, atts.Count);
+        Assert.Equal(3, atts.Count);
 
         Assert.Equal("spec.pdf", atts[0].Name);
         Assert.Equal("application/pdf", atts[0].ContentType);
@@ -121,6 +123,9 @@ public class NotificationSummaryBuilderTests
         Assert.Equal("blob.bin", atts[1].Name);
         Assert.Equal("application/octet-stream", atts[1].ContentType);
         Assert.Null(atts[1].SizeBytes);
+
+        Assert.Equal("blank.dat", atts[2].Name);
+        Assert.Equal("application/octet-stream", atts[2].ContentType);
     }
 
     [Fact]
@@ -145,21 +150,14 @@ public class NotificationSummaryBuilderTests
         Assert.Empty(s.ReviewLinks);
     }
 
-    [Fact]
-    public void DueBy_ComputedFromEscalateAfterDays()
-    {
-        var created = new DateTime(2026, 1, 10, 9, 0, 0, DateTimeKind.Utc);
-        var t = Template(deliveryDefaults: new DeliveryDefaults { EscalateAfterDays = 3 });
-        var s = Build(t, instance: Instance(questionId: t.QuestionId, createdAt: created));
-
-        Assert.Equal(created.AddDays(3), s.DueBy);
-    }
-
     [Theory]
     [InlineData(false, null)]   // no DeliveryDefaults at all
     [InlineData(true, null)]    // DeliveryDefaults set, EscalateAfterDays null
-    public void DueBy_NullWhenNoEscalation(bool hasDefaults, int? escalateAfterDays)
+    [InlineData(true, 3)]       // DeliveryDefaults set, EscalateAfterDays present — still null in PR-3
+    public void DueBy_AlwaysNullInPR3(bool hasDefaults, int? escalateAfterDays)
     {
+        // PRD §4.5 line 642 derives DueBy from InstanceRecipient.SentAt, which is per-recipient.
+        // DeliveryOrchestrator computes it in PR-6/#287 alongside RespondUrl personalisation.
         var t = Template(deliveryDefaults: hasDefaults
             ? new DeliveryDefaults { EscalateAfterDays = escalateAfterDays }
             : null);


### PR DESCRIPTION
## Linked issue

Closes #284

## Summary of changes

Foundation infrastructure for the QuestionService delivery layer in #29 Plan Phase B. Adds the shared `NotificationSummary` DTO + builder so the four delivery providers (Email, Jira, Teams, Slack) can render against a single shape instead of hand-rolling message bodies from raw template fields. **No active consumer yet** — providers wire in PR-4/#285 + PR-5/#286, orchestrator wires in PR-6/#287.

Six commits, each independently buildable:

- `ea51612` — `Services/Delivery/NotificationSummary.cs` (new) — shape from PRD §4.5 lines 220-269. Four classes in one file matching the PRD code block: `NotificationSummary`, `BatchQuestionRef`, `AttachmentRef`, `ReviewLinkRef`. Collections initialised to `new()` so providers can iterate without null-checks. `RespondUrl` is `required`; the orchestrator clones+overwrites per recipient in PR-6.
- `371c35d` — `Services/Delivery/IQuestionDeliveryProvider.cs` (modified) — adds `public NotificationSummary? Summary { get; set; }` on `DeliveryContext`. Nullable + no `required` so all four existing provider call sites compile untouched.
- `65bb4ed` — `Services/Delivery/NotificationSummaryBuilder.cs` (new) + `Program.cs` — pure synchronous mapper from `(template, instance, respondUrl, isReminder)` → `NotificationSummary`. Zero constructor deps. Registered as singleton in DI so PR-6 is a pure consumer.
- `fa29066` — `tests/Dotbot.Server.Tests/Unit/NotificationSummaryBuilderTests.cs` (new) — initial test suite covering field mappings.
- `21bfdc5` — review fixups: tighten fallbacks (`IsNullOrWhiteSpace` for `ProjectName` and `MediaType`), drop the `Description` fallback for `DeliverableSummary` (no provider reads `Description`), set `DueBy = null` and defer per-recipient computation to PR-6 (PRD §4.5 line 642 derives it from `InstanceRecipient.SentAt`, not `instance.CreatedAt`).
- `b46cfbf` — add `Context` field round-trip coverage (caught by follow-up review).

**Builder composition rules (current code):**
- `QuestionTitle` / `QuestionType` — direct copy from template
- `ProjectName` — `template.Project.Name` (when non-whitespace), else `template.Project.ProjectId`
- `DeliverableSummary` — `template.DeliverableSummary` only, no fallback. Validator already enforces non-empty for `approval` and `documentReview`; for other types it intentionally stays null and providers render `Context` separately as today (PRD §8 line 651).
- `Context` — direct copy
- `BatchQuestions` — single-element list keyed off the template's question (multi-question batches arrive in #289)
- `Attachments` / `ReviewLinks` — mapped from template-side `QuestionAttachment` / `ReferenceLink`; empty lists when source is null; `ContentType` falls back to `application/octet-stream` on null/empty/whitespace `MediaType`
- `RespondUrl` / `IsReminder` — pass-through parameters
- `DueBy` — always `null` in this PR. PR-6/#287 will compute it per recipient from `InstanceRecipient.SentAt + Template.DeliveryDefaults.EscalateAfterDays` alongside `RespondUrl` personalisation.

## Screenshots / recordings

N/A — no UI changes.

## Testing notes

**Automated:** `dotnet test server/dotbot.sln --configuration Release` → **109 unit tests pass**, 0 failed (91 prior + 18 new theory cases). CI matrix runs Ubuntu/Windows/macOS via `.github/workflows/server.yml`.

Coverage (`Unit/NotificationSummaryBuilderTests.cs`):
- Header — `QuestionTitle`/`QuestionType` round-trip, `ProjectName` 4-row Theory covering explicit name, null, empty, whitespace fallback to `ProjectId`
- `DeliverableSummary` 2-row Theory: pass-through and null
- `Context` 2-row Theory: pass-through and null
- `BatchQuestions` — single-entry composition + a dedicated test that locks the deferred-population contract (see scope deviation below)
- `Attachments` — 3-row body covering explicit `MediaType`, null, and whitespace fallback to `application/octet-stream`
- `ReferenceLinks` → `ReviewLinkRef` mapping (`Label → Title`)
- Null source collections produce empty (not null) lists
- `DueBy` — single Theory locking the "always null in PR-3" contract across all `DeliveryDefaults` shapes
- Parameter pass-through for `RespondUrl` and `IsReminder`

**Backward-compat:** All four existing providers (Email/Jira/Slack/Teams) compile unchanged — verified by clean `Release` build with zero warnings. The new `Summary` property on `DeliveryContext` is nullable + non-`required`, so every existing `new DeliveryContext { ... }` call site keeps working.

## Scope deviation from issue acceptance (deliberate)

The issue asks for unit tests on the builder including "partial batch / full-batch-answered" cases and per-type `AnsweredSummary` strings (`approval`, `priorityRanking`, `freeText`, etc.). Those are deferred:

`IsAnswered` and `AnsweredSummary` fields exist on `BatchQuestionRef` for shape stability, but this PR's builder leaves them at default (`false` / `null`). Reasoning:
1. `QuestionInstance` is single-question today — no multi-question batch model exists
2. `ReminderEscalationService` (#290) suppresses reminders for already-answered questions, so a single-question instance never carries an answered question into a notification
3. The multi-question batch model lands in #289 — population of these fields is its concern, where the lookup surface (`ResponseStorageService`) and the per-type formatter will be exercised in real flows

This drops the `ResponseStorageService` dependency from PR-3 entirely (no `IResponseReader` test seam, no Azure dep in test path, no async in the builder). PR-3 stays a pure DTO + sync mapper change. `BatchQuestions_AnsweredStateAtDefault` locks the contract so #289 has a clear hook to extend.

`DueBy` is also deferred to PR-6 for the per-recipient `SentAt` reason described above. The `DueBy_AlwaysNullInPR3` Theory locks that contract.

## Checklist

- [x] Tests added or updated (18 theory cases)
- [x] Docs updated — N/A; PRD-029 already added in PR-1/#312 covers the design
- [x] Linked issue exists (#284)
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)