### PR TITLE
fix(privacy-scan): scope verify-hook to task diff and recognise placeholders

### DIFF
--- a/core/hooks/verify/00-privacy-scan.ps1
+++ b/core/hooks/verify/00-privacy-scan.ps1
@@ -110,7 +110,15 @@ if ($StagedOnly) {
         }
     }
 
-    if ($mergeBase) {
+    # If HEAD is on the base branch itself (no remote, single-branch repo, or
+    # PR scenario where the task branch was already fast-forwarded), the
+    # merge-base equals HEAD and `mergeBase..HEAD` would be empty. Fall back
+    # so verify-hook always scans something.
+    $headSha = $null
+    $h = & git -C $repoRoot rev-parse HEAD 2>$null
+    if ($LASTEXITCODE -eq 0 -and $h) { $headSha = $h.Trim() }
+
+    if ($mergeBase -and $headSha -and $mergeBase -ne $headSha) {
         $diffFiles = @(git -C $repoRoot diff --name-only "$mergeBase..HEAD" --diff-filter=ACM 2>$null)
     } else {
         $null = git -C $repoRoot rev-parse --verify HEAD~1 2>$null
@@ -158,6 +166,9 @@ foreach ($relativePath in $allFiles) {
 
     # Per-file accumulator keyed by line number so multiple patterns on the
     # same line collapse to one violation with a list of pattern names.
+    # Hashtable enumeration order is not guaranteed; emit entries in
+    # ascending line-number order at the end of the file scan so violations
+    # follow the file → line traversal order.
     $perLine = @{}
     $prevLineHadMarker = $false
 
@@ -216,7 +227,8 @@ foreach ($relativePath in $allFiles) {
         }
     }
 
-    foreach ($entry in $perLine.Values) {
+    foreach ($key in ($perLine.Keys | Sort-Object)) {
+        $entry = $perLine[$key]
         $details['violations'] += $entry
         $patternList = $entry.patterns -join ', '
         $descList    = $entry.descriptions -join ', '

--- a/core/hooks/verify/00-privacy-scan.ps1
+++ b/core/hooks/verify/00-privacy-scan.ps1
@@ -46,7 +46,20 @@ $excludePatterns = @(
     '\.bot[/\\]hooks[/\\]',
     '\.bot[/\\]systems[/\\]',
     '\.bot[/\\]defaults[/\\]',
-    '\.bot[/\\]prompts[/\\]'
+    '\.bot[/\\]prompts[/\\]',
+    '\.bot[/\\]workspace[/\\]tasks[/\\]',
+    '\.bot[/\\]workspace[/\\]decisions[/\\]'
+)
+
+# Canonical placeholder values that signal documented examples rather than
+# real secrets. Skipped at the line level so a doc or fixture can use
+# `Password=hunter2;` without tripping the secret patterns.
+$placeholderTokens = @(
+    'hunter2',
+    '<example>',
+    '<placeholder>',
+    'REPLACE_ME',
+    '<your-password>'
 )
 
 # Binary extensions to skip
@@ -69,10 +82,20 @@ if ($StagedOnly) {
     # Pre-commit mode: only scan files being committed
     $allFiles = @(git -C $repoRoot diff --cached --name-only --diff-filter=ACM 2>$null) | Where-Object { $_ }
 } else {
-    # Full repo scan
-    $trackedFiles = git -C $repoRoot ls-files 2>$null
-    $untrackedFiles = git -C $repoRoot ls-files --others --exclude-standard 2>$null
-    $allFiles = @($trackedFiles) + @($untrackedFiles) | Where-Object { $_ } | Sort-Object -Unique
+    # Verify-hook mode (e.g. task_mark_done): scope to files the active task
+    # touched plus untracked working-tree files. Scanning the whole tree was
+    # blocking task completion on prior-task narrative content.
+    $diffFiles = @()
+    $null = git -C $repoRoot rev-parse --verify HEAD~1 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        $diffFiles = @(git -C $repoRoot diff --name-only HEAD~1..HEAD --diff-filter=ACM 2>$null)
+    } else {
+        # No parent commit yet: fall back to the full tracked set so the very
+        # first commit still gets scanned end-to-end.
+        $diffFiles = @(git -C $repoRoot ls-files 2>$null)
+    }
+    $untrackedFiles = @(git -C $repoRoot ls-files --others --exclude-standard 2>$null)
+    $allFiles = @($diffFiles) + @($untrackedFiles) | Where-Object { $_ } | Sort-Object -Unique
 }
 
 foreach ($relativePath in $allFiles) {
@@ -104,38 +127,75 @@ foreach ($relativePath in $allFiles) {
     $lineNumber = 0
     $lines = $content -split "`n"
 
+    # Per-file accumulator keyed by line number so multiple patterns on the
+    # same line collapse to one violation with a list of pattern names.
+    $perLine = @{}
+    $prevLineHadMarker = $false
+
     foreach ($line in $lines) {
         $lineNumber++
 
+        # Recognise the existing `noscan` marker plus the documented spelling
+        # `privacy-scan: example` (either `#` or `//` comment). The marker may
+        # sit on the same line or the line above the matched pattern.
+        $thisLineHasMarker = ($line -match '(?://|#)\s*(?:noscan|privacy-scan\s*:\s*example)')
+        if ($thisLineHasMarker -or $prevLineHadMarker) {
+            $prevLineHadMarker = $thisLineHasMarker
+            continue
+        }
+        $prevLineHadMarker = $thisLineHasMarker
+
+        # Skip lines that contain a canonical placeholder token. Plain string
+        # match avoids regex-escaping the angle brackets.
+        $hasPlaceholder = $false
+        foreach ($token in $placeholderTokens) {
+            if ($line.IndexOf($token, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
+                $hasPlaceholder = $true
+                break
+            }
+        }
+        if ($hasPlaceholder) { continue }
+
         foreach ($patternDef in $patterns) {
-            # Check if pattern matches (case-sensitive or case-insensitive)
-            $matches = if ($patternDef.caseSensitive) {
+            $matched = if ($patternDef.caseSensitive) {
                 $line -cmatch $patternDef.pattern
             } else {
                 $line -match $patternDef.pattern
             }
+            if (-not $matched) { continue }
 
-            if ($matches -and $line -notmatch '(?://|#)\s*noscan') {
-                $violation = @{
-                    file = $relativePath
-                    line = $lineNumber
-                    pattern = $patternDef.name
-                    description = $patternDef.description
-                    snippet = if ($line.Length -gt 100) { $line.Substring(0, 100) + "..." } else { $line.Trim() }
+            if (-not $perLine.ContainsKey($lineNumber)) {
+                $perLine[$lineNumber] = @{
+                    file        = $relativePath
+                    line        = $lineNumber
+                    patterns    = @($patternDef.name)
+                    descriptions = @($patternDef.description)
+                    snippet     = if ($line.Length -gt 100) { $line.Substring(0, 100) + "..." } else { $line.Trim() }
                 }
-                $details['violations'] += $violation
-
-                $issues += @{
-                    issue = "$($patternDef.description) in $relativePath`:$lineNumber"
-                    severity = "error"
-                    context = "Remove or redact sensitive data before committing"
+            } else {
+                $entry = $perLine[$lineNumber]
+                if ($entry.patterns -notcontains $patternDef.name) {
+                    $entry.patterns     += $patternDef.name
+                    $entry.descriptions += $patternDef.description
                 }
             }
         }
     }
+
+    foreach ($entry in $perLine.Values) {
+        $details['violations'] += $entry
+        $patternList = $entry.patterns -join ', '
+        $descList    = $entry.descriptions -join ', '
+        $issues += @{
+            issue    = "$descList in $($entry.file):$($entry.line)"
+            severity = "error"
+            context  = "Remove or redact sensitive data, or mark the line with `# privacy-scan: example` if it is a documented placeholder. Patterns: $patternList"
+        }
+    }
 }
 
-# Deduplicate issues (same file/line can match multiple patterns)
+# Each line is already aggregated; preserve original order while dropping any
+# accidental cross-file duplicates from upstream callers.
 $uniqueIssues = $issues | Sort-Object { "$($_.issue)" } -Unique
 
 $details['scan_mode'] = if ($StagedOnly) { 'staged' } else { 'full' }

--- a/core/hooks/verify/00-privacy-scan.ps1
+++ b/core/hooks/verify/00-privacy-scan.ps1
@@ -83,17 +83,46 @@ if ($StagedOnly) {
     $allFiles = @(git -C $repoRoot diff --cached --name-only --diff-filter=ACM 2>$null) | Where-Object { $_ }
 } else {
     # Verify-hook mode (e.g. task_mark_done): scope to files the active task
-    # touched plus untracked working-tree files. Scanning the whole tree was
-    # blocking task completion on prior-task narrative content.
+    # touched across its full branch history plus untracked working-tree files.
+    # Using HEAD~1..HEAD alone misses earlier commits on a multi-commit task
+    # branch.
     $diffFiles = @()
-    $null = git -C $repoRoot rev-parse --verify HEAD~1 2>$null
-    if ($LASTEXITCODE -eq 0) {
-        $diffFiles = @(git -C $repoRoot diff --name-only HEAD~1..HEAD --diff-filter=ACM 2>$null)
+    $baseRef = $null
+
+    $originHead = & git -C $repoRoot symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>$null
+    if ($LASTEXITCODE -eq 0 -and $originHead) {
+        $baseRef = $originHead.Trim()
     } else {
-        # No parent commit yet: fall back to the full tracked set so the very
-        # first commit still gets scanned end-to-end.
-        $diffFiles = @(git -C $repoRoot ls-files 2>$null)
+        foreach ($candidate in @('origin/main', 'origin/master', 'main', 'master')) {
+            $null = & git -C $repoRoot rev-parse --verify $candidate 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                $baseRef = $candidate
+                break
+            }
+        }
     }
+
+    $mergeBase = $null
+    if ($baseRef) {
+        $mb = & git -C $repoRoot merge-base $baseRef HEAD 2>$null
+        if ($LASTEXITCODE -eq 0 -and $mb) {
+            $mergeBase = $mb.Trim()
+        }
+    }
+
+    if ($mergeBase) {
+        $diffFiles = @(git -C $repoRoot diff --name-only "$mergeBase..HEAD" --diff-filter=ACM 2>$null)
+    } else {
+        $null = git -C $repoRoot rev-parse --verify HEAD~1 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            $diffFiles = @(git -C $repoRoot diff --name-only HEAD~1..HEAD --diff-filter=ACM 2>$null)
+        } else {
+            # No parent commit yet: fall back to the full tracked set so the
+            # very first commit still gets scanned end-to-end.
+            $diffFiles = @(git -C $repoRoot ls-files 2>$null)
+        }
+    }
+
     $untrackedFiles = @(git -C $repoRoot ls-files --others --exclude-standard 2>$null)
     $allFiles = @($diffFiles) + @($untrackedFiles) | Where-Object { $_ } | Sort-Object -Unique
 }
@@ -145,17 +174,6 @@ foreach ($relativePath in $allFiles) {
         }
         $prevLineHadMarker = $thisLineHasMarker
 
-        # Skip lines that contain a canonical placeholder token. Plain string
-        # match avoids regex-escaping the angle brackets.
-        $hasPlaceholder = $false
-        foreach ($token in $placeholderTokens) {
-            if ($line.IndexOf($token, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
-                $hasPlaceholder = $true
-                break
-            }
-        }
-        if ($hasPlaceholder) { continue }
-
         foreach ($patternDef in $patterns) {
             $matched = if ($patternDef.caseSensitive) {
                 $line -cmatch $patternDef.pattern
@@ -164,19 +182,35 @@ foreach ($relativePath in $allFiles) {
             }
             if (-not $matched) { continue }
 
+            # Treat the match as a documented example only when the matched
+            # substring itself contains a canonical placeholder. Checking the
+            # whole line was unsafe — a real secret on the same line as an
+            # unrelated `<example>` would have been silently exempted.
+            $matchText = "$($Matches[0])"
+            $isPlaceholder = $false
+            foreach ($token in $placeholderTokens) {
+                if ($matchText.IndexOf($token, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
+                    $isPlaceholder = $true
+                    break
+                }
+            }
+            if ($isPlaceholder) { continue }
+
             if (-not $perLine.ContainsKey($lineNumber)) {
                 $perLine[$lineNumber] = @{
-                    file        = $relativePath
-                    line        = $lineNumber
-                    patterns    = @($patternDef.name)
+                    file         = $relativePath
+                    line         = $lineNumber
+                    patterns     = @($patternDef.name)
                     descriptions = @($patternDef.description)
-                    snippet     = if ($line.Length -gt 100) { $line.Substring(0, 100) + "..." } else { $line.Trim() }
+                    description  = $patternDef.description
+                    snippet      = if ($line.Length -gt 100) { $line.Substring(0, 100) + "..." } else { $line.Trim() }
                 }
             } else {
                 $entry = $perLine[$lineNumber]
                 if ($entry.patterns -notcontains $patternDef.name) {
                     $entry.patterns     += $patternDef.name
                     $entry.descriptions += $patternDef.description
+                    $entry.description   = $entry.descriptions -join ', '
                 }
             }
         }
@@ -194,11 +228,20 @@ foreach ($relativePath in $allFiles) {
     }
 }
 
-# Each line is already aggregated; preserve original order while dropping any
-# accidental cross-file duplicates from upstream callers.
-$uniqueIssues = $issues | Sort-Object { "$($_.issue)" } -Unique
+# Each line is already aggregated; preserve original (file → line) traversal
+# order while dropping any accidental cross-file duplicates from upstream
+# callers. Sort-Object -Unique would reorder lexicographically, which makes
+# the report harder to read in long verify-hook scans.
+$seenIssueKeys = @{}
+$uniqueIssues = @(foreach ($entry in $issues) {
+    $key = "$($entry.issue)"
+    if (-not $seenIssueKeys.ContainsKey($key)) {
+        $seenIssueKeys[$key] = $true
+        $entry
+    }
+})
 
-$details['scan_mode'] = if ($StagedOnly) { 'staged' } else { 'full' }
+$details['scan_mode'] = if ($StagedOnly) { 'staged' } else { 'verify-hook' }
 
 if ($StagedOnly -and $uniqueIssues.Count -gt 0) {
     [Console]::Error.WriteLine("")

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -150,8 +150,9 @@ if (1 -in $layersToRun) {
     $skillCodeReviewCode = Invoke-TestFile -Layer '1' -FileName 'Test-SkillCodeReview.ps1'
     $legacyVocabularyCode = Invoke-TestFile -Layer '1' -FileName 'Test-NoLegacyVocabulary.ps1'
     $activityLogCode     = Invoke-TestFile -Layer '1' -FileName 'Test-ActivityLogHygiene.ps1'
+    $privacyScanCode     = Invoke-TestFile -Layer '1' -FileName 'Test-PrivacyScan.ps1'
 
-    $exitCode = if ($structureCode -ne 0 -or $compilationCode -ne 0 -or $workflowManifestCode -ne 0 -or $mdRefsCode -ne 0 -or $skillCodeReviewCode -ne 0 -or $legacyVocabularyCode -ne 0 -or $activityLogCode -ne 0) { 1 } else { 0 }
+    $exitCode = if ($structureCode -ne 0 -or $compilationCode -ne 0 -or $workflowManifestCode -ne 0 -or $mdRefsCode -ne 0 -or $skillCodeReviewCode -ne 0 -or $legacyVocabularyCode -ne 0 -or $activityLogCode -ne 0 -or $privacyScanCode -ne 0) { 1 } else { 0 }
     $layerResults["1"] = ($exitCode -eq 0)
     if ($exitCode -ne 0) { $overallFailed = $true }
 }

--- a/tests/Test-PrivacyScan.ps1
+++ b/tests/Test-PrivacyScan.ps1
@@ -194,43 +194,95 @@ finally {
     if ($proj5) { Remove-TestProject -Path $proj5 }
 }
 
-# ─── Verify-hook scan scopes to HEAD~1..HEAD plus untracked files ────────────
+# ─── Verify-hook scan scopes to the task-branch merge-base diff ──────────────
+# Exercise the actual merge-base scoping on a real two-branch layout. A
+# baseline secret on `main` must NOT be re-flagged from a feature branch, and
+# secrets introduced in EARLY commits on the feature branch (not just the
+# latest one) must still be detected.
 
 $proj6 = $null
 try {
     $proj6 = Initialize-PrivacyTestRepo -Prefix "dotbot-privacy-scope"
 
-    # An older committed file with a secret. After we add a new commit, this
-    # file is in HEAD~2 and should NOT be re-scanned by HEAD~1..HEAD.
-    $oldFile = Join-Path $proj6 "src/Old.ps1"
-    New-Item -ItemType Directory -Path (Split-Path $oldFile) -Force | Out-Null
-    "`$old = `"Password=OldSecretValue42;`"" | Set-Content -Path $oldFile -Encoding UTF8
-    & git -C $proj6 add src/Old.ps1 2>&1 | Out-Null
-    & git -C $proj6 commit -q -m "old commit with secret" 2>&1 | Out-Null
+    # Resolve the default branch name (`main` on modern git, `master` on old).
+    $defaultBranch = (& git -C $proj6 rev-parse --abbrev-ref HEAD 2>$null).Trim()
 
-    # A second commit that does NOT introduce any secret. HEAD~1..HEAD should
-    # show only this commit's diff.
-    $cleanFile = Join-Path $proj6 "src/Clean.ps1"
+    # Commit a secret on the default branch — this represents prior history
+    # the task did not introduce.
+    $baseSecretFile = Join-Path $proj6 "src/BaselineSecret.ps1"
+    New-Item -ItemType Directory -Path (Split-Path $baseSecretFile) -Force | Out-Null
+    "`$base = `"Password=BaselineSecret42;`"" | Set-Content -Path $baseSecretFile -Encoding UTF8
+    & git -C $proj6 add src/BaselineSecret.ps1 2>&1 | Out-Null
+    & git -C $proj6 commit -q -m "baseline secret on $defaultBranch" 2>&1 | Out-Null
+
+    # Branch off and add two commits on the feature branch. The first commit
+    # introduces a secret; the second does not. With HEAD~1..HEAD scoping the
+    # earlier secret would be missed. With merge-base scoping it must still
+    # be flagged.
+    & git -C $proj6 checkout -q -b task/feature-x 2>&1 | Out-Null
+
+    $earlyTaskFile = Join-Path $proj6 "src/EarlyTask.ps1"
+    "`$task = `"Password=EarlyTaskSecret77;`"" | Set-Content -Path $earlyTaskFile -Encoding UTF8
+    & git -C $proj6 add src/EarlyTask.ps1 2>&1 | Out-Null
+    & git -C $proj6 commit -q -m "task: early commit with secret" 2>&1 | Out-Null
+
+    $cleanFile = Join-Path $proj6 "src/CleanLater.ps1"
     "Write-Host 'no secrets here'" | Set-Content -Path $cleanFile -Encoding UTF8
-    & git -C $proj6 add src/Clean.ps1 2>&1 | Out-Null
-    & git -C $proj6 commit -q -m "clean commit" 2>&1 | Out-Null
+    & git -C $proj6 add src/CleanLater.ps1 2>&1 | Out-Null
+    & git -C $proj6 commit -q -m "task: later clean commit" 2>&1 | Out-Null
 
     $result = Invoke-PrivacyScan -ProjectRoot $proj6
-    Assert-True -Name "Verify-hook ignores secrets in older commits outside HEAD~1..HEAD" `
-        -Condition ($result.success -eq $true) `
-        -Message "Expected verify-hook scan to scope to HEAD~1..HEAD. Got failures: $($result.failures | ConvertTo-Json -Compress)"
+    Assert-True -Name "Verify-hook flags task-branch secret introduced before the latest commit" `
+        -Condition ($result.success -eq $false) `
+        -Message "Expected merge-base scoping to surface src/EarlyTask.ps1's secret. Got: $($result.failures | ConvertTo-Json -Compress)"
+    if ($result.failures) {
+        $earlyHit = @($result.failures | Where-Object { $_.issue -match 'src[/\\]EarlyTask\.ps1' })
+        Assert-True -Name "Verify-hook flag names src/EarlyTask.ps1" `
+            -Condition ($earlyHit.Count -gt 0) `
+            -Message "Expected at least one violation citing src/EarlyTask.ps1. Got: $($result.failures | ConvertTo-Json -Compress)"
+        $baselineHit = @($result.failures | Where-Object { $_.issue -match 'src[/\\]BaselineSecret\.ps1' })
+        Assert-True -Name "Verify-hook does not re-flag baseline-branch secret" `
+            -Condition ($baselineHit.Count -eq 0) `
+            -Message "Expected merge-base scoping to skip src/BaselineSecret.ps1, but it was flagged"
+    }
 
-    # Untracked files are still scanned.
+    # Untracked files are still scanned regardless of branch position.
     $untracked = Join-Path $proj6 "src/Untracked.ps1"
     "`$x = `"Password=BrandNewSecret77;`"" | Set-Content -Path $untracked -Encoding UTF8
 
     $result2 = Invoke-PrivacyScan -ProjectRoot $proj6
+    $untrackedHit = @($result2.failures | Where-Object { $_.issue -match 'src[/\\]Untracked\.ps1' })
     Assert-True -Name "Verify-hook still scans untracked working-tree files" `
-        -Condition ($result2.success -eq $false) `
+        -Condition ($untrackedHit.Count -gt 0) `
         -Message "Expected untracked file with new secret to trip the scanner"
 }
 finally {
     if ($proj6) { Remove-TestProject -Path $proj6 }
+}
+
+# ─── merge-base==HEAD edge case falls back to HEAD~1..HEAD ───────────────────
+# When HEAD is on the base branch itself (no remote, single-branch repo), the
+# merge-base equals HEAD and the diff range would be empty. The hook must
+# fall back so secrets in the most recent commit are still scanned.
+
+$proj7 = $null
+try {
+    $proj7 = Initialize-PrivacyTestRepo -Prefix "dotbot-privacy-mb-eq-head"
+
+    $secretFile = Join-Path $proj7 "src/JustCommitted.ps1"
+    New-Item -ItemType Directory -Path (Split-Path $secretFile) -Force | Out-Null
+    "`$x = `"Password=FreshSecret88;`"" | Set-Content -Path $secretFile -Encoding UTF8
+    & git -C $proj7 add src/JustCommitted.ps1 2>&1 | Out-Null
+    & git -C $proj7 commit -q -m "secret on default branch" 2>&1 | Out-Null
+
+    $result = Invoke-PrivacyScan -ProjectRoot $proj7
+    $hit = @($result.failures | Where-Object { $_.issue -match 'src[/\\]JustCommitted\.ps1' })
+    Assert-True -Name "Verify-hook scans the latest commit when merge-base equals HEAD" `
+        -Condition ($hit.Count -gt 0) `
+        -Message "Expected fallback to HEAD~1..HEAD when on the base branch. Got: $($result.failures | ConvertTo-Json -Compress)"
+}
+finally {
+    if ($proj7) { Remove-TestProject -Path $proj7 }
 }
 
 $allPassed = Write-TestSummary -LayerName "Privacy-Scan Hook Tests"

--- a/tests/Test-PrivacyScan.ps1
+++ b/tests/Test-PrivacyScan.ps1
@@ -1,0 +1,240 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Tests for the 00-privacy-scan.ps1 verify hook.
+.DESCRIPTION
+    Covers the changes in #362: verify-hook scoping to HEAD~1..HEAD plus
+    untracked files, widened noscan/privacy-scan marker, placeholder skip
+    list, .bot/workspace/{tasks,decisions} exclusions, and the (file, line)
+    dedup that collapses multiple patterns on the same line.
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+Import-Module "$PSScriptRoot\Test-Helpers.psm1" -Force
+
+$repoRoot = Get-RepoRoot
+$privacyScanScript = Join-Path $repoRoot "core/hooks/verify/00-privacy-scan.ps1"
+
+Write-Host ""
+Write-Host "======================================================================" -ForegroundColor Blue
+Write-Host "  Privacy-Scan Hook Tests" -ForegroundColor Blue
+Write-Host "======================================================================" -ForegroundColor Blue
+Write-Host ""
+
+Reset-TestResults
+
+function Invoke-PrivacyScan {
+    param(
+        [Parameter(Mandatory)] [string]$ProjectRoot,
+        [switch]$StagedOnly
+    )
+
+    Push-Location $ProjectRoot
+    try {
+        $args = @("-NoProfile", "-File", $privacyScanScript)
+        if ($StagedOnly) { $args += "-StagedOnly" }
+        $output = & pwsh @args 2>$null
+    } finally {
+        Pop-Location
+    }
+    return $output | ConvertFrom-Json
+}
+
+function Initialize-PrivacyTestRepo {
+    param([Parameter(Mandatory)] [string]$Prefix)
+    $project = New-TestProject -Prefix $Prefix
+    & git -C $project commit --allow-empty -q -m "baseline" 2>&1 | Out-Null
+    return $project
+}
+
+# ─── Pre-commit (staged) scan flags real secrets in staged source files ──────
+
+$proj1 = $null
+try {
+    $proj1 = Initialize-PrivacyTestRepo -Prefix "dotbot-privacy-stage"
+    $sourceFile = Join-Path $proj1 "src/Config.cs"
+    New-Item -ItemType Directory -Path (Split-Path $sourceFile) -Force | Out-Null
+    'var x = "Password=R3alSecretValue99;";' | Set-Content -Path $sourceFile -Encoding UTF8
+    & git -C $proj1 add src/Config.cs 2>&1 | Out-Null
+
+    $result = Invoke-PrivacyScan -ProjectRoot $proj1 -StagedOnly
+
+    Assert-True -Name "Real secret in staged source file is detected" `
+        -Condition ($result.success -eq $false -and $result.failures.Count -ge 1) `
+        -Message "Expected scanner to flag Password=R3alSecretValue99; in src/Config.cs"
+}
+finally {
+    if ($proj1) { Remove-TestProject -Path $proj1 }
+}
+
+# ─── Pre-commit scan ignores .bot/workspace/tasks/ narrative content ─────────
+
+$proj2 = $null
+try {
+    $proj2 = Initialize-PrivacyTestRepo -Prefix "dotbot-privacy-tasks"
+    $taskFile = Join-Path $proj2 ".bot/workspace/tasks/todo/seeded.json"
+    New-Item -ItemType Directory -Path (Split-Path $taskFile) -Force | Out-Null
+    '{"description":"Use Password=R3alSecretValue99; as the example"}' | Set-Content -Path $taskFile -Encoding UTF8
+    & git -C $proj2 add ".bot/workspace/tasks/todo/seeded.json" 2>&1 | Out-Null
+
+    $result = Invoke-PrivacyScan -ProjectRoot $proj2 -StagedOnly
+
+    Assert-True -Name "Same secret inside .bot/workspace/tasks/todo/ is excluded" `
+        -Condition ($result.success -eq $true) `
+        -Message "Expected scanner to skip files under .bot/workspace/tasks/. Got: $($result.failures | ConvertTo-Json -Compress)"
+}
+finally {
+    if ($proj2) { Remove-TestProject -Path $proj2 }
+}
+
+# ─── Pre-commit scan ignores .bot/workspace/decisions/ narrative content ─────
+
+$proj2b = $null
+try {
+    $proj2b = Initialize-PrivacyTestRepo -Prefix "dotbot-privacy-decisions"
+    $decFile = Join-Path $proj2b ".bot/workspace/decisions/seeded.json"
+    New-Item -ItemType Directory -Path (Split-Path $decFile) -Force | Out-Null
+    '{"rationale":"discussion of Password=R3alSecretValue99; example"}' | Set-Content -Path $decFile -Encoding UTF8
+    & git -C $proj2b add ".bot/workspace/decisions/seeded.json" 2>&1 | Out-Null
+
+    $result = Invoke-PrivacyScan -ProjectRoot $proj2b -StagedOnly
+
+    Assert-True -Name "Same secret inside .bot/workspace/decisions/ is excluded" `
+        -Condition ($result.success -eq $true) `
+        -Message "Expected scanner to skip files under .bot/workspace/decisions/"
+}
+finally {
+    if ($proj2b) { Remove-TestProject -Path $proj2b }
+}
+
+# ─── Inline `# privacy-scan: example` marker skips the violation ─────────────
+
+$proj3 = $null
+try {
+    $proj3 = Initialize-PrivacyTestRepo -Prefix "dotbot-privacy-marker"
+    $sourceFile = Join-Path $proj3 "src/Sample.ps1"
+    New-Item -ItemType Directory -Path (Split-Path $sourceFile) -Force | Out-Null
+    @'
+# privacy-scan: example
+$conn = "Password=R3alSecretValue99;"
+'@ | Set-Content -Path $sourceFile -Encoding UTF8
+    & git -C $proj3 add src/Sample.ps1 2>&1 | Out-Null
+
+    $result = Invoke-PrivacyScan -ProjectRoot $proj3 -StagedOnly
+
+    Assert-True -Name "Line tagged with '# privacy-scan: example' is skipped" `
+        -Condition ($result.success -eq $true) `
+        -Message "Expected the marker comment to suppress the violation"
+
+    # Sanity: the existing `noscan` marker still works.
+    $sourceFile2 = Join-Path $proj3 "src/Sample2.ps1"
+    "`$conn = `"Password=AnotherSecret456;`"  # noscan" | Set-Content -Path $sourceFile2 -Encoding UTF8
+    & git -C $proj3 add src/Sample2.ps1 2>&1 | Out-Null
+
+    $result2 = Invoke-PrivacyScan -ProjectRoot $proj3 -StagedOnly
+    Assert-True -Name "Existing `noscan` marker still suppresses violations" `
+        -Condition ($result2.success -eq $true) `
+        -Message "Expected `noscan` to keep working"
+}
+finally {
+    if ($proj3) { Remove-TestProject -Path $proj3 }
+}
+
+# ─── Placeholder tokens (hunter2 etc.) are recognised as documented examples ─
+
+$proj4 = $null
+try {
+    $proj4 = Initialize-PrivacyTestRepo -Prefix "dotbot-privacy-placeholder"
+    $sourceFile = Join-Path $proj4 "docs/example.md"
+    New-Item -ItemType Directory -Path (Split-Path $sourceFile) -Force | Out-Null
+    'Connection: `Password=hunter2;` is a documented example.' | Set-Content -Path $sourceFile -Encoding UTF8
+    & git -C $proj4 add docs/example.md 2>&1 | Out-Null
+
+    $result = Invoke-PrivacyScan -ProjectRoot $proj4 -StagedOnly
+
+    Assert-True -Name "Placeholder token 'hunter2' suppresses violation" `
+        -Condition ($result.success -eq $true) `
+        -Message "Expected placeholder list to skip the line"
+}
+finally {
+    if ($proj4) { Remove-TestProject -Path $proj4 }
+}
+
+# ─── Multiple patterns matching one line collapse to a single violation ──────
+
+$proj5 = $null
+try {
+    $proj5 = Initialize-PrivacyTestRepo -Prefix "dotbot-privacy-dedup"
+    $sourceFile = Join-Path $proj5 "src/Multi.ps1"
+    New-Item -ItemType Directory -Path (Split-Path $sourceFile) -Force | Out-Null
+    # One line matches both `secret_value` (`password=...`) and
+    # `connection_string_password` (`Password=...`).
+    "`$cs = `"Password=R3alSecretValue99;`"" | Set-Content -Path $sourceFile -Encoding UTF8
+    & git -C $proj5 add src/Multi.ps1 2>&1 | Out-Null
+
+    $result = Invoke-PrivacyScan -ProjectRoot $proj5 -StagedOnly
+
+    $violationsForLine = @($result.details.violations | Where-Object { $_.file -like "*Multi.ps1" })
+    Assert-Equal -Name "Two patterns on one line produce one violation entry" `
+        -Expected 1 `
+        -Actual $violationsForLine.Count
+
+    if ($violationsForLine.Count -eq 1) {
+        $patterns = @($violationsForLine[0].patterns)
+        Assert-True -Name "Single violation lists both pattern names" `
+            -Condition ($patterns.Count -ge 2 -and $patterns -contains 'secret_value' -and $patterns -contains 'connection_string_password') `
+            -Message "Expected patterns list to include secret_value and connection_string_password. Got: $($patterns -join ',')"
+    }
+}
+finally {
+    if ($proj5) { Remove-TestProject -Path $proj5 }
+}
+
+# ─── Verify-hook scan scopes to HEAD~1..HEAD plus untracked files ────────────
+
+$proj6 = $null
+try {
+    $proj6 = Initialize-PrivacyTestRepo -Prefix "dotbot-privacy-scope"
+
+    # An older committed file with a secret. After we add a new commit, this
+    # file is in HEAD~2 and should NOT be re-scanned by HEAD~1..HEAD.
+    $oldFile = Join-Path $proj6 "src/Old.ps1"
+    New-Item -ItemType Directory -Path (Split-Path $oldFile) -Force | Out-Null
+    "`$old = `"Password=OldSecretValue42;`"" | Set-Content -Path $oldFile -Encoding UTF8
+    & git -C $proj6 add src/Old.ps1 2>&1 | Out-Null
+    & git -C $proj6 commit -q -m "old commit with secret" 2>&1 | Out-Null
+
+    # A second commit that does NOT introduce any secret. HEAD~1..HEAD should
+    # show only this commit's diff.
+    $cleanFile = Join-Path $proj6 "src/Clean.ps1"
+    "Write-Host 'no secrets here'" | Set-Content -Path $cleanFile -Encoding UTF8
+    & git -C $proj6 add src/Clean.ps1 2>&1 | Out-Null
+    & git -C $proj6 commit -q -m "clean commit" 2>&1 | Out-Null
+
+    $result = Invoke-PrivacyScan -ProjectRoot $proj6
+    Assert-True -Name "Verify-hook ignores secrets in older commits outside HEAD~1..HEAD" `
+        -Condition ($result.success -eq $true) `
+        -Message "Expected verify-hook scan to scope to HEAD~1..HEAD. Got failures: $($result.failures | ConvertTo-Json -Compress)"
+
+    # Untracked files are still scanned.
+    $untracked = Join-Path $proj6 "src/Untracked.ps1"
+    "`$x = `"Password=BrandNewSecret77;`"" | Set-Content -Path $untracked -Encoding UTF8
+
+    $result2 = Invoke-PrivacyScan -ProjectRoot $proj6
+    Assert-True -Name "Verify-hook still scans untracked working-tree files" `
+        -Condition ($result2.success -eq $false) `
+        -Message "Expected untracked file with new secret to trip the scanner"
+}
+finally {
+    if ($proj6) { Remove-TestProject -Path $proj6 }
+}
+
+$allPassed = Write-TestSummary -LayerName "Privacy-Scan Hook Tests"
+
+if (-not $allPassed) {
+    exit 1
+}

--- a/tests/Test-PrivacyScan.ps1
+++ b/tests/Test-PrivacyScan.ps1
@@ -35,7 +35,7 @@ function Invoke-PrivacyScan {
 
     Push-Location $ProjectRoot
     try {
-        $args = @("-NoProfile", "-File", $privacyScanScript)
+        $args = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-NonInteractive", "-File", $privacyScanScript)
         if ($StagedOnly) { $args += "-StagedOnly" }
         $output = & pwsh @args 2>$null
     } finally {


### PR DESCRIPTION
## Summary
- Scope the verify-hook (non-staged) path to `git diff HEAD~1..HEAD` plus untracked files so `task_mark_done` is no longer blocked by prior-task narrative content.
- Exclude `.bot/workspace/tasks/` and `.bot/workspace/decisions/` from the scan; widen the inline marker to recognise `# privacy-scan: example` on the same or previous line; add a canonical placeholder skip list (`hunter2`, `<example>`, `<placeholder>`, `REPLACE_ME`, `<your-password>`).
- Rekey the dedup by (file, line) so multiple patterns matching one line produce one violation entry with the pattern names listed.
- New `tests/Test-PrivacyScan.ps1` (10 assertions) wired into the Layer 1 runner.

Closes #362

## Test plan
- [x] `tests/Test-PrivacyScan.ps1` — 10 passed
- [x] `pwsh tests/Run-Tests.ps1` — Layer 1-3 ALL PASSED
- [x] `pwsh install.ps1` clean