### PR TITLE
fix(runtime): pin claude cwd to task worktree

### DIFF
--- a/core/runtime/ClaudeCLI/ClaudeCLI.psm1
+++ b/core/runtime/ClaudeCLI/ClaudeCLI.psm1
@@ -401,7 +401,13 @@ function Invoke-ClaudeStream {
     
     .PARAMETER ShowVerbose
     Show detailed tool results and metadata.
-    
+
+    .PARAMETER WorkingDirectory
+    Optional working directory for the spawned claude.exe child process. If set,
+    overrides the default $global:DotbotProjectRoot. Used by the task execution
+    phase to pin Claude's cwd to the per-task git worktree so Edit/Write/Bash
+    tool calls land on the task branch instead of project root (#314).
+
     .EXAMPLE
     Invoke-ClaudeStream -Prompt "What files are in the current directory?"
     
@@ -574,11 +580,11 @@ function Invoke-ClaudeStream {
     # Claude's cwd controls where Edit/Write/Bash resolve relative paths.
     # - Default: $global:DotbotProjectRoot, so MCP discovery picks up .mcp.json.
     # - Task execution: Invoke-WorkflowProcess passes the worktree path so agent edits
-    #   land on the task branch, not on main. Worktree has a hardlinked .mcp.json so
-    #   MCP discovery still works.
-    if ($WorkingDirectory -and (Test-Path $WorkingDirectory)) {
+    #   land on the task branch, not on main. Worktree has .mcp.json copied in by
+    #   Copy-BuildArtifacts at creation time, so MCP discovery still works.
+    if ($WorkingDirectory -and (Test-Path -LiteralPath $WorkingDirectory -PathType Container)) {
         $psi.WorkingDirectory = $WorkingDirectory
-    } elseif ($global:DotbotProjectRoot -and (Test-Path $global:DotbotProjectRoot)) {
+    } elseif ($global:DotbotProjectRoot -and (Test-Path -LiteralPath $global:DotbotProjectRoot -PathType Container)) {
         $psi.WorkingDirectory = $global:DotbotProjectRoot
     }
     # Marker env var (informational, not functionally critical)

--- a/core/runtime/ClaudeCLI/ClaudeCLI.psm1
+++ b/core/runtime/ClaudeCLI/ClaudeCLI.psm1
@@ -433,7 +433,9 @@ function Invoke-ClaudeStream {
 
         [switch]$ShowVerbose,
 
-        [string[]]$PermissionArgs = @("--dangerously-skip-permissions")
+        [string[]]$PermissionArgs = @("--dangerously-skip-permissions"),
+
+        [string]$WorkingDirectory
     )
 
     # Clear any previous rate limit info
@@ -569,11 +571,14 @@ function Invoke-ClaudeStream {
     $psi.CreateNoWindow = $true
     $psi.StandardOutputEncoding = [System.Text.Encoding]::UTF8
     $psi.StandardErrorEncoding = [System.Text.Encoding]::UTF8
-    # Ensure claude.exe starts in the project root so it discovers .mcp.json
-    # and starts all configured MCP servers (including dotbot with yaml_write_ticket etc.).
-    # Without this, UI-launched processes inherit the server's CWD which
-    # may not be the project root — causing all mcp__dotbot__* tools to be missing.
-    if ($global:DotbotProjectRoot -and (Test-Path $global:DotbotProjectRoot)) {
+    # Claude's cwd controls where Edit/Write/Bash resolve relative paths.
+    # - Default: $global:DotbotProjectRoot, so MCP discovery picks up .mcp.json.
+    # - Task execution: Invoke-WorkflowProcess passes the worktree path so agent edits
+    #   land on the task branch, not on main. Worktree has a hardlinked .mcp.json so
+    #   MCP discovery still works.
+    if ($WorkingDirectory -and (Test-Path $WorkingDirectory)) {
+        $psi.WorkingDirectory = $WorkingDirectory
+    } elseif ($global:DotbotProjectRoot -and (Test-Path $global:DotbotProjectRoot)) {
         $psi.WorkingDirectory = $global:DotbotProjectRoot
     }
     # Marker env var (informational, not functionally critical)

--- a/core/runtime/ClaudeCLI/ClaudeCLI.psm1
+++ b/core/runtime/ClaudeCLI/ClaudeCLI.psm1
@@ -403,7 +403,7 @@ function Invoke-ClaudeStream {
     Show detailed tool results and metadata.
 
     .PARAMETER WorkingDirectory
-    Optional working directory for the spawned claude.exe child process. If set,
+    Optional working directory for the spawned Claude CLI child process. If set,
     overrides the default $global:DotbotProjectRoot. Used by the task execution
     phase to pin Claude's cwd to the per-task git worktree so Edit/Write/Bash
     tool calls land on the task branch instead of project root (#314).

--- a/core/runtime/ProviderCLI/ProviderCLI.psm1
+++ b/core/runtime/ProviderCLI/ProviderCLI.psm1
@@ -299,7 +299,8 @@ function Invoke-ProviderStream {
         [switch]$ShowDebugJson,
         [switch]$ShowVerbose,
         [string]$ProviderName,
-        [string]$PermissionMode
+        [string]$PermissionMode,
+        [string]$WorkingDirectory
     )
 
     # Clear any previous rate limit info
@@ -327,6 +328,7 @@ function Invoke-ProviderStream {
         if ($PersistSession) { $streamArgs['PersistSession'] = $true }
         if ($ShowDebugJson) { $streamArgs['ShowDebugJson'] = $true }
         if ($ShowVerbose)  { $streamArgs['ShowVerbose'] = $true }
+        if ($WorkingDirectory) { $streamArgs['WorkingDirectory'] = $WorkingDirectory }
 
         Invoke-ClaudeStream @streamArgs
 

--- a/core/runtime/ProviderCLI/ProviderCLI.psm1
+++ b/core/runtime/ProviderCLI/ProviderCLI.psm1
@@ -285,6 +285,15 @@ function Invoke-ProviderStream {
 
     .PARAMETER ProviderName
     Override provider name (default: from settings).
+
+    .PARAMETER WorkingDirectory
+    Optional working directory for the spawned provider child process. Currently
+    honored only by the Claude branch (forwarded to Invoke-ClaudeStream which
+    applies it to ProcessStartInfo.WorkingDirectory). For non-Claude providers
+    this is silently ignored — they spawn via PowerShell's call operator and pick
+    up the parent shell's cwd, so callers should Push-Location around the call
+    if a specific cwd is required. Used by task execution to pin the agent's
+    cwd to the per-task git worktree (#314).
     #>
     [CmdletBinding()]
     param(

--- a/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -1251,6 +1251,8 @@ Do NOT implement the task. Your job is research and preparation only.
                 if ($ShowVerbose) { $streamArgs['ShowVerbose'] = $true }
 
                 if ($permissionMode) { $streamArgs['PermissionMode'] = $permissionMode }
+                # Analysis phase runs before worktree creation, so cwd stays at project
+                # root. The phase is read-only by prompt contract (#314).
                 Invoke-ProviderStream @streamArgs
                 $exitCode = 0
             } catch {
@@ -1510,6 +1512,9 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
                 if ($ShowVerbose) { $streamArgs['ShowVerbose'] = $true }
 
                 if ($permissionMode) { $streamArgs['PermissionMode'] = $permissionMode }
+                # Execution phase: pin Claude's cwd to the worktree so Edit/Write/Bash
+                # land on the task branch instead of project root (#314).
+                if ($worktreePath) { $streamArgs['WorkingDirectory'] = $worktreePath }
                 Invoke-ProviderStream @streamArgs
                 $exitCode = 0
             } catch {

--- a/tests/Test-MockClaude.ps1
+++ b/tests/Test-MockClaude.ps1
@@ -202,14 +202,29 @@ try {
         $tempCwd = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-cwd-$([System.Guid]::NewGuid().ToString('N').Substring(0,8))"
         New-Item -Path $tempCwd -ItemType Directory -Force | Out-Null
 
-        # Resolve to canonical form (Windows temp paths can include short-name segments
-        # like RUNNER~1 vs runneradmin; the mock captures (Get-Location).Path which is
-        # already long-form, so we compare against the long-form too).
-        $expectedCwd = (Resolve-Path -LiteralPath $tempCwd).Path
+        # Canonicalize to match what the kernel reports as cwd inside the spawned process.
+        # - Windows: Resolve-Path expands short-name segments (RUNNER~1 -> runneradmin).
+        # - macOS:   /var, /tmp, /etc are symlinks to /private/*. getcwd() in the child
+        #            returns the resolved /private/* form, so we follow links here too.
+        # - Linux:   pwd -P resolves any symlinks in path components.
+        # Resolve-Path alone does not follow symlinks, so on POSIX we shell out to pwd -P.
+        function Get-CanonicalCwd {
+            param([Parameter(Mandatory)][string]$Path)
+            $resolved = (Resolve-Path -LiteralPath $Path).Path
+            if ($IsMacOS -or $IsLinux) {
+                $shellResolved = & /bin/sh -c "cd `"$resolved`" && pwd -P" 2>$null
+                if ($LASTEXITCODE -eq 0 -and $shellResolved) {
+                    $resolved = $shellResolved.Trim()
+                }
+            }
+            return $resolved
+        }
+
+        $expectedCwd = Get-CanonicalCwd -Path $tempCwd
 
         # Save and rebuild $global:DotbotProjectRoot so the fallback assertion is deterministic
         $savedDotbotProjectRoot = $global:DotbotProjectRoot
-        $global:DotbotProjectRoot = (Resolve-Path -LiteralPath (Split-Path -Parent $dotbotDir)).Path
+        $global:DotbotProjectRoot = Get-CanonicalCwd -Path (Split-Path -Parent $dotbotDir)
 
         try {
             # 1. -WorkingDirectory pins the child cwd

--- a/tests/Test-MockClaude.ps1
+++ b/tests/Test-MockClaude.ps1
@@ -191,6 +191,78 @@ try {
     Write-Host ""
 
     # ═══════════════════════════════════════════════════════════════════
+    # WORKING DIRECTORY (#314)
+    # ═══════════════════════════════════════════════════════════════════
+
+    Write-Host "  WORKING DIRECTORY (#314)" -ForegroundColor Cyan
+    Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+    if (Test-Path $claudeModule) {
+        $cwdLog = Join-Path $mockLogDir "mock-claude-cwd.log"
+        $tempCwd = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-cwd-$([System.Guid]::NewGuid().ToString('N').Substring(0,8))"
+        New-Item -Path $tempCwd -ItemType Directory -Force | Out-Null
+
+        # Resolve to canonical form (Windows temp paths can include short-name segments
+        # like RUNNER~1 vs runneradmin; the mock captures (Get-Location).Path which is
+        # already long-form, so we compare against the long-form too).
+        $expectedCwd = (Resolve-Path -LiteralPath $tempCwd).Path
+
+        # Save and rebuild $global:DotbotProjectRoot so the fallback assertion is deterministic
+        $savedDotbotProjectRoot = $global:DotbotProjectRoot
+        $global:DotbotProjectRoot = (Resolve-Path -LiteralPath (Split-Path -Parent $dotbotDir)).Path
+
+        try {
+            # 1. -WorkingDirectory pins the child cwd
+            try {
+                Invoke-ClaudeStream -Prompt "cwd test explicit" -Model "opus" -WorkingDirectory $tempCwd *>&1 | Out-Null
+                $captured = if (Test-Path $cwdLog) { (Get-Content $cwdLog -Raw).Trim() } else { "" }
+                Assert-True -Name "Invoke-ClaudeStream pins cwd to -WorkingDirectory (#314)" `
+                    -Condition ($captured -ieq $expectedCwd) `
+                    -Message "Expected cwd=$expectedCwd, got cwd=$captured"
+            } catch {
+                Write-TestResult -Name "Invoke-ClaudeStream pins cwd to -WorkingDirectory (#314)" -Status Fail -Message $_.Exception.Message
+            }
+
+            # 2. Without -WorkingDirectory, falls back to $global:DotbotProjectRoot
+            try {
+                Invoke-ClaudeStream -Prompt "cwd test fallback" -Model "opus" *>&1 | Out-Null
+                $captured = if (Test-Path $cwdLog) { (Get-Content $cwdLog -Raw).Trim() } else { "" }
+                Assert-True -Name "Invoke-ClaudeStream falls back to DotbotProjectRoot when -WorkingDirectory not set" `
+                    -Condition ($captured -ieq $global:DotbotProjectRoot) `
+                    -Message "Expected cwd=$global:DotbotProjectRoot, got cwd=$captured"
+            } catch {
+                Write-TestResult -Name "Invoke-ClaudeStream falls back to DotbotProjectRoot when -WorkingDirectory not set" -Status Fail -Message $_.Exception.Message
+            }
+
+            # 3. Invoke-ProviderStream forwards -WorkingDirectory through to Claude
+            try {
+                $providerModule = Join-Path $dotbotDir "core/runtime/ProviderCLI/ProviderCLI.psm1"
+                if (Test-Path $providerModule) {
+                    Import-Module $providerModule -Force
+                    Invoke-ProviderStream -Prompt "cwd test provider" -Model "opus" -ProviderName "claude" -WorkingDirectory $tempCwd *>&1 | Out-Null
+                    $captured = if (Test-Path $cwdLog) { (Get-Content $cwdLog -Raw).Trim() } else { "" }
+                    Assert-True -Name "Invoke-ProviderStream forwards -WorkingDirectory to Claude branch (#314)" `
+                        -Condition ($captured -ieq $expectedCwd) `
+                        -Message "Expected cwd=$expectedCwd, got cwd=$captured"
+                } else {
+                    Write-TestResult -Name "Invoke-ProviderStream forwards -WorkingDirectory to Claude branch (#314)" -Status Skip -Message "ProviderCLI module not found"
+                }
+            } catch {
+                Write-TestResult -Name "Invoke-ProviderStream forwards -WorkingDirectory to Claude branch (#314)" -Status Fail -Message $_.Exception.Message
+            }
+        } finally {
+            $global:DotbotProjectRoot = $savedDotbotProjectRoot
+            if (Test-Path $tempCwd) {
+                Remove-Item -Path $tempCwd -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    } else {
+        Write-TestResult -Name "Working directory tests" -Status Skip -Message "ClaudeCLI module not available"
+    }
+
+    Write-Host ""
+
+    # ═══════════════════════════════════════════════════════════════════
     # RATE LIMIT DETECTION
     # ═══════════════════════════════════════════════════════════════════
 

--- a/tests/Test-MockClaude.ps1
+++ b/tests/Test-MockClaude.ps1
@@ -231,8 +231,9 @@ try {
             try {
                 Invoke-ClaudeStream -Prompt "cwd test explicit" -Model "opus" -WorkingDirectory $tempCwd *>&1 | Out-Null
                 $captured = if (Test-Path $cwdLog) { (Get-Content $cwdLog -Raw).Trim() } else { "" }
+                $pathsMatch = if ($IsWindows) { $captured -ieq $expectedCwd } else { $captured -ceq $expectedCwd }
                 Assert-True -Name "Invoke-ClaudeStream pins cwd to -WorkingDirectory (#314)" `
-                    -Condition ($captured -ieq $expectedCwd) `
+                    -Condition $pathsMatch `
                     -Message "Expected cwd=$expectedCwd, got cwd=$captured"
             } catch {
                 Write-TestResult -Name "Invoke-ClaudeStream pins cwd to -WorkingDirectory (#314)" -Status Fail -Message $_.Exception.Message
@@ -242,8 +243,9 @@ try {
             try {
                 Invoke-ClaudeStream -Prompt "cwd test fallback" -Model "opus" *>&1 | Out-Null
                 $captured = if (Test-Path $cwdLog) { (Get-Content $cwdLog -Raw).Trim() } else { "" }
+                $pathsMatch = if ($IsWindows) { $captured -ieq $global:DotbotProjectRoot } else { $captured -ceq $global:DotbotProjectRoot }
                 Assert-True -Name "Invoke-ClaudeStream falls back to DotbotProjectRoot when -WorkingDirectory not set" `
-                    -Condition ($captured -ieq $global:DotbotProjectRoot) `
+                    -Condition $pathsMatch `
                     -Message "Expected cwd=$global:DotbotProjectRoot, got cwd=$captured"
             } catch {
                 Write-TestResult -Name "Invoke-ClaudeStream falls back to DotbotProjectRoot when -WorkingDirectory not set" -Status Fail -Message $_.Exception.Message
@@ -256,8 +258,9 @@ try {
                     Import-Module $providerModule -Force
                     Invoke-ProviderStream -Prompt "cwd test provider" -Model "opus" -ProviderName "claude" -WorkingDirectory $tempCwd *>&1 | Out-Null
                     $captured = if (Test-Path $cwdLog) { (Get-Content $cwdLog -Raw).Trim() } else { "" }
+                    $pathsMatch = if ($IsWindows) { $captured -ieq $expectedCwd } else { $captured -ceq $expectedCwd }
                     Assert-True -Name "Invoke-ProviderStream forwards -WorkingDirectory to Claude branch (#314)" `
-                        -Condition ($captured -ieq $expectedCwd) `
+                        -Condition $pathsMatch `
                         -Message "Expected cwd=$expectedCwd, got cwd=$captured"
                 } else {
                     Write-TestResult -Name "Invoke-ProviderStream forwards -WorkingDirectory to Claude branch (#314)" -Status Skip -Message "ProviderCLI module not found"

--- a/tests/mock-claude.ps1
+++ b/tests/mock-claude.ps1
@@ -18,6 +18,9 @@ $argsFile = Join-Path $logDir "mock-claude-args.log"
 # Log all received args for test assertions
 ($args -join "`n") | Set-Content -Path $argsFile -Encoding UTF8
 
+# Capture cwd so tests can assert WorkingDirectory plumbing (#314)
+(Get-Location).Path | Set-Content -Path (Join-Path $logDir "mock-claude-cwd.log") -Encoding UTF8
+
 # Determine mock mode (normal, rate-limit, error)
 $mode = "normal"
 if (Test-Path $modeFile) {


### PR DESCRIPTION
## Summary

Closes #314.

The Claude child process was always spawned with `WorkingDirectory = $global:DotbotProjectRoot`, so during the execution phase agent `Edit` / `Write` / `Bash` calls landed on the project root instead of the per-task git worktree. The wrong-folder edits then leaked into the squash-merge via the stash/pop cycle around merge, leaving the task branch with no real history of its own.

## Why `Push-Location` alone wasn't enough

`Push-Location $worktreePath` only updates PowerShell's `$PWD`. `System.Diagnostics.Process` reads `ProcessStartInfo.WorkingDirectory` directly and ignores the shell's location stack, so the Claude process inherited the server's cwd regardless of the parent shell.

PowerShell's `&` call operator *does* honour `$PWD`, which is why the existing `Push-Location` is intentionally kept — it covers non-Claude providers (codex/gemini) that spawn via `& $executable`.

## What changed

| File | Change |
|---|---|
| `core/runtime/ClaudeCLI/ClaudeCLI.psm1` | New `[string]$WorkingDirectory` parameter on `Invoke-ClaudeStream`. When set, it overrides `psi.WorkingDirectory`; otherwise the existing `$global:DotbotProjectRoot` fallback is used. |
| `core/runtime/ProviderCLI/ProviderCLI.psm1` | `Invoke-ProviderStream` accepts `[string]$WorkingDirectory` and forwards it into `$streamArgs` for the Claude branch. |
| `core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1` | Execution-phase call site passes `WorkingDirectory = $worktreePath`. Analysis-phase call site adds a comment explaining why it does **not** pass one (worktree is created after analysis; analysis is read-only by prompt contract). |
| `tests/mock-claude.ps1` | One-line addition: writes `(Get-Location).Path` to `$DOTBOT_MOCK_LOG_DIR/mock-claude-cwd.log` so tests can assert the spawned cwd. |
| `tests/Test-MockClaude.ps1` | New Layer 3 section "WORKING DIRECTORY (#314)" with three regression assertions. |

## Scope notes

- **Analysis phase is intentionally untouched.** The worktree is created at `New-TaskWorktree` (line ~1421), after the analysis call site at line 1256. Analysis stays at project root, which is correct for its read-only contract.
- **`.mcp.json` discovery still works** in the worktree: it's gitignored at the project root and `Copy-BuildArtifacts` (`WorktreeManager.psm1:992`) copies it into the worktree at creation time alongside other gitignored top-level files.
- **The stash/pop / squash-merge interaction is out of scope** — per @carlospedreira's comment, that's a separate question that needs its own focused reproduction. This PR only fixes the confirmed root cause: Claude editing the wrong folder.

## Test plan

New Layer 3 assertions in `tests/Test-MockClaude.ps1` (under "WORKING DIRECTORY (#314)"):

- [x] `Invoke-ClaudeStream -WorkingDirectory <dir>` -> child cwd equals `<dir>`
- [x] `Invoke-ClaudeStream` without `-WorkingDirectory` -> child cwd falls back to `$global:DotbotProjectRoot`
- [x] `Invoke-ProviderStream -WorkingDirectory <dir>` (Claude branch) -> forwarded to `Invoke-ClaudeStream`, child cwd equals `<dir>`