### PR TITLE
fix: clarify product-doc ambiguities during start-from-prompt

### DIFF
--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -149,10 +149,11 @@ if (1 -in $layersToRun) {
     $mdRefsCode          = Invoke-TestFile -Layer '1' -FileName 'Test-MdRefs.ps1'
     $skillCodeReviewCode = Invoke-TestFile -Layer '1' -FileName 'Test-SkillCodeReview.ps1'
     $legacyVocabularyCode = Invoke-TestFile -Layer '1' -FileName 'Test-NoLegacyVocabulary.ps1'
+    $clarificationCode    = Invoke-TestFile -Layer '1' -FileName 'Test-StartFromPromptClarification.ps1'
     $activityLogCode     = Invoke-TestFile -Layer '1' -FileName 'Test-ActivityLogHygiene.ps1'
     $privacyScanCode     = Invoke-TestFile -Layer '1' -FileName 'Test-PrivacyScan.ps1'
 
-    $exitCode = if ($structureCode -ne 0 -or $compilationCode -ne 0 -or $workflowManifestCode -ne 0 -or $mdRefsCode -ne 0 -or $skillCodeReviewCode -ne 0 -or $legacyVocabularyCode -ne 0 -or $activityLogCode -ne 0 -or $privacyScanCode -ne 0) { 1 } else { 0 }
+    $exitCode = if ($structureCode -ne 0 -or $compilationCode -ne 0 -or $workflowManifestCode -ne 0 -or $mdRefsCode -ne 0 -or $skillCodeReviewCode -ne 0 -or $legacyVocabularyCode -ne 0 -or $clarificationCode -ne 0 -or $activityLogCode -ne 0 -or $privacyScanCode -ne 0) { 1 } else { 0 }
     $layerResults["1"] = ($exitCode -eq 0)
     if ($exitCode -ne 0) { $overallFailed = $true }
 }

--- a/tests/Test-StartFromPromptClarification.ps1
+++ b/tests/Test-StartFromPromptClarification.ps1
@@ -42,8 +42,8 @@ Assert-True -Name 'mission.md template has no Open Questions section' `
     -Condition ($planProductBody -notmatch '(?m)^## Open Questions') `
     -Message '01-plan-product.md still emits a "## Open Questions" section in the mission.md template'
 
-Assert-FileContains -Name '01b-generate-decisions lists existing decisions to dedupe' `
-    -Path $genDecisions -Pattern 'decision_list'
+Assert-FileContains -Name '01b-generate-decisions has Step 0.5 listing existing decisions' `
+    -Path $genDecisions -Pattern 'Step 0\.5: List Existing Decisions'
 
 $results = Get-TestResults
 [void](Write-TestSummary -LayerName "Layer 1: start-from-prompt clarification")

--- a/tests/Test-StartFromPromptClarification.ps1
+++ b/tests/Test-StartFromPromptClarification.ps1
@@ -35,12 +35,22 @@ Assert-FileContains -Name '01-plan-product references task_mark_needs_input' `
 Assert-FileContains -Name '01-plan-product references decision_create' `
     -Path $planProduct -Pattern 'decision_create'
 
-# Negative: the mission.md template inside the prompt must not carry an
-# Open Questions section. Inline match because no Assert-FileNotContains exists.
+# Negative: the mission.md template block inside the prompt must not carry
+# an Open Questions section. Scoped to just the template — explanatory text
+# elsewhere in the prompt may legitimately mention the heading.
 $planProductBody = Get-Content $planProduct -Raw
+$missionTemplateMatch = [regex]::Match(
+    $planProductBody,
+    '(?ms)^### 1\.\s+`mission\.md`.*?(?=^### 2\.\s+`tech-stack\.md`)'
+)
+Assert-True -Name '01-plan-product contains the mission.md template section' `
+    -Condition $missionTemplateMatch.Success `
+    -Message 'Could not locate the mission.md template section in 01-plan-product.md'
+
+$missionTemplateBody = if ($missionTemplateMatch.Success) { $missionTemplateMatch.Value } else { '' }
 Assert-True -Name 'mission.md template has no Open Questions section' `
-    -Condition ($planProductBody -notmatch '(?m)^## Open Questions') `
-    -Message '01-plan-product.md still emits a "## Open Questions" section in the mission.md template'
+    -Condition ($missionTemplateBody -notmatch '(?m)^## Open Questions') `
+    -Message 'Mission.md template still emits a "## Open Questions" section'
 
 Assert-FileContains -Name '01b-generate-decisions has Step 0.5 listing existing decisions' `
     -Path $genDecisions -Pattern 'Step 0\.5: List Existing Decisions'

--- a/tests/Test-StartFromPromptClarification.ps1
+++ b/tests/Test-StartFromPromptClarification.ps1
@@ -45,6 +45,9 @@ Assert-True -Name 'mission.md template has no Open Questions section' `
 Assert-FileContains -Name '01b-generate-decisions has Step 0.5 listing existing decisions' `
     -Path $genDecisions -Pattern 'Step 0\.5: List Existing Decisions'
 
+Assert-FileContains -Name '01b-generate-decisions invokes decision_list with status accepted' `
+    -Path $genDecisions -Pattern 'mcp__dotbot__decision_list\(\{\s*status:\s*"accepted"\s*\}\)'
+
 $results = Get-TestResults
 [void](Write-TestSummary -LayerName "Layer 1: start-from-prompt clarification")
 if ($results.Failed -gt 0) { exit 1 } else { exit 0 }

--- a/tests/Test-StartFromPromptClarification.ps1
+++ b/tests/Test-StartFromPromptClarification.ps1
@@ -1,0 +1,50 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Layer 1: Hard gate — start-from-prompt clarification flow is wired in.
+.DESCRIPTION
+    Locks in the contract that 01-plan-product asks the user via
+    task_mark_needs_input and records decisions, the mission.md template
+    no longer contains an Open Questions section, and 01b-generate-decisions
+    dedupes against existing decisions.
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+Import-Module "$PSScriptRoot\Test-Helpers.psm1" -Force
+
+$repoRoot = Get-RepoRoot
+
+Write-Host ""
+Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Blue
+Write-Host "  Layer 1: start-from-prompt clarification (hard fail)" -ForegroundColor Blue
+Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Blue
+Write-Host ""
+
+Reset-TestResults
+
+$planProduct  = Join-Path $repoRoot 'workflows/start-from-prompt/recipes/prompts/01-plan-product.md'
+$genDecisions = Join-Path $repoRoot 'workflows/start-from-prompt/recipes/prompts/01b-generate-decisions.md'
+
+Assert-FileContains -Name '01-plan-product references task_mark_needs_input' `
+    -Path $planProduct -Pattern 'task_mark_needs_input'
+
+Assert-FileContains -Name '01-plan-product references decision_create' `
+    -Path $planProduct -Pattern 'decision_create'
+
+# Negative: the mission.md template inside the prompt must not carry an
+# Open Questions section. Inline match because no Assert-FileNotContains exists.
+$planProductBody = Get-Content $planProduct -Raw
+Assert-True -Name 'mission.md template has no Open Questions section' `
+    -Condition ($planProductBody -notmatch '(?m)^## Open Questions') `
+    -Message '01-plan-product.md still emits a "## Open Questions" section in the mission.md template'
+
+Assert-FileContains -Name '01b-generate-decisions lists existing decisions to dedupe' `
+    -Path $genDecisions -Pattern 'decision_list'
+
+$results = Get-TestResults
+[void](Write-TestSummary -LayerName "Layer 1: start-from-prompt clarification")
+if ($results.Failed -gt 0) { exit 1 } else { exit 0 }

--- a/workflows/start-from-prompt/recipes/prompts/01-plan-product.md
+++ b/workflows/start-from-prompt/recipes/prompts/01-plan-product.md
@@ -236,7 +236,7 @@ ToolSearch({ query: "select:mcp__dotbot__task_mark_needs_input,mcp__dotbot__deci
 1. List `.bot/workspace/product/briefing/` and read every file.
 2. Read `README.md` at the project root, `CLAUDE.md`, and any existing content in `docs/`.
 3. Read `.bot/workspace/product/interview-answers.json` if it exists. This file holds answers from any prior clarification round on this task. Schema: `{ "answers": [{ "question_id", "question", "answer_key", "answer_label", "answer", "context", "answered_at" }, ...] }`.
-4. Call `decision_list` to see decisions already recorded for this project.
+4. Call `mcp__dotbot__decision_list({ status: "accepted" })` to see accepted decisions already recorded for this project. These feed the Phase 4 dedupe and the Phase 5 `## Key Decisions` listing.
 
 ### Phase 2: Triage Ambiguities
 
@@ -270,7 +270,6 @@ mcp__dotbot__task_mark_needs_input({
     {
       question: "Single sentence question, ending with '?'",
       context: "1-2 sentences on why this matters for the product docs",
-      multi_select: false,
       options: [
         { key: "A", label: "Option A (recommended)", rationale: "Why this is the default" },
         { key: "B", label: "Alternative",            rationale: "When you might want this instead" },
@@ -317,7 +316,7 @@ For user-answered questions, fill `alternatives_considered` from the question's 
 
 Write `mission.md`, `tech-stack.md`, `entity-model.md` to `.bot/workspace/product/`, weaving every resolved answer into the appropriate section:
 
-- **`mission.md`**: drop the `## Open Questions` section. End with `## Key Decisions` listing each decision created in Phase 4 as `- <dec-id> — <title>`.
+- **`mission.md`**: drop the `## Open Questions` section. End with `## Key Decisions` listing every relevant accepted decision that informed the mission — both pre-existing accepted decisions discovered in Phase 1 and any decisions created in Phase 4 — as `- <dec-id> — <title>`.
 - **`tech-stack.md`**: where a decision drove a technology pick, reference it inline in the **Rationale** section (e.g. `FxConsole is vendored under src/SlashOps/vendor/FxConsole. See dec-XXXXXXXX for the vendor-vs-publish choice.`).
 - **`entity-model.md`**: where a decision drove a schema or invariant, reference it in the **Design Decisions** section already present at the bottom of the template.
 

--- a/workflows/start-from-prompt/recipes/prompts/01-plan-product.md
+++ b/workflows/start-from-prompt/recipes/prompts/01-plan-product.md
@@ -290,7 +290,7 @@ Always include a `Defer to later release` option when deferral is a coherent cho
 
 ### Phase 4: Record Decisions
 
-For every ambiguity now resolved (agent-decidable or user-answered), call `decision_create`. Skip ambiguities whose answer matches a decision returned by Phase 1's `decision_list` call (dedupe by `title`).
+For every ambiguity now resolved (agent-decidable or user-answered), call `decision_create`. Skip creation only when Phase 1's `decision_list` already returned an accepted decision for the same planning item: require the same `title` and at least one scope match, either overlapping workflow tags such as `clarification` / `stage:product-docs` or `related_task_ids` containing `{{TASK_ID}}`. Do not dedupe by `title` alone.
 
 ```
 mcp__dotbot__decision_create({
@@ -304,10 +304,12 @@ mcp__dotbot__decision_create({
   status: "accepted",
   type: "architecture | business | technical | process",
   impact: "high | medium | low",
-  tags: ["clarification", "stage:product-docs", "deliverable:<mission|tech-stack|entity-model>"],
+  tags: ["clarification", "stage:product-docs", "deliverable:mission"],
   related_task_ids: ["{{TASK_ID}}"]
 })
 ```
+
+The `deliverable:*` tag must be exactly one of `deliverable:mission`, `deliverable:tech-stack`, or `deliverable:entity-model` — pick the deliverable the decision most directly shapes. Do not emit the literal placeholder string `deliverable:<mission|tech-stack|entity-model>`.
 
 For user-answered questions, fill `alternatives_considered` from the question's `options` array (rejected options + their rationales). For agent-decidable items, name the considered alternative honestly even if it was a quick call.
 
@@ -336,7 +338,7 @@ If, after Phase 3, no user-blocking question remained (everything was agent-deci
 - **Large briefings**: If a briefing file read fails due to token limits, re-read with `offset` and `limit`. Do NOT skip large files.
 - Do NOT guess about things the briefing is silent on. Triage them in Phase 2 and either decide (with a Decision record) or ask via `task_mark_needs_input`.
 - Do NOT include an `Open Questions` section in `mission.md`. Every ambiguity ends up either in deliverable prose or as a Decision.
-- If the briefing is unusably thin (one-line prompt with no files), Phase 3 will surface a wide clarification round before any draft is written.
+- If the briefing is unusably thin (one-line prompt with no files), Phase 3 will surface up to four high-impact clarification questions before any draft is written.
 - Do NOT use `task_create` or other task-management MCP tools beyond `task_mark_needs_input` — this phase writes documents and decisions only.
 
 ## Success Criteria

--- a/workflows/start-from-prompt/recipes/prompts/01-plan-product.md
+++ b/workflows/start-from-prompt/recipes/prompts/01-plan-product.md
@@ -225,7 +225,7 @@ the decision records created by Phase 1b.]
 
 ### Phase 0: Load Tools
 
-Load dotbot MCP tools in a single ToolSearch batch (mirror the pattern in `01b-generate-decisions.md`):
+Load dotbot MCP tools in a single ToolSearch call using the comma-separated `select:` form. Same pattern as `core/prompts/98-analyse-task.md`.
 
 ```
 ToolSearch({ query: "select:mcp__dotbot__task_mark_needs_input,mcp__dotbot__decision_create,mcp__dotbot__decision_list" })

--- a/workflows/start-from-prompt/recipes/prompts/01-plan-product.md
+++ b/workflows/start-from-prompt/recipes/prompts/01-plan-product.md
@@ -10,6 +10,11 @@ You are a product documentation assistant for the dotbot autonomous development 
 
 Your task is to turn the user's brief (a prompt plus any briefing files they uploaded) into three foundational product documents. These documents describe what this product WILL be — its purpose, its technology, and its data model — at enough fidelity that subsequent planning and execution phases can rely on them without re-interviewing the user.
 
+## Session Context
+
+- **Session ID:** {{SESSION_ID}}
+- **Task ID:** {{TASK_ID}}
+
 ## Source Material
 
 Read these sources first, in this order:
@@ -25,7 +30,7 @@ Also check (and read if present):
 - `CLAUDE.md`
 - Any existing content in `docs/`
 
-If running autonomously (no interactive channel), make reasonable inferences from the briefing and proceed. If ambiguity would materially change the product docs, record it in the **Open Questions** section rather than guessing silently.
+Material ambiguity is handled in the Process section below — Phase 2 triages every ambiguity into agent-decidable or user-blocking, Phase 3 asks the user-blocking ones via `task_mark_needs_input`, and Phase 4 records every resolved ambiguity as a Decision. Do not park anything as an open question.
 
 ## Output Documents
 
@@ -62,9 +67,12 @@ Prefer capability names over implementation details.]
 [Technical, domain, or business constraints: platform requirements, compliance needs,
 performance expectations, integration dependencies, deployment limitations.]
 
-## Open Questions
-[Anything unclear in the briefing that the user should clarify before execution phases.
-Leave this section empty if everything is clear.]
+## Key Decisions
+
+[List of decision IDs that informed this mission, one per line, with the title.
+The dotbot decisions tab is the source of truth. This section is generated
+automatically from `decision_list` and is for human readers who want a quick
+audit trail. Format: `- dec-XXXXXXXX — Decision title`.]
 ```
 
 ### 2. `tech-stack.md` — Technology Stack
@@ -215,54 +223,103 @@ the decision records created by Phase 1b.]
 
 ## Process
 
-### Step 1: Read Briefing & Source Material
+### Phase 0: Load Tools
 
-Walk the `.bot/workspace/product/briefing/` directory, the project README, and any `docs/` content as described in **Source Material** above. Build a mental model of what the user wants to build before writing anything.
-
-### Step 2: Draft Mission
-
-Synthesise the briefing into `mission.md` using the template above. Keep it concise — this is a reference document, not marketing copy. The **Executive Summary** must be the first heading.
-
-### Step 3: Draft Tech Stack
-
-From the briefing, identify the runtime, frameworks, libraries, infrastructure, and tooling. Write `tech-stack.md` using the template above. If the briefing says "use X", capture it. If the briefing is silent on a category, record that in the **Rationale** section and flag it in `mission.md`'s **Open Questions**.
-
-### Step 4: Draft Entity Model
-
-Identify the core entities the product will manage. For each entity:
-
-1. Define its purpose.
-2. List its fields in the table format with type, description, and example.
-3. Identify its relationships with cardinality.
-4. Capture invariants.
-
-Document all enums. Build the Mermaid erDiagram with entity attributes. Describe the storage layer. Sketch the key API contracts.
-
-### Step 5: Clarifying Questions (Interactive Only)
-
-When running interactively and the briefing leaves material ambiguity, ask focused clarifying questions. Never ask more than 3 at a time. Examples:
+Load dotbot MCP tools in a single ToolSearch batch (mirror the pattern in `01b-generate-decisions.md`):
 
 ```
-Mission:
-- What problem does this solve that existing solutions don't?
-- Who is the primary user vs. secondary user?
-- What does "success" look like 6 months after launch?
-
-Tech Stack:
-- What's the target runtime environment (cloud, on-prem, desktop, mobile)?
-- Are there existing infrastructure constraints to inherit?
-- What are the performance and scale expectations?
-- Are there security or compliance requirements?
-
-Entity Model:
-- What are the main "things" this system manages?
-- How do these things relate to each other?
-- What state does each entity move through over its lifetime?
-- What data needs to persist vs. what's ephemeral?
-- Are there external systems providing authoritative data for any entity?
+ToolSearch({ query: "select:mcp__dotbot__task_mark_needs_input,mcp__dotbot__decision_create,mcp__dotbot__decision_list" })
 ```
 
-When running autonomously (e.g., from the workflow-launch endpoint), make reasonable inferences from the briefing and record unresolved ambiguity in `mission.md`'s **Open Questions** rather than pausing.
+### Phase 1: Read Source Material and Prior Answers
+
+1. List `.bot/workspace/product/briefing/` and read every file.
+2. Read `README.md` at the project root, `CLAUDE.md`, and any existing content in `docs/`.
+3. Read `.bot/workspace/product/interview-answers.json` if it exists. This file holds answers from any prior clarification round on this task. Schema: `{ "answers": [{ "question_id", "question", "answer_key", "answer_label", "answer", "context", "answered_at" }, ...] }`.
+4. Call `decision_list` to see decisions already recorded for this project.
+
+### Phase 2: Triage Ambiguities
+
+Build an internal list of every material ambiguity in the briefing — anything where two reasonable products could be built depending on the answer. For each ambiguity, classify as exactly one of:
+
+- **agent-decidable**: a sensible default exists, the trade-off is clear, and the choice does not change product identity. Examples: choice of test directory layout, default cache size, naming style for internal modules.
+- **user-blocking**: the choice changes product identity, scope, security posture, distribution model, target user, or roadmap ordering. Examples: vendor vs Gallery-publish a UI dependency, defaults for safe write roots, whether a major optional feature ships in the first release, smallest recommended model profile.
+
+The bar for user-blocking: would a senior product owner want to be in the room for this call? If yes, ask. If no, decide.
+
+Skip ambiguities already resolved in `interview-answers.json` from Phase 1.
+
+**Hard cap of four.** The runtime supports exactly one clarification round per task. If the user-blocking bucket exceeds four items, rank by:
+
+1. Reversibility: choices that are hard to undo later (security defaults, scope boundaries) outrank choices that can be revisited cheaply.
+2. Cross-cutting impact: choices that constrain multiple deliverables outrank choices isolated to one section.
+3. Roadmap effect: choices that change what ships in the first release outrank deferrable optimisations.
+
+Keep the top four as user-blocking. Demote the rest to agent-decidable for this run; record each demoted item as a Decision in Phase 4 with a note in `context` that it was below the clarification cap and chosen on agent judgement, so the user can revisit via the Decisions tab.
+
+### Phase 3: Ask User-Blocking Questions
+
+If the user-blocking bucket is empty after Phase 2's cap, skip to Phase 4.
+
+Otherwise, make a single `task_mark_needs_input` call with the entire batch (1-4 questions). Use the `questions:` array form, never the legacy singular `question:` form. Pattern:
+
+```
+mcp__dotbot__task_mark_needs_input({
+  task_id: "{{TASK_ID}}",
+  questions: [
+    {
+      question: "Single sentence question, ending with '?'",
+      context: "1-2 sentences on why this matters for the product docs",
+      multi_select: false,
+      options: [
+        { key: "A", label: "Option A (recommended)", rationale: "Why this is the default" },
+        { key: "B", label: "Alternative",            rationale: "When you might want this instead" },
+        { key: "C", label: "Defer to later release", rationale: "Park as a v0.X decision; current release proceeds with A" }
+      ],
+      recommendation: "A"
+    }
+  ]
+})
+```
+
+Then STOP. The runner will pause the task, surface the questions to the user, and resume this prompt once every pending question has been answered. On resume, re-enter Phase 1 — `interview-answers.json` will contain the new answers.
+
+Do not call `task_mark_needs_input` again on resume. The runtime sets `all_questions_answered = true` once the round closes and a second call will throw. On resume, proceed straight from Phase 1 (re-read answers) to Phase 4 (record decisions) to Phase 5 (write deliverables).
+
+Always include a `Defer to later release` option when deferral is a coherent choice. If the user picks it, that becomes an accepted Decision tagged `deferred`, with the chosen target release in `decision`. Do not park anything as an unresolved open question.
+
+### Phase 4: Record Decisions
+
+For every ambiguity now resolved (agent-decidable or user-answered), call `decision_create`. Skip ambiguities whose answer matches a decision returned by Phase 1's `decision_list` call (dedupe by `title`).
+
+```
+mcp__dotbot__decision_create({
+  title: "Short noun-phrase title (not a question)",
+  context: "1-3 sentences on the forces in play — what made this a real choice",
+  decision: "The specific choice. For deferred items: 'Defer to v0.X. Current release proceeds with <fallback>.'",
+  consequences: "What this constrains for downstream work",
+  alternatives_considered: [
+    { option: "Rejected option label", reason_rejected: "Why" }
+  ],
+  status: "accepted",
+  type: "architecture | business | technical | process",
+  impact: "high | medium | low",
+  tags: ["clarification", "stage:product-docs", "deliverable:<mission|tech-stack|entity-model>"],
+  related_task_ids: ["{{TASK_ID}}"]
+})
+```
+
+For user-answered questions, fill `alternatives_considered` from the question's `options` array (rejected options + their rationales). For agent-decidable items, name the considered alternative honestly even if it was a quick call.
+
+### Phase 5: Write the Three Deliverables
+
+Write `mission.md`, `tech-stack.md`, `entity-model.md` to `.bot/workspace/product/`, weaving every resolved answer into the appropriate section:
+
+- **`mission.md`**: drop the `## Open Questions` section. End with `## Key Decisions` listing each decision created in Phase 4 as `- <dec-id> — <title>`.
+- **`tech-stack.md`**: where a decision drove a technology pick, reference it inline in the **Rationale** section (e.g. `FxConsole is vendored under src/SlashOps/vendor/FxConsole. See dec-XXXXXXXX for the vendor-vs-publish choice.`).
+- **`entity-model.md`**: where a decision drove a schema or invariant, reference it in the **Design Decisions** section already present at the bottom of the template.
+
+If, after Phase 3, no user-blocking question remained (everything was agent-decidable), the deliverables and the decision list still cover every ambiguity — there is no separate "open questions" surface anywhere.
 
 ## Guidelines
 
@@ -276,20 +333,17 @@ When running autonomously (e.g., from the workflow-launch endpoint), make reason
 ## Important Rules
 
 - Write all three files directly to `.bot/workspace/product/`.
-- **Large briefings**: If a briefing file read fails due to token limits, re-read with `offset` and `limit` parameters. Do NOT skip large files — they typically contain the most important context.
-- Do NOT create tasks or use task management MCP tools — this phase writes documents only.
-- Do NOT guess about things the briefing is silent on. Record them as **Open Questions** in `mission.md`.
-- If the briefing is unusably thin (e.g. a one-line prompt with no files), note this explicitly in `mission.md` and flag the ambiguity rather than fabricating a product.
+- **Large briefings**: If a briefing file read fails due to token limits, re-read with `offset` and `limit`. Do NOT skip large files.
+- Do NOT guess about things the briefing is silent on. Triage them in Phase 2 and either decide (with a Decision record) or ask via `task_mark_needs_input`.
+- Do NOT include an `Open Questions` section in `mission.md`. Every ambiguity ends up either in deliverable prose or as a Decision.
+- If the briefing is unusably thin (one-line prompt with no files), Phase 3 will surface a wide clarification round before any draft is written.
+- Do NOT use `task_create` or other task-management MCP tools beyond `task_mark_needs_input` — this phase writes documents and decisions only.
 
 ## Success Criteria
 
 - Three markdown files exist in `.bot/workspace/product/`.
-- `mission.md` starts with `## Executive Summary`.
-- `tech-stack.md` covers all seven sections (Languages, Frameworks, Libraries, Tooling, Infrastructure, Dev Env, Rationale).
-- `entity-model.md` includes:
-  - At least one entity documented with the full field table.
-  - Every referenced enum has its own value table.
-  - A Mermaid `erDiagram` block with entity attributes (not just relationship lines).
-  - A Data Storage section.
-- Content is project-specific — no generic template placeholders left behind.
-- Technical and structural decisions are captured with rationale for Phase 1b to consume.
+- `mission.md` starts with `## Executive Summary` and ends with `## Key Decisions`. No `## Open Questions` section.
+- `tech-stack.md` covers the seven sections (Languages, Frameworks, Libraries, Tooling, Infrastructure, Dev Env, Rationale). Rationale references decision IDs where applicable.
+- `entity-model.md` includes at least one entity, all referenced enums, a Mermaid `erDiagram`, a Data Storage section, and a Design Decisions section that references decision IDs where applicable.
+- Every material ambiguity surfaced during planning has either a Decision record (status `accepted`) or is reflected in deliverable prose. Nothing is parked as an open question.
+- For each user-answered question in `interview-answers.json`, a Decision exists with matching `title` and `tags` containing `clarification` and `stage:product-docs`.

--- a/workflows/start-from-prompt/recipes/prompts/01b-generate-decisions.md
+++ b/workflows/start-from-prompt/recipes/prompts/01b-generate-decisions.md
@@ -30,6 +30,16 @@ Issue all ToolSearch calls above in a **single parallel batch** during Phase 0. 
 
 ## Instructions
 
+### Step 0.5: List Existing Decisions
+
+Phase 1 (`01-plan-product.md`) already records decisions for clarification answers and for ambiguities the agent resolved during product-doc drafting. Load them so this stage does not duplicate:
+
+```
+mcp__dotbot__decision_list({ status: "accepted" })
+```
+
+When iterating Step 2's candidates, skip any whose subject matches a decision already returned here. Match by `title` and overlap of `tags` (especially `stage:product-docs` and `clarification`). Do not record a new decision when an existing one already covers the same choice.
+
 ### Step 1: Read Source Documents
 
 Read all available source material. The interview summary is **optional** — it only exists when the workflow ran in interview mode. If the file does not exist, skip it and continue with the other reads; do not treat the missing file as an error.
@@ -63,6 +73,7 @@ Scan the source documents for decisions that meet ALL of these criteria:
 - Questions the user skipped
 - Implementation details that belong in task plans
 - Generic principles without a real trade-off
+- Items already recorded as decisions in Phase 1 (tag `stage:product-docs` or `clarification`)
 
 Aim for **3–10 decisions** from a typical workflow run. Fewer is better than padding with non-decisions.
 
@@ -96,7 +107,7 @@ mcp__dotbot__decision_create({
   status: "accepted",
   type: "architecture",
   impact: "high",
-  tags: ["platform", "scope", "titan"]
+  tags: ["platform", "scope", "stage:synthesis"]
 })
 ```
 

--- a/workflows/start-from-prompt/recipes/prompts/01b-generate-decisions.md
+++ b/workflows/start-from-prompt/recipes/prompts/01b-generate-decisions.md
@@ -38,7 +38,7 @@ Phase 1 (`01-plan-product.md`) already records decisions for clarification answe
 mcp__dotbot__decision_list({ status: "accepted" })
 ```
 
-When iterating Step 2's candidates, skip any whose subject matches a decision already returned here. Match by `title` and overlap of `tags` (especially `stage:product-docs` and `clarification`). Do not record a new decision when an existing one already covers the same choice.
+When iterating Step 2's candidates, skip any candidate whose `title` and relevant `tags` match a decision already returned here. Match by `title` and overlap of `tags` (especially `stage:product-docs` and `clarification`). Do not record a new decision when an existing one already covers the same choice.
 
 ### Step 1: Read Source Documents
 


### PR DESCRIPTION
## Summary

- Triage step in `01-plan-product.md` splits ambiguities into agent-decidable and user-blocking; user-blocking ones are asked via `task_mark_needs_input` (capped at four per the runtime constraint, ranked by reversibility, cross-cutting impact, and roadmap effect).
- Every resolved ambiguity becomes an accepted Decision, tagged `clarification` and `stage:product-docs`. Demoted items are also recorded so the user can revisit via the Decisions tab.
- `mission.md` no longer carries `## Open Questions`; it ends with `## Key Decisions` referencing the decision IDs.
- `01b-generate-decisions.md` dedupes against the Phase 1 decisions and refocuses on synthesis decisions only.

Closes #374

## Test plan

- [x] \`pwsh tests/Test-StartFromPromptClarification.ps1\` passes locally (4/4 green).
- [ ] \`pwsh install.ps1 && pwsh tests/Run-Tests.ps1\` — Layer 1-3 green locally.
- [ ] CI Layer 1-3 green on Windows, macOS, Linux.
- [ ] End-to-end dogfood against SlashOps: Product Documents stage pauses with up to four questions; answers produce a Decision and weave into the deliverables; no \`## Open Questions\` in \`mission.md\`.
- [ ] Copilot review threads addressed (reply + resolve).