### PR TITLE
fix(mcp): resolve project root to main repo from inside worktrees

### DIFF
--- a/core/mcp/Resolve-ProjectRoot.ps1
+++ b/core/mcp/Resolve-ProjectRoot.ps1
@@ -50,13 +50,47 @@ function Resolve-DotbotProjectRoot {
         }
     }
 
-    # Walk-up fallback. Restrict to `.git` *directories* so a worktree's
-    # gitfile (a regular file) does not re-introduce the worktree-as-root
-    # bug this resolver was written to fix.
+    # Walk-up fallback. Prefer `.git` directories. If the entry is a
+    # gitfile (a worktree's `.git` is a file containing `gitdir: <path>`),
+    # follow it to the per-worktree gitdir and read its `commondir` to
+    # resolve back to the main repository's shared `.git/`. Without this
+    # branch, a missing `git` on PATH would make the resolver return $null
+    # from inside any linked worktree.
     $current = $StartPath
     while ($current) {
-        if (Test-Path -LiteralPath (Join-Path $current ".git") -PathType Container) {
+        $gitPath = Join-Path $current ".git"
+        if (Test-Path -LiteralPath $gitPath -PathType Container) {
             return $current
+        }
+        if (Test-Path -LiteralPath $gitPath -PathType Leaf) {
+            $gitFileLine = Get-Content -LiteralPath $gitPath -TotalCount 1 -ErrorAction SilentlyContinue
+            if ($gitFileLine -match '^\s*gitdir:\s*(.+?)\s*$') {
+                $gitDir = $Matches[1]
+                $gitDirCandidate = if ([System.IO.Path]::IsPathRooted($gitDir)) {
+                    $gitDir
+                } else {
+                    Join-Path $current $gitDir
+                }
+                $resolvedGitDir = Resolve-Path -LiteralPath $gitDirCandidate -ErrorAction SilentlyContinue
+                if ($resolvedGitDir) {
+                    $commonDirPath = Join-Path $resolvedGitDir.Path "commondir"
+                    if (Test-Path -LiteralPath $commonDirPath -PathType Leaf) {
+                        $commonDir = Get-Content -LiteralPath $commonDirPath -TotalCount 1 -ErrorAction SilentlyContinue
+                        if ($commonDir) {
+                            $commonDirCandidate = if ([System.IO.Path]::IsPathRooted($commonDir)) {
+                                $commonDir
+                            } else {
+                                Join-Path $resolvedGitDir.Path $commonDir
+                            }
+                            $resolvedCommonDir = Resolve-Path -LiteralPath $commonDirCandidate -ErrorAction SilentlyContinue
+                            if ($resolvedCommonDir) {
+                                return Split-Path $resolvedCommonDir.Path -Parent
+                            }
+                        }
+                    }
+                    return Split-Path $resolvedGitDir.Path -Parent
+                }
+            }
         }
         $parent = Split-Path $current -Parent
         if ($parent -eq $current) { break }

--- a/core/mcp/Resolve-ProjectRoot.ps1
+++ b/core/mcp/Resolve-ProjectRoot.ps1
@@ -31,7 +31,13 @@ function Resolve-DotbotProjectRoot {
         return $null
     }
 
-    $gitCommonDir = & git -C $StartPath rev-parse --git-common-dir 2>$null
+    # Guard the git invocation so PowerShell's terminating
+    # CommandNotFoundException does not bypass the walk-up fallback when git
+    # is not on PATH (e.g. minimal CI containers).
+    $gitCommonDir = $null
+    if (Get-Command git -ErrorAction SilentlyContinue) {
+        $gitCommonDir = & git -C $StartPath rev-parse --git-common-dir 2>$null
+    }
     if ($LASTEXITCODE -eq 0 -and $gitCommonDir) {
         $candidate = if ([System.IO.Path]::IsPathRooted($gitCommonDir)) {
             $gitCommonDir
@@ -44,9 +50,12 @@ function Resolve-DotbotProjectRoot {
         }
     }
 
+    # Walk-up fallback. Restrict to `.git` *directories* so a worktree's
+    # gitfile (a regular file) does not re-introduce the worktree-as-root
+    # bug this resolver was written to fix.
     $current = $StartPath
     while ($current) {
-        if (Test-Path (Join-Path $current ".git")) {
+        if (Test-Path -LiteralPath (Join-Path $current ".git") -PathType Container) {
             return $current
         }
         $parent = Split-Path $current -Parent

--- a/core/mcp/Resolve-ProjectRoot.ps1
+++ b/core/mcp/Resolve-ProjectRoot.ps1
@@ -1,0 +1,57 @@
+# ═══════════════════════════════════════════════════════════════
+# FRAMEWORK FILE — DO NOT MODIFY IN TARGET PROJECTS
+# Managed by dotbot. Overwritten on 'dotbot init --force'.
+# ═══════════════════════════════════════════════════════════════
+<#
+.SYNOPSIS
+    Resolves the dotbot project root from a starting path.
+
+.DESCRIPTION
+    The MCP server (and its dot-sourced tools) read $global:DotbotProjectRoot
+    to locate .bot/workspace/tasks/ and other project-relative state. The walk-
+    up `Test-Path .git` strategy stops at the first `.git` it finds — which in
+    a linked git worktree is a *gitfile* at the worktree's root, not the main
+    repo. That made every agent-driven task-state transition write to the
+    worktree, where Complete-TaskWorktree later discarded it.
+
+    Resolve-DotbotProjectRoot prefers `git rev-parse --git-common-dir`, which
+    returns the path to the main repo's `.git/` regardless of whether the
+    caller is inside the main checkout or a linked worktree. The walk-up is
+    kept as a fallback for the no-git case (test fixtures, etc.).
+#>
+
+function Resolve-DotbotProjectRoot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$StartPath
+    )
+
+    if (-not (Test-Path -LiteralPath $StartPath)) {
+        return $null
+    }
+
+    $gitCommonDir = & git -C $StartPath rev-parse --git-common-dir 2>$null
+    if ($LASTEXITCODE -eq 0 -and $gitCommonDir) {
+        $candidate = if ([System.IO.Path]::IsPathRooted($gitCommonDir)) {
+            $gitCommonDir
+        } else {
+            Join-Path $StartPath $gitCommonDir
+        }
+        $resolved = Resolve-Path -LiteralPath $candidate -ErrorAction SilentlyContinue
+        if ($resolved) {
+            return Split-Path $resolved.Path -Parent
+        }
+    }
+
+    $current = $StartPath
+    while ($current) {
+        if (Test-Path (Join-Path $current ".git")) {
+            return $current
+        }
+        $parent = Split-Path $current -Parent
+        if ($parent -eq $current) { break }
+        $current = $parent
+    }
+    return $null
+}

--- a/core/mcp/dotbot-mcp.ps1
+++ b/core/mcp/dotbot-mcp.ps1
@@ -28,7 +28,7 @@ $PSStyle.OutputRendering = 'PlainText'
 # Auto-detect project root. In a linked git worktree, walking up looking for
 # `.git` would stop at the worktree's gitfile rather than the main repo, so
 # Resolve-DotbotProjectRoot prefers `git rev-parse --git-common-dir`.
-. "$PSScriptRoot\Resolve-ProjectRoot.ps1"
+. (Join-Path $PSScriptRoot 'Resolve-ProjectRoot.ps1')
 $script:ProjectRoot = Resolve-DotbotProjectRoot -StartPath $PSScriptRoot
 
 if (-not $script:ProjectRoot) {

--- a/core/mcp/dotbot-mcp.ps1
+++ b/core/mcp/dotbot-mcp.ps1
@@ -25,18 +25,11 @@ $WarningPreference = 'SilentlyContinue'
 # Disable ANSI colors in error output
 $PSStyle.OutputRendering = 'PlainText'
 
-# Auto-detect project root by walking up from script location to find .git folder
-$script:ProjectRoot = $null
-$currentPath = $PSScriptRoot
-while ($currentPath) {
-    if (Test-Path (Join-Path $currentPath ".git")) {
-        $script:ProjectRoot = $currentPath
-        break
-    }
-    $parent = Split-Path $currentPath -Parent
-    if ($parent -eq $currentPath) { break }  # Reached filesystem root
-    $currentPath = $parent
-}
+# Auto-detect project root. In a linked git worktree, walking up looking for
+# `.git` would stop at the worktree's gitfile rather than the main repo, so
+# Resolve-DotbotProjectRoot prefers `git rev-parse --git-common-dir`.
+. "$PSScriptRoot\Resolve-ProjectRoot.ps1"
+$script:ProjectRoot = Resolve-DotbotProjectRoot -StartPath $PSScriptRoot
 
 if (-not $script:ProjectRoot) {
     [Console]::Error.WriteLine("FATAL: Could not auto-detect project root. No .git folder found in parent directories of $PSScriptRoot")

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -1214,8 +1214,17 @@ try {
     } else {
         . $resolverScript
         $resolved = Resolve-DotbotProjectRoot -StartPath $worktreeMcpDir
-        $expectedRoot = (Resolve-Path -LiteralPath $testProject).Path
-        $actualRoot = if ($resolved) { (Resolve-Path -LiteralPath $resolved).Path } else { $null }
+
+        # macOS resolves /var to /private/var when git canonicalises a path
+        # but Resolve-Path leaves the alias intact. Compare both sides through
+        # `git rev-parse --show-toplevel` so the canonicalisation matches.
+        $expectedRoot = (& git -C $testProject rev-parse --show-toplevel 2>$null)
+        if ($expectedRoot) { $expectedRoot = $expectedRoot.Trim() }
+        $actualRoot = $null
+        if ($resolved -and (Test-Path $resolved)) {
+            $actualRoot = (& git -C $resolved rev-parse --show-toplevel 2>$null)
+            if ($actualRoot) { $actualRoot = $actualRoot.Trim() }
+        }
         Assert-Equal -Name "Resolve-DotbotProjectRoot returns main repo when started from worktree" `
             -Expected $expectedRoot `
             -Actual $actualRoot

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -1206,11 +1206,15 @@ try {
     $worktreeMcpDir = Join-Path $worktreePath ".bot/core/mcp"
     Assert-PathExists -Name "Worktree contains .bot/core/mcp/" -Path $worktreeMcpDir
 
-    $resolverScript = Join-Path $repoRoot "core/mcp/Resolve-ProjectRoot.ps1"
+    # Source the resolver from the worktree's .bot/core/mcp/, mirroring the
+    # path the MCP server's dot-source uses at runtime. Sourcing from the
+    # framework checkout would not catch a packaging/copy regression that
+    # left the helper out of the worktree's .bot tree.
+    $resolverScript = Join-Path $worktreeMcpDir "Resolve-ProjectRoot.ps1"
     if (-not (Test-Path $resolverScript)) {
-        Assert-True -Name "Resolve-ProjectRoot.ps1 helper exists in source" `
+        Assert-True -Name "Resolve-ProjectRoot.ps1 helper exists in worktree .bot/core/mcp/" `
             -Condition $false `
-            -Message "Expected helper at $resolverScript (added by #356)"
+            -Message "Expected helper at $resolverScript (copied into the worktree .bot tree)"
     } else {
         . $resolverScript
         $resolved = Resolve-DotbotProjectRoot -StartPath $worktreeMcpDir
@@ -1229,9 +1233,12 @@ try {
             -Expected $expectedRoot `
             -Actual $actualRoot
 
-        # End-to-end: with $global:DotbotProjectRoot set the way the fix produces,
-        # task-mark-needs-input invoked from the worktree updates the parent.
-        $global:DotbotProjectRoot = $expectedRoot
+        # End-to-end: simulate the worktree launch path. $global:DotbotProjectRoot
+        # gets the resolver's actual output, the tool script is dot-sourced from
+        # the worktree's .bot/core/mcp/tools/, and the cwd is the worktree. If
+        # any of those three couplings regress, the parent's task tree will not
+        # see the mutation.
+        $global:DotbotProjectRoot = $resolved
         $botDir = Join-Path $testProject ".bot"
         $inProgressDir = Join-Path $botDir "workspace/tasks/in-progress"
         $needsInputDir = Join-Path $botDir "workspace/tasks/needs-input"
@@ -1260,18 +1267,24 @@ try {
             function Write-BotLog { param([string]$Level, [string]$Message, $Exception) }
         }
 
-        $needsInputScript = Join-Path $botDir "core/mcp/tools/task-mark-needs-input/script.ps1"
-        Assert-PathExists -Name "task-mark-needs-input script exists in test project" -Path $needsInputScript
-        . $needsInputScript
+        $needsInputScript = Join-Path $worktreePath ".bot/core/mcp/tools/task-mark-needs-input/script.ps1"
+        Assert-PathExists -Name "task-mark-needs-input script exists in worktree" -Path $needsInputScript
 
-        $result = Invoke-TaskMarkNeedsInput -Arguments @{
-            task_id  = $taskId
-            question = @{
-                question       = "Mock question for regression"
-                context        = "test"
-                options        = @("A", "B")
-                recommendation = "A"
+        Push-Location $worktreePath
+        try {
+            . $needsInputScript
+
+            $result = Invoke-TaskMarkNeedsInput -Arguments @{
+                task_id  = $taskId
+                question = @{
+                    question       = "Mock question for regression"
+                    context        = "test"
+                    options        = @("A", "B")
+                    recommendation = "A"
+                }
             }
+        } finally {
+            Pop-Location
         }
 
         Assert-True -Name "task-mark-needs-input returns success when invoked from worktree" `

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -1182,6 +1182,114 @@ finally {
     $global:DotbotProjectRoot = $savedDotbotProjectRoot
 }
 
+# ─── MCP project root resolves to main repo from worktree ────────────────────
+# Regression for #356: walking up from $PSScriptRoot to find .git stops at a
+# linked worktree's gitfile, so the MCP server resolved $global:DotbotProjectRoot
+# to the worktree. Every agent-driven task-state mutation then wrote into the
+# worktree, where Complete-TaskWorktree later discarded those writes.
+# Resolve-DotbotProjectRoot now prefers `git rev-parse --git-common-dir`.
+
+$testProject = $null
+$worktreePath = $null
+$savedDotbotProjectRoot = $global:DotbotProjectRoot
+try {
+    $testProject = New-SourceBackedTestProject -RepoRoot $repoRoot
+
+    # New-TestProject already ran `git init` and made an initial commit. Stage
+    # the copied-in .bot/ tree and commit so the worktree has it on disk.
+    & git -C $testProject add -A 2>&1 | Out-Null
+    & git -C $testProject commit -q -m "seed bot tree" 2>&1 | Out-Null
+
+    $worktreePath = "$testProject-wt"
+    & git -C $testProject worktree add --detach -q $worktreePath HEAD 2>&1 | Out-Null
+
+    $worktreeMcpDir = Join-Path $worktreePath ".bot/core/mcp"
+    Assert-PathExists -Name "Worktree contains .bot/core/mcp/" -Path $worktreeMcpDir
+
+    $resolverScript = Join-Path $repoRoot "core/mcp/Resolve-ProjectRoot.ps1"
+    if (-not (Test-Path $resolverScript)) {
+        Assert-True -Name "Resolve-ProjectRoot.ps1 helper exists in source" `
+            -Condition $false `
+            -Message "Expected helper at $resolverScript (added by #356)"
+    } else {
+        . $resolverScript
+        $resolved = Resolve-DotbotProjectRoot -StartPath $worktreeMcpDir
+        $expectedRoot = (Resolve-Path -LiteralPath $testProject).Path
+        $actualRoot = if ($resolved) { (Resolve-Path -LiteralPath $resolved).Path } else { $null }
+        Assert-Equal -Name "Resolve-DotbotProjectRoot returns main repo when started from worktree" `
+            -Expected $expectedRoot `
+            -Actual $actualRoot
+
+        # End-to-end: with $global:DotbotProjectRoot set the way the fix produces,
+        # task-mark-needs-input invoked from the worktree updates the parent.
+        $global:DotbotProjectRoot = $expectedRoot
+        $botDir = Join-Path $testProject ".bot"
+        $inProgressDir = Join-Path $botDir "workspace/tasks/in-progress"
+        $needsInputDir = Join-Path $botDir "workspace/tasks/needs-input"
+
+        $taskId = "wt-needsinput-001"
+        $taskPath = Join-Path $inProgressDir "$taskId.json"
+        [ordered]@{
+            id = $taskId
+            name = "Worktree resolution test"
+            description = "Seeded for #356 regression coverage"
+            category = "feature"
+            priority = 10
+            effort = "S"
+            status = "in-progress"
+            dependencies = @()
+            acceptance_criteria = @()
+            steps = @()
+            applicable_standards = @()
+            applicable_agents = @()
+            created_at = "2026-04-28T00:00:00Z"
+            updated_at = "2026-04-28T00:00:00Z"
+            completed_at = $null
+        } | ConvertTo-Json -Depth 10 | Set-Content -Path $taskPath -Encoding UTF8
+
+        if (-not (Get-Command Write-BotLog -ErrorAction SilentlyContinue)) {
+            function Write-BotLog { param([string]$Level, [string]$Message, $Exception) }
+        }
+
+        $needsInputScript = Join-Path $botDir "core/mcp/tools/task-mark-needs-input/script.ps1"
+        Assert-PathExists -Name "task-mark-needs-input script exists in test project" -Path $needsInputScript
+        . $needsInputScript
+
+        $result = Invoke-TaskMarkNeedsInput -Arguments @{
+            task_id  = $taskId
+            question = @{
+                question       = "Mock question for regression"
+                context        = "test"
+                options        = @("A", "B")
+                recommendation = "A"
+            }
+        }
+
+        Assert-True -Name "task-mark-needs-input returns success when invoked from worktree" `
+            -Condition ($result.success -eq $true) `
+            -Message "Expected success=true"
+
+        Assert-PathNotExists -Name "Parent in-progress task removed by worktree-issued mark-needs-input" `
+            -Path (Join-Path $inProgressDir "$taskId.json")
+        Assert-PathExists -Name "Parent needs-input has the new task file" `
+            -Path (Join-Path $needsInputDir "$taskId.json")
+        Assert-PathNotExists -Name "Worktree task tree was not written" `
+            -Path (Join-Path $worktreePath ".bot/workspace/tasks/needs-input/$taskId.json")
+    }
+}
+finally {
+    if ($worktreePath -and $testProject -and (Test-Path $worktreePath)) {
+        & git -C $testProject worktree remove --force $worktreePath 2>&1 | Out-Null
+    }
+    if ($worktreePath -and (Test-Path $worktreePath)) {
+        Remove-Item -Recurse -Force $worktreePath -ErrorAction SilentlyContinue
+    }
+    if ($testProject) {
+        Remove-TestProject -Path $testProject
+    }
+    $global:DotbotProjectRoot = $savedDotbotProjectRoot
+}
+
 $allPassed = Write-TestSummary -LayerName "Task Action Source Tests"
 
 if (-not $allPassed) {


### PR DESCRIPTION
## Summary
- Replace the walk-up `Test-Path .git` strategy in `core/mcp/dotbot-mcp.ps1` with `git rev-parse --git-common-dir` so the resolver returns the main repo from inside a linked worktree.
- Extract the resolution into `core/mcp/Resolve-ProjectRoot.ps1` so `dotbot-mcp.ps1` and the regression test share one source.
- Add a worktree-based regression test in `tests/Test-TaskActions.ps1` that fails on `main` and asserts a worktree-issued `task-mark-needs-input` updates the parent's task tree.

Closes #356

## Test plan
- [x] New section "MCP project root resolves to main repo from worktree" in `tests/Test-TaskActions.ps1` passes
- [x] `pwsh tests/Run-Tests.ps1` passes (Layer 1-3 ALL PASSED)
- [x] `pwsh install.ps1` clean