### PR TITLE
fix(runtime): keep paused tasks alive instead of squash-merging

### DIFF
--- a/core/runtime/modules/MergeConflictEscalation.psm1
+++ b/core/runtime/modules/MergeConflictEscalation.psm1
@@ -16,9 +16,11 @@ function Move-TaskToMergeConflictNeedsInput {
     `$global:DotbotProjectRoot/.bot`.
 
     .OUTPUTS
-    @{ success; new_path; notified; notification_silent; notification_reason }
+    @{ success; new_path; notified; notification_silent; notification_reason; source_status }
     notification_silent is $true when the project hasn't opted into notifications
-    (no NotificationClient module or settings.enabled = $false).
+    (no NotificationClient module or settings.enabled = $false). source_status is
+    the directory the task was found in (`done`, `in-progress`, `needs-input`), or
+    $null when the task was not found.
     #>
     param(
         [Parameter(Mandatory)] [string] $TaskId,
@@ -35,15 +37,31 @@ function Move-TaskToMergeConflictNeedsInput {
         $BotRoot = Join-Path $global:DotbotProjectRoot '.bot'
     }
 
-    $doneDir = Join-Path $TasksBaseDir "done"
     $needsInputDir = Join-Path $TasksBaseDir "needs-input"
 
-    $taskFile = Get-ChildItem -LiteralPath $doneDir -Filter "*.json" -File -ErrorAction SilentlyContinue | Where-Object {
-        try {
-            $c = Get-Content $_.FullName -Raw | ConvertFrom-Json
-            $c.id -eq $TaskId
-        } catch { $false }
-    } | Select-Object -First 1
+    # Look across done/, in-progress/, and needs-input/. The escalation handler
+    # historically only checked done/ on the assumption that task_mark_done had
+    # already moved the task there before the merge attempt. That assumption
+    # breaks when a paused task or a still-in-progress task is routed here
+    # (for example when a runner upstream of this helper misclassifies state).
+    # Reporting the directory we found the task in keeps the escalation
+    # diagnosable when callers cross-check.
+    $sourceStatus = $null
+    $taskFile = $null
+    foreach ($status in @('done', 'in-progress', 'needs-input')) {
+        $dir = Join-Path $TasksBaseDir $status
+        $candidate = Get-ChildItem -LiteralPath $dir -Filter "*.json" -File -ErrorAction SilentlyContinue | Where-Object {
+            try {
+                $c = Get-Content $_.FullName -Raw | ConvertFrom-Json
+                $c.id -eq $TaskId
+            } catch { $false }
+        } | Select-Object -First 1
+        if ($candidate) {
+            $taskFile = $candidate
+            $sourceStatus = $status
+            break
+        }
+    }
 
     if (-not $taskFile) {
         return @{
@@ -51,7 +69,8 @@ function Move-TaskToMergeConflictNeedsInput {
             new_path            = $null
             notified            = $false
             notification_silent = $false
-            notification_reason = "Task file not found in done/"
+            notification_reason = "Task file not found in done/, in-progress/, or needs-input/"
+            source_status       = $null
         }
     }
 
@@ -119,13 +138,19 @@ function Move-TaskToMergeConflictNeedsInput {
         New-Item -ItemType Directory -Force -Path $needsInputDir | Out-Null
     }
     $newPath = Join-Path $needsInputDir $taskFile.Name
-    $taskContent | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $newPath -Encoding UTF8
-    try {
-        Remove-Item -LiteralPath $taskFile.FullName -Force -ErrorAction Stop
-    } catch {
-        # Rollback: remove the newly written file to avoid split-brain (task in both done/ and needs-input/)
-        Remove-Item -LiteralPath $newPath -Force -ErrorAction SilentlyContinue
-        throw
+    if ($sourceStatus -eq 'needs-input') {
+        # Already in the target directory — write in place, no rename, no delete.
+        $taskContent | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $taskFile.FullName -Encoding UTF8
+        $newPath = $taskFile.FullName
+    } else {
+        $taskContent | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $newPath -Encoding UTF8
+        try {
+            Remove-Item -LiteralPath $taskFile.FullName -Force -ErrorAction Stop
+        } catch {
+            # Rollback: remove the newly written file to avoid split-brain (task in both source and needs-input/)
+            Remove-Item -LiteralPath $newPath -Force -ErrorAction SilentlyContinue
+            throw
+        }
     }
 
     $notified = $false
@@ -177,6 +202,7 @@ function Move-TaskToMergeConflictNeedsInput {
         notified            = $notified
         notification_silent = $silent
         notification_reason = $reason
+        source_status       = $sourceStatus
     }
 }
 

--- a/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -1477,6 +1477,11 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
         Write-ProcessFile -Id $procId -Data $processData
 
         $taskSuccess = $false
+        # Set when the agent calls task_mark_needs_input. Distinct from
+        # taskSuccess because a paused task is neither a success nor a failure
+        # — its worktree must be retained so the executor can resume after
+        # task_answer_question moves the task back to analysing/.
+        $taskParked = $false
         $postScriptFailed = $false
         $postScriptError = $null
         # Distinguishes which post-task hook actually flipped postScriptFailed
@@ -1584,11 +1589,13 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
                 )
             } catch { Write-BotLog -Level Debug -Message "Failed to parse data" -Exception $_ }
 
-            # Agent called task_mark_needs_input — task is paused for human input, not a failure
+            # Agent called task_mark_needs_input — task is paused for human input.
+            # Mark it parked (not success, not failure) so the post-task path
+            # below leaves the worktree alive and does not squash-merge.
             if ($nowNeedsInput) {
                 Write-Status "Task paused for human input: $($task.name)" -Type Info
                 Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task '$($task.name)' paused — waiting for human input (needs-input)"
-                $taskSuccess = $true   # Not a failure — clean exit
+                $taskParked = $true
                 break
             }
 
@@ -1782,9 +1789,18 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
         $env:DOTBOT_CURRENT_TASK_ID = $null
         $env:CLAUDE_SESSION_ID = $null
 
-        Write-Diag "Task result: success=$taskSuccess"
+        Write-Diag "Task result: success=$taskSuccess parked=$taskParked"
 
-        if ($taskSuccess) {
+        if ($taskParked) {
+            # Task is paused awaiting user input. Leave the worktree alive so
+            # the executor can resume after task_answer_question moves the
+            # task back to analysing/. Do NOT squash-merge, do NOT count as
+            # completed — the runner's main loop will pick the task up again
+            # via the normal task_get_next path once answers arrive.
+            $processData.heartbeat_status = "Paused (needs-input): $($task.name)"
+            Write-ProcessFile -Id $procId -Data $processData
+            Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task parked (needs-input): $($task.name) — worktree retained at $worktreePath"
+        } elseif ($taskSuccess) {
             # Squash-merge task branch to main
             if ($worktreePath) {
                 Write-Status "Merging task branch to main..." -Type Process

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2844,6 +2844,80 @@ if (Test-Path $mergeEscModule) {
             -Condition ($missingResult.success -eq $false) `
             -Message "Expected success=false when task file not found in done/"
 
+        Assert-True -Name "Missing task: notification_reason names all three search dirs" `
+            -Condition ($missingResult.notification_reason -match 'done/' -and `
+                        $missingResult.notification_reason -match 'in-progress/' -and `
+                        $missingResult.notification_reason -match 'needs-input/') `
+            -Message "Expected notification_reason to mention done/, in-progress/, and needs-input/, got: $($missingResult.notification_reason)"
+
+        # --- Widened lookup: task found in in-progress/ ---
+        # The escalation helper historically only searched done/. A task that is
+        # still in in-progress/ when a merge-conflict is escalated (e.g. an
+        # upstream caller mis-classifies state) was reported as "not found in
+        # done/" and the runner emitted a misleading log line. The helper now
+        # searches done/, in-progress/, and needs-input/ in order.
+        $mceInProgress = Join-Path $mceWorkspace "in-progress"
+        New-Item -ItemType Directory -Force -Path $mceInProgress | Out-Null
+
+        $fakeTaskIdIp = "inprog01"
+        $fakeTaskJsonIp = @{
+            id         = $fakeTaskIdIp
+            name       = "Fake in-progress task"
+            status     = "in-progress"
+            created_at = "2026-04-29T00:00:00.0000000Z"
+            updated_at = "2026-04-29T00:00:00.0000000Z"
+        } | ConvertTo-Json -Depth 10
+        $fakeTaskFileIp = Join-Path $mceInProgress "$fakeTaskIdIp.json"
+        Set-Content -Path $fakeTaskFileIp -Value $fakeTaskJsonIp -Encoding UTF8
+
+        $resultIp = Move-TaskToMergeConflictNeedsInput `
+            -TaskId $fakeTaskIdIp `
+            -TasksBaseDir $mceWorkspace `
+            -MergeResult $fakeMergeResult `
+            -WorktreePath $fakeWorktreePath `
+            -BotRoot $mceBotRoot
+
+        Assert-True -Name "in-progress source: escalation succeeds" `
+            -Condition ($resultIp.success -eq $true) `
+            -Message "Expected success=true when task is in in-progress/"
+        Assert-Equal -Name "in-progress source: source_status='in-progress'" `
+            -Expected 'in-progress' -Actual $resultIp.source_status
+        Assert-PathNotExists -Name "in-progress source: original file deleted" `
+            -Path $fakeTaskFileIp
+        Assert-PathExists -Name "in-progress source: task file landed in needs-input/" `
+            -Path (Join-Path $mceNeedsInput "$fakeTaskIdIp.json")
+
+        # --- Widened lookup: task already in needs-input/ (idempotent) ---
+        $fakeTaskIdNi = "needsin01"
+        $fakeTaskJsonNi = @{
+            id         = $fakeTaskIdNi
+            name       = "Fake already-paused task"
+            status     = "needs-input"
+            created_at = "2026-04-29T00:00:00.0000000Z"
+            updated_at = "2026-04-29T00:00:00.0000000Z"
+        } | ConvertTo-Json -Depth 10
+        $fakeTaskFileNi = Join-Path $mceNeedsInput "$fakeTaskIdNi.json"
+        Set-Content -Path $fakeTaskFileNi -Value $fakeTaskJsonNi -Encoding UTF8
+
+        $resultNi = Move-TaskToMergeConflictNeedsInput `
+            -TaskId $fakeTaskIdNi `
+            -TasksBaseDir $mceWorkspace `
+            -MergeResult $fakeMergeResult `
+            -WorktreePath $fakeWorktreePath `
+            -BotRoot $mceBotRoot
+
+        Assert-True -Name "needs-input source: escalation succeeds idempotently" `
+            -Condition ($resultNi.success -eq $true) `
+            -Message "Expected success=true when task is already in needs-input/"
+        Assert-Equal -Name "needs-input source: source_status='needs-input'" `
+            -Expected 'needs-input' -Actual $resultNi.source_status
+        Assert-PathExists -Name "needs-input source: task file stayed in needs-input/" `
+            -Path $fakeTaskFileNi
+        $reloadedNi = Get-Content $fakeTaskFileNi -Raw | ConvertFrom-Json
+        Assert-True -Name "needs-input source: pending_question populated in place" `
+            -Condition ($reloadedNi.pending_question -and $reloadedNi.pending_question.id -eq 'merge-conflict') `
+            -Message "Expected pending_question.id='merge-conflict' written in place"
+
         # --- Regression: hashtable shape (matches Complete-TaskWorktree's real return) ---
         # Previously the helper probed $MergeResult.PSObject.Properties['conflict_files'],
         # which is $null for [hashtable], so conflict_files were silently dropped from the

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1075,6 +1075,29 @@ Assert-True -Name "Invoke-WorkflowProcess has elseif (postScriptFailed) branch" 
 Assert-True -Name "Invoke-WorkflowProcess calls Invoke-PostScriptFailureEscalation" `
     -Condition ($workflowSrc -match 'Invoke-PostScriptFailureEscalation')
 
+# Regression guards for paused-task handling. When the agent calls
+# task_mark_needs_input, the orchestrator must NOT take the success path —
+# Complete-TaskWorktree squash-merges and increments tasks_completed, both
+# of which corrupt state for a paused task. See plan
+# scalable-foraging-feigenbaum.md for the symptom trace.
+Assert-True -Name "Invoke-WorkflowProcess initialises taskParked=false" `
+    -Condition ($workflowSrc -match '\$taskParked\s*=\s*\$false')
+Assert-True -Name "Invoke-WorkflowProcess sets taskParked=true on needs-input" `
+    -Condition ($workflowSrc -match '\$taskParked\s*=\s*\$true')
+$parkedBranchMatch = [regex]::Match($workflowSrc, 'if\s*\(\s*\$taskParked\s*\)\s*\{(?<body>[\s\S]*?)\}\s*elseif\s*\(\s*\$taskSuccess\s*\)')
+Assert-True -Name "Invoke-WorkflowProcess has if (taskParked) branch before merge" `
+    -Condition $parkedBranchMatch.Success `
+    -Message "Expected the parked branch to come before the success branch so merge is skipped for paused tasks"
+$parkedBranchBody = if ($parkedBranchMatch.Success) { $parkedBranchMatch.Groups['body'].Value } else { '' }
+Assert-True -Name "Paused branch does NOT call Complete-TaskWorktree" `
+    -Condition ($parkedBranchBody -notmatch 'Complete-TaskWorktree') `
+    -Message "Paused tasks must skip the squash-merge — Complete-TaskWorktree should not appear inside the if (taskParked) branch"
+Assert-True -Name "Paused branch does NOT increment tasks_completed" `
+    -Condition ($parkedBranchBody -notmatch '\$tasksProcessed\+\+') `
+    -Message "tasks_completed must not be incremented for paused tasks"
+Assert-True -Name "Paused branch emits 'Paused (needs-input)' heartbeat" `
+    -Condition ($workflowSrc -match '"Paused\s*\(needs-input\):\s*\$\(\$task\.name\)"')
+
 Write-Host ""
 
 # ═══════════════════════════════════════════════════════════════════

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1078,8 +1078,8 @@ Assert-True -Name "Invoke-WorkflowProcess calls Invoke-PostScriptFailureEscalati
 # Regression guards for paused-task handling. When the agent calls
 # task_mark_needs_input, the orchestrator must NOT take the success path —
 # Complete-TaskWorktree squash-merges and increments tasks_completed, both
-# of which corrupt state for a paused task. See plan
-# scalable-foraging-feigenbaum.md for the symptom trace.
+# of which corrupt state for a paused task. See issue #382 for the
+# symptom trace.
 Assert-True -Name "Invoke-WorkflowProcess initialises taskParked=false" `
     -Condition ($workflowSrc -match '\$taskParked\s*=\s*\$false')
 Assert-True -Name "Invoke-WorkflowProcess sets taskParked=true on needs-input" `


### PR DESCRIPTION
Closes #382.

## Summary

When the agent calls `task_mark_needs_input`, the orchestrator was flagging the run as `$taskSuccess=$true` and falling into the `Complete-TaskWorktree` branch, which squash-merges to main. The merge itself was wrong (a paused task is not done), and the merge cleanup also reset the worktree, throwing away the executor's `needs-input/` move and the questions written into `pending_questions`. The runner then logged `Task completed` with `tasks_completed=1`, parked at `Waiting for new tasks...`, and the queue blocked behind a task it mistakenly believed had finished. Three downstream tasks with `dependencies: [<paused task>]` never dispatched even after the user populated `interview-answers.json`.

See #382 for the full symptom trace from a SlashOps dogfood run.

## Changes

- `core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1` — introduce `$taskParked` flag, set on `task_mark_needs_input`. Add `if ($taskParked) { ... } elseif ($taskSuccess) { ... }` ahead of the merge branch so paused tasks skip `Complete-TaskWorktree`, keep the worktree alive, do not bump `tasks_completed`, and emit a `Paused (needs-input):` heartbeat.
- `core/runtime/modules/MergeConflictEscalation.psm1` — widen the lookup across `done/`, `in-progress/`, `needs-input/`. Result now carries `source_status`. Already-in-`needs-input/` case writes in place rather than self-overwriting + deleting. Updated `notification_reason` text covers all three directories.

A latent third issue (the broad `git checkout -- .bot/workspace/tasks` inside `Complete-TaskWorktree`) is reachable today only via the parked-task path. Now that the parked path no longer runs `Complete-TaskWorktree`, that issue is dead code on this code path. Recommended follow-up to tighten the checkout scope, but not a blocker for closing #382.

## Tests

- `tests/Test-WorkflowManifest.ps1` — six new source-grep guards for the parked-state branch shape (initialised, set on needs-input, branch appears before the success branch, does not call `Complete-TaskWorktree`, does not bump `tasks_completed`, emits the new heartbeat string).
- `tests/Test-Components.ps1` — three new escalation cases:
  - `notification_reason` mentions all three search directories.
  - Task in `in-progress/` is moved to `needs-input/` and the result reports `source_status='in-progress'`.
  - Task already in `needs-input/` is updated idempotently in place with `source_status='needs-input'`.

Local verification:

- `pwsh tests/Test-WorkflowManifest.ps1` — 396 / 396 pass.
- `pwsh tests/Test-Components.ps1` — 439 / 439 pass.

## Test plan

- [ ] Cross-platform CI (`test.yml`) green on Windows / macOS / Linux.
- [ ] GitHub Copilot review feedback addressed.
- [ ] End-to-end on SlashOps: re-trigger the `start-from-prompt` workflow that originally surfaced the bug; confirm the runner logs `Task parked (needs-input)` (not `Squash-merged` or `Task completed`), `tasks_completed` stays 0, the task file lands in `tasks/needs-input/` with `pending_questions` populated, the user can answer via `task_answer_question`, and the workflow runs to completion with decisions in `decisions/accepted/` and dependent tasks dispatched in order.