### PR TITLE
Bugfix framework integrity paths

### DIFF
--- a/core/mcp/modules/FrameworkIntegrity.psm1
+++ b/core/mcp/modules/FrameworkIntegrity.psm1
@@ -23,6 +23,7 @@
 $script:ProtectedPaths = @(
     '.bot/core',
     '.bot/hooks',
+    '.bot/recipes',
     '.bot/settings/providers',
     '.bot/settings/settings.default.json',
     '.bot/settings/theme.default.json',

--- a/core/mcp/modules/FrameworkIntegrity.psm1
+++ b/core/mcp/modules/FrameworkIntegrity.psm1
@@ -23,13 +23,11 @@
 $script:ProtectedPaths = @(
     '.bot/core',
     '.bot/hooks',
-    '.bot/recipes',
     '.bot/settings/providers',
     '.bot/settings/settings.default.json',
     '.bot/settings/theme.default.json',
     '.bot/go.ps1',
     '.bot/init.ps1',
-    '.bot/workflow.yaml',
     '.bot/.gitignore',
     '.bot/.manifest.json',
     '.bot/README.md'

--- a/scripts/init-project.ps1
+++ b/scripts/init-project.ps1
@@ -1263,7 +1263,15 @@ if ($LASTEXITCODE -ne 0) {
     # then commit framework paths + manifest if anything actually changed.
     New-FrameworkManifest -Root $ProjectDir -Generator 'dotbot init --force' -Paths $frameworkPaths
 
-    $stagePaths = $frameworkPaths + @('.bot/.manifest.json')
+    # Filter to paths that actually exist on disk — git add chokes on a single
+    # missing pathspec (`fatal: pathspec '...' did not match any files`) and
+    # aborts the entire stage operation, which then surfaces as a silent
+    # "Framework update commit failed" because `Submit-ForceCommit` runs git
+    # commit with nothing staged. Filtering here keeps a single stale entry
+    # in $script:ProtectedPaths from breaking init --force.
+    $stagePaths = @(($frameworkPaths + @('.bot/.manifest.json')) | Where-Object {
+        Test-Path -LiteralPath (Join-Path $ProjectDir $_)
+    })
     $dirty = git -C $ProjectDir status --porcelain -- @stagePaths 2>$null
     if ($dirty) {
         Write-DotbotCommand "Committing framework file updates..."

--- a/scripts/init-project.ps1
+++ b/scripts/init-project.ps1
@@ -1263,14 +1263,14 @@ if ($LASTEXITCODE -ne 0) {
     # then commit framework paths + manifest if anything actually changed.
     New-FrameworkManifest -Root $ProjectDir -Generator 'dotbot init --force' -Paths $frameworkPaths
 
-    # Filter to paths that actually exist on disk — git add chokes on a single
-    # missing pathspec (`fatal: pathspec '...' did not match any files`) and
-    # aborts the entire stage operation, which then surfaces as a silent
-    # "Framework update commit failed" because `Submit-ForceCommit` runs git
-    # commit with nothing staged. Filtering here keeps a single stale entry
-    # in $script:ProtectedPaths from breaking init --force.
+    # Keep paths that are on disk OR tracked in git. Drops stale list entries
+    # (would abort `git add` with a pathspec error), but preserves
+    # tracked-then-deleted paths so migration deletions still get staged.
     $stagePaths = @(($frameworkPaths + @('.bot/.manifest.json')) | Where-Object {
-        Test-Path -LiteralPath (Join-Path $ProjectDir $_)
+        $abs = Join-Path $ProjectDir $_
+        if (Test-Path -LiteralPath $abs) { return $true }
+        $tracked = git -C $ProjectDir ls-files -- $_ 2>$null
+        return [bool]$tracked
     })
     $dirty = git -C $ProjectDir status --porcelain -- @stagePaths 2>$null
     if ($dirty) {

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -4427,10 +4427,9 @@ if ((Test-Path $manifestModule) -and (Test-Path $frameworkIntegrityModule)) {
         & git config user.email "test@test.com" 2>$null
         & git config user.name "Test" 2>$null
 
-        # Create a .bot/ structure with two protected dirs and a protected file.
-        # Include the sentinel file (dotbot-mcp.ps1) at .bot/core/mcp/ that
-        # Test-FrameworkIntegrity uses to detect pre-first-commit state via git log.
-        $protectedPaths = @('.bot/core', '.bot/go.ps1')
+        # Fixture: dotbot-mcp.ps1 is the sentinel Test-FrameworkIntegrity probes
+        # for pre-first-commit detection; .bot/go.ps1 is the tampering target.
+        $protectedPaths = Get-FrameworkProtectedPaths
         New-Item -ItemType Directory -Path (Join-Path $fiTestDir ".bot/core/mcp") -Force | Out-Null
         Set-Content -Path (Join-Path $fiTestDir ".bot/core/mcp/dotbot-mcp.ps1") -Value "# mcp server" -Encoding UTF8
         Set-Content -Path (Join-Path $fiTestDir ".bot/go.ps1") -Value "# go" -Encoding UTF8

--- a/tests/Test-Structure.ps1
+++ b/tests/Test-Structure.ps1
@@ -369,16 +369,23 @@ if (-not $dotbotInstalled) {
         Assert-PathExists -Name "-Force: .control/settings.json preserved" -Path $dummySettings
         Assert-PathExists -Name "-Force: system files refreshed" -Path (Join-Path $botDir "core/mcp/dotbot-mcp.ps1")
 
-        # Regression guard: init --force must leave a clean .bot/ tree, else
-        # the next workflow run's integrity gate trips with "tampered".
-        Push-Location $testProject
-        try {
-            $dirtyAfterForce = & git status --porcelain -- .bot/ 2>$null
-            Assert-True -Name "-Force: clean working tree (no uncommitted .bot/ changes)" `
-                -Condition ([string]::IsNullOrWhiteSpace(($dirtyAfterForce -join "`n"))) `
-                -Message "init --force left uncommitted .bot/ changes:`n$($dirtyAfterForce -join "`n")"
-        } finally {
-            Pop-Location
+        # Regression guard: init --force must leave a clean framework tree,
+        # else the next workflow run's integrity gate trips with "tampered".
+        # Scope to the protected-paths list — workspace/ and .control/ hold
+        # user/runtime data the test deliberately seeds and aren't framework.
+        $integrityModule = Join-Path $dotbotDir "core/mcp/modules/FrameworkIntegrity.psm1"
+        if (Test-Path $integrityModule) {
+            Import-Module $integrityModule -Force
+            $protectedPaths = @(Get-FrameworkProtectedPaths)
+            Push-Location $testProject
+            try {
+                $dirtyFramework = & git status --porcelain -- @protectedPaths 2>$null
+                Assert-True -Name "-Force: clean framework tree (no uncommitted protected-path changes)" `
+                    -Condition ([string]::IsNullOrWhiteSpace(($dirtyFramework -join "`n"))) `
+                    -Message "init --force left uncommitted framework changes:`n$($dirtyFramework -join "`n")"
+            } finally {
+                Pop-Location
+            }
         }
 
         if ($initialInstanceId) {

--- a/tests/Test-Structure.ps1
+++ b/tests/Test-Structure.ps1
@@ -376,7 +376,7 @@ if (-not $dotbotInstalled) {
         $integrityModule = Join-Path $dotbotDir "core/mcp/modules/FrameworkIntegrity.psm1"
         if (Test-Path $integrityModule) {
             Import-Module $integrityModule -Force
-            $protectedPaths = @(Get-FrameworkProtectedPaths)
+            $protectedPaths = Get-FrameworkProtectedPaths
             Push-Location $testProject
             try {
                 $dirtyFramework = & git status --porcelain -- @protectedPaths 2>$null
@@ -425,6 +425,26 @@ if (-not $dotbotInstalled) {
                 $relativePathKey = $relativePath -replace '\\', '/'
                 $expectedPath = Join-Path $botDir3 $relativePath
                 Assert-PathExists -Name "--: dotnet overlay file present ($relativePathKey)" -Path $expectedPath
+            }
+
+            # Real $script:ProtectedPaths must fully resolve under a stack-included
+            # install. .bot/recipes is conditionally populated by stacks; on the
+            # default no-stack flavor it correctly stays absent (the staging filter
+            # tolerates that), but a stale entry in $script:ProtectedPaths that no
+            # install path ever creates would surface here.
+            $integrityModule = Join-Path $dotbotDir "core/mcp/modules/FrameworkIntegrity.psm1"
+            if (Test-Path $integrityModule) {
+                Import-Module $integrityModule -Force
+                $stackProtectedPaths = Get-FrameworkProtectedPaths
+                $stackStale = @()
+                foreach ($p in $stackProtectedPaths) {
+                    if (-not (Test-Path -LiteralPath (Join-Path $testProject3 $p))) {
+                        $stackStale += $p
+                    }
+                }
+                Assert-True -Name "--: every protected path resolves under -Stack dotnet" `
+                    -Condition ($stackStale.Count -eq 0) `
+                    -Message "Stale `$script:ProtectedPaths entries (not installed by core+dotnet stack): $($stackStale -join ', ')"
             }
 
         } finally {

--- a/tests/Test-Structure.ps1
+++ b/tests/Test-Structure.ps1
@@ -369,6 +369,18 @@ if (-not $dotbotInstalled) {
         Assert-PathExists -Name "-Force: .control/settings.json preserved" -Path $dummySettings
         Assert-PathExists -Name "-Force: system files refreshed" -Path (Join-Path $botDir "core/mcp/dotbot-mcp.ps1")
 
+        # Regression guard: init --force must leave a clean .bot/ tree, else
+        # the next workflow run's integrity gate trips with "tampered".
+        Push-Location $testProject
+        try {
+            $dirtyAfterForce = & git status --porcelain -- .bot/ 2>$null
+            Assert-True -Name "-Force: clean working tree (no uncommitted .bot/ changes)" `
+                -Condition ([string]::IsNullOrWhiteSpace(($dirtyAfterForce -join "`n"))) `
+                -Message "init --force left uncommitted .bot/ changes:`n$($dirtyAfterForce -join "`n")"
+        } finally {
+            Pop-Location
+        }
+
         if ($initialInstanceId) {
             $settingsAfterForce = Get-Content $settingsDefault -Raw | ConvertFrom-Json
             Assert-Equal -Name "-Force: preserves existing settings.instance_id" `

--- a/tests/Test-Structure.ps1
+++ b/tests/Test-Structure.ps1
@@ -380,6 +380,10 @@ if (-not $dotbotInstalled) {
             Push-Location $testProject
             try {
                 $dirtyFramework = & git status --porcelain -- @protectedPaths 2>$null
+                $gitStatusExitCode = $LASTEXITCODE
+                Assert-True -Name "-Force: git status for protected paths succeeds" `
+                    -Condition ($gitStatusExitCode -eq 0) `
+                    -Message "git status --porcelain -- @protectedPaths failed with exit code $gitStatusExitCode"
                 Assert-True -Name "-Force: clean framework tree (no uncommitted protected-path changes)" `
                     -Condition ([string]::IsNullOrWhiteSpace(($dirtyFramework -join "`n"))) `
                     -Message "init --force left uncommitted framework changes:`n$($dirtyFramework -join "`n")"


### PR DESCRIPTION
## Linked issue

Closes #354

## Summary of changes

`$script:ProtectedPaths` still listed `.bot/workflow.yaml`, both retired by #345 and #347. On `dotbot init --force`, `git add -- @stagePaths` aborted on the first missing pathspec (`fatal: pathspec '.bot/workflow.yaml' did not match any files`), leaving nothing staged. The follow-up commit then exited non-zero with "no changes added to commit", and `Submit-ForceCommit`'s `2>$null` swallowed the real error — surfacing only the generic `⚠ Framework update commit failed` warning. The uncommitted framework state then tripped the integrity gate on the next workflow run.

- `core/mcp/modules/FrameworkIntegrity.psm1` — drop `.bot/workflow.yaml` from `$script:ProtectedPaths` (no longer created post-refactor).
- `scripts/init-project.ps1` — defensively filter `$stagePaths` to paths that exist on disk, so a single stale entry can't silently abort the stage operation again.

## Screenshots / recordings

N/A — CLI fix, no UI surface.

## Testing notes

1. Fresh target project, any current dotbot install:
   ```pwsh
   mkdir test-project; cd test-project; git init
   dotbot init
   ```
2. From the target project: `dotbot init --force`.
3. **Before this PR:** `⚠ Framework update commit failed`; running the suggested `DOTBOT_FORCE_COMMIT=1 git commit` reveals `fatal: pathspec '.bot/workflow.yaml' did not match any files`.
4. **After this PR:** `✓ Framework update committed`. `git log -1` shows the `chore: update dotbot framework files` commit, `git status .bot/` is clean.


## Checklist


- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
