### PR TITLE
fix: validate group fan-out at 03a; bind GROUP_APPLICABLE_DECISIONS

### DIFF
--- a/core/runtime/expand-task-groups.ps1
+++ b/core/runtime/expand-task-groups.ps1
@@ -186,8 +186,17 @@ foreach ($group in $sortedGroups) {
     # Build applicable-decisions list. 03a is supposed to populate
     # $group.applicable_decisions with dec-XXXXXXXX IDs. The 03b prompt reads
     # each ID via decision_get; an empty list signals the fallback path.
-    $applicableDecisions = if ($group.applicable_decisions -and @($group.applicable_decisions).Count -gt 0) {
-        @($group.applicable_decisions) -join ', '
+    $validApplicableDecisions = if ($group.applicable_decisions) {
+        @($group.applicable_decisions) |
+            ForEach-Object {
+                if ($_ -is [string]) { $_.Trim() }
+            } |
+            Where-Object { $_ -and $_ -match '^dec-[a-f0-9]{8}$' }
+    } else {
+        @()
+    }
+    $applicableDecisions = if (@($validApplicableDecisions).Count -gt 0) {
+        @($validApplicableDecisions) -join ', '
     } else {
         "(none)"
     }

--- a/core/runtime/expand-task-groups.ps1
+++ b/core/runtime/expand-task-groups.ps1
@@ -183,6 +183,15 @@ foreach ($group in $sortedGroups) {
     $priorityMin = if ($group.priority_range -and $group.priority_range.Count -ge 2) { $group.priority_range[0] } else { 1 }
     $priorityMax = if ($group.priority_range -and $group.priority_range.Count -ge 2) { $group.priority_range[1] } else { 100 }
 
+    # Build applicable-decisions list. 03a is supposed to populate
+    # $group.applicable_decisions with dec-XXXXXXXX IDs. The 03b prompt reads
+    # each ID via decision_get; an empty list signals the fallback path.
+    $applicableDecisions = if ($group.applicable_decisions -and @($group.applicable_decisions).Count -gt 0) {
+        @($group.applicable_decisions) -join ', '
+    } else {
+        "(none)"
+    }
+
     # Substitute template variables
     $prompt = $template
     $prompt = $prompt -replace '\{\{GROUP_ID\}\}', $group.id
@@ -194,6 +203,7 @@ foreach ($group in $sortedGroups) {
     $prompt = $prompt -replace '\{\{PRIORITY_MAX\}\}', $priorityMax
     $prompt = $prompt -replace '\{\{CATEGORY_HINT\}\}', $group.category_hint
     $prompt = $prompt -replace '\{\{DEPENDENCY_TASKS\}\}', $depTasksJson
+    $prompt = $prompt -replace '\{\{GROUP_APPLICABLE_DECISIONS\}\}', $applicableDecisions
 
     # Snapshot todo directory before expansion
     $beforeFiles = @()

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1349,10 +1349,12 @@ Assert-True -Name "Fix#E: 03a category_hint row forbids inventing new categories
 Assert-True -Name "Fix#E: 03a category_hint row cites task_create_bulk validator" `
     -Condition ($planTaskGroupsSrc -match '(?s)`category_hint`.*?`task_create_bulk`\s+validator')
 
-# ── Batch 3, Fix F: 03b-expand-task-group.md must constrain expansion so the
-# per-group task count is capped, only valid categories are allowed,
-# dependency names are exact, and an empty {{GROUP_APPLICABLE_DECISIONS}}
-# triggers a decision_list fallback rather than silent zero-ADR expansion.
+# ── Batch 3, Fix F: 03b-expand-task-group.md must enforce the per-task
+# quality bar, leave group sizing to 03a (Fix#H owns the fan-out cap),
+# allow only the closed category enum, align dependency naming with what
+# the task_create_bulk validator actually accepts, and treat an empty
+# {{GROUP_APPLICABLE_DECISIONS}} via a decision_list fallback rather than
+# silent zero-ADR expansion.
 Assert-True -Name "Fix#F: 03b leads with per-task quality bar (logical, context-friendly, executable, testable)" `
     -Condition ($expandTaskGroupSrc -match 'logical,\s+context-friendly,\s+executable,\s+testable\s+unit')
 Assert-True -Name "Fix#F: 03b states group sizing is 03a's responsibility" `

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1354,7 +1354,7 @@ Assert-True -Name "Fix#E: 03a category_hint row cites task_create_bulk validator
 # dependency names are exact, and an empty {{GROUP_APPLICABLE_DECISIONS}}
 # triggers a decision_list fallback rather than silent zero-ADR expansion.
 Assert-True -Name "Fix#F: 03b caps total tasks per group at 10" `
-    -Condition ($expandTaskGroupSrc -match 'Cap\s+the\s+total\s+tasks\s+per\s+group\s+at\s+10')
+    -Condition ($expandTaskGroupSrc -match 'total\s+tasks\s+per\s+group:?\s+10')
 Assert-True -Name "Fix#F: 03b states the 5-10 sweet spot for tasks per group" `
     -Condition ($expandTaskGroupSrc -match '(?s)5-10\s+tasks\s+per\s+group')
 Assert-True -Name "Fix#F: 03b lists all six valid category enum values" `
@@ -1368,12 +1368,19 @@ Assert-True -Name "Fix#F: 03b forbids inventing categories like testing or front
     -Condition ($expandTaskGroupSrc -match 'Do\s+\*\*NOT\*\*\s+invent\s+categories.*?`testing`')
 Assert-True -Name "Fix#F: 03b cites task_create_bulk validator for category enum" `
     -Condition ($expandTaskGroupSrc -match '(?s)closed\s+enum.*?task_create_bulk.*?validator')
-Assert-True -Name "Fix#F: 03b requires verbatim dependency names" `
-    -Condition ($expandTaskGroupSrc -match 'verbatim,\s+unmodified.*?`name`\s+value')
-Assert-True -Name "Fix#F: 03b warns dependency validator does exact string matching" `
-    -Condition ($expandTaskGroupSrc -match 'validator\s+does\s+exact\s+string\s+matching')
-Assert-True -Name "Fix#F: 03b has fallback when GROUP_APPLICABLE_DECISIONS is empty" `
-    -Condition ($expandTaskGroupSrc -match '(?s)`\{\{GROUP_APPLICABLE_DECISIONS\}\}`\s+is\s+`\(none\)`\s+or\s+empty.*?decision_list')
+Assert-True -Name "Fix#F: 03b documents the four resolution strategies the validator accepts" `
+    -Condition (($expandTaskGroupSrc -match 'exact\s+`id`\s+match') -and `
+                ($expandTaskGroupSrc -match 'exact\s+`name`\s+match') -and `
+                ($expandTaskGroupSrc -match 'slug\s+match') -and `
+                ($expandTaskGroupSrc -match 'fuzzy\s+slug\s+substring\s+match'))
+Assert-True -Name "Fix#F: 03b recommends id for cross-group dependencies" `
+    -Condition ($expandTaskGroupSrc -match '(?s)Cross-group\s+dependencies.*?task\s+\*\*`id`\*\*')
+Assert-True -Name "Fix#F: 03b recommends exact name for intra-batch dependencies" `
+    -Condition ($expandTaskGroupSrc -match '(?s)Intra-batch\s+dependencies.*?exact\s+`name`')
+Assert-True -Name "Fix#F: 03b marks slug/fuzzy as fallback, not contract" `
+    -Condition ($expandTaskGroupSrc -match 'fallbacks?,\s+not\s+a\s+contract')
+Assert-True -Name "Fix#F: 03b has decision_list fallback when GROUP_APPLICABLE_DECISIONS has no dec- IDs" `
+    -Condition ($expandTaskGroupSrc -match '(?s)contains\s+no\s+`dec-`\s+IDs.*?decision_list')
 
 # ── Batch 3, Fix G: expand-task-groups.ps1 must substitute
 # {{GROUP_APPLICABLE_DECISIONS}} from each group's applicable_decisions field

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1414,6 +1414,10 @@ Assert-True -Name "Fix#H: 03a anti-patterns forbid kitchen-sink groups" `
     -Condition ($planTaskGroupsSrc -match '[Kk]itchen-sink\s+groups')
 Assert-True -Name "Fix#H: 03a Step 2.5 surfaces the fan-out heuristic table" `
     -Condition ($planTaskGroupsSrc -match '(?s)Step\s+2\.5.*?Scope\s+shape.*?per-task\s+expansion')
+Assert-True -Name "Fix#H: 03a example task-groups.json includes applicable_decisions" `
+    -Condition ($planTaskGroupsSrc -match '"applicable_decisions":\s*\[')
+Assert-True -Name "Fix#H: 03a Field Reference declares applicable_decisions as a required field" `
+    -Condition ($planTaskGroupsSrc -match '\|\s+`applicable_decisions`\s+\|\s+Yes\s+\|')
 
 Write-Host ""
 

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1389,7 +1389,7 @@ Assert-True -Name "Fix#F: 03b has decision_list fallback when GROUP_APPLICABLE_D
 # ── Batch 3, Fix G: expand-task-groups.ps1 must substitute
 # {{GROUP_APPLICABLE_DECISIONS}} from each group's applicable_decisions field
 # so the prompt actually receives the ADR ID list 03a recorded.
-$expandScriptPath = Join-Path $repoRoot "core\runtime\expand-task-groups.ps1"
+$expandScriptPath = Join-Path $repoRoot "core" "runtime" "expand-task-groups.ps1"
 Assert-PathExists -Name "Fix#G: expand-task-groups.ps1 exists" -Path $expandScriptPath
 $expandScriptSrc = Get-Content $expandScriptPath -Raw
 Assert-True -Name "Fix#G: expand-task-groups.ps1 substitutes GROUP_APPLICABLE_DECISIONS" `

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1349,6 +1349,45 @@ Assert-True -Name "Fix#E: 03a category_hint row forbids inventing new categories
 Assert-True -Name "Fix#E: 03a category_hint row cites task_create_bulk validator" `
     -Condition ($planTaskGroupsSrc -match '(?s)`category_hint`.*?`task_create_bulk`\s+validator')
 
+# ── Batch 3, Fix F: 03b-expand-task-group.md must constrain expansion so the
+# per-group task count is capped, only valid categories are allowed,
+# dependency names are exact, and an empty {{GROUP_APPLICABLE_DECISIONS}}
+# triggers a decision_list fallback rather than silent zero-ADR expansion.
+Assert-True -Name "Fix#F: 03b caps total tasks per group at 10" `
+    -Condition ($expandTaskGroupSrc -match 'Cap\s+the\s+total\s+tasks\s+per\s+group\s+at\s+10')
+Assert-True -Name "Fix#F: 03b states the 5-10 sweet spot for tasks per group" `
+    -Condition ($expandTaskGroupSrc -match '(?s)5-10\s+tasks\s+per\s+group')
+Assert-True -Name "Fix#F: 03b lists all six valid category enum values" `
+    -Condition (($expandTaskGroupSrc -match '`infrastructure`') -and `
+                ($expandTaskGroupSrc -match '`core`') -and `
+                ($expandTaskGroupSrc -match '`feature`') -and `
+                ($expandTaskGroupSrc -match '`enhancement`') -and `
+                ($expandTaskGroupSrc -match '`ui-ux`') -and `
+                ($expandTaskGroupSrc -match '`bugfix`'))
+Assert-True -Name "Fix#F: 03b forbids inventing categories like testing or frontend" `
+    -Condition ($expandTaskGroupSrc -match 'Do\s+\*\*NOT\*\*\s+invent\s+categories.*?`testing`')
+Assert-True -Name "Fix#F: 03b cites task_create_bulk validator for category enum" `
+    -Condition ($expandTaskGroupSrc -match '(?s)closed\s+enum.*?task_create_bulk.*?validator')
+Assert-True -Name "Fix#F: 03b requires verbatim dependency names" `
+    -Condition ($expandTaskGroupSrc -match 'verbatim,\s+unmodified.*?`name`\s+value')
+Assert-True -Name "Fix#F: 03b warns dependency validator does exact string matching" `
+    -Condition ($expandTaskGroupSrc -match 'validator\s+does\s+exact\s+string\s+matching')
+Assert-True -Name "Fix#F: 03b has fallback when GROUP_APPLICABLE_DECISIONS is empty" `
+    -Condition ($expandTaskGroupSrc -match '(?s)`\{\{GROUP_APPLICABLE_DECISIONS\}\}`\s+is\s+`\(none\)`\s+or\s+empty.*?decision_list')
+
+# ── Batch 3, Fix G: expand-task-groups.ps1 must substitute
+# {{GROUP_APPLICABLE_DECISIONS}} from each group's applicable_decisions field
+# so the prompt actually receives the ADR ID list 03a recorded.
+$expandScriptPath = Join-Path $repoRoot "core\runtime\expand-task-groups.ps1"
+Assert-PathExists -Name "Fix#G: expand-task-groups.ps1 exists" -Path $expandScriptPath
+$expandScriptSrc = Get-Content $expandScriptPath -Raw
+Assert-True -Name "Fix#G: expand-task-groups.ps1 substitutes GROUP_APPLICABLE_DECISIONS" `
+    -Condition ($expandScriptSrc -match "-replace\s+'[^']*GROUP_APPLICABLE_DECISIONS")
+Assert-True -Name "Fix#G: expand-task-groups.ps1 reads group.applicable_decisions" `
+    -Condition ($expandScriptSrc -match '\$group\.applicable_decisions')
+Assert-True -Name "Fix#G: expand-task-groups.ps1 emits '(none)' when applicable_decisions is empty" `
+    -Condition ($expandScriptSrc -match '"\(none\)"')
+
 Write-Host ""
 
 # ═══════════════════════════════════════════════════════════════════

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1353,10 +1353,16 @@ Assert-True -Name "Fix#E: 03a category_hint row cites task_create_bulk validator
 # per-group task count is capped, only valid categories are allowed,
 # dependency names are exact, and an empty {{GROUP_APPLICABLE_DECISIONS}}
 # triggers a decision_list fallback rather than silent zero-ADR expansion.
-Assert-True -Name "Fix#F: 03b caps total tasks per group at 10" `
-    -Condition ($expandTaskGroupSrc -match 'total\s+tasks\s+per\s+group:?\s+10')
-Assert-True -Name "Fix#F: 03b states the 5-10 sweet spot for tasks per group" `
-    -Condition ($expandTaskGroupSrc -match '(?s)5-10\s+tasks\s+per\s+group')
+Assert-True -Name "Fix#F: 03b leads with per-task quality bar (logical, context-friendly, executable, testable)" `
+    -Condition ($expandTaskGroupSrc -match 'logical,\s+context-friendly,\s+executable,\s+testable\s+unit')
+Assert-True -Name "Fix#F: 03b states group sizing is owned by 03a, not 03b" `
+    -Condition ($expandTaskGroupSrc -match 'Group\s+sizing\s+is\s+owned\s+by\s+03a')
+Assert-True -Name "Fix#F: 03b emits group_size_warning: too-broad at 12+ tasks" `
+    -Condition ($expandTaskGroupSrc -match '(?s)12\s+or\s+more\s+tasks.*?group_size_warning:\s*too-broad')
+Assert-True -Name "Fix#F: 03b emits group_size_warning: too-narrow at 1-2 tasks" `
+    -Condition ($expandTaskGroupSrc -match '(?s)\*\*1-2\s+tasks\*\*.*?group_size_warning:\s*too-narrow')
+Assert-True -Name "Fix#F: 03b output includes group_size_warning instruction" `
+    -Condition ($expandTaskGroupSrc -match '(?s)##\s+Output.*?group_size_warning')
 Assert-True -Name "Fix#F: 03b lists all six valid category enum values" `
     -Condition (($expandTaskGroupSrc -match '`infrastructure`') -and `
                 ($expandTaskGroupSrc -match '`core`') -and `

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1355,14 +1355,10 @@ Assert-True -Name "Fix#E: 03a category_hint row cites task_create_bulk validator
 # triggers a decision_list fallback rather than silent zero-ADR expansion.
 Assert-True -Name "Fix#F: 03b leads with per-task quality bar (logical, context-friendly, executable, testable)" `
     -Condition ($expandTaskGroupSrc -match 'logical,\s+context-friendly,\s+executable,\s+testable\s+unit')
-Assert-True -Name "Fix#F: 03b states group sizing is owned by 03a, not 03b" `
-    -Condition ($expandTaskGroupSrc -match 'Group\s+sizing\s+is\s+owned\s+by\s+03a')
-Assert-True -Name "Fix#F: 03b emits group_size_warning: too-broad at 12+ tasks" `
-    -Condition ($expandTaskGroupSrc -match '(?s)12\s+or\s+more\s+tasks.*?group_size_warning:\s*too-broad')
-Assert-True -Name "Fix#F: 03b emits group_size_warning: too-narrow at 1-2 tasks" `
-    -Condition ($expandTaskGroupSrc -match '(?s)\*\*1-2\s+tasks\*\*.*?group_size_warning:\s*too-narrow')
-Assert-True -Name "Fix#F: 03b output includes group_size_warning instruction" `
-    -Condition ($expandTaskGroupSrc -match '(?s)##\s+Output.*?group_size_warning')
+Assert-True -Name "Fix#F: 03b states group sizing is 03a's responsibility" `
+    -Condition ($expandTaskGroupSrc -match "Group\s+sizing\s+is\s+03a's\s+responsibility")
+Assert-True -Name "Fix#F: 03b does not police group size or emit group_size_warning" `
+    -Condition (-not ($expandTaskGroupSrc -match 'group_size_warning'))
 Assert-True -Name "Fix#F: 03b lists all six valid category enum values" `
     -Condition (($expandTaskGroupSrc -match '`infrastructure`') -and `
                 ($expandTaskGroupSrc -match '`core`') -and `
@@ -1400,6 +1396,22 @@ Assert-True -Name "Fix#G: expand-task-groups.ps1 reads group.applicable_decision
     -Condition ($expandScriptSrc -match '\$group\.applicable_decisions')
 Assert-True -Name "Fix#G: expand-task-groups.ps1 emits '(none)' when applicable_decisions is empty" `
     -Condition ($expandScriptSrc -match '"\(none\)"')
+
+# ── Batch 3, Fix H: 03a-plan-task-groups.md owns group sizing — must validate
+# expansion fan-out and split groups whose scope would expand to 12+ tasks
+# at 03b's per-task quality bar, before writing task-groups.json.
+Assert-True -Name "Fix#H: 03a has Step 2.5 Validate Expansion Fan-Out" `
+    -Condition ($planTaskGroupsSrc -match '###\s+Step\s+2\.5:\s+Validate\s+Expansion\s+Fan-Out')
+Assert-True -Name "Fix#H: 03a tells the planner group sizing is its responsibility" `
+    -Condition ($planTaskGroupsSrc -match 'Group\s+sizing\s+is\s+your\s+responsibility,\s+not\s+03b')
+Assert-True -Name "Fix#H: 03a forces a split when a group would expand to 12+ tasks" `
+    -Condition ($planTaskGroupsSrc -match '(?s)12\s+or\s+more\s+well-sized\s+tasks.*?split\s+it\s+now')
+Assert-True -Name "Fix#H: 03a tightens estimated_task_count guidance to 3-10 healthy range" `
+    -Condition ($planTaskGroupsSrc -match '(?s)`estimated_task_count`.*?(?:3-10|range\s+is\s+\*\*3-10\*\*)')
+Assert-True -Name "Fix#H: 03a anti-patterns forbid kitchen-sink groups" `
+    -Condition ($planTaskGroupsSrc -match '[Kk]itchen-sink\s+groups')
+Assert-True -Name "Fix#H: 03a Step 2.5 surfaces the fan-out heuristic table" `
+    -Condition ($planTaskGroupsSrc -match '(?s)Step\s+2\.5.*?Scope\s+shape.*?per-task\s+expansion')
 
 Write-Host ""
 

--- a/workflows/start-from-prompt/recipes/prompts/03a-plan-task-groups.md
+++ b/workflows/start-from-prompt/recipes/prompts/03a-plan-task-groups.md
@@ -64,8 +64,29 @@ Not all projects need all of these. Adapt to the actual project scope. Merge sma
 - Anything that doesn't contribute to a shippable product
 - **Effort-based buckets** (e.g. "Quick Wins", "Tech Debt", "Stretch Goals") — group by *functional area*, not by size or priority.
 - **Groups whose scope cannot yield per-task acceptance criteria** — if you can't state what "done" looks like for each scope item, the group is too vague to expand.
+- **Kitchen-sink groups** that bundle multiple unrelated functional concerns under one name (e.g. "Terminal UI, Preflight, Initialize, and Distribution"). Each `name` should describe one coherent concern; if you find yourself joining domains with "and", split.
 
 Each group's acceptance criteria should describe a **deployable increment** — something you could demo or ship independently.
+
+### Step 2.5: Validate Expansion Fan-Out
+
+Group sizing is your responsibility, not 03b's. 03b expands each group at the per-task quality bar (one logical, context-friendly, executable, testable unit per task) and produces as many tasks as that bar demands. If a group's scope would naturally yield 12 or more well-sized tasks at expansion time, the group is too broad — **split it now**, before writing `task-groups.json`.
+
+For each draft group, mentally walk its `scope` items and ask: *"How many distinct logical units of work does this scope require, given the per-task quality bar?"* Use the typical-task heuristic below.
+
+| Scope shape | Likely per-task expansion |
+|-------------|--------------------------|
+| One small entity (CRUD + tests) | 2-4 tasks |
+| One feature with handlers, validation, persistence, tests | 4-7 tasks |
+| One subsystem touching 2-3 layers | 6-10 tasks |
+| Multiple subsystems bundled | 12+ tasks → **split** |
+
+Healthy groups land in the **3-10 task** range. Set `estimated_task_count` to your honest estimate per group. If your estimate is 12+, you have one of two problems:
+
+- The group bundles unrelated concerns — split into two or more functionally focused groups.
+- A single scope item is itself a subsystem — promote it to its own group.
+
+Splitting at this stage is cheap (you are still writing JSON); splitting after 03b has produced 20 questionable tasks is expensive. **Do the work here.**
 
 ### Step 3: Define Group Dependencies
 
@@ -155,7 +176,7 @@ The file format:
 | `effort_days` | Yes | Estimated developer-days to complete this group (1-20) |
 | `scope` | Yes | Array of specific items to implement (these become task seeds) |
 | `acceptance_criteria` | Yes | Group-level success conditions |
-| `estimated_task_count` | Yes | Expected number of tasks (2-8 per group) |
+| `estimated_task_count` | Yes | Realistic estimate of how many tasks 03b will produce when expanding this group at the per-task quality bar (one logical / context-friendly / executable / testable unit each). Healthy range is **3-10**. If your estimate is 12+, the group is too broad — split it (Step 2.5) before writing this file. |
 | `depends_on` | Yes | Array of group IDs this depends on (empty for root groups) |
 | `priority_range` | Yes | `[min, max]` — priority range for tasks in this group |
 | `category_hint` | Yes | Default category for tasks in this group. Must be one of the six valid `category` enum values (see [Task Schema Reference](#task-schema-reference-inherited-by-phase-2b) below): `infrastructure`, `core`, `feature`, `enhancement`, `ui-ux`, or `bugfix`. Use `ui-ux` for all user-facing / frontend work. **Do NOT invent new categories** like `frontend`, `backend`, or `api` — the MCP `task_create_bulk` validator will reject them. |

--- a/workflows/start-from-prompt/recipes/prompts/03a-plan-task-groups.md
+++ b/workflows/start-from-prompt/recipes/prompts/03a-plan-task-groups.md
@@ -159,7 +159,8 @@ The file format:
       "estimated_task_count": 4,
       "depends_on": [],
       "priority_range": [1, 10],
-      "category_hint": "infrastructure"
+      "category_hint": "infrastructure",
+      "applicable_decisions": ["dec-abc12345", "dec-def67890"]
     }
   ]
 }
@@ -180,6 +181,7 @@ The file format:
 | `depends_on` | Yes | Array of group IDs this depends on (empty for root groups) |
 | `priority_range` | Yes | `[min, max]` — priority range for tasks in this group |
 | `category_hint` | Yes | Default category for tasks in this group. Must be one of the six valid `category` enum values (see [Task Schema Reference](#task-schema-reference-inherited-by-phase-2b) below): `infrastructure`, `core`, `feature`, `enhancement`, `ui-ux`, or `bugfix`. Use `ui-ux` for all user-facing / frontend work. **Do NOT invent new categories** like `frontend`, `backend`, or `api` — the MCP `task_create_bulk` validator will reject them. |
+| `applicable_decisions` | Yes | Array of accepted-decision IDs (`dec-XXXXXXXX`) that materially constrain this group's implementation. The 03b expansion runtime substitutes this list into `{{GROUP_APPLICABLE_DECISIONS}}` and the prompt reads each via `decision_get`. Use `[]` only when no accepted decisions touch this group's domain — an empty list forces 03b's `decision_list` fallback. Pull candidates from the `decision_list` call you made in Step 1 and include any whose `consequences` reference this group's name, scope items, or category. |
 
 ---
 

--- a/workflows/start-from-prompt/recipes/prompts/03b-expand-task-group.md
+++ b/workflows/start-from-prompt/recipes/prompts/03b-expand-task-group.md
@@ -14,11 +14,10 @@ You are a task planning assistant. Your job is to create detailed, implementable
 
 **Built-in tools** (`WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`) are always available — never use ToolSearch for them.
 
-**Load dotbot tools** (all in parallel, a single batch):
+**Load dotbot tools** (single bulk call — `select:` accepts a comma-separated list):
 
 ```
-ToolSearch({ query: "select:mcp__dotbot__decision_get" })
-ToolSearch({ query: "select:mcp__dotbot__task_create_bulk" })
+ToolSearch({ query: "select:mcp__dotbot__decision_get,mcp__dotbot__decision_list,mcp__dotbot__task_create_bulk" })
 ```
 
 Issue all ToolSearch calls above in a **single parallel batch** during Phase 0. Do **NOT** broaden the queries or try alternative search terms. If a `select:` query returns no schema on the first attempt, the dotbot MCP server is still warming up — while **still in Phase 0**, wait briefly and retry the **exact same** `select:` call. Once Phase 0 is complete, do not call ToolSearch again. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".

--- a/workflows/start-from-prompt/recipes/prompts/03b-expand-task-group.md
+++ b/workflows/start-from-prompt/recipes/prompts/03b-expand-task-group.md
@@ -20,7 +20,7 @@ You are a task planning assistant. Your job is to create detailed, implementable
 ToolSearch({ query: "select:mcp__dotbot__decision_get,mcp__dotbot__decision_list,mcp__dotbot__task_create_bulk" })
 ```
 
-Issue all ToolSearch calls above in a **single parallel batch** during Phase 0. Do **NOT** broaden the queries or try alternative search terms. If a `select:` query returns no schema on the first attempt, the dotbot MCP server is still warming up — while **still in Phase 0**, wait briefly and retry the **exact same** `select:` call. Once Phase 0 is complete, do not call ToolSearch again. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
+Issue this ToolSearch call once during Phase 0. Do **NOT** broaden the query, split it across multiple calls, or try alternative search terms. If the bulk `select:` query returns no schemas on the first attempt, the dotbot MCP server is still warming up — while **still in Phase 0**, wait briefly and retry the **exact same** `select:` call. Once Phase 0 is complete, do not call ToolSearch again. If you see any `mcp__dotbot__*` tool listed as deferred in your initial tool list, that is expected — ToolSearch loads the schema on demand. Do NOT refuse on the grounds that these tools are "missing".
 
 ---
 
@@ -76,7 +76,7 @@ The decision `decision` and `consequences` sections define hard constraints — 
 **Each task must be a logical, context-friendly, executable, testable unit.** That quality bar — not a numeric ceiling — determines how many tasks a group produces. Every task you create must be:
 
 - **A single logical unit of work** with one coherent intent (one feature, one entity, one configuration concern). Not a bundle of loosely related changes.
-- **Completable in 1-4 hours** of focused work — effort `S`, `M`, or at most `L`. If a candidate task would be `XL`, split it; if it would be smaller than `XS`, fold it into a related task.
+- **Completable in 1-8 hours** of focused work — effort `S`, `M`, or at most `L` (matching the sizing table below). If a candidate task would be `XL` (1-2 days), split it; if it would be smaller than `XS` (under 1 hour), fold it into a related task.
 - **Context-friendly** — small enough to fit comfortably in a single LLM context window at execution time, including the files it touches and the patterns it follows.
 - **Independently testable** — the executor can write or run a test that verifies this task is done, without waiting on a sibling task in the same batch.
 

--- a/workflows/start-from-prompt/recipes/prompts/03b-expand-task-group.md
+++ b/workflows/start-from-prompt/recipes/prompts/03b-expand-task-group.md
@@ -74,15 +74,20 @@ The decision `decision` and `consequences` sections define hard constraints — 
 
 ### Step 2: Break Down Scope Items into Tasks
 
-**Hard cap — total tasks per group: 10.** Aim for 5-10 tasks per group; never exceed 10. This ceiling is the binding constraint and overrides any per-scope-item guidance below.
+**Each task must be a logical, context-friendly, executable, testable unit.** That quality bar — not a numeric ceiling — determines how many tasks a group produces. Every task you create must be:
 
-For each scope item, **typically** generate 1-3 tasks — but treat that as an advisory typical, not a per-item entitlement. If the group has 6+ scope items, do not blindly multiply; merge closely related items into a single larger (M or L) task so the per-group total stays at or below 10. A group of 8 M-effort tasks is healthier than a group of 18 XS-effort tasks. If even with merging the group genuinely cannot fit in 10 tasks, the group itself is mis-scoped — emit at most 10 tasks and note the overflow in the final summary so 03a's grouping can be revisited.
+- **A single logical unit of work** with one coherent intent (one feature, one entity, one configuration concern). Not a bundle of loosely related changes.
+- **Completable in 1-4 hours** of focused work — effort `S`, `M`, or at most `L`. If a candidate task would be `XL`, split it; if it would be smaller than `XS`, fold it into a related task.
+- **Context-friendly** — small enough to fit comfortably in a single LLM context window at execution time, including the files it touches and the patterns it follows.
+- **Independently testable** — the executor can write or run a test that verifies this task is done, without waiting on a sibling task in the same batch.
 
-Each task should be:
+For each scope item, generate as many tasks as the bar above demands — typically 1-3, sometimes more when a single scope item maps to several distinct logical units. Do not pad. Do not merge unrelated work just to keep the count down.
 
-- **Completable in 1-4 hours** of focused work
-- **Independently testable** where possible
-- **Small enough** to fit in a single LLM context window
+**Group-size feedback signal.** Group sizing is owned by 03a, not by this prompt. Your job is to produce well-sized tasks, not to police the count. But the count is a useful signal back to 03a:
+
+- If you naturally produce **12 or more tasks** for this group, the group is likely too broad. Emit all the well-sized tasks the scope genuinely needs, and **include `group_size_warning: too-broad` in your final summary** so 03a's grouping can be revisited on the next plan-review cycle. Do **not** artificially shrink the count by merging tasks that should stay separate.
+- If you struggle to produce more than **1-2 tasks** for a group, the group may be too narrow. Include `group_size_warning: too-narrow` in your final summary so 03a can consider merging it with a sibling.
+- If the count falls in the typical 3-11 band, no warning is needed.
 
 **Task sizing guide:**
 
@@ -191,3 +196,4 @@ After creating all tasks, report:
 - Number of tasks created
 - Task names and their priorities
 - Any cross-group dependencies added (with justification)
+- `group_size_warning: too-broad` (if you produced 12+ tasks) or `group_size_warning: too-narrow` (if you produced 1-2). Omit the field when the count is in the typical 3-11 band.

--- a/workflows/start-from-prompt/recipes/prompts/03b-expand-task-group.md
+++ b/workflows/start-from-prompt/recipes/prompts/03b-expand-task-group.md
@@ -60,25 +60,29 @@ Read these files for project context:
 - `.bot/workspace/product/entity-model.md` — Data model and relationships
 - Any other `.md` files in `.bot/workspace/product/` for additional context
 
-If `{{GROUP_APPLICABLE_DECISIONS}}` is non-empty, read each decision by ID:
-```javascript
-// For each decision ID listed in GROUP_APPLICABLE_DECISIONS:
-mcp__dotbot__decision_get({ decision_id: "dec-XXXXXXXX" })
-```
+**Decision loading — single decision tree:**
 
-If `{{GROUP_APPLICABLE_DECISIONS}}` is `(none)` or empty, do not assume zero decisions apply. Call `mcp__dotbot__decision_list({ status: "accepted" })` and pull any decisions whose `tags`, `decision`, or `consequences` reference this group's name, scope items, or category. Use those as the constraint set for this group's tasks. Silently producing tasks that ignore an existing ADR is the failure mode this fallback prevents.
+- **If `{{GROUP_APPLICABLE_DECISIONS}}` contains one or more `dec-XXXXXXXX` IDs** (the runtime substitutes a comma-separated list like `dec-abc12345, dec-def67890`), read each one:
+  ```javascript
+  // For each `dec-XXXXXXXX` ID present in GROUP_APPLICABLE_DECISIONS:
+  mcp__dotbot__decision_get({ decision_id: "dec-XXXXXXXX" })
+  ```
+
+- **If `{{GROUP_APPLICABLE_DECISIONS}}` is the literal string `(none)`, empty, or contains no `dec-` IDs**, do not assume zero decisions apply. Call `mcp__dotbot__decision_list({ status: "accepted" })` and pull any decisions whose `tags`, `decision`, or `consequences` reference this group's name, scope items, or category. Silently producing tasks that ignore an existing ADR is the failure mode this fallback prevents.
 
 The decision `decision` and `consequences` sections define hard constraints — do not create tasks that would violate them.
 
 ### Step 2: Break Down Scope Items into Tasks
 
-For each scope item listed above, create 1-3 detailed tasks. Each task should be:
+**Hard cap — total tasks per group: 10.** Aim for 5-10 tasks per group; never exceed 10. This ceiling is the binding constraint and overrides any per-scope-item guidance below.
+
+For each scope item, **typically** generate 1-3 tasks — but treat that as an advisory typical, not a per-item entitlement. If the group has 6+ scope items, do not blindly multiply; merge closely related items into a single larger (M or L) task so the per-group total stays at or below 10. A group of 8 M-effort tasks is healthier than a group of 18 XS-effort tasks. If even with merging the group genuinely cannot fit in 10 tasks, the group itself is mis-scoped — emit at most 10 tasks and note the overflow in the final summary so 03a's grouping can be revisited.
+
+Each task should be:
 
 - **Completable in 1-4 hours** of focused work
 - **Independently testable** where possible
 - **Small enough** to fit in a single LLM context window
-
-**Cap the total tasks per group at 10.** Aim for 5-10 tasks per group; never exceed 10. If a group's scope appears to need more than 10 tasks, you are slicing too thinly — merge closely related sub-items into single larger (M or L) tasks rather than cutting smaller ones. A group of 8 M-effort tasks is healthier than a group of 18 XS-effort tasks. If even with merging the group genuinely cannot fit in 10 tasks, that is a signal the group itself is mis-scoped — emit at most 10 tasks and note the overflow in the final summary so 03a's grouping can be revisited.
 
 **Task sizing guide:**
 
@@ -104,7 +108,14 @@ Set `dependencies` on every task that cannot start without another task completi
 
 **Valid `category` values (closed enum — `task_create_bulk` validator rejects anything else):** `infrastructure`, `core`, `feature`, `enhancement`, `ui-ux`, `bugfix`. Use the `{{CATEGORY_HINT}}` value as the default and override per-task only when a different value from this list fits better. Do **NOT** invent categories such as `testing`, `test`, `frontend`, `backend`, `api`, `ops`, or `platform` — they will all fail validation and force a retry.
 
-**Dependency naming (exact string match required):** every entry in a task's `dependencies` array must be the **verbatim, unmodified** `name` value of either (a) a task earlier in the same `task_create_bulk` call, or (b) a task in `{{DEPENDENCY_TASKS}}` from a prerequisite group. Do not paraphrase, abbreviate, change punctuation, or pluralise. The validator does exact string matching and will reject the whole bulk with a "dependency name not found" error if any entry does not match.
+**Dependency naming — what the validator actually accepts.** The `task_create_bulk` validator resolves each entry in a task's `dependencies` array against existing tasks (in the index plus earlier tasks in this same bulk call) using, in order: (a) exact `id` match, (b) exact `name` match, (c) slug match (lowercase, non-word characters stripped, whitespace collapsed to hyphens), and (d) fuzzy slug substring match. Any one of these is enough; you do not need pixel-perfect strings.
+
+Best practice for the two cases this prompt produces:
+
+- **Cross-group dependencies** — when referencing tasks from `{{DEPENDENCY_TASKS}}` (prerequisite groups), use the task **`id`**. IDs are stable and unambiguous; they are already in the JSON for those tasks.
+- **Intra-batch dependencies** — when referencing earlier tasks in this same `task_create_bulk` call, use the **exact `name`** you wrote for that task. IDs are not assigned until the bulk runs, so names are the only handle available.
+
+Slug and fuzzy matching are fallbacks, not a contract — relying on them across a paraphrased name is fragile. If you cannot supply an `id` or the exact `name`, omit the dependency rather than guess.
 
 Use `mcp__dotbot__task_create_bulk` to create all tasks for this group. Every task MUST include:
 

--- a/workflows/start-from-prompt/recipes/prompts/03b-expand-task-group.md
+++ b/workflows/start-from-prompt/recipes/prompts/03b-expand-task-group.md
@@ -83,11 +83,7 @@ The decision `decision` and `consequences` sections define hard constraints — 
 
 For each scope item, generate as many tasks as the bar above demands — typically 1-3, sometimes more when a single scope item maps to several distinct logical units. Do not pad. Do not merge unrelated work just to keep the count down.
 
-**Group-size feedback signal.** Group sizing is owned by 03a, not by this prompt. Your job is to produce well-sized tasks, not to police the count. But the count is a useful signal back to 03a:
-
-- If you naturally produce **12 or more tasks** for this group, the group is likely too broad. Emit all the well-sized tasks the scope genuinely needs, and **include `group_size_warning: too-broad` in your final summary** so 03a's grouping can be revisited on the next plan-review cycle. Do **not** artificially shrink the count by merging tasks that should stay separate.
-- If you struggle to produce more than **1-2 tasks** for a group, the group may be too narrow. Include `group_size_warning: too-narrow` in your final summary so 03a can consider merging it with a sibling.
-- If the count falls in the typical 3-11 band, no warning is needed.
+**Group sizing is 03a's responsibility, not yours.** 03a has already validated that this group's scope expands to a healthy task count (`estimated_task_count`, typically 3-10). Your job is per-task quality. Produce well-sized tasks for the scope you have; do not adjust the count to hit a number, and do not second-guess 03a's grouping decisions here.
 
 **Task sizing guide:**
 
@@ -196,4 +192,3 @@ After creating all tasks, report:
 - Number of tasks created
 - Task names and their priorities
 - Any cross-group dependencies added (with justification)
-- `group_size_warning: too-broad` (if you produced 12+ tasks) or `group_size_warning: too-narrow` (if you produced 1-2). Omit the field when the count is in the typical 3-11 band.

--- a/workflows/start-from-prompt/recipes/prompts/03b-expand-task-group.md
+++ b/workflows/start-from-prompt/recipes/prompts/03b-expand-task-group.md
@@ -60,11 +60,14 @@ Read these files for project context:
 - `.bot/workspace/product/entity-model.md` — Data model and relationships
 - Any other `.md` files in `.bot/workspace/product/` for additional context
 
-If `{{GROUP_APPLICABLE_DECISIONS}}` is non-empty, read each decision:
+If `{{GROUP_APPLICABLE_DECISIONS}}` is non-empty, read each decision by ID:
 ```javascript
 // For each decision ID listed in GROUP_APPLICABLE_DECISIONS:
 mcp__dotbot__decision_get({ decision_id: "dec-XXXXXXXX" })
 ```
+
+If `{{GROUP_APPLICABLE_DECISIONS}}` is `(none)` or empty, do not assume zero decisions apply. Call `mcp__dotbot__decision_list({ status: "accepted" })` and pull any decisions whose `tags`, `decision`, or `consequences` reference this group's name, scope items, or category. Use those as the constraint set for this group's tasks. Silently producing tasks that ignore an existing ADR is the failure mode this fallback prevents.
+
 The decision `decision` and `consequences` sections define hard constraints — do not create tasks that would violate them.
 
 ### Step 2: Break Down Scope Items into Tasks
@@ -74,6 +77,8 @@ For each scope item listed above, create 1-3 detailed tasks. Each task should be
 - **Completable in 1-4 hours** of focused work
 - **Independently testable** where possible
 - **Small enough** to fit in a single LLM context window
+
+**Cap the total tasks per group at 10.** Aim for 5-10 tasks per group; never exceed 10. If a group's scope appears to need more than 10 tasks, you are slicing too thinly — merge closely related sub-items into single larger (M or L) tasks rather than cutting smaller ones. A group of 8 M-effort tasks is healthier than a group of 18 XS-effort tasks. If even with merging the group genuinely cannot fit in 10 tasks, that is a signal the group itself is mis-scoped — emit at most 10 tasks and note the overflow in the final summary so 03a's grouping can be revisited.
 
 **Task sizing guide:**
 
@@ -96,6 +101,10 @@ Before creating tasks, analyze which tasks depend on others:
 Set `dependencies` on every task that cannot start without another task completing first. Tasks with no real prerequisites should have `dependencies: []`.
 
 ### Step 3: Create Tasks via MCP
+
+**Valid `category` values (closed enum — `task_create_bulk` validator rejects anything else):** `infrastructure`, `core`, `feature`, `enhancement`, `ui-ux`, `bugfix`. Use the `{{CATEGORY_HINT}}` value as the default and override per-task only when a different value from this list fits better. Do **NOT** invent categories such as `testing`, `test`, `frontend`, `backend`, `api`, `ops`, or `platform` — they will all fail validation and force a retry.
+
+**Dependency naming (exact string match required):** every entry in a task's `dependencies` array must be the **verbatim, unmodified** `name` value of either (a) a task earlier in the same `task_create_bulk` call, or (b) a task in `{{DEPENDENCY_TASKS}}` from a prerequisite group. Do not paraphrase, abbreviate, change punctuation, or pluralise. The validator does exact string matching and will reject the whole bulk with a "dependency name not found" error if any entry does not match.
 
 Use `mcp__dotbot__task_create_bulk` to create all tasks for this group. Every task MUST include:
 


### PR DESCRIPTION
## Linked issue

Closes #360

## Summary of changes

Phase 2b task-group expansion was producing 5-20 tasks per group with invalid categories like `testing`, paraphrased dependency names that failed `task_create_bulk` validation, and zero ADR context for most groups because `{{GROUP_APPLICABLE_DECISIONS}}` was never substituted by the runtime.

The PR originally proposed a hard cap at 03b (10 tasks per group). Architectural review reversed that: a numeric cap conflicts with the per-task quality bar (a group that genuinely produces 20 well-sized tasks is fine; the real problem is over-broad groups). **Group sizing is owned by 03a**, not 03b — so the constraint moved up to 03a where it belongs.

**Runtime — bind the missing template variable.**

- `core/runtime/expand-task-groups.ps1` now reads `$group.applicable_decisions` (which 03a populates per group) and substitutes it as a comma-separated ID list. When empty or missing, emits the literal string `(none)` so the prompt's fallback path can detect the case explicitly.

**03a — own group sizing via fan-out validation.**

`workflows/start-from-prompt/recipes/prompts/03a-plan-task-groups.md`:

- New **Step 2.5: Validate Expansion Fan-Out** with a scope-shape → per-task heuristic table. If a draft group's scope would expand to 12+ well-sized tasks at 03b's per-task quality bar, the planner is told to split or rescope before writing `task-groups.json`.
- `estimated_task_count` description tightened: healthy range is 3-10; 12+ is a split signal.
- New anti-pattern: **kitchen-sink groups** (multiple unrelated functional concerns bundled — exactly the failure mode the dogfood run exposed, e.g. *"Terminal UI, Preflight, Initialize, and Distribution"*).

**03b — focus on per-task quality, trust 03a's sizing.**

`workflows/start-from-prompt/recipes/prompts/03b-expand-task-group.md`:

- **Per-task quality bar** is now the explicit contract: each task must be a single logical unit, completable in 1-4 hours (S/M/L), context-friendly, and independently testable. No numeric cap.
- **Closed category enum.** Lists the six valid `category` values (`infrastructure`, `core`, `feature`, `enhancement`, `ui-ux`, `bugfix`) and forbids invented categories such as `testing`, `frontend`, `backend`, `api`.
- **Decision-tree dependency loading.** A single decision keyed on whether `{{GROUP_APPLICABLE_DECISIONS}}` contains `dec-XXXXXXXX` IDs (read each via `decision_get`) versus `(none)` / empty / no `dec-` IDs (fall back to `decision_list({status: "accepted"})` filtered by group name/scope). No more ambiguity around the "non-empty" framing.
- **Dependency naming aligned with the actual validator.** `task_create_bulk:117-130` accepts `id`, exact `name`, slug, or fuzzy slug match. Prompt now recommends `id` for cross-group and exact `name` for intra-batch; slug/fuzzy are documented as fallbacks rather than promoted as the contract.
- **Phase 0 bulk-loads `decision_list`** so the empty-IDs fallback has its tool available without violating the single-Phase-0-call contract.

**Tests.**

- `Test-WorkflowManifest.ps1` adds a Fix#H block asserting 03a's Step 2.5, the kitchen-sink ban, the 12+ split rule, and the tightened `estimated_task_count` range.
- Fix#F assertions cover the per-task quality bar at 03b, the validator's four resolution strategies (`id`, exact name, slug, fuzzy), the cross-group/intra-batch best practice, the decision-tree fallback, the Phase 0 bulk-load, and the literal absence of `group_size_warning` policing.
- Fix#G assertions cover the runtime substitution.

## Screenshots / recordings

N/A — runtime and prompt changes, no UI surface.

## Testing notes

Local source-direct test pass:

```
pwsh tests/Test-WorkflowManifest.ps1   # 379 passed / 379 total
```

To reproduce the original failure mode without this PR:
1. Run start-from-prompt against a project with multiple accepted decisions in `.bot/workspace/decisions/accepted/`.
2. Watch Phase 2b. The agent will report *"the GROUP_APPLICABLE_DECISIONS placeholder is unfilled, so no ADRs to load"* for groups that have `applicable_decisions` populated.
3. Observe wide variance in task counts (5-20 per group) and at least one `task_create_bulk` retry caused by an invalid category like `testing`.

After this PR:
1. Each group expansion sees its actual `applicable_decisions` IDs and reads them via `decision_get`.
2. Group fan-out is bounded at planning time (03a Step 2.5), not at expansion time, so 03b only ever sees scopes that expand to a healthy 3-10 tasks.
3. Categories are constrained to the six valid values; invented categories are surfaced and rejected at the prompt level before the validator round-trip.
4. Dependency names use IDs for cross-group and exact names for intra-batch — no more retries on paraphrased entries.

## Checklist

- [x] Tests added or updated
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)