### PR TITLE
test(ui): add Layer 5 Playwright UI E2E regression suite (#204)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,3 +164,94 @@ jobs:
           DOTBOT_JIRA_EMAIL_RECIPIENT: ${{ secrets.DOTBOT_JIRA_EMAIL_RECIPIENT }}
         run: |
           pwsh -NoProfile -ExecutionPolicy Bypass -File tests/Run-Tests.ps1 -Layer 4
+
+  test-ui:
+    name: Layer 5 - UI E2E (Playwright)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PowerShell
+        shell: bash
+        run: |
+          if ! command -v pwsh &> /dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y powershell
+          fi
+
+      - name: Install powershell-yaml module
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          # Ensure PSGallery exists and is trusted
+          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Default
+          }
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+
+          # Ensure NuGet provider for PowerShellGet v2 (best-effort — already present on most PS7 runners)
+          Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -ErrorAction SilentlyContinue | Out-Null
+
+          # Try classic install first, then PSResourceGet fallback
+          try {
+            Install-Module -Name powershell-yaml -Repository PSGallery -Scope CurrentUser -Force -AllowClobber
+          } catch {
+            Write-Host "Install-Module failed, trying Install-PSResource..."
+            if (-not (Get-Module -ListAvailable -Name Microsoft.PowerShell.PSResourceGet)) {
+              Install-Module Microsoft.PowerShell.PSResourceGet -Scope CurrentUser -Force -AllowClobber
+            }
+            Import-Module Microsoft.PowerShell.PSResourceGet
+            Install-PSResource -Name powershell-yaml -Repository PSGallery -TrustRepository -Scope CurrentUser -Reinstall
+          }
+
+      - name: Install dotbot globally
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -ExecutionPolicy Bypass -File install.ps1
+
+      - name: Setup Node.js (with npm cache)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: tests/e2e/package-lock.json
+
+      - name: Install Playwright npm dependencies
+        working-directory: tests/e2e
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('tests/e2e/package-lock.json') }}
+
+      - name: Install Playwright Chromium + system deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: tests/e2e
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only (cached browser)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        working-directory: tests/e2e
+        run: npx playwright install-deps chromium
+
+      - name: Run Layer 5 (UI E2E)
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -ExecutionPolicy Bypass -File tests/Run-Tests.ps1 -Layer 5
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            tests/e2e/playwright-report/
+            tests/e2e/test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -3,15 +3,17 @@
 .SYNOPSIS
     Test runner for dotbot integration test suite.
 .DESCRIPTION
-    Orchestrates test layers 1-4. Use -Layer to select which layers to run.
+    Orchestrates test layers 1-5. Use -Layer to select which layers to run.
 .PARAMETER Layer
-    Which layer(s) to run: 1, 2, 3, 4, or 'all' (default: 'all' runs 1-3; use 4 explicitly)
+    Which layer(s) to run: 1, 2, 3, 4, 5, or 'all' (default: 'all' runs 1-3;
+    use 4 or 5 explicitly).
 .EXAMPLE
-    ./Run-Tests.ps1                # Runs layers 1-3
-    ./Run-Tests.ps1 -Layer 1       # Runs layer 1 only
-    ./Run-Tests.ps1 -Layer all     # Runs layers 1-3
-    ./Run-Tests.ps1 -Layer 4       # Runs layer 4 only (requires Claude credentials)
-    ./Run-Tests.ps1 -Layer 1,2,3,4 # Runs all layers including E2E
+    ./Run-Tests.ps1                  # Runs layers 1-3
+    ./Run-Tests.ps1 -Layer 1         # Runs layer 1 only
+    ./Run-Tests.ps1 -Layer all       # Runs layers 1-3
+    ./Run-Tests.ps1 -Layer 4         # Runs layer 4 only (requires Claude credentials)
+    ./Run-Tests.ps1 -Layer 5         # Runs layer 5 only (Playwright UI E2E)
+    ./Run-Tests.ps1 -Layer 1,2,3,4,5 # Runs every layer
 #>
 
 [CmdletBinding()]
@@ -38,9 +40,10 @@ foreach ($l in $Layer) {
         '2'    { $layersToRun += 2 }
         '3'    { $layersToRun += 3 }
         '4'    { $layersToRun += 4 }
+        '5'    { $layersToRun += 5 }
         default {
             Write-Host "  Unknown layer: $l" -ForegroundColor Red
-            Write-Host "  Valid values: 1, 2, 3, 4, all" -ForegroundColor Yellow
+            Write-Host "  Valid values: 1, 2, 3, 4, 5, all" -ForegroundColor Yellow
             exit 1
         }
     }
@@ -57,7 +60,7 @@ Write-Host ""
 # run against stale code and produce confusing failures.
 $devDir = Split-Path $PSScriptRoot -Parent  # repo root
 $installDir = Join-Path $HOME "dotbot"
-if ((Test-Path $installDir) -and (2 -in $layersToRun -or 3 -in $layersToRun -or 4 -in $layersToRun)) {
+if ((Test-Path $installDir) -and (2 -in $layersToRun -or 3 -in $layersToRun -or 4 -in $layersToRun -or 5 -in $layersToRun)) {
     # scripts/ is included so changes to init-project.ps1 / Platform-Functions.psm1
     # / etc. trigger an auto-reinstall (and downstream golden rebuild).
     $devNewest = (Get-ChildItem "$devDir/core","$devDir/workflows","$devDir/stacks","$devDir/scripts" -Recurse -File -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -First 1).LastWriteTime
@@ -190,6 +193,13 @@ if (4 -in $layersToRun) {
 
     $layerResults["4"] = ($claudeExit -eq 0 -and $teamsExit -eq 0 -and $emailExit -eq 0 -and $jiraExit -eq 0)
     if ($claudeExit -ne 0 -or $teamsExit -ne 0 -or $emailExit -ne 0 -or $jiraExit -ne 0) { $overallFailed = $true }
+}
+
+# Layer 5: UI E2E (Playwright)
+if (5 -in $layersToRun) {
+    $exitCode = Invoke-TestFile -Layer '5' -FileName 'Test-UI-E2E.ps1'
+    $layerResults["5"] = ($exitCode -eq 0)
+    if ($exitCode -ne 0) { $overallFailed = $true }
 }
 
 # Overall summary

--- a/tests/Test-UI-E2E.ps1
+++ b/tests/Test-UI-E2E.ps1
@@ -70,12 +70,14 @@ if (-not (Test-Path (Join-Path $e2eDir "package.json"))) {
 
 $playwrightInstalled = Test-Path (Join-Path $e2eDir "node_modules/@playwright/test")
 if (-not $playwrightInstalled) {
-    Write-Host "  → Installing Playwright npm dependencies (one-time)..." -ForegroundColor Cyan
+    $packageLockPath = Join-Path $e2eDir "package-lock.json"
+    $npmCommand = if (Test-Path $packageLockPath) { "ci" } else { "install" }
+    Write-Host "  → Installing Playwright npm dependencies (one-time) using 'npm $npmCommand'..." -ForegroundColor Cyan
     Push-Location $e2eDir
     try {
-        & npm install --no-audit --no-fund --loglevel=error 2>&1 | Out-Host
+        & npm $npmCommand --no-audit --no-fund --loglevel=error 2>&1 | Out-Host
         if ($LASTEXITCODE -ne 0) {
-            throw "npm install failed (exit $LASTEXITCODE)"
+            throw "npm $npmCommand failed (exit $LASTEXITCODE)"
         }
     } finally {
         Pop-Location

--- a/tests/Test-UI-E2E.ps1
+++ b/tests/Test-UI-E2E.ps1
@@ -1,0 +1,247 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Layer 5: UI E2E regression suite (Playwright-driven).
+.DESCRIPTION
+    Boots the dotbot Control Panel UI server (core/ui/server.ps1) against a
+    freshly-cloned golden .bot/ snapshot and runs the Playwright specs in
+    tests/e2e/ against the live server. Tests interact with the real backend
+    over real HTTP — no /api/* mocking. State is driven by seeding real files
+    under .bot/workspace/, .bot/.control/processes/, etc.
+
+    On first run, auto-installs npm dependencies inside tests/e2e/ and the
+    Playwright Chromium browser binary. Both are cached for subsequent runs.
+
+    Requires:
+        - Node.js + npm in PATH
+        - PowerShell 7+
+        - dotbot installed at ~/dotbot (Run-Tests.ps1 auto-installs it)
+        - Network access on first run (registry.npmjs.org + cdn.playwright.dev)
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+Import-Module "$PSScriptRoot\Test-Helpers.psm1" -Force
+
+$dotbotDir = Get-DotbotInstallDir
+$e2eDir    = Join-Path $PSScriptRoot "e2e"
+
+Write-Host ""
+Write-Host "══════════════════════════════════════════════════════════════════" -ForegroundColor Blue
+Write-Host "  Layer 5: UI E2E Regression Suite (Playwright)" -ForegroundColor Blue
+Write-Host "══════════════════════════════════════════════════════════════════" -ForegroundColor Blue
+Write-Host ""
+
+Reset-TestResults
+
+# ═══════════════════════════════════════════════════════════════════
+# PRE-FLIGHT CHECKS
+# ═══════════════════════════════════════════════════════════════════
+
+if (-not (Test-Path (Join-Path $dotbotDir "core/ui/server.ps1"))) {
+    Write-TestResult -Name "Layer 5 prerequisites" -Status Fail `
+        -Message "dotbot not installed at $dotbotDir — run 'pwsh install.ps1' first"
+    Write-TestSummary -LayerName "Layer 5: UI E2E"
+    exit 1
+}
+
+if (-not (Get-Command node -ErrorAction SilentlyContinue) -or
+    -not (Get-Command npm  -ErrorAction SilentlyContinue) -or
+    -not (Get-Command npx  -ErrorAction SilentlyContinue)) {
+    Write-TestResult -Name "Layer 5 prerequisites" -Status Fail `
+        -Message "node/npm/npx not in PATH — install Node.js 18+"
+    Write-TestSummary -LayerName "Layer 5: UI E2E"
+    exit 1
+}
+
+if (-not (Test-Path (Join-Path $e2eDir "package.json"))) {
+    Write-TestResult -Name "Layer 5 prerequisites" -Status Fail `
+        -Message "tests/e2e/package.json missing — Layer 5 scaffold not in place"
+    Write-TestSummary -LayerName "Layer 5: UI E2E"
+    exit 1
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# AUTO-INSTALL: npm deps + Playwright Chromium browser
+# ═══════════════════════════════════════════════════════════════════
+
+$playwrightInstalled = Test-Path (Join-Path $e2eDir "node_modules/@playwright/test")
+if (-not $playwrightInstalled) {
+    Write-Host "  → Installing Playwright npm dependencies (one-time)..." -ForegroundColor Cyan
+    Push-Location $e2eDir
+    try {
+        & npm install --no-audit --no-fund --loglevel=error 2>&1 | Out-Host
+        if ($LASTEXITCODE -ne 0) {
+            throw "npm install failed (exit $LASTEXITCODE)"
+        }
+    } finally {
+        Pop-Location
+    }
+}
+
+# Any chromium-* subdir counts as cached — Playwright manages exact versioning.
+$browserCacheRoot = if ($IsWindows) {
+    Join-Path $env:LOCALAPPDATA "ms-playwright"
+} else {
+    Join-Path $HOME ".cache/ms-playwright"
+}
+$chromiumCached = (Test-Path $browserCacheRoot) -and `
+    @(Get-ChildItem -Path $browserCacheRoot -Directory -Filter "chromium-*" -ErrorAction SilentlyContinue).Count -gt 0
+if (-not $chromiumCached) {
+    Write-Host "  → Installing Playwright Chromium browser (~150 MB, one-time)..." -ForegroundColor Cyan
+    Push-Location $e2eDir
+    try {
+        # --with-deps installs the OS shared libraries Chromium needs
+        # (libnspr4, libnss3, libgbm1, libasound2 …) alongside the browser
+        # binary. On Linux it shells out to apt-get and may require sudo;
+        # on macOS / Windows it's a no-op.
+        & npx --no-install playwright install --with-deps chromium 2>&1 | Out-Host
+        if ($LASTEXITCODE -ne 0) {
+            throw "Playwright browser install failed (exit $LASTEXITCODE). On Linux without root, run: sudo npx playwright install-deps chromium"
+        }
+    } finally {
+        Pop-Location
+    }
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# UI SERVER LIFECYCLE HELPERS (mirrored from Test-ServerStartup.ps1)
+# ═══════════════════════════════════════════════════════════════════
+
+function Start-UiServer {
+    param([Parameter(Mandatory)][string]$BotDir)
+
+    $serverScript = Join-Path $BotDir "core/ui/server.ps1"
+    if (-not (Test-Path $serverScript)) {
+        throw "UI server script not found: $serverScript"
+    }
+
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName  = "pwsh"
+    $psi.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$serverScript`""
+    $psi.WorkingDirectory      = Split-Path -Parent $BotDir
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $psi.UseShellExecute = $false
+    $psi.CreateNoWindow  = $true
+
+    $process = [System.Diagnostics.Process]::Start($psi)
+    # Drain stdout/stderr async — the server's Write-Host output otherwise
+    # fills the OS pipe buffer and stalls the listener.
+    $process.BeginOutputReadLine()
+    $process.BeginErrorReadLine()
+    return $process
+}
+
+function Wait-ForUiPort {
+    param(
+        [Parameter(Mandatory)][string]$BotDir,
+        [int]$TimeoutSeconds = 30
+    )
+    $portFile = Join-Path $BotDir ".control/ui-port"
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        if (Test-Path $portFile) {
+            $raw = (Get-Content $portFile -Raw -ErrorAction SilentlyContinue)
+            if ($raw) {
+                $trimmed = $raw.Trim()
+                if ($trimmed -match '^\d+$') { return [int]$trimmed }
+            }
+        }
+        Start-Sleep -Milliseconds 250
+    }
+    return 0
+}
+
+function Wait-ForServerReady {
+    param(
+        [Parameter(Mandatory)][int]$Port,
+        [int]$TimeoutSeconds = 30
+    )
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        try {
+            $r = Invoke-WebRequest -Uri "http://localhost:$Port/api/info" -TimeoutSec 2 -ErrorAction Stop
+            if ($r.StatusCode -eq 200) { return $true }
+        } catch {
+            Write-Verbose "Server not ready yet: $_"
+        }
+        Start-Sleep -Milliseconds 500
+    }
+    return $false
+}
+
+function Stop-UiServer {
+    param([System.Diagnostics.Process]$Process)
+    if (-not $Process) { return }
+    if (-not $Process.HasExited) {
+        try { $Process.Kill() } catch { Write-Verbose "Stop-UiServer kill: $_" }
+        try { [void]$Process.WaitForExit(3000) } catch { Write-Verbose "Stop-UiServer wait: $_" }
+    }
+    try { $Process.Dispose() } catch { Write-Verbose "Stop-UiServer dispose: $_" }
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# RUN
+# ═══════════════════════════════════════════════════════════════════
+
+$project   = $null
+$server    = $null
+$exitCode  = 1
+
+try {
+    Write-Host "  → Cloning fixture from golden snapshot..." -ForegroundColor Cyan
+    $project = New-TestProjectFromGolden -Flavor 'default'
+
+    Write-Host "  → Starting UI server against fixture..." -ForegroundColor Cyan
+    $server = Start-UiServer -BotDir $project.BotDir
+
+    $port = Wait-ForUiPort -BotDir $project.BotDir -TimeoutSeconds 30
+    if ($port -le 0) {
+        throw "UI server did not write .control/ui-port within 30s"
+    }
+
+    if (-not (Wait-ForServerReady -Port $port -TimeoutSeconds 30)) {
+        throw "UI server bound port $port but /api/info did not respond within 30s"
+    }
+
+    $url = "http://localhost:$port"
+    Write-Host "  → UI server ready at $url" -ForegroundColor Green
+    Write-Host ""
+
+    # DOTBOT_E2E_BOT_DIR lets specs seed real files under the fixture's
+    # .bot/ to drive backend state.
+    $env:DOTBOT_E2E_URL     = $url
+    $env:DOTBOT_E2E_BOT_DIR = $project.BotDir
+
+    Push-Location $e2eDir
+    try {
+        & npx --no-install playwright test 2>&1 | Out-Host
+        $exitCode = $LASTEXITCODE
+    } finally {
+        Pop-Location
+        Remove-Item Env:\DOTBOT_E2E_URL     -ErrorAction SilentlyContinue
+        Remove-Item Env:\DOTBOT_E2E_BOT_DIR -ErrorAction SilentlyContinue
+    }
+} catch {
+    Write-Host "  ✗ Layer 5 setup failed: $($_.Exception.Message)" -ForegroundColor Red
+    $exitCode = 1
+} finally {
+    Stop-UiServer -Process $server
+    if ($project) { Remove-TestProject -Path $project.ProjectRoot }
+}
+
+Write-Host ""
+if ($exitCode -eq 0) {
+    Write-Host "  Layer 5: ✓ ALL PASSED" -ForegroundColor Green
+} else {
+    Write-Host "  Layer 5: ✗ FAILED (Playwright exit $exitCode)" -ForegroundColor Red
+    Write-Host "  HTML report: $e2eDir/playwright-report/index.html" -ForegroundColor DarkGray
+    Write-Host "  Traces:      $e2eDir/test-results/" -ForegroundColor DarkGray
+}
+Write-Host ""
+
+exit $exitCode

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+test-results/
+playwright-report/
+playwright/.cache/

--- a/tests/e2e/helpers/fixture.ts
+++ b/tests/e2e/helpers/fixture.ts
@@ -1,0 +1,110 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+
+const botDir = process.env.DOTBOT_E2E_BOT_DIR;
+if (!botDir) {
+  throw new Error(
+    "DOTBOT_E2E_BOT_DIR not set. Layer 5 specs must be launched via tests/Test-UI-E2E.ps1.",
+  );
+}
+
+export const BOT_DIR = botDir;
+export const TASKS_DIR = path.join(BOT_DIR, "workspace", "tasks");
+export const PROCESSES_DIR = path.join(BOT_DIR, ".control", "processes");
+
+export type TaskStatus =
+  | "todo"
+  | "analysing"
+  | "analysed"
+  | "needs-input"
+  | "in-progress"
+  | "done"
+  | "skipped"
+  | "cancelled"
+  | "split";
+
+export interface SeededTask {
+  id: string;
+  shortId: string;
+  filePath: string;
+  status: TaskStatus;
+}
+
+export function seedTask(
+  status: TaskStatus,
+  overrides: Record<string, unknown> = {},
+): SeededTask {
+  const id = (overrides.id as string) ?? randomUUID();
+  const shortId = id.slice(0, 8);
+  const name = (overrides.name as string) ?? `e2e-${shortId}`;
+
+  const task = {
+    id,
+    name,
+    description: `E2E fixture task ${shortId}`,
+    category: "feature",
+    status,
+    priority: 50,
+    effort: "S",
+    created_at: new Date().toISOString().replace(/\.\d+Z$/, "Z"),
+    workflow: "start-from-prompt",
+    ...overrides,
+  };
+
+  const dir = path.join(TASKS_DIR, status);
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, `${name}-${shortId}.json`);
+  fs.writeFileSync(filePath, JSON.stringify(task, null, 2), "utf8");
+  return { id, shortId, filePath, status };
+}
+
+export function moveTask(task: SeededTask, newStatus: TaskStatus): SeededTask {
+  const targetDir = path.join(TASKS_DIR, newStatus);
+  fs.mkdirSync(targetDir, { recursive: true });
+  const newPath = path.join(targetDir, path.basename(task.filePath));
+  fs.renameSync(task.filePath, newPath);
+  return { ...task, filePath: newPath, status: newStatus };
+}
+
+export function removeTask(task: SeededTask): void {
+  if (fs.existsSync(task.filePath)) {
+    fs.unlinkSync(task.filePath);
+  }
+}
+
+export interface SeededProcess {
+  id: string;
+  filePath: string;
+}
+
+export function seedProcess(
+  overrides: Record<string, unknown> = {},
+): SeededProcess {
+  const id = (overrides.id as string) ?? `e2e-${randomUUID().slice(0, 8)}`;
+  const proc = {
+    id,
+    type: "execution",
+    status: "running",
+    // Server's Get-Process aliveness check (ProcessAPI.psm1) flips any
+    // process with a dead PID to 'stopped' on the next poll. Use the
+    // test runner's own PID so the row stays in its declared status.
+    pid: process.pid,
+    started_at: new Date().toISOString().replace(/\.\d+Z$/, "Z"),
+    last_heartbeat: new Date().toISOString().replace(/\.\d+Z$/, "Z"),
+    description: `E2E fixture process ${id}`,
+    workflow: "start-from-prompt",
+    ...overrides,
+  };
+
+  fs.mkdirSync(PROCESSES_DIR, { recursive: true });
+  const filePath = path.join(PROCESSES_DIR, `proc-${id}.json`);
+  fs.writeFileSync(filePath, JSON.stringify(proc, null, 2), "utf8");
+  return { id, filePath };
+}
+
+export function removeProcess(proc: SeededProcess): void {
+  if (fs.existsSync(proc.filePath)) {
+    fs.unlinkSync(proc.filePath);
+  }
+}

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,93 @@
+{
+  "name": "dotbot-ui-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dotbot-ui-e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0",
+        "typescript": "^5.6.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "dotbot-ui-e2e",
+  "version": "1.0.0",
+  "description": "Layer 5: Playwright E2E regression suite for the dotbot Control Panel UI.",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from "@playwright/test";
+
+const baseURL = process.env.DOTBOT_E2E_URL;
+if (!baseURL) {
+  throw new Error(
+    "DOTBOT_E2E_URL is not set. Layer 5 tests are launched via tests/Test-UI-E2E.ps1, " +
+      "which boots the UI server against a golden .bot/ fixture and exports the URL.",
+  );
+}
+
+export default defineConfig({
+  testDir: "./specs",
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: process.env.CI
+    ? [["list"], ["html", { open: "never" }]]
+    : [["list"]],
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  use: {
+    baseURL,
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+});

--- a/tests/e2e/specs/controls.spec.ts
+++ b/tests/e2e/specs/controls.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+import {
+  seedProcess,
+  removeProcess,
+  type SeededProcess,
+} from "../helpers/fixture";
+
+test.describe("Control buttons emit correct backend requests", () => {
+  test('panic RESET button POSTs /api/control with {action:"reset"}', async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(page.locator('.tab[data-tab="overview"]')).toHaveClass(
+      /active/,
+    );
+
+    // app.js's DOMContentLoaded handler awaits initSidebar() before calling
+    // initControlButtons(), so the panic-reset listener isn't attached at
+    // load. Without this wait the click silently no-ops.
+    await page.waitForLoadState("networkidle");
+
+    const reset = page.locator("#panic-reset");
+    await expect(reset).toBeVisible();
+
+    const [request] = await Promise.all([
+      page.waitForRequest(
+        (req) => req.url().endsWith("/api/control") && req.method() === "POST",
+        { timeout: 5_000 },
+      ),
+      reset.click(),
+    ]);
+
+    const body = JSON.parse(request.postData() ?? "{}");
+    expect(body.action).toBe("reset");
+  });
+
+  test("workflow Stop button POSTs /api/workflows/{name}/stop when a runner is active", async ({
+    page,
+  }) => {
+    // server.ps1 flips has_running_process=true for a workflow when any
+    // task-runner's description contains the workflow name.
+    const proc: SeededProcess = seedProcess({
+      type: "task-runner",
+      status: "running",
+      description: "Running start-from-prompt workflow",
+    });
+
+    try {
+      await page.goto("/");
+
+      const stopBtn = page.locator(
+        '#workflow-controls-container .process-control-row[data-workflow="start-from-prompt"] .wf-stop-btn',
+      );
+      await expect(stopBtn).toBeVisible({ timeout: 10_000 });
+      await expect(stopBtn).toBeEnabled({ timeout: 10_000 });
+
+      const [request] = await Promise.all([
+        page.waitForRequest(
+          (req) =>
+            /\/api\/workflows\/start-from-prompt\/stop$/.test(req.url()) &&
+            req.method() === "POST",
+          { timeout: 5_000 },
+        ),
+        stopBtn.click(),
+      ]);
+
+      expect(request.method()).toBe("POST");
+    } finally {
+      removeProcess(proc);
+    }
+  });
+});

--- a/tests/e2e/specs/error-handling.spec.ts
+++ b/tests/e2e/specs/error-handling.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Network-layer fault injection via page.route() — the only mocking in
+ * the suite. The browser receives a genuine HTTP 500 over a real
+ * connection; the server, .bot/, DOM and polling cycle are untouched.
+ */
+
+test.describe("UI degrades gracefully on server errors", () => {
+  test("a 500 from /api/state does not throw a JS error or freeze the page", async ({
+    page,
+  }) => {
+    const pageErrors: string[] = [];
+    const consoleErrors: string[] = [];
+    page.on("pageerror", (err) => pageErrors.push(err.message));
+    page.on("console", (msg) => {
+      if (msg.type() === "error") consoleErrors.push(msg.text());
+    });
+
+    await page.route("**/api/state", async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "simulated transient backend error" }),
+      });
+    });
+
+    await page.goto("/");
+
+    // Two poll cycles at 3s each, plus margin.
+    await page.waitForTimeout(7_000);
+
+    expect(
+      pageErrors,
+      `Uncaught page errors:\n${pageErrors.join("\n")}`,
+    ).toEqual([]);
+
+    await page.locator('.tab[data-tab="settings"]').click();
+    await expect(page.locator("#tab-settings")).toHaveClass(/active/);
+    await page.locator('.tab[data-tab="overview"]').click();
+    await expect(page.locator("#tab-overview")).toHaveClass(/active/);
+
+    // Confirm the error path ran rather than passing silently.
+    const sawPollError = consoleErrors.some((m) => /Poll error/i.test(m));
+    expect(
+      sawPollError,
+      `expected at least one "Poll error:" console message; got:\n${consoleErrors.join("\n")}`,
+    ).toBe(true);
+  });
+
+  test("after the error clears, the next poll re-renders state", async ({
+    page,
+  }) => {
+    let failNext = true;
+    await page.route("**/api/state", async (route) => {
+      if (failNext) {
+        failNext = false;
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: '{"error":"transient"}',
+        });
+      } else {
+        // Recovery is exercised against the real server, not a second mock.
+        await route.continue();
+      }
+    });
+
+    await page.goto("/");
+    await expect(page.locator("#todo-count")).toHaveText("0", {
+      timeout: 10_000,
+    });
+  });
+});

--- a/tests/e2e/specs/lists.spec.ts
+++ b/tests/e2e/specs/lists.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "@playwright/test";
+import {
+  seedTask,
+  removeTask,
+  type SeededTask,
+  seedProcess,
+  removeProcess,
+  type SeededProcess,
+} from "../helpers/fixture";
+
+test.describe("Task list rendering (Roadmap tab)", () => {
+  const seeded: SeededTask[] = [];
+
+  test.afterEach(async () => {
+    while (seeded.length > 0) {
+      const t = seeded.pop()!;
+      try {
+        removeTask(t);
+      } catch {}
+    }
+  });
+
+  test("renders one row per todo task with the seeded name", async ({
+    page,
+  }) => {
+    const a = seedTask("todo", { name: "list-spec-alpha" });
+    const b = seedTask("todo", { name: "list-spec-bravo" });
+    const c = seedTask("todo", { name: "list-spec-charlie" });
+    seeded.push(a, b, c);
+
+    await page.goto("/");
+    // Wait for the seeded tasks to land in state before opening the tab,
+    // otherwise the assertion can race the "Loading…" placeholder.
+    await expect(page.locator("#todo-count")).toHaveText("3", {
+      timeout: 10_000,
+    });
+
+    await page.locator('.tab[data-tab="pipeline"]').click();
+    await expect(page.locator("#tab-pipeline")).toHaveClass(/active/);
+
+    const rows = page.locator("#upcoming-tasks .task-list-item");
+    await expect(rows).toHaveCount(3, { timeout: 10_000 });
+
+    const names = page.locator("#upcoming-tasks .task-list-item-name");
+    await expect(names).toContainText([
+      "list-spec-alpha",
+      "list-spec-bravo",
+      "list-spec-charlie",
+    ]);
+  });
+
+  test("renders empty state when no tasks exist", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator("#todo-count")).toHaveText("0", {
+      timeout: 10_000,
+    });
+    await page.locator('.tab[data-tab="pipeline"]').click();
+    await expect(page.locator("#upcoming-tasks .task-list-item")).toHaveCount(
+      0,
+    );
+  });
+});
+
+test.describe("Process list rendering (Processes tab)", () => {
+  const seededProcs: SeededProcess[] = [];
+
+  test.afterEach(async () => {
+    while (seededProcs.length > 0) {
+      const p = seededProcs.pop()!;
+      try {
+        removeProcess(p);
+      } catch {}
+    }
+  });
+
+  test("renders a row for a seeded running process", async ({ page }) => {
+    const proc = seedProcess({
+      type: "execution",
+      status: "running",
+      description: "list-spec running execution",
+    });
+    seededProcs.push(proc);
+
+    await page.goto("/");
+    await page.locator('.tab[data-tab="processes"]').click();
+    await expect(page.locator("#tab-processes")).toHaveClass(/active/);
+
+    const row = page.locator(
+      `#process-list .process-row[data-process-id="${proc.id}"]`,
+    );
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await expect(row).toContainText("list-spec running execution");
+  });
+
+  test("renders empty state when no process JSONs exist", async ({ page }) => {
+    await page.goto("/");
+    await page.locator('.tab[data-tab="processes"]').click();
+    await expect(page.locator("#tab-processes")).toHaveClass(/active/);
+
+    await expect(page.locator("#process-list .empty-state")).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/tests/e2e/specs/polling.spec.ts
+++ b/tests/e2e/specs/polling.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "@playwright/test";
+import {
+  seedTask,
+  moveTask,
+  removeTask,
+  type SeededTask,
+} from "../helpers/fixture";
+
+test.describe("State polling reflects backend state in the DOM", () => {
+  const seeded: SeededTask[] = [];
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator('.tab[data-tab="overview"]')).toHaveClass(
+      /active/,
+    );
+  });
+
+  test.afterEach(async () => {
+    while (seeded.length > 0) {
+      const t = seeded.pop()!;
+      try {
+        removeTask(t);
+      } catch {}
+    }
+  });
+
+  test("todo count increments after a task JSON appears in workspace/tasks/todo/", async ({
+    page,
+  }) => {
+    await expect(page.locator("#todo-count")).toHaveText("0");
+
+    seeded.push(seedTask("todo"));
+
+    // Poll interval is 3s; allow up to 10s for two cycles.
+    await expect(page.locator("#todo-count")).toHaveText("1", {
+      timeout: 10_000,
+    });
+    await expect(page.locator("#pipeline-todo-count")).toHaveText("1");
+  });
+
+  test("moving a task from todo to in-progress shifts the counts", async ({
+    page,
+  }) => {
+    const task = seedTask("todo");
+    seeded.push(task);
+
+    await expect(page.locator("#todo-count")).toHaveText("1", {
+      timeout: 10_000,
+    });
+    await expect(page.locator("#progress-count")).toHaveText("0");
+
+    const moved = moveTask(task, "in-progress");
+    // Re-track so afterEach removes the new path, not the original todo/ path.
+    seeded[seeded.length - 1] = moved;
+
+    await expect(page.locator("#todo-count")).toHaveText("0", {
+      timeout: 10_000,
+    });
+    await expect(page.locator("#progress-count")).toHaveText("1");
+  });
+
+  test("multiple seeded tasks across statuses produce the correct counts", async ({
+    page,
+  }) => {
+    seeded.push(seedTask("todo"));
+    seeded.push(seedTask("todo"));
+    seeded.push(seedTask("todo"));
+    seeded.push(seedTask("analysing"));
+    seeded.push(seedTask("done"));
+
+    await expect(page.locator("#todo-count")).toHaveText("3", {
+      timeout: 10_000,
+    });
+    await expect(page.locator("#analysing-count")).toHaveText("1");
+    // #done-count is done + skipped combined; only 'done' was seeded.
+    await expect(page.locator("#done-count")).toHaveText("1");
+  });
+
+  test("connection indicator carries no error class while the server is healthy", async ({
+    page,
+  }) => {
+    const indicator = page.locator(
+      "#connection-status, .connection-status, .status-dot",
+    );
+    if ((await indicator.count()) > 0) {
+      const cls = (await indicator.first().getAttribute("class")) ?? "";
+      expect(cls).not.toMatch(/error|disconnect/i);
+    }
+  });
+});

--- a/tests/e2e/specs/settings.spec.ts
+++ b/tests/e2e/specs/settings.spec.ts
@@ -9,6 +9,7 @@ test.describe("Settings persistence via real /api/settings", () => {
   const settingsBackup: Record<string, string> = {};
   const settingsCandidates = [
     path.join(BOT_DIR, ".control", "settings.json"),
+    path.join(BOT_DIR, ".control", "ui-settings.json"),
     path.join(BOT_DIR, "settings", "settings.user.json"),
   ];
 

--- a/tests/e2e/specs/settings.spec.ts
+++ b/tests/e2e/specs/settings.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "@playwright/test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { BOT_DIR } from "../helpers/fixture";
+
+test.describe("Settings persistence via real /api/settings", () => {
+  // Specs share one fixture (workers=1); restore the settings file so
+  // downstream specs aren't polluted by what we toggled here.
+  const settingsBackup: Record<string, string> = {};
+  const settingsCandidates = [
+    path.join(BOT_DIR, ".control", "settings.json"),
+    path.join(BOT_DIR, "settings", "settings.user.json"),
+  ];
+
+  test.beforeAll(() => {
+    for (const f of settingsCandidates) {
+      if (fs.existsSync(f)) settingsBackup[f] = fs.readFileSync(f, "utf8");
+    }
+  });
+
+  test.afterAll(() => {
+    for (const f of settingsCandidates) {
+      if (settingsBackup[f] !== undefined) {
+        fs.writeFileSync(f, settingsBackup[f], "utf8");
+      } else if (fs.existsSync(f)) {
+        fs.unlinkSync(f);
+      }
+    }
+  });
+
+  test('toggling "show debug" issues POST /api/settings and survives reload', async ({
+    page,
+  }) => {
+    await page.goto("/");
+    // initSettingsToggles() binds change handlers after several awaited
+    // fetches inside the DOMContentLoaded handler.
+    await page.waitForLoadState("networkidle");
+    await page.locator('.tab[data-tab="settings"]').click();
+    await expect(page.locator("#tab-settings")).toHaveClass(/active/);
+
+    // show-debug lives in #settings-execution, which starts hidden until
+    // its sub-nav item is selected.
+    await page
+      .locator('.settings-nav-item[data-settings-section="execution"]')
+      .click();
+    await expect(page.locator("#settings-execution")).not.toHaveClass(/hidden/);
+
+    // The <input> is CSS-hidden; users click the wrapping <label>, which
+    // is what dispatches click+change on the underlying checkbox.
+    const toggle = page.locator("#setting-show-debug");
+    await expect(toggle).toHaveCount(1);
+    const toggleLabel = toggle.locator(
+      'xpath=ancestor::label[contains(@class,"toggle-switch")][1]',
+    );
+    await expect(toggleLabel).toBeVisible();
+
+    const initial = await toggle.isChecked();
+    const target = !initial;
+
+    const [request] = await Promise.all([
+      page.waitForRequest(
+        (req) => req.url().endsWith("/api/settings") && req.method() === "POST",
+        { timeout: 5_000 },
+      ),
+      toggleLabel.click(),
+    ]);
+
+    const body = JSON.parse(request.postData() ?? "{}");
+    expect(body.showDebug).toBe(target);
+
+    // Reload exercises the GET round-trip: stored value → /api/settings → UI.
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    await page.locator('.tab[data-tab="settings"]').click();
+    await page
+      .locator('.settings-nav-item[data-settings-section="execution"]')
+      .click();
+    const reloaded = page.locator("#setting-show-debug");
+    await expect(reloaded).toHaveCount(1);
+    await expect(reloaded).toBeChecked({ checked: target, timeout: 5_000 });
+  });
+});

--- a/tests/e2e/specs/tabs.spec.ts
+++ b/tests/e2e/specs/tabs.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect, Page } from "@playwright/test";
+
+const TABS = [
+  "overview",
+  "product",
+  "pipeline",
+  "processes",
+  "decisions",
+  "workflow",
+  "settings",
+] as const;
+
+test.describe("Tab navigation", () => {
+  test.beforeEach(async ({ page }) => {
+    // Track only uncaught JS exceptions. console.error is too noisy: the
+    // app legitimately logs poll failures there, and the browser emits
+    // "Failed to load resource: net::*" for transient network blips.
+    const pageErrors: string[] = [];
+    page.on("pageerror", (err) => pageErrors.push(err.message));
+    (page as Page & { __pageErrors: string[] }).__pageErrors = pageErrors;
+
+    await page.goto("/");
+    await expect(page.locator('.tab[data-tab="overview"]')).toHaveClass(
+      /active/,
+    );
+  });
+
+  for (const id of TABS) {
+    test(`switches to "${id}" tab and shows matching pane`, async ({
+      page,
+    }) => {
+      await page.locator(`.tab[data-tab="${id}"]`).click();
+
+      await expect(page.locator(`.tab[data-tab="${id}"]`)).toHaveClass(
+        /active/,
+      );
+      await expect(page.locator(`#tab-${id}`)).toHaveClass(/active/);
+
+      const errors = (page as Page & { __pageErrors: string[] }).__pageErrors;
+      expect(
+        errors,
+        `Uncaught page errors after switching to "${id}":\n${errors.join("\n")}`,
+      ).toEqual([]);
+    });
+  }
+
+  test("activating one tab deactivates the previously active pane", async ({
+    page,
+  }) => {
+    await page.locator('.tab[data-tab="settings"]').click();
+    await expect(page.locator("#tab-settings")).toHaveClass(/active/);
+    await expect(page.locator("#tab-overview")).not.toHaveClass(/active/);
+  });
+});

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["specs/**/*.ts", "helpers/**/*.ts", "playwright.config.ts"]
+}

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Linked issue

Closes #204

## Summary of changes

A new Layer 5 test layer (`pwsh tests/Run-Tests.ps1 -Layer 5`) boots `core/ui/server.ps1` against a freshly cloned golden `.bot/` and runs Playwright specs against the live backend. State is driven by seeding real task and process JSONs on disk, not by mocking `/api/*`. The single exception is a `page.route()` 500 injection in `error-handling.spec.ts` for transient fault injection, documented inline.

The suite ships 21 specs across 6 files, covering the issue's acceptance criteria: all 7 tabs render and switch, the 3 second state poll updates DOM counts, task and process lists render from real backend data, control buttons send the correct POSTs (`/api/control`, `/api/workflows/{name}/stop`), the settings form persists round trip via `/api/settings`, and the UI degrades gracefully on transient 500s.

`tests/Test-UI-E2E.ps1` is the entry wrapper. It runs pre-flight checks, auto installs npm dependencies and Chromium (`--with-deps`) on first run, builds the fixture from a golden snapshot, starts the UI server, hands `DOTBOT_E2E_URL` and `DOTBOT_E2E_BOT_DIR` to Playwright, and tears everything down on exit.

`tests/Run-Tests.ps1` wires Layer 5 as opt in (matching Layer 4). It is not part of `-Layer all`, and runs only when `-Layer 5` is requested explicitly.

`.github/workflows/test.yml` adds a `test-ui` job on `ubuntu-latest` with npm and Playwright browser caching, plus artifact upload of `playwright-report/` and `test-results/` on failure (7 day retention).

## Screenshots / recordings

Not applicable. Backend test infrastructure, no UI changes.

## Testing notes

1. `pwsh tests/Run-Tests.ps1 -Layer 5` produced 21 of 21 passing.
2. `pwsh tests/Run-Tests.ps1 -Layer 1` still passes, confirming the dispatcher edits did not regress earlier layers.
3. `pwsh install.ps1` runs clean.

## Checklist

Tests added or updated: yes. This PR is the new test layer (21 specs).

Docs updated: no behaviour change. The new layer is documented in the `Run-Tests.ps1` help block.

Linked issue exists: Closes #204.

Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md): yes.