### PR TITLE
fix(runtime): split intentional skips from framework errors (#318)

### DIFF
--- a/core/mcp/modules/TaskIndexCache.psm1
+++ b/core/mcp/modules/TaskIndexCache.psm1
@@ -514,12 +514,16 @@ function Update-TaskIndex {
                         $script:TaskIndex.DoneSlugs += $slug
                     }
                     'skipped' {
-                        $script:TaskIndex.Skipped[$content.id] = $entry
                         # Issue #318: intentional skips satisfy dependents,
                         # framework-error skips block them. Discriminate via
                         # the canonical skip reason (latest skip_history entry,
-                        # or top-level skip_reason fallback).
-                        if (-not (Test-IsFrameworkErrorSkip -TaskContent $content)) {
+                        # or top-level skip_reason fallback). Cache the result
+                        # on the entry so Get-DeadlockedTasks can read it
+                        # without a second filesystem pass.
+                        $isFrameworkErrorSkip = Test-IsFrameworkErrorSkip -TaskContent $content
+                        $entry | Add-Member -NotePropertyName is_framework_error_skip -NotePropertyValue $isFrameworkErrorSkip
+                        $script:TaskIndex.Skipped[$content.id] = $entry
+                        if (-not $isFrameworkErrorSkip) {
                             $script:TaskIndex.DoneIds += $content.id
                             $script:TaskIndex.DoneNames += $content.name
                             $slug = ($content.name -replace '[^a-zA-Z0-9\s-]', '' -replace '\s+', '-').ToLowerInvariant()
@@ -871,12 +875,9 @@ function Get-DeadlockedTasks {
     $blockerNameMap = @{}
 
     foreach ($t in $index.Skipped.Values) {
-        if (-not $t.file_path -or -not (Test-Path -LiteralPath $t.file_path)) { continue }
-        try {
-            $content = Get-Content -LiteralPath $t.file_path -Raw | ConvertFrom-Json
-        } catch { continue }
-
-        if (-not (Test-IsFrameworkErrorSkip -TaskContent $content)) { continue }
+        # Update-TaskIndex computed is_framework_error_skip when it loaded
+        # this entry — no need to re-read and re-parse the file here.
+        if (-not $t.is_framework_error_skip) { continue }
 
         $blockerLookup.Add($t.id)   | Out-Null
         $blockerLookup.Add($t.name) | Out-Null

--- a/core/mcp/modules/TaskIndexCache.psm1
+++ b/core/mcp/modules/TaskIndexCache.psm1
@@ -871,9 +871,9 @@ function Get-DeadlockedTasks {
     $blockerNameMap = @{}
 
     foreach ($t in $index.Skipped.Values) {
-        if (-not $t.file_path -or -not (Test-Path $t.file_path)) { continue }
+        if (-not $t.file_path -or -not (Test-Path -LiteralPath $t.file_path)) { continue }
         try {
-            $content = Get-Content -Path $t.file_path -Raw | ConvertFrom-Json
+            $content = Get-Content -LiteralPath $t.file_path -Raw | ConvertFrom-Json
         } catch { continue }
 
         if (-not (Test-IsFrameworkErrorSkip -TaskContent $content)) { continue }
@@ -937,10 +937,14 @@ function Get-TaskTerminalState {
     Returns the terminal state name for a task, or $null if not terminal.
 
     .DESCRIPTION
-    Terminal states are done, skipped, failed, cancelled, split. Returns the
-    state name as a string when the task lives in one of those buckets; $null
+    Terminal states are done, skipped, cancelled, split. Returns the state
+    name as a string when the task lives in one of those buckets; $null
     otherwise. Used by Test-TaskCompletion so the runner stops the retry loop
     on any terminal outcome (issue #318).
+
+    Note: there is no separate failed/ directory. Framework-error skips live
+    in skipped/ and are discriminated via skip_history[].reason — see
+    Test-IsFrameworkErrorSkip.
     #>
     param(
         [Parameter(Mandatory = $true)]

--- a/core/mcp/modules/TaskIndexCache.psm1
+++ b/core/mcp/modules/TaskIndexCache.psm1
@@ -15,13 +15,67 @@ $script:TaskIndex = @{
     InProgress = @{}
     Done = @{}
     Split = @{}         # Tasks that were split into sub-tasks
-    Skipped = @{}       # Tasks that were skipped
+    Skipped = @{}       # All skipped tasks (intentional + framework error)
     Cancelled = @{}     # Tasks that were cancelled
+    # Dependency-satisfier lookups: covers done + split + INTENTIONALLY SKIPPED
+    # tasks. Framework-error skips ('non-recoverable', 'max-retries') are
+    # excluded — they block dependents. Named "Done*" for backward compatibility
+    # with Test-DependencyMet's signature (see issue #318).
     DoneIds = @()       # Quick lookup for dependency checking (by id)
     DoneNames = @()     # Quick lookup for dependency checking (by name)
     DoneSlugs = @()     # Quick lookup for dependency checking (by slug)
     IgnoreMap = @{}     # Effective ignore state for todo tasks
     BaseDir = $null
+}
+
+# Single source of truth for skip-reason classification (issue #318).
+# Both task-mark-skipped/script.ps1 and core/runtime/modules/task-reset.ps1
+# import these via Get-IntentionalSkipReasons / Get-FrameworkSkipReasons /
+# Test-IsFrameworkErrorSkip — do not duplicate the lists in those callers.
+$script:IntentionalSkipReasons = @(
+    'not-applicable',
+    'precondition-unmet',
+    'superseded',
+    'user-requested',
+    'condition-not-met'
+)
+# A skipped task whose canonical reason is in this set is treated as a hard
+# failure: it blocks dependents and shows up in deadlock detection. Anything
+# else (including unknown values) is an intentional skip and satisfies dependents.
+$script:FrameworkSkipReasons = @('non-recoverable', 'max-retries')
+
+function Get-IntentionalSkipReasons {
+    return @($script:IntentionalSkipReasons)
+}
+
+function Get-FrameworkSkipReasons {
+    return @($script:FrameworkSkipReasons)
+}
+
+function Test-IsFrameworkErrorSkip {
+    <#
+    .SYNOPSIS
+    True if the given task content represents a framework-error skip.
+
+    .DESCRIPTION
+    Looks at the latest entry in skip_history (canonical) and falls back to
+    the top-level skip_reason field (used by direct Set-TaskState callers
+    like task-get-next). Tasks with no recognisable skip reason are treated
+    as intentional (safer default — does not stall pipelines).
+    #>
+    param([object]$TaskContent)
+    $reason = $null
+    if ($TaskContent -and $TaskContent.skip_history) {
+        $entries = @($TaskContent.skip_history)
+        if ($entries.Count -gt 0) {
+            $latest = $entries[-1]
+            if ($latest -and $latest.reason) { $reason = [string]$latest.reason }
+        }
+    }
+    if (-not $reason -and $TaskContent -and $TaskContent.skip_reason) {
+        $reason = [string]$TaskContent.skip_reason
+    }
+    return $reason -in $script:FrameworkSkipReasons
 }
 
 function Initialize-TaskIndex {
@@ -459,7 +513,19 @@ function Update-TaskIndex {
                         $slug = ($content.name -replace '[^a-zA-Z0-9\s-]', '' -replace '\s+', '-').ToLowerInvariant()
                         $script:TaskIndex.DoneSlugs += $slug
                     }
-                    'skipped' { $script:TaskIndex.Skipped[$content.id] = $entry }
+                    'skipped' {
+                        $script:TaskIndex.Skipped[$content.id] = $entry
+                        # Issue #318: intentional skips satisfy dependents,
+                        # framework-error skips block them. Discriminate via
+                        # the canonical skip reason (latest skip_history entry,
+                        # or top-level skip_reason fallback).
+                        if (-not (Test-IsFrameworkErrorSkip -TaskContent $content)) {
+                            $script:TaskIndex.DoneIds += $content.id
+                            $script:TaskIndex.DoneNames += $content.name
+                            $slug = ($content.name -replace '[^a-zA-Z0-9\s-]', '' -replace '\s+', '-').ToLowerInvariant()
+                            $script:TaskIndex.DoneSlugs += $slug
+                        }
+                    }
                     'cancelled' { $script:TaskIndex.Cancelled[$content.id] = $entry }
                 }
             } catch {
@@ -779,33 +845,50 @@ function Get-NextAnalysedTask {
 function Get-DeadlockedTasks {
     <#
     .SYNOPSIS
-    Returns info about todo tasks that are blocked by at least one skipped dependency.
+    Returns info about todo tasks blocked by at least one framework-error skip.
 
     .DESCRIPTION
     Called when Get-NextTask returns null to distinguish a dependency deadlock from a
     genuine wait (e.g. analysis still running). Returns a PSCustomObject with BlockedCount
     (number of blocked todo tasks) and BlockerNames (skipped task names causing the block).
+
+    Issue #318: only framework-error skips ('non-recoverable', 'max-retries')
+    block dependents. Intentional skips ('not-applicable' etc.) satisfy
+    dependencies and therefore can never cause a deadlock.
     #>
 
     $index = Get-TaskIndex
-    if ($index.Todo.Count   -eq 0) { return [PSCustomObject]@{ BlockedCount = 0; BlockerNames = @() } }
+    if ($index.Todo.Count    -eq 0) { return [PSCustomObject]@{ BlockedCount = 0; BlockerNames = @() } }
     if ($index.Skipped.Count -eq 0) { return [PSCustomObject]@{ BlockedCount = 0; BlockerNames = @() } }
 
-    # Build a case-insensitive lookup set covering id, name, and slug of every
-    # skipped task so dependency strings can be matched in one Contains() call.
-    $skippedLookup = [System.Collections.Generic.HashSet[string]]::new(
+    # Filter to framework-error skips only. We need the original task content
+    # (with skip_history / skip_reason), which is not on the trimmed $entry
+    # objects in the index — re-read from disk. This runs only when Get-NextTask
+    # finds no candidate, so it's not on the hot path.
+    $blockerLookup = [System.Collections.Generic.HashSet[string]]::new(
         [System.StringComparer]::OrdinalIgnoreCase
     )
-    # Map from any form (id/name/slug) back to the task name for reporting.
-    $skippedNameMap = @{}
+    $blockerNameMap = @{}
+
     foreach ($t in $index.Skipped.Values) {
-        $skippedLookup.Add($t.id)   | Out-Null
-        $skippedLookup.Add($t.name) | Out-Null
+        if (-not $t.file_path -or -not (Test-Path $t.file_path)) { continue }
+        try {
+            $content = Get-Content -Path $t.file_path -Raw | ConvertFrom-Json
+        } catch { continue }
+
+        if (-not (Test-IsFrameworkErrorSkip -TaskContent $content)) { continue }
+
+        $blockerLookup.Add($t.id)   | Out-Null
+        $blockerLookup.Add($t.name) | Out-Null
         $slug = ($t.name -replace '[^a-zA-Z0-9\s-]', '' -replace '\s+', '-').ToLowerInvariant()
-        $skippedLookup.Add($slug)   | Out-Null
-        $skippedNameMap[$t.id]   = $t.name
-        $skippedNameMap[$t.name] = $t.name
-        $skippedNameMap[$slug]   = $t.name
+        $blockerLookup.Add($slug)   | Out-Null
+        $blockerNameMap[$t.id]   = $t.name
+        $blockerNameMap[$t.name] = $t.name
+        $blockerNameMap[$slug]   = $t.name
+    }
+
+    if ($blockerLookup.Count -eq 0) {
+        return [PSCustomObject]@{ BlockedCount = 0; BlockerNames = @() }
     }
 
     $count = 0
@@ -820,16 +903,16 @@ function Get-DeadlockedTasks {
         foreach ($dep in $deps) {
             if (-not $dep) { continue }
 
-            # If the dependency is already satisfied by a done/split task, skip it.
+            # If the dependency is already satisfied (done/split/intentional-skip), skip it.
             if (Test-DependencyMet -Dependency $dep `
                     -DoneNames $index.DoneNames `
                     -DoneSlugs $index.DoneSlugs `
                     -DoneIds   $index.DoneIds) { continue }
 
-            # The dependency is unmet — is the blocker a skipped task?
-            if ($skippedLookup.Contains($dep)) {
+            # The dependency is unmet — is the blocker a framework-error skip?
+            if ($blockerLookup.Contains($dep)) {
                 $count++
-                $blockerNames.Add($skippedNameMap[$dep]) | Out-Null
+                $blockerNames.Add($blockerNameMap[$dep]) | Out-Null
                 break  # count each blocked task only once
             }
         }
@@ -846,6 +929,30 @@ function Test-TaskDone {
 
     $index = Get-TaskIndex
     return $TaskId -in $index.DoneIds
+}
+
+function Get-TaskTerminalState {
+    <#
+    .SYNOPSIS
+    Returns the terminal state name for a task, or $null if not terminal.
+
+    .DESCRIPTION
+    Terminal states are done, skipped, failed, cancelled, split. Returns the
+    state name as a string when the task lives in one of those buckets; $null
+    otherwise. Used by Test-TaskCompletion so the runner stops the retry loop
+    on any terminal outcome (issue #318).
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TaskId
+    )
+
+    $index = Get-TaskIndex
+    if ($index.Done.ContainsKey($TaskId))      { return 'done' }
+    if ($index.Skipped.ContainsKey($TaskId))   { return 'skipped' }
+    if ($index.Cancelled.ContainsKey($TaskId)) { return 'cancelled' }
+    if ($index.Split.ContainsKey($TaskId))     { return 'split' }
+    return $null
 }
 
 function Get-TaskById {
@@ -999,6 +1106,10 @@ Export-ModuleMember -Function @(
     'Get-NextAnalysedTask',
     'Get-DeadlockedTasks',
     'Test-TaskDone',
+    'Get-TaskTerminalState',
+    'Test-IsFrameworkErrorSkip',
+    'Get-IntentionalSkipReasons',
+    'Get-FrameworkSkipReasons',
     'Test-DependencyMet',
     'Test-AllDependenciesMet',
     'Get-TaskById',

--- a/core/mcp/tools/task-mark-skipped/metadata.yaml
+++ b/core/mcp/tools/task-mark-skipped/metadata.yaml
@@ -1,5 +1,11 @@
 name: task_mark_skipped
-description: Mark a task as skipped and move it to the skipped directory with skip history
+description: |
+  Mark a task as skipped (terminal state) and move it to the skipped/ directory.
+
+  The skip_reason discriminates intent — INTENTIONAL skips satisfy downstream
+  dependencies, FRAMEWORK errors block them. Agents should use one of the
+  intentional reasons; the runtime emits framework reasons itself when an
+  execution path fails terminally.
 inputSchema:
   type: object
   properties:
@@ -8,8 +14,25 @@ inputSchema:
       description: The unique ID of the task to mark as skipped
     skip_reason:
       type: string
-      description: Reason for skipping (e.g., "non-recoverable", "max-retries")
+      description: |
+        Intentional (skip satisfies dependents):
+          - not-applicable: task does not apply to this run
+          - precondition-unmet: external requirement is missing
+          - superseded: work has been done elsewhere
+          - user-requested: operator asked for the skip
+          - condition-not-met: manifest condition evaluated to false (runtime)
+        Framework error (skip blocks dependents and may auto-retry on restart):
+          - non-recoverable: unrecoverable error in setup or execution
+          - max-retries: retry budget exhausted
       enum:
+        - not-applicable
+        - precondition-unmet
+        - superseded
+        - user-requested
+        - condition-not-met
         - non-recoverable
         - max-retries
+    skip_detail:
+      type: string
+      description: Optional free-text detail (error message, condition expression, etc.) appended to the skip_history entry.
   required: [task_id, skip_reason]

--- a/core/mcp/tools/task-mark-skipped/script.ps1
+++ b/core/mcp/tools/task-mark-skipped/script.ps1
@@ -1,4 +1,39 @@
 Import-Module (Join-Path $global:DotbotProjectRoot ".bot/core/mcp/modules/TaskStore.psm1") -Force
+# Single source of truth for skip-reason classification (issue #318) lives in
+# TaskIndexCache.psm1. Do NOT inline the reason lists here — keep this file
+# free of duplication so adding/removing a reason only touches one place.
+if (-not (Get-Module TaskIndexCache)) {
+    Import-Module (Join-Path $global:DotbotProjectRoot ".bot/core/mcp/modules/TaskIndexCache.psm1") -DisableNameChecking
+}
+
+function Test-IsIntentionalSkipReason {
+    param([string]$Reason)
+    return $Reason -in (Get-IntentionalSkipReasons)
+}
+
+function Test-IsFrameworkSkipReason {
+    param([string]$Reason)
+    return $Reason -in (Get-FrameworkSkipReasons)
+}
+
+function Get-EffectiveSkipReason {
+    <#
+    .SYNOPSIS
+    Resolve the canonical skip reason for a task. Latest skip_history[].reason
+    wins; falls back to the top-level skip_reason field. Returns $null if
+    neither is present.
+    #>
+    param([object]$TaskContent)
+    if ($TaskContent.skip_history) {
+        $entries = @($TaskContent.skip_history)
+        if ($entries.Count -gt 0) {
+            $latest = $entries[-1]
+            if ($latest.reason) { return [string]$latest.reason }
+        }
+    }
+    if ($TaskContent.skip_reason) { return [string]$TaskContent.skip_reason }
+    return $null
+}
 
 function Invoke-TaskMarkSkipped {
     param(
@@ -7,11 +42,12 @@ function Invoke-TaskMarkSkipped {
 
     $taskId = $Arguments['task_id']
     $skipReason = $Arguments['skip_reason']
+    $skipDetail = $Arguments['skip_detail']
 
     if (-not $taskId) { throw "Task ID is required" }
     if (-not $skipReason) { throw "Skip reason is required" }
 
-    $validReasons = @('non-recoverable', 'max-retries')
+    $validReasons = (Get-IntentionalSkipReasons) + (Get-FrameworkSkipReasons)
     if ($skipReason -notin $validReasons) {
         throw "Invalid skip reason. Must be one of: $($validReasons -join ', ')"
     }
@@ -33,11 +69,12 @@ function Invoke-TaskMarkSkipped {
         }
     }
 
-    $skipEntry = @{
+    $skipEntry = [ordered]@{
         skipped_at = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
         reason     = $skipReason
     }
-    $skipHistory += $skipEntry
+    if ($skipDetail) { $skipEntry.detail = $skipDetail }
+    $skipHistory += [pscustomobject]$skipEntry
 
     $allStatuses = @('todo', 'analysing', 'needs-input', 'analysed', 'in-progress', 'done', 'skipped', 'split', 'cancelled')
 
@@ -64,8 +101,7 @@ function Invoke-TaskMarkSkipped {
         skip_reason  = $skipReason
         skip_count   = $skipHistory.Count
         skip_history = $skipHistory
+        intentional  = (Test-IsIntentionalSkipReason -Reason $skipReason)
         file_path    = $result.file_path
     }
 }
-
-

--- a/core/mcp/tools/task-mark-skipped/script.ps1
+++ b/core/mcp/tools/task-mark-skipped/script.ps1
@@ -11,30 +11,6 @@ function Test-IsIntentionalSkipReason {
     return $Reason -in (Get-IntentionalSkipReasons)
 }
 
-function Test-IsFrameworkSkipReason {
-    param([string]$Reason)
-    return $Reason -in (Get-FrameworkSkipReasons)
-}
-
-function Get-EffectiveSkipReason {
-    <#
-    .SYNOPSIS
-    Resolve the canonical skip reason for a task. Latest skip_history[].reason
-    wins; falls back to the top-level skip_reason field. Returns $null if
-    neither is present.
-    #>
-    param([object]$TaskContent)
-    if ($TaskContent.skip_history) {
-        $entries = @($TaskContent.skip_history)
-        if ($entries.Count -gt 0) {
-            $latest = $entries[-1]
-            if ($latest.reason) { return [string]$latest.reason }
-        }
-    }
-    if ($TaskContent.skip_reason) { return [string]$TaskContent.skip_reason }
-    return $null
-}
-
 function Invoke-TaskMarkSkipped {
     param(
         [hashtable]$Arguments

--- a/core/mcp/tools/task-mark-skipped/test.ps1
+++ b/core/mcp/tools/task-mark-skipped/test.ps1
@@ -20,7 +20,7 @@ try {
 
     $result = Invoke-TaskMarkSkipped -Arguments @{
         task_id = $created.task_id
-        skip_reason = 'non-recoverable'
+        skip_reason = 'not-applicable'
     }
 
     Assert-True -Name "task-mark-skipped: returns success" `
@@ -55,19 +55,46 @@ try {
             -Message "Expected 1 entry, got $($content.skip_history.Count)"
 
         Assert-Equal -Name "task-mark-skipped: skip_history reason matches" `
-            -Expected 'non-recoverable' `
+            -Expected 'not-applicable' `
             -Actual $content.skip_history[0].reason
 
         # Skip again to verify append
         $result2 = Invoke-TaskMarkSkipped -Arguments @{
             task_id = $created.task_id
-            skip_reason = 'max-retries'
+            skip_reason = 'precondition-unmet'
         }
 
         Assert-Equal -Name "task-mark-skipped: second skip_count is 2" `
             -Expected 2 `
             -Actual $result2.skip_count
     }
+
+    # Framework-error reasons accepted with skip_detail (runtime emits these)
+    $frameworkResult = Invoke-TaskMarkSkipped -Arguments @{
+        task_id = $created.task_id
+        skip_reason = 'non-recoverable'
+        skip_detail = 'simulated unrecoverable error'
+    }
+    Assert-True -Name "task-mark-skipped: accepts framework reason 'non-recoverable'" `
+        -Condition ($frameworkResult.success -eq $true) `
+        -Message "Got: $($frameworkResult.message)"
+    Assert-True -Name "task-mark-skipped: framework reason flagged intentional=false" `
+        -Condition ($frameworkResult.intentional -eq $false) `
+        -Message "Expected intentional=false, got $($frameworkResult.intentional)"
+
+    # Reject unknown reasons
+    $rejected = $false
+    try {
+        Invoke-TaskMarkSkipped -Arguments @{
+            task_id = $created.task_id
+            skip_reason = 'arbitrary-error-text'
+        } | Out-Null
+    } catch {
+        $rejected = $true
+    }
+    Assert-True -Name "task-mark-skipped: rejects unknown reason" `
+        -Condition $rejected `
+        -Message "Unknown skip_reason should be rejected"
 
 } finally {
     foreach ($file in $cleanupFiles) {

--- a/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -1629,7 +1629,7 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
             if (-not $failureReason.recoverable) {
                 Write-Status "Non-recoverable failure - skipping" -Type Error
                 try {
-                    $detail = $failureReason.reason ?? $failureReason.message ?? 'non-recoverable failure'
+                    $detail = $failureReason.description ?? $failureReason.type ?? 'non-recoverable failure'
                     Invoke-TaskMarkSkipped -Arguments @{ task_id = $task.id; skip_reason = 'non-recoverable'; skip_detail = $detail } | Out-Null
                 } catch { Write-BotLog -Level Warn -Message "Task operation failed" -Exception $_ }
                 break

--- a/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -835,7 +835,7 @@ try {
                     Write-Status $typeError -Type Error
                     Write-ProcessActivity -Id $procId -ActivityType "error" -Message "$($task.name): $typeError"
                     try {
-                        Invoke-TaskMarkSkipped -Arguments @{ task_id = $task.id; skip_reason = $typeError } | Out-Null
+                        Invoke-TaskMarkSkipped -Arguments @{ task_id = $task.id; skip_reason = 'non-recoverable'; skip_detail = $typeError } | Out-Null
                     } catch { Write-BotLog -Level Debug -Message "Logging operation failed" -Exception $_ }
                     if (Test-TaskIsMandatory $task) {
                         Write-Status "Mandatory task failed: $($task.name) - stopping workflow" -Type Error
@@ -876,7 +876,7 @@ try {
                     Write-Status $typeError -Type Error
                     Write-ProcessActivity -Id $procId -ActivityType "error" -Message "$($task.name): $typeError"
                     try {
-                        Invoke-TaskMarkSkipped -Arguments @{ task_id = $task.id; skip_reason = $typeError } | Out-Null
+                        Invoke-TaskMarkSkipped -Arguments @{ task_id = $task.id; skip_reason = 'non-recoverable'; skip_detail = $typeError } | Out-Null
                     } catch { Write-BotLog -Level Debug -Message "Logging operation failed" -Exception $_ }
                     if (Test-TaskIsMandatory $task) {
                         Write-Status "Mandatory task failed: $($task.name) - stopping workflow" -Type Error
@@ -1100,7 +1100,7 @@ try {
             } else {
                 Write-Status "Task failed: $($task.name)" -Type Error
                 try {
-                    Invoke-TaskMarkSkipped -Arguments @{ task_id = $task.id; skip_reason = "$taskTypeVal execution failed: $typeError" } | Out-Null
+                    Invoke-TaskMarkSkipped -Arguments @{ task_id = $task.id; skip_reason = 'non-recoverable'; skip_detail = "$taskTypeVal execution failed: $typeError" } | Out-Null
                 } catch { Write-BotLog -Level Debug -Message "Session operation failed" -Exception $_ }
 
                 # Mandatory-task halt (#213): script/mcp/task_gen failure
@@ -1482,6 +1482,12 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
         # — its worktree must be retained so the executor can resume after
         # task_answer_question moves the task back to analysing/.
         $taskParked = $false
+        # Set when the task ended in a terminal state other than done
+        # (skipped/cancelled/split). Distinct from taskSuccess because we must
+        # NOT squash-merge the worktree, NOT count the task as completed, and
+        # NOT log "task -> done". The worktree still has to be cleaned up.
+        $taskTerminal = $false
+        $taskTerminalState = $null
         $postScriptFailed = $false
         $postScriptError = $null
         # Distinguishes which post-task hook actually flipped postScriptFailed
@@ -1557,8 +1563,21 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
 
             # Check completion
             $completionCheck = Test-TaskCompletion -TaskId $task.id
-            Write-Diag "Completion check: completed=$($completionCheck.completed)"
+            Write-Diag "Completion check: completed=$($completionCheck.completed) method=$($completionCheck.method) terminal_state=$($completionCheck.terminal_state)"
             if ($completionCheck.completed) {
+                # Issue #318: distinguish done from other terminal states
+                # (skipped/cancelled/split). Only done squash-merges to main and
+                # counts as a completed task. Other terminals must clean up the
+                # worktree without merging — otherwise an agent calling
+                # task_mark_skipped silently merges its abandoned work.
+                if ($completionCheck.method -eq 'TerminalState' -and $completionCheck.terminal_state -ne 'done') {
+                    $taskTerminalState = $completionCheck.terminal_state
+                    Write-Status "Task ended in terminal state: $taskTerminalState" -Type Info
+                    Write-Information "task_state_change: $($task.id) -> $taskTerminalState [execution]" -Tags @('dotbot', 'task', 'state')
+                    Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task ended in terminal state '$taskTerminalState': $($task.name)"
+                    $taskTerminal = $true
+                    break
+                }
                 Write-Status "Task completed!" -Type Complete
                 Write-Information "task_state_change: $($task.id) -> done [execution]" -Tags @('dotbot', 'task', 'state')
                 Invoke-SessionIncrementCompleted -Arguments @{} | Out-Null
@@ -1610,7 +1629,8 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
             if (-not $failureReason.recoverable) {
                 Write-Status "Non-recoverable failure - skipping" -Type Error
                 try {
-                    Invoke-TaskMarkSkipped -Arguments @{ task_id = $task.id; skip_reason = "non-recoverable" } | Out-Null
+                    $detail = $failureReason.reason ?? $failureReason.message ?? 'non-recoverable failure'
+                    Invoke-TaskMarkSkipped -Arguments @{ task_id = $task.id; skip_reason = 'non-recoverable'; skip_detail = $detail } | Out-Null
                 } catch { Write-BotLog -Level Warn -Message "Task operation failed" -Exception $_ }
                 break
             }
@@ -1618,7 +1638,7 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
             if ($attemptNumber -ge $maxRetriesPerTask) {
                 Write-Status "Max retries exhausted" -Type Error
                 try {
-                    Invoke-TaskMarkSkipped -Arguments @{ task_id = $task.id; skip_reason = "max-retries" } | Out-Null
+                    Invoke-TaskMarkSkipped -Arguments @{ task_id = $task.id; skip_reason = 'max-retries'; skip_detail = "Retry budget exhausted after $attemptNumber attempt(s)" } | Out-Null
                 } catch { Write-BotLog -Level Warn -Message "Task operation failed" -Exception $_ }
                 break
             }
@@ -1868,6 +1888,31 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
                 Write-Status "$sourceLabel escalation failed: $($_.Exception.Message)" -Type Error
                 Write-ProcessActivity -Id $procId -ActivityType "error" -Message "$sourceLabel escalation failed for $($task.name): $($_.Exception.Message)"
             }
+        } elseif ($taskTerminal) {
+            # Issue #318: task settled into a terminal state other than done
+            # (skipped/cancelled/split). Clean up the worktree without
+            # squash-merging — the work is intentionally abandoned (intentional
+            # skip) or the agent already produced child tasks (split). Do NOT
+            # bump consecutive_failures — these are not failures.
+            Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task ended in terminal state '$taskTerminalState': $($task.name) — cleaning worktree, no merge"
+            if ($worktreePath) {
+                Write-Status "Cleaning up worktree for $taskTerminalState task..." -Type Info
+                try {
+                    Remove-Junctions -WorktreePath $worktreePath -ErrorOnFailure $false | Out-Null
+                    git -C $projectRoot worktree remove $worktreePath --force 2>$null
+                    git -C $projectRoot branch -D $branchName 2>$null
+                } finally {
+                    Initialize-WorktreeMap -BotRoot $botRoot
+                    Invoke-WorktreeMapLocked -Action {
+                        $cleanupMap = Read-WorktreeMap
+                        $cleanupMap.Remove($task.id)
+                        Write-WorktreeMap -Map $cleanupMap
+                    }
+                    try { Assert-OnBaseBranch -ProjectRoot $projectRoot | Out-Null } catch { Write-BotLog -Level Warn -Message "Task operation failed" -Exception $_ }
+                }
+            }
+            $processData.heartbeat_status = "Terminal ($taskTerminalState): $($task.name)"
+            Write-ProcessFile -Id $procId -Data $processData
         } else {
             Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task failed: $($task.name)"
 

--- a/core/runtime/modules/task-reset.ps1
+++ b/core/runtime/modules/task-reset.ps1
@@ -141,6 +141,12 @@ function Reset-SkippedTasks {
             Import-Module $taskIndexModule -DisableNameChecking
         }
     }
+    if (-not (Get-Command Test-IsFrameworkErrorSkip -ErrorAction SilentlyContinue)) {
+        # Without the classifier the per-file try/catch would swallow a
+        # CommandNotFoundException and silently leave every skipped task in
+        # place. Surface the failure once instead.
+        throw "Reset-SkippedTasks requires Test-IsFrameworkErrorSkip from TaskIndexCache.psm1, which could not be loaded."
+    }
 
     foreach ($taskFile in $skippedTasks) {
         try {

--- a/core/runtime/modules/task-reset.ps1
+++ b/core/runtime/modules/task-reset.ps1
@@ -95,11 +95,21 @@ function Reset-InProgressTasks {
 function Reset-SkippedTasks {
     <#
     .SYNOPSIS
-    Reset all skipped tasks to todo status
-    
+    Auto-retry skipped tasks that failed with a framework error (issue #318).
+
+    .DESCRIPTION
+    Operates on the skipped/ directory. Tasks whose latest skip is
+    INTENTIONAL ('not-applicable', 'precondition-unmet', etc.) are LEFT
+    ALONE — those are deliberate decisions and must not be auto-retried.
+    Tasks whose latest skip is a framework error ('non-recoverable',
+    'max-retries') are moved back to todo/ for another attempt.
+
+    A persistently failing task (skip_history.Count >= 3) is left in
+    skipped/ for operator inspection.
+
     .PARAMETER TasksBaseDir
     Base directory containing task subdirectories (todo, in-progress, skipped, done)
-    
+
     .OUTPUTS
     Array of hashtables with reset task information
     #>
@@ -107,28 +117,58 @@ function Reset-SkippedTasks {
         [Parameter(Mandatory = $true)]
         [string]$TasksBaseDir
     )
-    
+
     $resetTasks = @()
     $skippedDir = Join-Path $TasksBaseDir "skipped"
-    
+
     if (-not (Test-Path $skippedDir)) {
         return $resetTasks
     }
-    
+
     $skippedTasks = @(Get-ChildItem -Path $skippedDir -Filter "*.json" -File -ErrorAction SilentlyContinue)
-    
+
     if ($skippedTasks.Count -eq 0) {
         return $resetTasks
     }
-    
+
+    # Skip-reason classification lives in TaskIndexCache.psm1 (single source of
+    # truth, issue #318). Invoke-WorkflowProcess.ps1 already imports it before
+    # dot-sourcing this script, so the function is in scope. Defensive import
+    # guard for direct/test callers that load task-reset.ps1 in isolation.
+    if (-not (Get-Command Test-IsFrameworkErrorSkip -ErrorAction SilentlyContinue)) {
+        $taskIndexModule = Join-Path $PSScriptRoot "..\..\mcp\modules\TaskIndexCache.psm1"
+        if (Test-Path $taskIndexModule) {
+            Import-Module $taskIndexModule -DisableNameChecking
+        }
+    }
+
     foreach ($taskFile in $skippedTasks) {
         try {
             # Re-verify file exists (may have been moved by concurrent process)
             if (-not (Test-Path $taskFile.FullName)) { continue }
 
-            $taskContent = Get-Content -Path $taskFile.FullName -Raw | ConvertFrom-Json
+            $taskContent = Get-Content -LiteralPath $taskFile.FullName -Raw | ConvertFrom-Json
             $taskId = $taskContent.id
             $taskName = $taskContent.name
+
+            # Issue #318: only framework-error skips are auto-retried.
+            # Intentional skips (not-applicable etc.) are deliberate and stay put.
+            if (-not (Test-IsFrameworkErrorSkip -TaskContent $taskContent)) {
+                continue
+            }
+
+            # Resolve the canonical reason once for reporting (latest
+            # skip_history entry, fall back to top-level skip_reason).
+            $latestReason = $null
+            if ($taskContent.skip_history) {
+                $entries = @($taskContent.skip_history)
+                if ($entries.Count -gt 0 -and $entries[-1].reason) {
+                    $latestReason = [string]$entries[-1].reason
+                }
+            }
+            if (-not $latestReason -and $taskContent.skip_reason) {
+                $latestReason = [string]$taskContent.skip_reason
+            }
 
             # Guard against infinite skip loops — leave persistently-failing tasks for manual review
             $skipCount = ($taskContent.skip_history | Measure-Object).Count
@@ -152,20 +192,20 @@ function Reset-SkippedTasks {
             $taskContent.status = "todo"
             $taskContent.updated_at = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
 
-            # Preserve skip_history as audit trail
-            # (don't clear it - this is intentional to maintain history for debugging)
+            # Preserve skip_history as audit trail (intentional)
 
             # Write to todo directory
             $taskContent | ConvertTo-Json -Depth 10 | Set-Content -Path $todoPath -Force
 
             # Remove from skipped (ignore if already gone — concurrent process handled it)
             Remove-Item -Path $taskFile.FullName -Force -ErrorAction SilentlyContinue
-            
+
             $resetTasks += @{
                 id = $taskId
                 name = $taskName
                 file = $taskFile.Name
-                skip_count = ($taskContent.skip_history | Measure-Object).Count
+                skip_count = $skipCount
+                last_reason = $latestReason
             }
         } catch {
             Write-BotLog -Level Warn -Message "Error processing skipped task: $($taskFile.Name)" -Exception $_

--- a/core/runtime/modules/test-task-completion.ps1
+++ b/core/runtime/modules/test-task-completion.ps1
@@ -29,14 +29,32 @@ function Test-TaskCompletion {
 
     # Index always reads fresh from filesystem (no caching)
 
-    # Primary method: Check if task was moved to done directory using fresh cache
-    if (Test-TaskDone -TaskId $TaskId) {
+    # Primary method: look at the task's physical directory (issue #318). We
+    # cannot rely on Test-TaskDone here — that helper consults DoneIds, which
+    # also includes intentional skips and split parents (dependency satisfiers).
+    # The completion check must distinguish "task ended in done/" from "task
+    # ended in skipped/cancelled/split"; otherwise the runner squash-merges
+    # an intentionally skipped task to main.
+    $terminalState = Get-TaskTerminalState -TaskId $TaskId
+    if ($terminalState -eq 'done') {
         $task = Get-TaskById -TaskId $TaskId
         return @{
             completed = $true
             method = "TaskStatusCheck"
             reason = "Task found in done directory"
             task_file = $task.file_path
+        }
+    }
+    if ($terminalState) {
+        # skipped/cancelled/split — terminal but not done. The runner uses
+        # method=TerminalState to clean up the worktree without merging.
+        $task = Get-TaskById -TaskId $TaskId
+        return @{
+            completed     = $true
+            method        = "TerminalState"
+            reason        = "Task is in terminal state: $terminalState"
+            terminal_state = $terminalState
+            task_file     = $task.file_path
         }
     }
 
@@ -60,7 +78,7 @@ function Test-TaskCompletion {
 
         # Double-check if task is actually in done directory
         # (cache was already refreshed at start of function)
-        if (Test-TaskDone -TaskId $TaskId) {
+        if ((Get-TaskTerminalState -TaskId $TaskId) -eq 'done') {
             $task = Get-TaskById -TaskId $TaskId
             return @{
                 completed = $true

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -683,11 +683,13 @@ try {
     Assert-Equal -Name "No deadlock when no skipped tasks exist" `
         -Expected 0 -Actual $result1.BlockedCount
 
-    # ── Scenario 2: Deadlock — todo task depends on a skipped task ──
-    $skippedTask = [ordered]@{
-        id = "dl-skipped-prereq"
-        name = "Skipped prerequisite"
-        description = "Was skipped"
+    # ── Scenario 2 (issue #318): No deadlock — INTENTIONAL skip satisfies deps ──
+    # An intentional skip (task_mark_skipped with not-applicable etc.) should
+    # unblock dependents, not deadlock them.
+    $intentionalSkipped = [ordered]@{
+        id = "dl-intentional-prereq"
+        name = "Intentional skip prereq"
+        description = "Intentionally skipped (not applicable)"
         category = "feature"
         priority = 5
         effort = "S"
@@ -700,35 +702,62 @@ try {
         created_at = "2026-03-06T12:00:00Z"
         updated_at = "2026-03-06T12:00:00Z"
         completed_at = $null
+        skip_history = @(@{ skipped_at = "2026-03-06T12:30:00Z"; reason = "not-applicable" })
     }
-    $skippedTask | ConvertTo-Json -Depth 10 | Set-Content `
-        -Path (Join-Path $skippedDir "dl-skipped-prereq.json") -Encoding UTF8
+    $intentionalSkipped | ConvertTo-Json -Depth 10 | Set-Content `
+        -Path (Join-Path $skippedDir "dl-intentional-prereq.json") -Encoding UTF8
 
-    # Add a todo task that depends on the skipped task
     New-TestTaskFile -TasksTodoDir $todoDir `
-        -TaskId "dl-blocked-1" -Name "Blocked by skipped" `
-        -Description "Depends on skipped prerequisite" -Priority 20 `
-        -Dependencies @("dl-skipped-prereq") | Out-Null
+        -TaskId "dl-after-intentional" -Name "Runs after intentional skip" `
+        -Description "Depends on intentionally skipped prereq" -Priority 20 `
+        -Dependencies @("dl-intentional-prereq") | Out-Null
+
+    Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
+    $resultIntentional = Get-DeadlockedTasks
+    Assert-Equal -Name "No deadlock: intentional skip satisfies dependency (issue #318)" `
+        -Expected 0 -Actual $resultIntentional.BlockedCount
+
+    # ── Scenario 3 (issue #318): Deadlock — todo depends on a FRAMEWORK-ERROR skip ──
+    # Same skipped/ directory, but skip_history reason is 'non-recoverable'.
+    $frameworkSkipped = [ordered]@{
+        id = "dl-framework-prereq"
+        name = "Framework-error prereq"
+        description = "Skipped due to non-recoverable error"
+        category = "feature"
+        priority = 5
+        effort = "S"
+        status = "skipped"
+        dependencies = @()
+        acceptance_criteria = @()
+        steps = @()
+        applicable_standards = @()
+        applicable_agents = @()
+        created_at = "2026-03-06T12:00:00Z"
+        updated_at = "2026-03-06T12:00:00Z"
+        completed_at = $null
+        skip_history = @(@{ skipped_at = "2026-03-06T12:30:00Z"; reason = "non-recoverable"; detail = "missing dependency" })
+    }
+    $frameworkSkipped | ConvertTo-Json -Depth 10 | Set-Content `
+        -Path (Join-Path $skippedDir "dl-framework-prereq.json") -Encoding UTF8
+
+    New-TestTaskFile -TasksTodoDir $todoDir `
+        -TaskId "dl-blocked-1" -Name "Blocked by framework error" `
+        -Description "Depends on framework-error prereq" -Priority 20 `
+        -Dependencies @("dl-framework-prereq") | Out-Null
 
     Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
     $result2 = Get-DeadlockedTasks
-    Assert-Equal -Name "Deadlock detected: one todo task blocked by skipped prerequisite" `
+    Assert-Equal -Name "Deadlock detected: todo blocked by framework-error skip (issue #318)" `
         -Expected 1 -Actual $result2.BlockedCount
     Assert-True -Name "Deadlock reports correct blocker name" `
-        -Condition ($result2.BlockerNames -contains "Skipped prerequisite") `
-        -Message "Expected blocker name 'Skipped prerequisite', got: $($result2.BlockerNames -join ', ')"
-
-    # ── Scenario 3: No deadlock — todo task has no deps (should not count) ──
-    # dl-free-1 (no deps) is still in todo alongside dl-blocked-1 (blocked).
-    # BlockedCount should still be 1, not 2.
-    Assert-Equal -Name "Unblocked todo tasks are not counted as deadlocked" `
-        -Expected 1 -Actual $result2.BlockedCount
+        -Condition ($result2.BlockerNames -contains "Framework-error prereq") `
+        -Message "Expected blocker name 'Framework-error prereq', got: $($result2.BlockerNames -join ', ')"
 
     # ── Scenario 4: Dependency satisfied by done task — not a deadlock ──
     $doneTask = [ordered]@{
-        id = "dl-skipped-prereq"
-        name = "Skipped prerequisite"
-        description = "Was skipped but then completed"
+        id = "dl-framework-prereq"
+        name = "Framework-error prereq"
+        description = "Recovered and completed"
         category = "feature"
         priority = 5
         effort = "S"
@@ -743,8 +772,9 @@ try {
         completed_at = "2026-03-06T13:00:00Z"
     }
     $doneDir = Join-Path $tasksBaseDir "done"
+    Remove-Item -Path (Join-Path $skippedDir "dl-framework-prereq.json") -Force -ErrorAction SilentlyContinue
     $doneTask | ConvertTo-Json -Depth 10 | Set-Content `
-        -Path (Join-Path $doneDir "dl-skipped-prereq.json") -Encoding UTF8
+        -Path (Join-Path $doneDir "dl-framework-prereq.json") -Encoding UTF8
 
     Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
     $result4 = Get-DeadlockedTasks
@@ -752,6 +782,271 @@ try {
         -Expected 0 -Actual $result4.BlockedCount
 }
 finally {
+    if ($testProject) {
+        Remove-TestProject -Path $testProject
+    }
+}
+
+# ─── Test-TaskCompletion terminal-state detection (issue #318) ──────────────
+# Verifies the runtime sees skipped/cancelled/split as terminal so the runner
+# stops the retry loop (and skips the squash-merge) when an agent calls
+# task_mark_skipped or a task_get-next-driven auto-skip lands the task in
+# skipped/.
+
+$testProject = $null
+$savedDotbotProjectRoot = $global:DotbotProjectRoot
+try {
+    $testProject = New-SourceBackedTestProject -RepoRoot $repoRoot
+    $botDir       = Join-Path $testProject ".bot"
+    $tasksBaseDir = Join-Path $botDir "workspace\tasks"
+    $skippedDir   = Join-Path $tasksBaseDir "skipped"
+    $cancelledDir = Join-Path $tasksBaseDir "cancelled"
+    $splitDir     = Join-Path $tasksBaseDir "split"
+    $doneDir      = Join-Path $tasksBaseDir "done"
+    $inProgressDir = Join-Path $tasksBaseDir "in-progress"
+
+    $global:DotbotProjectRoot = $testProject
+
+    $taskIndexModule = Join-Path $botDir "core/mcp/modules/TaskIndexCache.psm1"
+    Import-Module $taskIndexModule -Force
+
+    Assert-True -Name "TaskIndexCache exports Get-TaskTerminalState (issue #318)" `
+        -Condition ((Get-Command -Module TaskIndexCache).Name -contains 'Get-TaskTerminalState') `
+        -Message "Expected Get-TaskTerminalState to be exported"
+
+    # Dot-source the runtime helper (not a module — it caches a reference to
+    # $global:DotbotProjectRoot via Initialize-TaskIndex on first load).
+    $completionScript = Join-Path $botDir "core/runtime/modules/test-task-completion.ps1"
+    . $completionScript
+
+    Assert-True -Name "test-task-completion dot-source exposes Test-TaskCompletion" `
+        -Condition ($null -ne (Get-Command Test-TaskCompletion -ErrorAction SilentlyContinue)) `
+        -Message "Expected Test-TaskCompletion to be defined after dot-sourcing"
+
+    function New-TerminalStateFixture {
+        param(
+            [Parameter(Mandatory)][string]$TaskId,
+            [Parameter(Mandatory)][string]$Status,
+            [Parameter(Mandatory)][string]$Dir,
+            [object]$SkipHistory
+        )
+        $task = [ordered]@{
+            id = $TaskId
+            name = "Fixture $TaskId"
+            description = "Terminal-state fixture for #318"
+            category = "feature"
+            priority = 5
+            effort = "S"
+            status = $Status
+            dependencies = @()
+            acceptance_criteria = @()
+            steps = @()
+            applicable_standards = @()
+            applicable_agents = @()
+            created_at = "2026-03-06T12:00:00Z"
+            updated_at = "2026-03-06T12:00:00Z"
+            completed_at = $null
+        }
+        if ($SkipHistory) { $task.skip_history = $SkipHistory }
+        $task | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $Dir "$TaskId.json") -Encoding UTF8
+    }
+
+    # ── Scenario 1: intentional skip → terminal ──
+    New-TerminalStateFixture -TaskId "tc-intent" -Status "skipped" -Dir $skippedDir `
+        -SkipHistory @(@{ skipped_at = "2026-03-06T12:30:00Z"; reason = "not-applicable" })
+
+    Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
+    $resultIntent = Test-TaskCompletion -TaskId "tc-intent"
+    Assert-True -Name "Intentional skip is reported completed=true (issue #318)" `
+        -Condition ($resultIntent.completed -eq $true) `
+        -Message "Expected completed=true, got $($resultIntent.completed)"
+    Assert-Equal -Name "Intentional skip reports method=TerminalState" `
+        -Expected "TerminalState" -Actual $resultIntent.method
+    Assert-Equal -Name "Intentional skip reports terminal_state=skipped" `
+        -Expected "skipped" -Actual $resultIntent.terminal_state
+
+    # ── Scenario 2: framework-error skip → still terminal (runner cleans up) ──
+    New-TerminalStateFixture -TaskId "tc-framework" -Status "skipped" -Dir $skippedDir `
+        -SkipHistory @(@{ skipped_at = "2026-03-06T12:30:00Z"; reason = "non-recoverable"; detail = "boom" })
+
+    Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
+    $resultFramework = Test-TaskCompletion -TaskId "tc-framework"
+    Assert-Equal -Name "Framework-error skip reports method=TerminalState" `
+        -Expected "TerminalState" -Actual $resultFramework.method
+    Assert-Equal -Name "Framework-error skip reports terminal_state=skipped" `
+        -Expected "skipped" -Actual $resultFramework.terminal_state
+
+    # ── Scenario 3: cancelled → terminal ──
+    New-TerminalStateFixture -TaskId "tc-cancelled" -Status "cancelled" -Dir $cancelledDir
+    Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
+    $resultCancelled = Test-TaskCompletion -TaskId "tc-cancelled"
+    Assert-Equal -Name "Cancelled task reports terminal_state=cancelled" `
+        -Expected "cancelled" -Actual $resultCancelled.terminal_state
+
+    # ── Scenario 4: split → terminal (children replace parent) ──
+    New-TerminalStateFixture -TaskId "tc-split" -Status "split" -Dir $splitDir
+    Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
+    $resultSplit = Test-TaskCompletion -TaskId "tc-split"
+    Assert-Equal -Name "Split task reports terminal_state=split" `
+        -Expected "split" -Actual $resultSplit.terminal_state
+
+    # ── Scenario 5: done → method=TaskStatusCheck (regression guard) ──
+    # The new terminal-state branch must come AFTER the done check so the
+    # runner still squash-merges done tasks the way it always has.
+    New-TerminalStateFixture -TaskId "tc-done" -Status "done" -Dir $doneDir
+    Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
+    $resultDone = Test-TaskCompletion -TaskId "tc-done"
+    Assert-Equal -Name "Done task still reports method=TaskStatusCheck (not TerminalState)" `
+        -Expected "TaskStatusCheck" -Actual $resultDone.method
+
+    # ── Scenario 6: in-progress (no terminal) → completed=false ──
+    New-TerminalStateFixture -TaskId "tc-running" -Status "in-progress" -Dir $inProgressDir
+    Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
+    $resultRunning = Test-TaskCompletion -TaskId "tc-running"
+    Assert-True -Name "In-progress task reports completed=false" `
+        -Condition ($resultRunning.completed -eq $false) `
+        -Message "Expected completed=false for in-progress task, got $($resultRunning.completed)"
+}
+finally {
+    $global:DotbotProjectRoot = $savedDotbotProjectRoot
+    if ($testProject) {
+        Remove-TestProject -Path $testProject
+    }
+}
+
+# ─── Reset-SkippedTasks polarity guard (issue #318) ──────────────────────────
+# Headline runtime fix: framework-error skips auto-retry, intentional skips do
+# NOT. A regression that flips this comparison (`-in` vs `-notin`) would
+# silently re-introduce the original bug — the agent's "not applicable"
+# decision being wiped out on next workflow restart.
+
+$testProject = $null
+$savedDotbotProjectRoot = $global:DotbotProjectRoot
+try {
+    $testProject = New-SourceBackedTestProject -RepoRoot $repoRoot
+    $botDir       = Join-Path $testProject ".bot"
+    $tasksBaseDir = Join-Path $botDir "workspace\tasks"
+    $todoDir      = Join-Path $tasksBaseDir "todo"
+    $skippedDir   = Join-Path $tasksBaseDir "skipped"
+
+    $global:DotbotProjectRoot = $testProject
+
+    # Reset-SkippedTasks lives in task-reset.ps1 (dot-sourced, not a module).
+    # It calls Test-IsFrameworkErrorSkip from TaskIndexCache, so import that first.
+    Import-Module (Join-Path $botDir "core/mcp/modules/TaskIndexCache.psm1") -Force
+    . (Join-Path $botDir "core/runtime/modules/task-reset.ps1")
+
+    function New-SkippedFixture {
+        param(
+            [Parameter(Mandatory)][string]$TaskId,
+            [Parameter(Mandatory)][string]$Reason,
+            [string]$Detail,
+            [int]$HistoryCount = 1
+        )
+        $history = @()
+        for ($i = 1; $i -le $HistoryCount; $i++) {
+            $entry = [ordered]@{
+                skipped_at = "2026-04-29T12:0${i}:00Z"
+                reason     = $Reason
+            }
+            if ($Detail) { $entry.detail = $Detail }
+            $history += $entry
+        }
+        $task = [ordered]@{
+            id = $TaskId
+            name = "Fixture $TaskId"
+            description = "Reset-SkippedTasks fixture for #318"
+            category = "feature"
+            priority = 5
+            effort = "S"
+            status = "skipped"
+            dependencies = @()
+            acceptance_criteria = @()
+            steps = @()
+            applicable_standards = @()
+            applicable_agents = @()
+            created_at = "2026-04-29T11:00:00Z"
+            updated_at = "2026-04-29T11:00:00Z"
+            completed_at = $null
+            skip_history = $history
+        }
+        $task | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $skippedDir "$TaskId.json") -Encoding UTF8
+    }
+
+    # ── Scenario 1: intentional skip is LEFT ALONE ──
+    New-SkippedFixture -TaskId "rs-intent" -Reason "not-applicable"
+    $reset1 = Reset-SkippedTasks -TasksBaseDir $tasksBaseDir
+    Assert-True -Name "Reset-SkippedTasks: intentional skip not retried (issue #318)" `
+        -Condition (-not ($reset1 | Where-Object { $_.id -eq 'rs-intent' })) `
+        -Message "Expected rs-intent to be left alone, got reset"
+    Assert-True -Name "Reset-SkippedTasks: intentional skip stays in skipped/" `
+        -Condition (Test-Path (Join-Path $skippedDir "rs-intent.json")) `
+        -Message "Expected rs-intent.json to remain in skipped/"
+    Assert-True -Name "Reset-SkippedTasks: intentional skip not moved to todo/" `
+        -Condition (-not (Test-Path (Join-Path $todoDir "rs-intent.json"))) `
+        -Message "Expected rs-intent.json NOT to appear in todo/"
+
+    # ── Scenario 2: framework-error skip IS retried ──
+    New-SkippedFixture -TaskId "rs-framework" -Reason "non-recoverable" -Detail "boom"
+    $reset2 = Reset-SkippedTasks -TasksBaseDir $tasksBaseDir
+    $frameworkReset = $reset2 | Where-Object { $_.id -eq 'rs-framework' }
+    Assert-True -Name "Reset-SkippedTasks: framework-error skip is retried" `
+        -Condition ($null -ne $frameworkReset) `
+        -Message "Expected rs-framework to be reset, got nothing"
+    Assert-Equal -Name "Reset-SkippedTasks: reset entry reports last_reason" `
+        -Expected "non-recoverable" -Actual $frameworkReset.last_reason
+    Assert-True -Name "Reset-SkippedTasks: framework-error skip moved to todo/" `
+        -Condition (Test-Path (Join-Path $todoDir "rs-framework.json")) `
+        -Message "Expected rs-framework.json in todo/"
+    Assert-True -Name "Reset-SkippedTasks: framework-error skip removed from skipped/" `
+        -Condition (-not (Test-Path (Join-Path $skippedDir "rs-framework.json"))) `
+        -Message "Expected rs-framework.json removed from skipped/"
+
+    # ── Scenario 3: persistently failing framework skip is left alone (>=3 attempts) ──
+    New-SkippedFixture -TaskId "rs-stuck" -Reason "max-retries" -HistoryCount 3
+    $reset3 = Reset-SkippedTasks -TasksBaseDir $tasksBaseDir
+    Assert-True -Name "Reset-SkippedTasks: skip_count>=3 left for manual review" `
+        -Condition (-not ($reset3 | Where-Object { $_.id -eq 'rs-stuck' })) `
+        -Message "Expected rs-stuck to remain in skipped/ for manual review"
+    Assert-True -Name "Reset-SkippedTasks: stuck task stays in skipped/" `
+        -Condition (Test-Path (Join-Path $skippedDir "rs-stuck.json")) `
+        -Message "Expected rs-stuck.json to remain in skipped/"
+
+    # ── Scenario 4: top-level skip_reason fallback (task-get-next path) ──
+    # task-get-next writes top-level skip_reason without populating skip_history.
+    # Reset-SkippedTasks must classify those correctly via the fallback.
+    $conditionTask = [ordered]@{
+        id = "rs-condition"
+        name = "Condition skip"
+        description = "Condition not met at runtime"
+        category = "feature"
+        priority = 5
+        effort = "S"
+        status = "skipped"
+        dependencies = @()
+        acceptance_criteria = @()
+        steps = @()
+        applicable_standards = @()
+        applicable_agents = @()
+        created_at = "2026-04-29T11:00:00Z"
+        updated_at = "2026-04-29T11:00:00Z"
+        completed_at = $null
+        skip_reason = "condition-not-met"
+        skip_detail = "platform != linux"
+    }
+    $conditionTask | ConvertTo-Json -Depth 10 | Set-Content `
+        -Path (Join-Path $skippedDir "rs-condition.json") -Encoding UTF8
+
+    $reset4 = Reset-SkippedTasks -TasksBaseDir $tasksBaseDir
+    Assert-True -Name "Reset-SkippedTasks: top-level intentional skip_reason left alone" `
+        -Condition (-not ($reset4 | Where-Object { $_.id -eq 'rs-condition' })) `
+        -Message "Expected condition-not-met task to be left alone (intentional)"
+    Assert-True -Name "Reset-SkippedTasks: condition-not-met task stays in skipped/" `
+        -Condition (Test-Path (Join-Path $skippedDir "rs-condition.json")) `
+        -Message "Expected rs-condition.json to remain in skipped/"
+}
+finally {
+    $global:DotbotProjectRoot = $savedDotbotProjectRoot
     if ($testProject) {
         Remove-TestProject -Path $testProject
     }

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -871,6 +871,9 @@ try {
 
     Initialize-TaskIndex -TasksBaseDir $tasksBaseDir
     $resultFramework = Test-TaskCompletion -TaskId "tc-framework"
+    Assert-True -Name "Framework-error skip is reported completed=true (issue #318)" `
+        -Condition ($resultFramework.completed -eq $true) `
+        -Message "Expected completed=true, got $($resultFramework.completed)"
     Assert-Equal -Name "Framework-error skip reports method=TerminalState" `
         -Expected "TerminalState" -Actual $resultFramework.method
     Assert-Equal -Name "Framework-error skip reports terminal_state=skipped" `


### PR DESCRIPTION
## Summary

Closes #318 — `task_mark_skipped` was overloaded for both intentional "not applicable" decisions and framework errors. The result: completion check missed `skipped/` as terminal → retry loop → worktree collision → max-retries skip → silently deadlocked dependents. None of the symptoms pointed back to the root cause.

This PR splits the two meanings cleanly via `skip_history[].reason` discrimination (no new physical state directory — kept the storage simple per the issue's "or equivalent separation" allowance).

## What changed

### State machine
- **`Test-TaskCompletion`** now returns `completed=true` with `method=TerminalState` for any task that lands in `skipped/`, `cancelled/`, or `split/`. The runner breaks out of the retry loop and cleans up the worktree **without squash-merging** — so an agent calling `task_mark_skipped` mid-execution no longer silently merges its abandoned work to `main`.
- **`Get-TaskTerminalState`** added to `TaskIndexCache.psm1` as the single check for terminal residency.

### Skip-reason classification
Two disjoint sets, both validated by the agent-facing tool:

| Class | Reasons | Effect on dependents | Auto-retried by `Reset-SkippedTasks`? |
|---|---|---|---|
| **Intentional** | `not-applicable`, `precondition-unmet`, `superseded`, `user-requested`, `condition-not-met` | Satisfy (added to `DoneIds`) | No — deliberate decision, leave it alone |
| **Framework error** | `non-recoverable`, `max-retries` | Block (surfaced via `Get-DeadlockedTasks` with explicit blocker name) | Yes, until `skip_history.Count >= 3` |

`task_mark_skipped` accepts both, but the metadata description steers agents to intentional reasons; the runtime emits framework reasons itself.

### Single source of truth
The reason lists used to drift across three files. Now consolidated in `core/mcp/modules/TaskIndexCache.psm1`:

- `Get-IntentionalSkipReasons`, `Get-FrameworkSkipReasons` — exported accessors
- `Test-IsFrameworkErrorSkip -TaskContent <obj>` — canonical classifier (reads `skip_history[-1].reason`, falls back to top-level `skip_reason` for `task-get-next` callers)

`task-mark-skipped/script.ps1` and `core/runtime/modules/task-reset.ps1` import from there instead of inlining.

### Worktree cleanup
`Invoke-WorkflowProcess.ps1` now has a dedicated terminal-state branch: when a task settles into `skipped`/`cancelled`/`split`, the worktree is removed and the worktree map updated, but `consecutive_failures` is **not** bumped (these aren't failures) and no merge is attempted.

## Files touched

| File | Why |
|---|---|
| `core/mcp/modules/TaskIndexCache.psm1` | Canonical reason lists, `Test-IsFrameworkErrorSkip`, `Get-TaskTerminalState`; intentional skips added to `DoneIds`; `Get-DeadlockedTasks` filters to framework-only blockers |
| `core/mcp/tools/task-mark-skipped/{metadata.yaml,script.ps1}` | Enum expanded with intentional reasons, optional `skip_detail` field, `intentional` flag in response |
| `core/runtime/modules/test-task-completion.ps1` | Terminal-state branch using `Get-TaskTerminalState` |
| `core/runtime/modules/task-reset.ps1` | `Reset-SkippedTasks` only auto-retries framework-error skips |
| `core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1` | New terminal-state cleanup branch; runtime calls to `Invoke-TaskMarkSkipped` use proper enum values + `skip_detail` |
| `tests/Test-TaskActions.ps1` | New `Test-TaskCompletion` terminal-state suite (6 scenarios), new `Reset-SkippedTasks` polarity guard suite (4 scenarios), `Get-DeadlockedTasks` updated for intentional-vs-framework |
| `core/mcp/tools/task-mark-skipped/test.ps1` | Asserts `intentional` flag, accepts framework reasons, rejects unknown reasons |

## Reproduction (from issue #318) — before/after

| Step | Before | After |
|---|---|---|
| Agent calls `task_mark_skipped` mid-execution | `Test-TaskCompletion` returns `completed=false` → retry → `New-TaskWorktree` fails (path/branch already registered) → max-retries skip appended | `Test-TaskCompletion` returns `completed=true method=TerminalState` → runner breaks → worktree removed cleanly |
| Dependent of an intentionally skipped task | Stuck in `analysed/` indefinitely; `task-get-next` reports "blocked by unmet dependencies" with no detail | Runs (intentional skip is in `DoneIds`) |
| Dependent of a framework-error skipped task | Same silent deadlock | Surfaced by `Get-DeadlockedTasks` with explicit blocker name |

## Test plan

- [x] `pwsh tests/Run-Tests.ps1` — Layer 2 + Layer 3 green; Test-TaskActions covers all new branches
- [x] `Test-TaskCompletion` returns correct `method`/`terminal_state` for done / intentional-skip / framework-skip / cancelled / split / in-progress
- [x] `Get-DeadlockedTasks` reports zero blockers when prereq is intentionally skipped, reports framework-error blocker by name otherwise
- [x] `Reset-SkippedTasks` leaves intentional skips, retries framework skips, leaves `skip_count >= 3` for manual review, handles top-level `skip_reason` fallback (task-get-next path)
- [x] `task-mark-skipped` accepts intentional + framework reasons, rejects unknown, returns `intentional` flag

## Notes

- No new physical state directory; the issue's "or equivalent separation" allowance covered this. If a `failed/` directory is preferred later, the discriminator function is the only place to swap.
- Layer 1 `Test-Structure.ps1` failure observed during local run was an environmental Windows file-lock on the user's `~/dotbot` install dir, unrelated to this change.