### PR TITLE
fix(init): merge core MCP entries into existing .mcp.json (#315)

### DIFF
--- a/scripts/init-project.ps1
+++ b/scripts/init-project.ps1
@@ -876,52 +876,97 @@ if (Test-Path $initScript) {
 }
 
 # ---------------------------------------------------------------------------
-# Create .mcp.json with MCP server configuration
+# Create or merge .mcp.json with MCP server configuration
+#
+# A pre-existing .mcp.json (e.g. user-maintained `github` / `figma` entries)
+# must NOT be overwritten or skipped — we merge core entries in while
+# preserving everything the user added. See issue #315.
 # ---------------------------------------------------------------------------
 $mcpJsonPath = Join-Path $ProjectDir ".mcp.json"
-if (Test-Path $mcpJsonPath) {
-    Write-DotbotWarning ".mcp.json already exists -- skipping"
+
+# Playwright MCP output goes to .bot/.control/ (gitignored) — uses a relative
+# path so .mcp.json doesn't contain absolute user paths that trip the privacy scan
+$pwOutputDir = ".bot/.control/playwright-output"
+
+# On Windows, npx must be invoked via 'cmd /c' for stdio MCP servers
+if ($IsWindows) {
+    $npxCommand = "cmd"
+    $npxContext7Args = @("/c", "npx", "-y", "@upstash/context7-mcp@latest")
+    $npxPlaywrightArgs = @("/c", "npx", "-y", "@playwright/mcp@latest", "--output-dir", $pwOutputDir)
 } else {
-    Write-Status "Creating .mcp.json (dotbot + Context7 + Playwright)"
+    $npxCommand = "npx"
+    $npxContext7Args = @("-y", "@upstash/context7-mcp@latest")
+    $npxPlaywrightArgs = @("-y", "@playwright/mcp@latest", "--output-dir", $pwOutputDir)
+}
 
-    # Playwright MCP output goes to .bot/.control/ (gitignored) — uses a relative
-    # path so .mcp.json doesn't contain absolute user paths that trip the privacy scan
-    $pwOutputDir = ".bot/.control/playwright-output"
+# Core entries owned by the framework. Order matters — written in this order
+# in the resulting file, with any user-added entries appended after.
+$coreServers = [ordered]@{
+    dotbot = [ordered]@{
+        type    = "stdio"
+        command = "pwsh"
+        args    = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", ".bot/core/mcp/dotbot-mcp.ps1")
+        env     = @{}
+    }
+    context7 = [ordered]@{
+        type    = "stdio"
+        command = $npxCommand
+        args    = $npxContext7Args
+        env     = @{}
+    }
+    playwright = [ordered]@{
+        type    = "stdio"
+        command = $npxCommand
+        args    = $npxPlaywrightArgs
+        env     = @{}
+    }
+}
 
-    # On Windows, npx must be invoked via 'cmd /c' for stdio MCP servers
-    if ($IsWindows) {
-        $npxCommand = "cmd"
-        $npxContext7Args = @("/c", "npx", "-y", "@upstash/context7-mcp@latest")
-        $npxPlaywrightArgs = @("/c", "npx", "-y", "@playwright/mcp@latest", "--output-dir", $pwOutputDir)
-    } else {
-        $npxCommand = "npx"
-        $npxContext7Args = @("-y", "@upstash/context7-mcp@latest")
-        $npxPlaywrightArgs = @("-y", "@playwright/mcp@latest", "--output-dir", $pwOutputDir)
+if (Test-Path $mcpJsonPath) {
+    Write-Status "Merging .mcp.json (preserving user entries)"
+    try {
+        $existing = Get-Content $mcpJsonPath -Raw | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        throw ".mcp.json exists but is not valid JSON: $($_.Exception.Message). Fix or remove the file and re-run dotbot init."
     }
 
-    $mcpConfig = @{
-        mcpServers = [ordered]@{
-            dotbot = [ordered]@{
-                type    = "stdio"
-                command = "pwsh"
-                args    = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", ".bot/core/mcp/dotbot-mcp.ps1")
-                env     = @{}
-            }
-            context7 = [ordered]@{
-                type    = "stdio"
-                command = $npxCommand
-                args    = $npxContext7Args
-                env     = @{}
-            }
-            playwright = [ordered]@{
-                type    = "stdio"
-                command = $npxCommand
-                args    = $npxPlaywrightArgs
-                env     = @{}
+    $mergedServers = [ordered]@{}
+    $existingHasMcpServers = $existing -and $existing.PSObject.Properties['mcpServers'] -and $existing.mcpServers
+
+    # Core first, in canonical order
+    foreach ($coreName in $coreServers.Keys) {
+        $existingEntry = $null
+        if ($existingHasMcpServers -and $existing.mcpServers.PSObject.Properties[$coreName]) {
+            $existingEntry = $existing.mcpServers.$coreName
+        }
+
+        if ($existingEntry -and -not $Force) {
+            $mergedServers[$coreName] = $existingEntry
+            Write-DotbotCommand "Kept existing '$coreName' entry (use -Force to refresh)"
+        } else {
+            $mergedServers[$coreName] = $coreServers[$coreName]
+            $action = if ($existingEntry) { "Refreshed" } else { "Added" }
+            Write-DotbotCommand "$action '$coreName' entry"
+        }
+    }
+
+    # Preserve any non-core (user-added) servers verbatim
+    if ($existingHasMcpServers) {
+        foreach ($prop in $existing.mcpServers.PSObject.Properties) {
+            if (-not $coreServers.Contains($prop.Name)) {
+                $mergedServers[$prop.Name] = $prop.Value
+                Write-DotbotCommand "Preserved '$($prop.Name)' entry"
             }
         }
     }
-    $mcpConfig | ConvertTo-Json -Depth 5 | Set-Content -Path $mcpJsonPath -Encoding UTF8
+
+    $mcpConfig = @{ mcpServers = $mergedServers }
+    $mcpConfig | ConvertTo-Json -Depth 10 | Set-Content -Path $mcpJsonPath -Encoding UTF8
+    Write-Success "Merged .mcp.json"
+} else {
+    Write-Status "Creating .mcp.json (dotbot + Context7 + Playwright)"
+    $mcpConfig = @{ mcpServers = $coreServers }
+    $mcpConfig | ConvertTo-Json -Depth 10 | Set-Content -Path $mcpJsonPath -Encoding UTF8
     Write-Success "Created .mcp.json"
 }
 

--- a/scripts/init-project.ps1
+++ b/scripts/init-project.ps1
@@ -930,28 +930,33 @@ if (Test-Path $mcpJsonPath) {
         throw ".mcp.json exists but is not valid JSON: $($_.Exception.Message). Fix or remove the file and re-run dotbot init."
     }
 
+    # Validate root shape. ConvertFrom-Json returns $null for an empty file
+    # and unwraps scalars/arrays; both would silently corrupt the merge.
+    # Treat $null as "no usable content" and rebuild from a fresh object;
+    # throw on any non-object root so the user gets a friendly message.
+    if ($null -ne $existing -and -not ($existing -is [System.Management.Automation.PSCustomObject])) {
+        throw ".mcp.json root is not a JSON object: got $($existing.GetType().Name). Fix or remove the file and re-run dotbot init."
+    }
+    if ($null -eq $existing) {
+        $existing = [pscustomobject]@{}
+    }
+
     $mergedServers = [ordered]@{}
-    $hasMcpServersProp = $existing -and $existing.PSObject.Properties['mcpServers']
+    $hasMcpServersProp = [bool]$existing.PSObject.Properties['mcpServers']
     if ($hasMcpServersProp -and $existing.mcpServers -and -not ($existing.mcpServers -is [System.Management.Automation.PSCustomObject])) {
         throw ".mcp.json has 'mcpServers' but it is not an object: got $($existing.mcpServers.GetType().Name). Fix or remove the file and re-run dotbot init."
     }
     $existingHasMcpServers = $hasMcpServersProp -and $existing.mcpServers
 
-    # Core first, in canonical order
+    # Core entries are framework-owned: always use the canonical value so
+    # upgrades after a framework path move (e.g. #345 moved the dotbot MCP
+    # server from .bot/systems/ to .bot/core/) self-heal on re-init. User
+    # entries with non-core names are preserved verbatim in the next loop.
     foreach ($coreName in $coreServers.Keys) {
-        $existingEntry = $null
-        if ($existingHasMcpServers -and $existing.mcpServers.PSObject.Properties[$coreName]) {
-            $existingEntry = $existing.mcpServers.$coreName
-        }
-
-        if ($existingEntry -and -not $Force) {
-            $mergedServers[$coreName] = $existingEntry
-            Write-DotbotCommand "Kept existing '$coreName' entry (use -Force to refresh)"
-        } else {
-            $mergedServers[$coreName] = $coreServers[$coreName]
-            $action = if ($existingEntry) { "Refreshed" } else { "Added" }
-            Write-DotbotCommand "$action '$coreName' entry"
-        }
+        $hadExisting = $existingHasMcpServers -and $existing.mcpServers.PSObject.Properties[$coreName]
+        $mergedServers[$coreName] = $coreServers[$coreName]
+        $action = if ($hadExisting) { "Refreshed" } else { "Added" }
+        Write-DotbotCommand "$action '$coreName' entry"
     }
 
     # Preserve any non-core (user-added) servers verbatim
@@ -966,7 +971,7 @@ if (Test-Path $mcpJsonPath) {
 
     # Preserve any non-mcpServers top-level keys (e.g. tool-specific settings)
     # by mutating $existing in place rather than rebuilding from scratch.
-    if ($existing.PSObject.Properties['mcpServers']) {
+    if ($hasMcpServersProp) {
         $existing.mcpServers = $mergedServers
     } else {
         $existing | Add-Member -NotePropertyName 'mcpServers' -NotePropertyValue $mergedServers -Force

--- a/scripts/init-project.ps1
+++ b/scripts/init-project.ps1
@@ -960,8 +960,14 @@ if (Test-Path $mcpJsonPath) {
         }
     }
 
-    $mcpConfig = @{ mcpServers = $mergedServers }
-    $mcpConfig | ConvertTo-Json -Depth 10 | Set-Content -Path $mcpJsonPath -Encoding UTF8
+    # Preserve any non-mcpServers top-level keys (e.g. tool-specific settings)
+    # by mutating $existing in place rather than rebuilding from scratch.
+    if ($existing.PSObject.Properties['mcpServers']) {
+        $existing.mcpServers = $mergedServers
+    } else {
+        $existing | Add-Member -NotePropertyName 'mcpServers' -NotePropertyValue $mergedServers -Force
+    }
+    $existing | ConvertTo-Json -Depth 10 | Set-Content -Path $mcpJsonPath -Encoding UTF8
     Write-Success "Merged .mcp.json"
 } else {
     Write-Status "Creating .mcp.json (dotbot + Context7 + Playwright)"

--- a/scripts/init-project.ps1
+++ b/scripts/init-project.ps1
@@ -931,7 +931,11 @@ if (Test-Path $mcpJsonPath) {
     }
 
     $mergedServers = [ordered]@{}
-    $existingHasMcpServers = $existing -and $existing.PSObject.Properties['mcpServers'] -and $existing.mcpServers
+    $hasMcpServersProp = $existing -and $existing.PSObject.Properties['mcpServers']
+    if ($hasMcpServersProp -and $existing.mcpServers -and -not ($existing.mcpServers -is [System.Management.Automation.PSCustomObject])) {
+        throw ".mcp.json has 'mcpServers' but it is not an object: got $($existing.mcpServers.GetType().Name). Fix or remove the file and re-run dotbot init."
+    }
+    $existingHasMcpServers = $hasMcpServersProp -and $existing.mcpServers
 
     # Core first, in canonical order
     foreach ($coreName in $coreServers.Keys) {

--- a/scripts/init-project.ps1
+++ b/scripts/init-project.ps1
@@ -959,10 +959,17 @@ if (Test-Path $mcpJsonPath) {
         Write-DotbotCommand "$action '$coreName' entry"
     }
 
-    # Preserve any non-core (user-added) servers verbatim
+    # Preserve any non-core (user-added) servers verbatim. Use a
+    # case-insensitive name match so a user entry like "Dotbot" is treated
+    # as the same key as canonical "dotbot" rather than producing two
+    # parallel servers in the merged file.
     if ($existingHasMcpServers) {
+        $coreNamesCi = [System.Collections.Generic.HashSet[string]]::new(
+            [string[]]@($coreServers.Keys),
+            [System.StringComparer]::OrdinalIgnoreCase
+        )
         foreach ($prop in $existing.mcpServers.PSObject.Properties) {
-            if (-not $coreServers.Contains($prop.Name)) {
+            if (-not $coreNamesCi.Contains($prop.Name)) {
                 $mergedServers[$prop.Name] = $prop.Value
                 Write-DotbotCommand "Preserved '$($prop.Name)' entry"
             }

--- a/tests/Test-Structure.ps1
+++ b/tests/Test-Structure.ps1
@@ -474,6 +474,70 @@ if (-not $dotbotInstalled) {
     } finally {
         Remove-TestProject -Path $invalidProject
     }
+
+    # Case 5: empty .mcp.json (parses to $null) is treated as no usable
+    # content and rebuilt cleanly with the core entries.
+    $emptyProject = New-TestProject -Prefix "dotbot-test-mcpempty"
+    try {
+        $emptyMcpJson = Join-Path $emptyProject ".mcp.json"
+        "" | Set-Content -Path $emptyMcpJson -Encoding UTF8
+
+        Push-Location $emptyProject
+        & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
+        $emptyExit = $LASTEXITCODE
+        Pop-Location
+
+        Assert-True -Name "merge: empty .mcp.json initialises cleanly (no null-deref)" `
+            -Condition ($emptyExit -eq 0) `
+            -Message "Expected init to succeed against an empty .mcp.json, got exit=$emptyExit"
+        $mcpEmpty = Get-Content $emptyMcpJson -Raw | ConvertFrom-Json
+        Assert-True -Name "merge: empty .mcp.json has core 'dotbot' entry after init" `
+            -Condition ($null -ne $mcpEmpty.mcpServers.dotbot) `
+            -Message "dotbot core entry missing after init against empty .mcp.json"
+    } finally {
+        Remove-TestProject -Path $emptyProject
+    }
+
+    # Case 6: non-object root (array, string, scalar) fails loudly instead
+    # of silently corrupting the file via Add-Member unrolling.
+    $nonObjProject = New-TestProject -Prefix "dotbot-test-mcpnonobj"
+    try {
+        $nonObjMcpJson = Join-Path $nonObjProject ".mcp.json"
+        '[1, 2, 3]' | Set-Content -Path $nonObjMcpJson -Encoding UTF8
+
+        Push-Location $nonObjProject
+        $nonObjOutput = & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-String
+        $nonObjExit = $LASTEXITCODE
+        Pop-Location
+
+        Assert-True -Name "merge: non-object root fails loudly (non-zero exit AND specific error)" `
+            -Condition (($nonObjExit -ne 0) -and ($nonObjOutput -match '(?i)(not a JSON object|root)')) `
+            -Message "Expected init to fail with non-zero exit and root-shape error for non-object .mcp.json, got exit=$nonObjExit, output: $nonObjOutput"
+    } finally {
+        Remove-TestProject -Path $nonObjProject
+    }
+
+    # Case 7: stale core entry (e.g. left over from a pre-#345 path layout)
+    # is auto-refreshed even without -Force, so re-init self-heals after a
+    # framework path move. Without this, .bot/go.ps1 would still fail with
+    # "Dotbot MCP server not registered".
+    $staleProject = New-TestProject -Prefix "dotbot-test-mcpstale"
+    try {
+        $staleMcpJson = Join-Path $staleProject ".mcp.json"
+        '{ "mcpServers": { "dotbot": { "command": "pwsh", "args": [".bot/systems/mcp/dotbot-mcp.ps1"] } } }' |
+            Set-Content -Path $staleMcpJson -Encoding UTF8
+
+        Push-Location $staleProject
+        & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
+        Pop-Location
+
+        $mcpStale = Get-Content $staleMcpJson -Raw | ConvertFrom-Json
+        Assert-True -Name "merge: stale core entry auto-refreshed without -Force" `
+            -Condition (($mcpStale.mcpServers.dotbot.args -join ' ') -notmatch 'systems/mcp') `
+            -Message "Stale .bot/systems/mcp/ path retained on re-init; expected canonical .bot/core/mcp/ path"
+    } finally {
+        Remove-TestProject -Path $staleProject
+    }
     }
 
     # --- Init with -Stack dotnet ---

--- a/tests/Test-Structure.ps1
+++ b/tests/Test-Structure.ps1
@@ -379,6 +379,76 @@ if (-not $dotbotInstalled) {
     } finally {
         Remove-TestProject -Path $testProject
     }
+
+    # --- Init merges into pre-existing .mcp.json (regression for #315) ---
+    Write-Host ""
+    Write-Host "  INIT MCP MERGE (#315)" -ForegroundColor Cyan
+    Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+    # Case 1: pre-existing user entry must be preserved AND core entries added.
+    $mergeProject = New-TestProject -Prefix "dotbot-test-mcpmerge"
+    try {
+        $mergeMcpJson = Join-Path $mergeProject ".mcp.json"
+        '{ "mcpServers": { "myserver": { "command": "echo", "args": ["hi"] } } }' |
+            Set-Content -Path $mergeMcpJson -Encoding UTF8
+
+        Push-Location $mergeProject
+        & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
+        Pop-Location
+
+        $mcpAfter = Get-Content $mergeMcpJson -Raw | ConvertFrom-Json
+        Assert-True -Name "merge: user 'myserver' entry preserved" `
+            -Condition ($null -ne $mcpAfter.mcpServers.myserver) `
+            -Message "User-added 'myserver' entry was lost during merge"
+        Assert-True -Name "merge: core 'dotbot' entry added" `
+            -Condition ($null -ne $mcpAfter.mcpServers.dotbot) `
+            -Message "dotbot core entry not merged into existing .mcp.json"
+        Assert-True -Name "merge: core 'context7' entry added" `
+            -Condition ($null -ne $mcpAfter.mcpServers.context7) `
+            -Message "context7 core entry not merged into existing .mcp.json"
+        Assert-True -Name "merge: core 'playwright' entry added" `
+            -Condition ($null -ne $mcpAfter.mcpServers.playwright) `
+            -Message "playwright core entry not merged into existing .mcp.json"
+    } finally {
+        Remove-TestProject -Path $mergeProject
+    }
+
+    # Case 2: -Force refreshes a tampered core entry to canonical form.
+    $forceProject = New-TestProject -Prefix "dotbot-test-mcpforce"
+    try {
+        $forceMcpJson = Join-Path $forceProject ".mcp.json"
+        '{ "mcpServers": { "dotbot": { "command": "WRONG", "args": [] } } }' |
+            Set-Content -Path $forceMcpJson -Encoding UTF8
+
+        Push-Location $forceProject
+        & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") -Force 2>&1 | Out-Null
+        Pop-Location
+
+        $mcpForced = Get-Content $forceMcpJson -Raw | ConvertFrom-Json
+        Assert-Equal -Name "merge -Force: refreshes tampered core dotbot.command" `
+            -Expected "pwsh" `
+            -Actual "$($mcpForced.mcpServers.dotbot.command)"
+    } finally {
+        Remove-TestProject -Path $forceProject
+    }
+
+    # Case 3: invalid JSON fails loudly instead of silently overwriting/skipping.
+    $invalidProject = New-TestProject -Prefix "dotbot-test-mcpinvalid"
+    try {
+        $invalidMcpJson = Join-Path $invalidProject ".mcp.json"
+        "not valid json {" | Set-Content -Path $invalidMcpJson -Encoding UTF8
+
+        Push-Location $invalidProject
+        $invalidOutput = & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-String
+        $invalidExit = $LASTEXITCODE
+        Pop-Location
+
+        Assert-True -Name "merge: invalid JSON fails loudly (non-zero exit or error in output)" `
+            -Condition (($invalidExit -ne 0) -or ($invalidOutput -match '\.mcp\.json')) `
+            -Message "Expected init to fail with .mcp.json error, got exit=$invalidExit, output: $invalidOutput"
+    } finally {
+        Remove-TestProject -Path $invalidProject
+    }
     }
 
     # --- Init with -Stack dotnet ---

--- a/tests/Test-Structure.ps1
+++ b/tests/Test-Structure.ps1
@@ -432,7 +432,32 @@ if (-not $dotbotInstalled) {
         Remove-TestProject -Path $forceProject
     }
 
-    # Case 3: invalid JSON fails loudly instead of silently overwriting/skipping.
+    # Case 3: non-mcpServers top-level keys are preserved verbatim.
+    $extraKeyProject = New-TestProject -Prefix "dotbot-test-mcpextra"
+    try {
+        $extraMcpJson = Join-Path $extraKeyProject ".mcp.json"
+        '{ "version": "1.0", "inputs": [{ "id": "x", "type": "promptString" }], "mcpServers": { "myserver": { "command": "echo" } } }' |
+            Set-Content -Path $extraMcpJson -Encoding UTF8
+
+        Push-Location $extraKeyProject
+        & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $dotbotDir "scripts\init-project.ps1") 2>&1 | Out-Null
+        Pop-Location
+
+        $mcpExtra = Get-Content $extraMcpJson -Raw | ConvertFrom-Json
+        Assert-Equal -Name "merge: top-level 'version' key preserved" `
+            -Expected "1.0" `
+            -Actual "$($mcpExtra.version)"
+        Assert-True -Name "merge: top-level 'inputs' key preserved" `
+            -Condition ($null -ne $mcpExtra.inputs -and $mcpExtra.inputs.Count -eq 1) `
+            -Message "Top-level 'inputs' array was lost during merge"
+        Assert-True -Name "merge: core entries still added alongside extra keys" `
+            -Condition ($null -ne $mcpExtra.mcpServers.dotbot) `
+            -Message "dotbot core entry not merged when extra top-level keys present"
+    } finally {
+        Remove-TestProject -Path $extraKeyProject
+    }
+
+    # Case 4: invalid JSON fails loudly instead of silently overwriting/skipping.
     $invalidProject = New-TestProject -Prefix "dotbot-test-mcpinvalid"
     try {
         $invalidMcpJson = Join-Path $invalidProject ".mcp.json"
@@ -443,9 +468,9 @@ if (-not $dotbotInstalled) {
         $invalidExit = $LASTEXITCODE
         Pop-Location
 
-        Assert-True -Name "merge: invalid JSON fails loudly (non-zero exit or error in output)" `
-            -Condition (($invalidExit -ne 0) -or ($invalidOutput -match '\.mcp\.json')) `
-            -Message "Expected init to fail with .mcp.json error, got exit=$invalidExit, output: $invalidOutput"
+        Assert-True -Name "merge: invalid JSON fails loudly (non-zero exit AND specific error)" `
+            -Condition (($invalidExit -ne 0) -and ($invalidOutput -match '(?i)(not valid json|invalid json|convertfrom-json|unexpected character)')) `
+            -Message "Expected init to fail with non-zero exit and invalid-JSON error for .mcp.json, got exit=$invalidExit, output: $invalidOutput"
     } finally {
         Remove-TestProject -Path $invalidProject
     }


### PR DESCRIPTION
## Summary

Closes #315 — `dotbot init` skipped existing `.mcp.json` instead of merging the framework's core MCP entries (`dotbot`, `context7`, `playwright`).

If a project already had a user-maintained `.mcp.json` (e.g. `github`, `figma` servers), init printed `".mcp.json already exists -- skipping"` and never wrote the core entries. `--force` did not help — same skip path. Downstream, `pwsh .bot/go.ps1` failed with `Dotbot MCP server not registered`.

## What changed

`scripts/init-project.ps1` — replaced the skip-if-exists branch with a merge:

- **Pre-existing `.mcp.json`** is parsed; invalid JSON now `throw`s with an actionable message instead of being silently skipped or overwritten.
- **Core entries** (`dotbot`, `context7`, `playwright`) are added when missing. If already present, they are left alone unless `-Force` is passed; with `-Force`, they are refreshed to the canonical definition.
- **User-added entries** (`github`, `figma`, anything non-core) are preserved verbatim, after the core entries.
- File is re-emitted with `ConvertTo-Json -Depth 10` so nested args/env survive the round-trip.

Inline merge logic was kept rather than rerouting through `Merge-McpServers` in `core/runtime/modules/workflow-manifest.ps1` — that helper has skip-if-exists semantics by design (used by workflow installs) and no `-Force` refresh path. Bolting both onto it would change its contract for every existing caller (`scripts/workflow-add.ps1`, the workflow loop in `init-project.ps1:507`).

## Behaviour matrix

| Scenario | Before | After |
|----------|--------|-------|
| No `.mcp.json` | core entries written | core entries written (unchanged) |
| `.mcp.json` with user entry only | **skipped** — core missing, `go.ps1` fails | core merged in, user entry preserved |
| `.mcp.json` with tampered core entry, no `-Force` | skipped | tampered entry kept (with note: "use `-Force` to refresh") |
| `.mcp.json` with tampered core entry, `-Force` | skipped | refreshed to canonical |
| Invalid JSON | skipped (silent) | `throw` with `.mcp.json` error message |

## Tests

Added Layer 1 regression cases under **INIT MCP MERGE (#315)** in `tests/Test-Structure.ps1`:

1. Pre-existing user entry (`myserver`) is preserved **and** all three core entries are added.
2. `-Force` refreshes a tampered core entry (`dotbot.command = "WRONG"` → `"pwsh"`).
3. Invalid JSON causes init to fail loudly (non-zero exit or `.mcp.json` referenced in output).

## Test plan

- [ ] `pwsh install.ps1` succeeds
- [ ] `pwsh tests/Run-Tests.ps1` — all of layers 1-3 green, including the new `INIT MCP MERGE (#315)` cases
- [ ] Manual repro from the issue: pre-write a `.mcp.json` with `myserver`, run `dotbot init --force`, confirm `myserver` + `dotbot` + `context7` + `playwright` all present
- [ ] `pwsh .bot/go.ps1` starts cleanly afterwards (no "Dotbot MCP server not registered")
- [ ] Invalid JSON case: pre-write garbage, run init, confirm loud failure rather than silent skip