### PR TITLE
fix: tighten pre-flight ToolSearch and analysing-state MCP lookups

### DIFF
--- a/core/mcp/tools/plan-get/script.ps1
+++ b/core/mcp/tools/plan-get/script.ps1
@@ -11,9 +11,11 @@ function Invoke-PlanGet {
         throw "Task ID is required"
     }
 
-    # Find task file by ID (search all status directories)
+    # Find task file by ID. Match TaskStore's $script:ValidStatuses so a task can be
+    # resolved at any lifecycle stage — analysing, needs-input, and split were missing
+    # from the earlier list, which made plan_get fail during the analysis phase.
     $tasksBaseDir = Join-Path $global:DotbotProjectRoot ".bot\workspace\tasks"
-    $statusDirs = @('todo', 'in-progress', 'done', 'skipped', 'cancelled')
+    $statusDirs = @('todo', 'analysing', 'needs-input', 'analysed', 'in-progress', 'done', 'split', 'skipped', 'cancelled')
     $taskFile = $null
     $task = $null
 
@@ -34,7 +36,7 @@ function Invoke-PlanGet {
     }
 
     if (-not $taskFile) {
-        throw "Task not found with ID: $taskId"
+        throw "Task not found with ID: $taskId (searched: $($statusDirs -join ', '))"
     }
 
     # Check if task has plan_path field

--- a/core/mcp/tools/plan-get/script.ps1
+++ b/core/mcp/tools/plan-get/script.ps1
@@ -1,3 +1,5 @@
+Import-Module (Join-Path $global:DotbotProjectRoot ".bot/core/mcp/modules/TaskStore.psm1") -Force
+
 function Invoke-PlanGet {
     param(
         [hashtable]$Arguments
@@ -11,33 +13,15 @@ function Invoke-PlanGet {
         throw "Task ID is required"
     }
 
-    # Find task file by ID. Match TaskStore's $script:ValidStatuses so a task can be
-    # resolved at any lifecycle stage — analysing, needs-input, and split were missing
-    # from the earlier list, which made plan_get fail during the analysis phase.
-    $tasksBaseDir = Join-Path $global:DotbotProjectRoot ".bot\workspace\tasks"
-    $statusDirs = @('todo', 'analysing', 'needs-input', 'analysed', 'in-progress', 'done', 'split', 'skipped', 'cancelled')
-    $taskFile = $null
-    $task = $null
-
-    foreach ($status in $statusDirs) {
-        $statusDir = Join-Path $tasksBaseDir $status
-        if (Test-Path $statusDir) {
-            $files = Get-ChildItem -Path $statusDir -Filter "*.json" -ErrorAction SilentlyContinue
-            foreach ($file in $files) {
-                $taskContent = Get-Content $file.FullName -Raw | ConvertFrom-Json
-                if ($taskContent.id -eq $taskId) {
-                    $taskFile = $file.FullName
-                    $task = $taskContent
-                    break
-                }
-            }
-            if ($taskFile) { break }
-        }
+    # Resolve task across every valid status. Find-TaskFileById defaults to
+    # TaskStore's $script:ValidStatuses so additions to the lifecycle do not
+    # silently skip plan_get.
+    $found = Find-TaskFileById -TaskId $taskId
+    if (-not $found) {
+        throw "Task not found with ID: $taskId"
     }
 
-    if (-not $taskFile) {
-        throw "Task not found with ID: $taskId (searched: $($statusDirs -join ', '))"
-    }
+    $task = $found.Content
 
     # Check if task has plan_path field
     if (-not $task.plan_path) {

--- a/core/mcp/tools/task-get-context/script.ps1
+++ b/core/mcp/tools/task-get-context/script.ps1
@@ -11,36 +11,36 @@ function Invoke-TaskGetContext {
         throw "Task ID is required"
     }
 
-    # Define tasks directories
+    # Search every status directory where a task can carry useful context.
+    # analysing: task is being analysed but no analysis payload exists yet — return minimal context.
+    # needs-input: task is paused awaiting clarification — context already accumulated.
+    # analysed / in-progress: task has its full pre-flight analysis available.
     $tasksBaseDir = Join-Path $global:DotbotProjectRoot ".bot\workspace\tasks"
-    $analysedDir = Join-Path $tasksBaseDir "analysed"
-    $inProgressDir = Join-Path $tasksBaseDir "in-progress"
+    $searchStatuses = @('analysing', 'needs-input', 'analysed', 'in-progress')
 
-    # Find the task file (can be in analysed or in-progress)
     $taskFile = $null
     $currentStatus = $null
-
-    foreach ($searchDir in @($analysedDir, $inProgressDir)) {
-        if (Test-Path $searchDir) {
-            $files = Get-ChildItem -Path $searchDir -Filter "*.json" -File
-            foreach ($file in $files) {
-                try {
-                    $content = Get-Content -Path $file.FullName -Raw | ConvertFrom-Json
-                    if ($content.id -eq $taskId) {
-                        $taskFile = $file
-                        $currentStatus = if ($searchDir -eq $analysedDir) { 'analysed' } else { 'in-progress' }
-                        break
-                    }
-                } catch {
-                    # Continue searching
+    foreach ($status in $searchStatuses) {
+        $searchDir = Join-Path $tasksBaseDir $status
+        if (-not (Test-Path $searchDir)) { continue }
+        $files = Get-ChildItem -Path $searchDir -Filter "*.json" -File -ErrorAction SilentlyContinue
+        foreach ($file in $files) {
+            try {
+                $content = Get-Content -Path $file.FullName -Raw | ConvertFrom-Json
+                if ($content.id -eq $taskId) {
+                    $taskFile = $file
+                    $currentStatus = $status
+                    break
                 }
+            } catch {
+                # Continue searching
             }
-            if ($taskFile) { break }
         }
+        if ($taskFile) { break }
     }
 
     if (-not $taskFile) {
-        throw "Task with ID '$taskId' not found in analysed or in-progress status"
+        throw "Task with ID '$taskId' not found in any of: $($searchStatuses -join ', ')"
     }
 
     # Read task content

--- a/core/mcp/tools/task-get-context/script.ps1
+++ b/core/mcp/tools/task-get-context/script.ps1
@@ -1,3 +1,5 @@
+Import-Module (Join-Path $global:DotbotProjectRoot ".bot/core/mcp/modules/TaskStore.psm1") -Force
+
 function Invoke-TaskGetContext {
     param(
         [hashtable]$Arguments
@@ -11,40 +13,17 @@ function Invoke-TaskGetContext {
         throw "Task ID is required"
     }
 
-    # Search every status directory where a task can carry useful context.
+    # Resolve task across every status where it can carry useful context.
     # analysing: task is being analysed but no analysis payload exists yet — return minimal context.
     # needs-input: task is paused awaiting clarification — context already accumulated.
     # analysed / in-progress: task has its full pre-flight analysis available.
-    $tasksBaseDir = Join-Path $global:DotbotProjectRoot ".bot\workspace\tasks"
     $searchStatuses = @('analysing', 'needs-input', 'analysed', 'in-progress')
-
-    $taskFile = $null
-    $currentStatus = $null
-    foreach ($status in $searchStatuses) {
-        $searchDir = Join-Path $tasksBaseDir $status
-        if (-not (Test-Path $searchDir)) { continue }
-        $files = Get-ChildItem -Path $searchDir -Filter "*.json" -File -ErrorAction SilentlyContinue
-        foreach ($file in $files) {
-            try {
-                $content = Get-Content -Path $file.FullName -Raw | ConvertFrom-Json
-                if ($content.id -eq $taskId) {
-                    $taskFile = $file
-                    $currentStatus = $status
-                    break
-                }
-            } catch {
-                # Continue searching
-            }
-        }
-        if ($taskFile) { break }
-    }
-
-    if (-not $taskFile) {
+    $found = Find-TaskFileById -TaskId $taskId -SearchStatuses $searchStatuses
+    if (-not $found) {
         throw "Task with ID '$taskId' not found in any of: $($searchStatuses -join ', ')"
     }
-
-    # Read task content
-    $taskContent = Get-Content -Path $taskFile.FullName -Raw | ConvertFrom-Json
+    $taskContent = $found.Content
+    $currentStatus = $found.Status
 
     # Check if task has analysis data
     $hasAnalysis = $taskContent.PSObject.Properties['analysis'] -and $taskContent.analysis
@@ -78,10 +57,15 @@ function Invoke-TaskGetContext {
     # Return full analysis context
     $analysis = $taskContent.analysis
 
-    # Resolve Decision content from applicable_decisions list
+    # Decisions: prefer the analyser's embedded `analysis.decisions` payload
+    # when present (richer text — decision, consequences, alternatives_considered
+    # already inlined). Fall back to resolving from the task's `applicable_decisions`
+    # ID list when the analyser didn't embed them.
+    $hasEmbeddedDecisions = $analysis.PSObject.Properties['decisions'] -and `
+        $analysis.decisions -and @($analysis.decisions).Count -gt 0
     $decisionContent = @()
     $decisionIds = @($taskContent.applicable_decisions | Where-Object { $_ -match '^dec-[a-f0-9]{8}$' })
-    if ($decisionIds.Count -gt 0) {
+    if (-not $hasEmbeddedDecisions -and $decisionIds.Count -gt 0) {
         $decisionsBaseDir = Join-Path $global:DotbotProjectRoot ".bot\workspace\decisions"
         $decisionStatuses = @('accepted', 'proposed', 'deprecated', 'superseded')
         foreach ($decId in $decisionIds) {
@@ -165,8 +149,16 @@ function Invoke-TaskGetContext {
             # Questions that were resolved
             questions_resolved = $analysis.questions_resolved
 
-            # Applicable Decisions with content
-            decisions = $decisionContent
+            # Verbatim briefing excerpts the analyser embedded for the executor
+            # (1-3 line quotes from mission/tech-stack/entity-model/briefing
+            # files keyed by file path). Pass-through; null when the analyser
+            # did not write this field.
+            briefing_excerpts = $analysis.briefing_excerpts
+
+            # Applicable Decisions with content. Embedded payload from the
+            # analyser wins when present; otherwise resolved from
+            # applicable_decisions IDs above.
+            decisions = if ($hasEmbeddedDecisions) { $analysis.decisions } else { $decisionContent }
         }
     }
 }

--- a/core/prompts/98-analyse-task.md
+++ b/core/prompts/98-analyse-task.md
@@ -12,21 +12,15 @@ You are an autonomous AI coding agent performing **pre-flight analysis** of a ta
 
 **Built-in tools** (`WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`) are always available — never use ToolSearch for them.
 
-**Load dotbot tools** (all in parallel, a single batch):
+**Load dotbot tools** (single bulk call — `select:` accepts a comma-separated list):
 
 ```
-ToolSearch({ query: "select:mcp__dotbot__task_mark_analysing" })
-ToolSearch({ query: "select:mcp__dotbot__task_mark_analysed" })
-ToolSearch({ query: "select:mcp__dotbot__task_mark_needs_input" })
-ToolSearch({ query: "select:mcp__dotbot__task_mark_skipped" })
-ToolSearch({ query: "select:mcp__dotbot__decision_create" })
-ToolSearch({ query: "select:mcp__dotbot__decision_list" })
-ToolSearch({ query: "select:mcp__dotbot__decision_get" })
-ToolSearch({ query: "select:mcp__dotbot__plan_get" })
-ToolSearch({ query: "select:mcp__dotbot__plan_create" })
+ToolSearch({ query: "select:mcp__dotbot__task_mark_analysing,mcp__dotbot__task_mark_analysed,mcp__dotbot__task_mark_needs_input,mcp__dotbot__task_mark_skipped,mcp__dotbot__decision_create,mcp__dotbot__decision_list,mcp__dotbot__decision_get,mcp__dotbot__plan_get,mcp__dotbot__plan_create" })
 ```
 
-Issue all ToolSearch calls above in a **single parallel batch** during Phase 0. Do **NOT** broaden the queries or try alternative search terms. If a `select:` query returns no schema on the first attempt, the dotbot MCP server is still warming up — while **still in Phase 0**, wait briefly and retry the **exact same** `select:` call. Once Phase 0 is complete, do not call ToolSearch again. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
+Issue this ToolSearch call once during Phase 0. Do **NOT** broaden the query, split it across multiple calls, or try alternative search terms. If the bulk `select:` query returns no schemas on the first attempt, the dotbot MCP server is still warming up — while **still in Phase 0**, wait briefly and retry the **exact same** `select:` call. Once Phase 0 is complete, do not call ToolSearch again. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
+
+**Do not call `mcp__dotbot__task_get_context` during analysis.** All task fields you need are already substituted into this prompt above ({{TASK_DESCRIPTION}}, {{ACCEPTANCE_CRITERIA}}, {{TASK_STEPS}}, {{APPLICABLE_AGENTS}}, {{APPLICABLE_STANDARDS}}). `task_get_context` is for the execution phase (99-autonomous-task) where it returns the analysed package back. Calling it during analysis succeeds but returns minimal context — skip the call.
 
 ---
 
@@ -479,7 +473,14 @@ Then STOP and wait for approval before continuing.
 
 ### Phase 10: Complete Analysis
 
-Once all phases are complete (and no questions/splits pending), mark the task as analysed:
+Once all phases are complete (and no questions/splits pending), mark the task as analysed.
+
+**Embed for the executor.** The execution phase (99-autonomous-task) is instructed to trust this package and not re-read source files unless a section is marked `TODO`. So the analysis you submit must contain everything the executor needs — not pointers to source. Specifically:
+
+- Pull short verbatim excerpts (1-3 lines per quote) from any briefing or product file the executor would otherwise re-read, and include them under `briefing_excerpts` keyed by file path.
+- Inline the 2-3 line pattern snippets from `files.patterns_from` into `implementation.key_patterns` as actual text, not as "see file X line Y".
+- For decisions, copy the `decision` and `consequences` text into the `decisions` array; do not list IDs alone.
+- If a section truly cannot be resolved during analysis, write the literal string `"TODO"` for that field — that is the only signal the executor uses to authorise re-reading source.
 
 ```
 mcp__dotbot__task_mark_analysed({
@@ -491,6 +492,10 @@ mcp__dotbot__task_mark_analysed({
     standards: { ... },
     decisions: [ ... ],     // Decision constraints resolved in Phase 5 + any created during Phase 1.5/8 question resolution
     product_context: { ... },
+    briefing_excerpts: {
+      "mission.md": "Quoted lines from mission that the executor needs",
+      "tech-stack.md": "Quoted runtime / framework constraints"
+    },
     implementation: { ... }
   }
 })

--- a/core/prompts/99-autonomous-task.md
+++ b/core/prompts/99-autonomous-task.md
@@ -12,19 +12,13 @@ You are an autonomous AI coding agent operating in Go Mode. Your mission is to c
 
 **Built-in tools** (`WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`) are always available — never use ToolSearch for them.
 
-**Load dotbot tools** (all in parallel, a single batch):
+**Load dotbot tools** (single bulk call — `select:` accepts a comma-separated list):
 
 ```
-ToolSearch({ query: "select:mcp__dotbot__task_get_context" })
-ToolSearch({ query: "select:mcp__dotbot__task_mark_in_progress" })
-ToolSearch({ query: "select:mcp__dotbot__task_mark_done" })
-ToolSearch({ query: "select:mcp__dotbot__task_mark_skipped" })
-ToolSearch({ query: "select:mcp__dotbot__plan_get" })
-ToolSearch({ query: "select:mcp__dotbot__plan_create" })
-ToolSearch({ query: "select:mcp__dotbot__steering_heartbeat" })
+ToolSearch({ query: "select:mcp__dotbot__task_get_context,mcp__dotbot__task_mark_in_progress,mcp__dotbot__task_mark_done,mcp__dotbot__task_mark_skipped,mcp__dotbot__plan_get,mcp__dotbot__plan_create,mcp__dotbot__steering_heartbeat" })
 ```
 
-Issue all ToolSearch calls above in a **single parallel batch**. Do not call ToolSearch again after Phase 0. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
+Issue this ToolSearch call once during Phase 0. Do **NOT** broaden the query, split it across multiple calls, or try alternative search terms. If the bulk `select:` query returns no schemas on the first attempt, the dotbot MCP server is still warming up — while **still in Phase 0**, wait briefly and retry the **exact same** `select:` call. Once Phase 0 is complete, do not call ToolSearch again. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
 
 ---
 
@@ -108,6 +102,9 @@ You are working on branch `{{BRANCH_NAME}}`.
    - **implementation.approach**: Recommended implementation approach
    - **implementation.key_patterns**: Specific patterns to follow
    - **implementation.risks**: Known risks to watch for
+   - **product_context** and any `briefing_excerpts`: pre-extracted quotes from `mission.md`, `tech-stack.md`, `entity-model.md`, and other briefing files
+   
+   **Trust this package as authoritative.** It was prepared by a dedicated pre-flight pass with full briefing access. Do NOT re-read `mission.md`, `tech-stack.md`, `entity-model.md`, briefing files, or files in `files.patterns_from` if the analysis already extracted what you need. Re-read source only when (a) you are about to write to a `files.to_modify` entry, (b) the analysis explicitly marks a section `TODO`, or (c) a specific symbol or snippet is referenced in the analysis but not extracted. Re-reading what is already packaged wastes turns and tokens for no signal.
    
    If `has_analysis: false`, fall back to exploration (see Legacy Mode below).
 

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -1102,6 +1102,18 @@ try {
             entities = @{ primary = @("Foo"); related = @() }
             files = @{ to_modify = @("src/Foo.cs"); patterns_from = @(); tests_to_update = @() }
             implementation = @{ approach = "test approach" }
+            briefing_excerpts = [ordered]@{
+                "mission.md"    = "Foo is the central entity"
+                "tech-stack.md" = ".NET 10, EF Core 10"
+            }
+            decisions = @(
+                [ordered]@{
+                    id           = "dec-deadbeef"
+                    title        = "Inline decision title"
+                    decision     = "Use repository pattern"
+                    consequences = "All data access goes through IRepo<T>"
+                }
+            )
         }
         created_at = "2026-04-27T12:00:00Z"
         updated_at = "2026-04-27T12:30:00Z"
@@ -1134,6 +1146,12 @@ try {
     Assert-Equal -Name "task_get_context returns status=analysed for task in analysed/" `
         -Expected "analysed" `
         -Actual $analysedResult.status
+    Assert-Equal -Name "task_get_context passes through analysis.briefing_excerpts" `
+        -Expected "Foo is the central entity" `
+        -Actual $analysedResult.analysis.briefing_excerpts.'mission.md'
+    Assert-True -Name "task_get_context prefers embedded analysis.decisions over resolved IDs" `
+        -Condition (@($analysedResult.analysis.decisions).Count -eq 1 -and $analysedResult.analysis.decisions[0].id -eq 'dec-deadbeef') `
+        -Message "Expected embedded decision payload to win over resolved-from-IDs path"
 
     # Dot-source plan-get and call its function. Both tasks have no plan_path so
     # has_plan=false is expected — we just need the lookup to succeed.

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -1025,6 +1025,145 @@ finally {
     $global:DotbotProjectRoot = $savedDotbotProjectRoot
 }
 
+# ─── task-get-context and plan-get resolve analysing-state tasks ─────────────
+# Regression: both tools used to throw on tasks that had been marked analysing
+# (the canonical state during the pre-flight analysis phase). The handlers now
+# search every lifecycle directory where the task can carry useful context.
+
+$testProject = $null
+$savedDotbotProjectRoot = $global:DotbotProjectRoot
+try {
+    $testProject = New-SourceBackedTestProject -RepoRoot $repoRoot
+    $botDir       = Join-Path $testProject ".bot"
+    $tasksBaseDir = Join-Path $botDir "workspace\tasks"
+    $analysingDir = Join-Path $tasksBaseDir "analysing"
+    $analysedDir  = Join-Path $tasksBaseDir "analysed"
+
+    $global:DotbotProjectRoot = $testProject
+
+    $dotBotLogModule = Join-Path $botDir "core/runtime/modules/DotBotLog.psm1"
+    if (Test-Path $dotBotLogModule) {
+        Import-Module $dotBotLogModule -Force -DisableNameChecking | Out-Null
+        $tgcLogsDir = Join-Path $botDir ".control\logs"
+        $tgcControlDir = Join-Path $botDir ".control"
+        if (-not (Test-Path $tgcLogsDir)) { New-Item -ItemType Directory -Path $tgcLogsDir -Force | Out-Null }
+        if (-not (Test-Path $tgcControlDir)) { New-Item -ItemType Directory -Path $tgcControlDir -Force | Out-Null }
+        if (Get-Command Initialize-DotBotLog -ErrorAction SilentlyContinue) {
+            Initialize-DotBotLog -LogDir $tgcLogsDir -ControlDir $tgcControlDir -ProjectRoot $testProject -ConsoleEnabled $false | Out-Null
+        }
+    }
+
+    # Stub Write-BotLog if not loaded — the tool scripts rely on it.
+    if (-not (Get-Command Write-BotLog -ErrorAction SilentlyContinue)) {
+        function Write-BotLog { param([string]$Level, [string]$Message, $Exception) }
+    }
+
+    # Task in analysing/ — no analysis payload yet.
+    $analysingTaskPath = Join-Path $analysingDir "ctx-analysing.json"
+    [ordered]@{
+        id = "ctx-analysing"
+        name = "Task being analysed"
+        description = "Has no analysis payload yet"
+        category = "feature"
+        priority = 10
+        effort = "S"
+        status = "analysing"
+        dependencies = @()
+        acceptance_criteria = @()
+        steps = @()
+        applicable_standards = @()
+        applicable_agents = @()
+        applicable_decisions = @()
+        created_at = "2026-04-27T12:00:00Z"
+        updated_at = "2026-04-27T12:00:00Z"
+        completed_at = $null
+    } | ConvertTo-Json -Depth 10 | Set-Content -Path $analysingTaskPath -Encoding UTF8
+
+    # Task in analysed/ — full analysis payload, sanity check that the broadened
+    # search list still resolves it correctly.
+    $analysedTaskPath = Join-Path $analysedDir "ctx-analysed.json"
+    [ordered]@{
+        id = "ctx-analysed"
+        name = "Analysed task"
+        description = "Has analysis payload"
+        category = "feature"
+        priority = 20
+        effort = "M"
+        status = "analysed"
+        dependencies = @()
+        acceptance_criteria = @()
+        steps = @()
+        applicable_standards = @()
+        applicable_agents = @()
+        applicable_decisions = @()
+        analysis = [ordered]@{
+            analysed_at = "2026-04-27T12:30:00Z"
+            analysed_by = "test"
+            entities = @{ primary = @("Foo"); related = @() }
+            files = @{ to_modify = @("src/Foo.cs"); patterns_from = @(); tests_to_update = @() }
+            implementation = @{ approach = "test approach" }
+        }
+        created_at = "2026-04-27T12:00:00Z"
+        updated_at = "2026-04-27T12:30:00Z"
+        completed_at = $null
+    } | ConvertTo-Json -Depth 10 | Set-Content -Path $analysedTaskPath -Encoding UTF8
+
+    # Dot-source task-get-context and call its function.
+    $taskGetContextScript = Join-Path $botDir "core/mcp/tools/task-get-context/script.ps1"
+    Assert-PathExists -Name "task-get-context script exists in test project" -Path $taskGetContextScript
+    . $taskGetContextScript
+    Assert-True -Name "task-get-context dot-source exposes Invoke-TaskGetContext" `
+        -Condition ($null -ne (Get-Command Invoke-TaskGetContext -ErrorAction SilentlyContinue)) `
+        -Message "Expected Invoke-TaskGetContext to be defined after dot-sourcing task-get-context script"
+
+    $analysingResult = Invoke-TaskGetContext -Arguments @{ task_id = "ctx-analysing" }
+    Assert-True -Name "task_get_context returns success for analysing-state task" `
+        -Condition ($analysingResult.success -eq $true) `
+        -Message "Expected success=true for analysing-state task"
+    Assert-True -Name "task_get_context reports has_analysis=false for analysing-state task" `
+        -Condition ($analysingResult.has_analysis -eq $false) `
+        -Message "Expected has_analysis=false (no analysis payload yet)"
+    Assert-Equal -Name "task_get_context returns status=analysing for task in analysing/" `
+        -Expected "analysing" `
+        -Actual $analysingResult.status
+
+    $analysedResult = Invoke-TaskGetContext -Arguments @{ task_id = "ctx-analysed" }
+    Assert-True -Name "task_get_context still resolves analysed-state task with payload" `
+        -Condition ($analysedResult.success -eq $true -and $analysedResult.has_analysis -eq $true) `
+        -Message "Expected has_analysis=true for analysed task"
+    Assert-Equal -Name "task_get_context returns status=analysed for task in analysed/" `
+        -Expected "analysed" `
+        -Actual $analysedResult.status
+
+    # Dot-source plan-get and call its function. Both tasks have no plan_path so
+    # has_plan=false is expected — we just need the lookup to succeed.
+    $planGetScript = Join-Path $botDir "core/mcp/tools/plan-get/script.ps1"
+    Assert-PathExists -Name "plan-get script exists in test project" -Path $planGetScript
+    . $planGetScript
+    Assert-True -Name "plan-get dot-source exposes Invoke-PlanGet" `
+        -Condition ($null -ne (Get-Command Invoke-PlanGet -ErrorAction SilentlyContinue)) `
+        -Message "Expected Invoke-PlanGet to be defined after dot-sourcing plan-get script"
+
+    $planAnalysing = Invoke-PlanGet -Arguments @{ task_id = "ctx-analysing" }
+    Assert-True -Name "plan_get resolves analysing-state task without throwing" `
+        -Condition ($planAnalysing.success -eq $true) `
+        -Message "Expected plan_get to find task in analysing/, got: $($planAnalysing | ConvertTo-Json -Depth 3)"
+    Assert-True -Name "plan_get reports has_plan=false when task has no plan_path" `
+        -Condition ($planAnalysing.has_plan -eq $false) `
+        -Message "Expected has_plan=false for analysing-state task without plan_path"
+
+    $planAnalysed = Invoke-PlanGet -Arguments @{ task_id = "ctx-analysed" }
+    Assert-True -Name "plan_get still resolves analysed-state task" `
+        -Condition ($planAnalysed.success -eq $true) `
+        -Message "Expected plan_get to find analysed task"
+}
+finally {
+    if ($testProject) {
+        Remove-TestProject -Path $testProject
+    }
+    $global:DotbotProjectRoot = $savedDotbotProjectRoot
+}
+
 $allPassed = Write-TestSummary -LayerName "Task Action Source Tests"
 
 if (-not $allPassed) {


### PR DESCRIPTION
## Linked issue

Closes #358

## Summary of changes

Three correlated failures were burning ~250-500 turns per start-from-prompt workflow run against SlashOps. Source: `.bot/.control/activity.jsonl` from a live dogfood run — 50+ events for the ToolSearch storm, 25+ for `task_get_context` errors, 5+ for `plan_get`.

**Engine — widen MCP lookups via the canonical helper.**

- `core/mcp/tools/task-get-context/script.ps1` and `core/mcp/tools/plan-get/script.ps1` now import `core/mcp/modules/TaskStore.psm1` and delegate to `Find-TaskFileById`. The local status-directory list is gone, so `$ValidStatuses` drift is no longer possible. `task-get-context` searches `analysing, needs-input, analysed, in-progress`; `plan-get` searches every valid status (was missing four of nine).
- `task-get-context` now passes `analysis.briefing_excerpts` through to its response and prefers an analyser-embedded `analysis.decisions` payload over the resolved-from-IDs path. The 98/99 prompt contract (analyser embeds, executor trusts) now actually flows through the engine.

**Prompts — collapse Phase 0; force trust between analyser and executor.**

- `core/prompts/98-analyse-task.md`: nine `ToolSearch({query: "select:tool"})` lines become one bulk `select:tool1,tool2,...` query. The "do **NOT** broaden / retry **exact same** `select:`" wording is preserved, so `Test-WorkflowManifest.ps1` Fix#3 still asserts. 98 also tells the analyser not to call `task_get_context` (task fields are already substituted into the prompt) and to embed verbatim briefing excerpts plus inline pattern snippets in the `task_mark_analysed` payload under a `briefing_excerpts` field.
- `core/prompts/99-autonomous-task.md`: seven `ToolSearch` lines become one. The executor is told to trust the analysis package as authoritative and only re-read source files when (a) writing to a `to_modify` entry, (b) a section is explicitly marked `TODO`, or (c) a referenced symbol was not extracted.

**Tests.**

- `Test-TaskActions.ps1` adds a source-direct scenario that creates an analysing-state task and an analysed-state task, dot-sources both tool scripts, and asserts both tools resolve both states without throwing. Includes pass-through assertions for `briefing_excerpts` and embedded-decisions preference.

## Screenshots / recordings

N/A — engine and prompt changes, no UI surface.

## Testing notes

Local source-direct tests pass:

```
pwsh tests/Test-WorkflowManifest.ps1   # 358 passed / 358 total
pwsh tests/Test-TaskActions.ps1        # 133 passed / 133 total (13 new)
```

To reproduce the original failure mode against SlashOps without this PR:
1. Run start-from-prompt against any project with `dotbot init` set up.
2. Tail `.bot/.control/activity.jsonl` and look for runs of nine consecutive ToolSearch events at the top of every analyse phase, plus `MCP error -32603: Tool execution failed: Task with ID '...' not found in analysed or in-progress status` after every `task_mark_analysing`.

After this PR:
1. Phase 0 produces a single ToolSearch event per phase.
2. `task_get_context` returns `has_analysis: false` with `status: "analysing"` for tasks that have not been marked analysed yet.
3. `plan_get` returns `has_plan: false` for tasks without a plan, regardless of lifecycle state.
4. When the analyser embeds `briefing_excerpts` or richer `decisions[]` in the analysed payload, the executor receives them verbatim — no more silent drop.

## Checklist

- [x] Tests added or updated
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)