### PR TITLE
fix(activity-log): tighten compaction guard, scope correlation_id, seed UI corr_id

### DIFF
--- a/core/runtime/ClaudeCLI/ClaudeCLI.psm1
+++ b/core/runtime/ClaudeCLI/ClaudeCLI.psm1
@@ -1047,8 +1047,16 @@ function Invoke-ClaudeStream {
                 return
             }
 
-            # Real context compaction (B0a) — system event with a compaction summary in $evt.message,
-            # or event type explicitly contains 'compact'
+            # Real context compaction (B0a). Only emit when we have an explicit
+            # compaction signal: event type contains 'compact', subtype is the
+            # documented 'compact_boundary', or a non-empty $evt.message.
+            # Without this guard every unrecognised system subtype was logged
+            # as a fake "context auto-compacted" entry.
+            $isCompact = ("$($evt.type)" -match 'compact') -or
+                         ($subtype -eq 'compact_boundary') -or
+                         ($evt.message -and "$($evt.message)".Trim().Length -gt 0)
+            if (-not $isCompact) { return }
+
             $compactMsg = if ($evt.message) { Get-PreviewText "$($evt.message)" 200 } else { "context auto-compacted" }
             $ctxTokens = $state.lastTurnInput + $state.lastTurnCacheRead
             $pct = [math]::Round($ctxTokens / 200000 * 100, 1)

--- a/core/runtime/launch-process.ps1
+++ b/core/runtime/launch-process.ps1
@@ -77,6 +77,11 @@ param(
 
 Set-StrictMode -Version 1.0
 
+# Reset DOTBOT_CORRELATION_ID per launch. Without this, child processes
+# inherit the parent's value via the environment, so Write-BotLog calls in
+# this run leak the previous process's correlation_id into activity events.
+$env:DOTBOT_CORRELATION_ID = "corr-$([guid]::NewGuid().ToString().Substring(0,8))"
+
 # --- Configuration ---
 
 # Determine phase for activity logging
@@ -289,11 +294,9 @@ if (-not (Request-ProcessLock -LockType $lockKey)) {
 $sessionId = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH-mm-ssZ")
 $claudeSessionId = New-ProviderSession
 
-# Set process ID and correlation ID env vars for structured logging
+# Set process ID env var for structured logging. The correlation ID was
+# already reset at the top of the script.
 $env:DOTBOT_PROCESS_ID = $procId
-if (-not $env:DOTBOT_CORRELATION_ID) {
-    $env:DOTBOT_CORRELATION_ID = "corr-$([guid]::NewGuid().ToString().Substring(0,8))"
-}
 
 $processData = @{
     id              = $procId

--- a/core/ui/server.ps1
+++ b/core/ui/server.ps1
@@ -24,6 +24,13 @@ param(
 
 Set-StrictMode -Version 1.0
 
+# Establish a stable correlation_id for the UI server's lifetime so events
+# emitted from request handlers (e.g. /api/aether/scan) carry a value that
+# joins them to the rest of the server's activity stream.
+if (-not $env:DOTBOT_CORRELATION_ID) {
+    $env:DOTBOT_CORRELATION_ID = "corr-ui-$([guid]::NewGuid().ToString().Substring(0,8))"
+}
+
 # ---------------------------------------------------------------------------
 # Pending-tasks runner identity
 # ---------------------------------------------------------------------------

--- a/core/ui/server.ps1
+++ b/core/ui/server.ps1
@@ -26,10 +26,10 @@ Set-StrictMode -Version 1.0
 
 # Establish a stable correlation_id for the UI server's lifetime so events
 # emitted from request handlers (e.g. /api/aether/scan) carry a value that
-# joins them to the rest of the server's activity stream.
-if (-not $env:DOTBOT_CORRELATION_ID) {
-    $env:DOTBOT_CORRELATION_ID = "corr-ui-$([guid]::NewGuid().ToString().Substring(0,8))"
-}
+# joins them to the rest of the server's activity stream. Unconditional —
+# inheriting the parent shell's DOTBOT_CORRELATION_ID would defeat the
+# purpose of scoping the id per UI-server lifetime.
+$env:DOTBOT_CORRELATION_ID = "corr-ui-$([guid]::NewGuid().ToString().Substring(0,8))"
 
 # ---------------------------------------------------------------------------
 # Pending-tasks runner identity

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -149,8 +149,9 @@ if (1 -in $layersToRun) {
     $mdRefsCode          = Invoke-TestFile -Layer '1' -FileName 'Test-MdRefs.ps1'
     $skillCodeReviewCode = Invoke-TestFile -Layer '1' -FileName 'Test-SkillCodeReview.ps1'
     $legacyVocabularyCode = Invoke-TestFile -Layer '1' -FileName 'Test-NoLegacyVocabulary.ps1'
+    $activityLogCode     = Invoke-TestFile -Layer '1' -FileName 'Test-ActivityLogHygiene.ps1'
 
-    $exitCode = if ($structureCode -ne 0 -or $compilationCode -ne 0 -or $workflowManifestCode -ne 0 -or $mdRefsCode -ne 0 -or $skillCodeReviewCode -ne 0 -or $legacyVocabularyCode -ne 0) { 1 } else { 0 }
+    $exitCode = if ($structureCode -ne 0 -or $compilationCode -ne 0 -or $workflowManifestCode -ne 0 -or $mdRefsCode -ne 0 -or $skillCodeReviewCode -ne 0 -or $legacyVocabularyCode -ne 0 -or $activityLogCode -ne 0) { 1 } else { 0 }
     $layerResults["1"] = ($exitCode -eq 0)
     if ($exitCode -ne 0) { $overallFailed = $true }
 }

--- a/tests/Test-ActivityLogHygiene.ps1
+++ b/tests/Test-ActivityLogHygiene.ps1
@@ -1,0 +1,110 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Tests for #367: activity-log hygiene.
+.DESCRIPTION
+    Covers three of the four sub-bugs in #367:
+      1. ClaudeCLI.psm1's compaction catch-all no longer fires for
+         unrecognised system events with no message.
+      3. launch-process.ps1 resets DOTBOT_CORRELATION_ID at startup so
+         child processes do not inherit the parent's value via env vars.
+      4. UI server (core/ui/server.ps1) seeds DOTBOT_CORRELATION_ID at
+         startup so events such as the Aether-conduit-discovered log
+         carry a correlation_id.
+
+    Sub-bug 2 (sub-agent task_started/task_progress/task_notification
+    pair semantics) is intentionally not addressed by this PR — the
+    upstream Claude Code intent could not be confirmed, and the issue
+    body authorises shipping 1, 3, 4 only in that case.
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+Import-Module "$PSScriptRoot\Test-Helpers.psm1" -Force
+
+$repoRoot = Get-RepoRoot
+
+Write-Host ""
+Write-Host "======================================================================" -ForegroundColor Blue
+Write-Host "  Activity-Log Hygiene Tests" -ForegroundColor Blue
+Write-Host "======================================================================" -ForegroundColor Blue
+Write-Host ""
+
+Reset-TestResults
+
+# ─── Sub-bug 1: compaction catch-all is gated on an explicit signal ──────────
+
+$claudeCliPath = Join-Path $repoRoot "core/runtime/ClaudeCLI/ClaudeCLI.psm1"
+Assert-PathExists -Name "ClaudeCLI.psm1 exists" -Path $claudeCliPath
+$claudeCliSource = Get-Content $claudeCliPath -Raw
+
+Assert-True -Name "Compaction emission is gated on `$isCompact" `
+    -Condition ($claudeCliSource -match '\$isCompact\s*=') `
+    -Message "Expected ClaudeCLI.psm1 to compute an isCompact gate before emitting the 'compact' activity event"
+
+Assert-True -Name "Compact gate references compact_boundary subtype" `
+    -Condition ($claudeCliSource -match "compact_boundary") `
+    -Message "Expected the compact gate to recognise 'compact_boundary' as an explicit subtype"
+
+Assert-True -Name "Compact gate short-circuits when not compact" `
+    -Condition ($claudeCliSource -match 'if\s*\(-not\s*\$isCompact\)\s*\{\s*return\s*\}') `
+    -Message "Expected `if (-not `$isCompact) { return }` after the gate"
+
+# ─── Sub-bug 3: launch-process.ps1 resets DOTBOT_CORRELATION_ID early ────────
+
+$launchProcessPath = Join-Path $repoRoot "core/runtime/launch-process.ps1"
+Assert-PathExists -Name "launch-process.ps1 exists" -Path $launchProcessPath
+$launchProcessSource = Get-Content $launchProcessPath -Raw
+
+Assert-True -Name "launch-process.ps1 sets DOTBOT_CORRELATION_ID unconditionally" `
+    -Condition ($launchProcessSource -match '\$env:DOTBOT_CORRELATION_ID\s*=\s*"corr-') `
+    -Message "Expected an unconditional reset of DOTBOT_CORRELATION_ID in launch-process.ps1"
+
+Assert-True -Name "launch-process.ps1 reset is not gated by a `if (-not env:DOTBOT_CORRELATION_ID)` check" `
+    -Condition (-not ($launchProcessSource -match 'if\s*\(\s*-not\s*\$env:DOTBOT_CORRELATION_ID\s*\)')) `
+    -Message "Expected the inherited-value guard to be gone (the bug was that inheriting leaked correlation_ids across processes)"
+
+$launchProcessLines = $launchProcessSource -split "`r?`n"
+$resetLine = $null
+for ($i = 0; $i -lt $launchProcessLines.Count; $i++) {
+    if ($launchProcessLines[$i] -match '^\s*\$env:DOTBOT_CORRELATION_ID\s*=\s*"corr-') {
+        $resetLine = $i + 1
+        break
+    }
+}
+Assert-True -Name "DOTBOT_CORRELATION_ID reset happens early (before line 100)" `
+    -Condition ($resetLine -ne $null -and $resetLine -lt 100) `
+    -Message "Expected reset to happen before any Write-BotLog calls; found at line $resetLine"
+
+# Behavioral check: launching a small child pwsh that imports DotBotLog and
+# emits an event picks up a fresh correlation_id, not whatever was inherited.
+$child = & pwsh -NoProfile -Command @'
+$env:DOTBOT_CORRELATION_ID = "corr-from-parent"
+& pwsh -NoProfile -Command {
+    # Source the early-reset block from launch-process.ps1 (lines 78-83 area)
+    $env:DOTBOT_CORRELATION_ID = "corr-$([guid]::NewGuid().ToString().Substring(0,8))"
+    Write-Output $env:DOTBOT_CORRELATION_ID
+}
+'@
+Assert-True -Name "Fresh launch produces a correlation_id distinct from the parent's" `
+    -Condition ($child -and ($child -ne "corr-from-parent")) `
+    -Message "Expected a fresh corr- value, got: $child"
+
+# ─── Sub-bug 4: UI server seeds DOTBOT_CORRELATION_ID at startup ─────────────
+
+$serverPath = Join-Path $repoRoot "core/ui/server.ps1"
+Assert-PathExists -Name "server.ps1 exists" -Path $serverPath
+$serverSource = Get-Content $serverPath -Raw
+
+Assert-True -Name "server.ps1 seeds DOTBOT_CORRELATION_ID with a corr-ui- prefix" `
+    -Condition ($serverSource -match '\$env:DOTBOT_CORRELATION_ID\s*=\s*"corr-ui-') `
+    -Message "Expected server.ps1 to seed a corr-ui-* value at startup so Aether and other handler-emitted events carry a correlation_id"
+
+$allPassed = Write-TestSummary -LayerName "Activity-Log Hygiene Tests"
+
+if (-not $allPassed) {
+    exit 1
+}

--- a/tests/Test-ActivityLogHygiene.ps1
+++ b/tests/Test-ActivityLogHygiene.ps1
@@ -79,20 +79,6 @@ Assert-True -Name "DOTBOT_CORRELATION_ID reset happens early (before line 100)" 
     -Condition ($resetLine -ne $null -and $resetLine -lt 100) `
     -Message "Expected reset to happen before any Write-BotLog calls; found at line $resetLine"
 
-# Behavioral check: launching a small child pwsh that imports DotBotLog and
-# emits an event picks up a fresh correlation_id, not whatever was inherited.
-$child = & pwsh -NoProfile -Command @'
-$env:DOTBOT_CORRELATION_ID = "corr-from-parent"
-& pwsh -NoProfile -Command {
-    # Source the early-reset block from launch-process.ps1 (lines 78-83 area)
-    $env:DOTBOT_CORRELATION_ID = "corr-$([guid]::NewGuid().ToString().Substring(0,8))"
-    Write-Output $env:DOTBOT_CORRELATION_ID
-}
-'@
-Assert-True -Name "Fresh launch produces a correlation_id distinct from the parent's" `
-    -Condition ($child -and ($child -ne "corr-from-parent")) `
-    -Message "Expected a fresh corr- value, got: $child"
-
 # ─── Sub-bug 4: UI server seeds DOTBOT_CORRELATION_ID at startup ─────────────
 
 $serverPath = Join-Path $repoRoot "core/ui/server.ps1"
@@ -102,6 +88,10 @@ $serverSource = Get-Content $serverPath -Raw
 Assert-True -Name "server.ps1 seeds DOTBOT_CORRELATION_ID with a corr-ui- prefix" `
     -Condition ($serverSource -match '\$env:DOTBOT_CORRELATION_ID\s*=\s*"corr-ui-') `
     -Message "Expected server.ps1 to seed a corr-ui-* value at startup so Aether and other handler-emitted events carry a correlation_id"
+
+Assert-True -Name "server.ps1 reset is unconditional (no `if (-not env:DOTBOT_CORRELATION_ID)` gate)" `
+    -Condition (-not ($serverSource -match 'if\s*\(\s*-not\s*\$env:DOTBOT_CORRELATION_ID\s*\)\s*\{[^}]*"corr-ui-')) `
+    -Message "Expected the seed to be unconditional; gating on the inherited value would let the parent's correlation_id leak through"
 
 $allPassed = Write-TestSummary -LayerName "Activity-Log Hygiene Tests"
 


### PR DESCRIPTION
## Summary
- Tighten the compaction catch-all in `ClaudeCLI.psm1` so an unrecognised `system` event no longer logs a fake `context auto-compacted` entry. The branch now requires an explicit signal: event type contains `compact`, subtype `compact_boundary`, or non-empty `$evt.message`.
- Reset `DOTBOT_CORRELATION_ID` unconditionally at the top of `launch-process.ps1` so child processes do not inherit the parent's value through the environment and leak it across process boundaries.
- Seed `DOTBOT_CORRELATION_ID` at the top of `core/ui/server.ps1` so request-handler emissions (including the Aether-conduit-discovered event at `server.ps1:785`) carry a `corr-ui-*` value through `Write-BotLog`'s default.

Sub-bug 2 (sub-agent `task_started` / `task_progress` / `task_notification` pair semantics) is intentionally not in this PR. The upstream Claude Code intent could not be confirmed from the dotbot source, and the issue body authorises shipping the other three sub-bugs alone in that case. A follow-up issue should track confirmation against the upstream emitter and a decision on whether to drop or relabel those events.

Closes #367

## Test plan
- [x] New `tests/Test-ActivityLogHygiene.ps1` (11 assertions) passes; fails 6 of 11 on `main` without the fix.
- [x] `pwsh tests/Run-Tests.ps1` — Layer 1-3 ALL PASSED
- [x] `pwsh install.ps1` clean