### PR TITLE
fix(prompts): warn that the Bash tool runs Bash, not PowerShell

### DIFF
--- a/core/prompts/98-analyse-task.md
+++ b/core/prompts/98-analyse-task.md
@@ -12,6 +12,8 @@ You are an autonomous AI coding agent performing **pre-flight analysis** of a ta
 
 **Built-in tools** (`WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`) are always available — never use ToolSearch for them.
 
+> The Bash tool runs Bash, not PowerShell. Do not use `$obj.property`, `$_.Name`, `Get-ChildItem`, or `Where-Object`. Use `jq` for JSON, `awk` or `cut` for fields, `$(command)` for substitution, `grep` and `find` for filtering. If you need PowerShell semantics, run `pwsh -Command "<script>"` explicitly.
+
 **Load dotbot tools** (single bulk call — `select:` accepts a comma-separated list):
 
 ```

--- a/core/prompts/99-autonomous-task.md
+++ b/core/prompts/99-autonomous-task.md
@@ -12,6 +12,8 @@ You are an autonomous AI coding agent operating in Go Mode. Your mission is to c
 
 **Built-in tools** (`WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`) are always available — never use ToolSearch for them.
 
+> The Bash tool runs Bash, not PowerShell. Do not use `$obj.property`, `$_.Name`, `Get-ChildItem`, or `Where-Object`. Use `jq` for JSON, `awk` or `cut` for fields, `$(command)` for substitution, `grep` and `find` for filtering. If you need PowerShell semantics, run `pwsh -Command "<script>"` explicitly.
+
 **Load dotbot tools** (single bulk call — `select:` accepts a comma-separated list):
 
 ```

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1419,6 +1419,26 @@ Assert-True -Name "Fix#H: 03a example task-groups.json includes applicable_decis
 Assert-True -Name "Fix#H: 03a Field Reference declares applicable_decisions as a required field" `
     -Condition ($planTaskGroupsSrc -match '\|\s+`applicable_decisions`\s+\|\s+Yes\s+\|')
 
+# ── #364: Both core prompts must warn that the Bash tool runs Bash, not
+# PowerShell. Agents picked up PowerShell's $obj.property syntax from the
+# project's PowerShell-heavy code and got `extglob.project_name: command not
+# found` errors when piping JSON through Bash.
+$bashWarningPrompts = @(
+    (Join-Path $repoRoot "core/prompts/99-autonomous-task.md"),
+    (Join-Path $repoRoot "core/prompts/98-analyse-task.md")
+)
+foreach ($pf in $bashWarningPrompts) {
+    $relName = Split-Path $pf -Leaf
+    Assert-PathExists -Name "#364: $relName exists" -Path $pf
+    $src = Get-Content $pf -Raw
+    Assert-True -Name "#364: $relName warns the Bash tool runs Bash, not PowerShell" `
+        -Condition ($src -match 'Bash\s+tool\s+runs\s+Bash,\s+not\s+PowerShell')
+    Assert-True -Name "#364: $relName names `$obj.property as a forbidden idiom" `
+        -Condition ($src -match '\$obj\.property')
+    Assert-True -Name "#364: $relName tells the agent to use pwsh -Command for PowerShell semantics" `
+        -Condition ($src -match 'pwsh\s+-Command')
+}
+
 Write-Host ""
 
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Insert an explicit warning right after the Phase 0 built-in-tools header in `core/prompts/98-analyse-task.md` and `core/prompts/99-autonomous-task.md` telling the agent that the `Bash` tool runs Bash, not PowerShell, naming `$obj.property` / `$_.Name` / `Get-ChildItem` / `Where-Object` as forbidden idioms, and pointing to `pwsh -Command "<script>"` for cases that need PowerShell semantics.
- Extend `tests/Test-WorkflowManifest.ps1` with assertions that both prompts contain the literal substring `Bash tool runs Bash, not PowerShell`, the example forbidden idiom `$obj.property`, and the `pwsh -Command` escape hatch.

Closes #364

## Test plan
- [x] `tests/Test-WorkflowManifest.ps1` — 389 passed (6 of 389 fail on `main` without the prompt change)
- [x] `pwsh tests/Run-Tests.ps1` — Layer 1-3 ALL PASSED
- [x] `pwsh install.ps1` clean