### PR TITLE
test(server): add integration tests for POST /api/templates (#395)

### DIFF
--- a/server/src/Dotbot.Server/DashboardAuthMiddleware.cs
+++ b/server/src/Dotbot.Server/DashboardAuthMiddleware.cs
@@ -17,7 +17,7 @@ public class DashboardAuthMiddleware
         _next = next;
     }
 
-    public async Task InvokeAsync(HttpContext context, AdministratorService adminService)
+    public async Task InvokeAsync(HttpContext context, IAdministratorService adminService)
     {
         var path = context.Request.Path.Value ?? "";
 

--- a/server/src/Dotbot.Server/DotbotAgent.cs
+++ b/server/src/Dotbot.Server/DotbotAgent.cs
@@ -15,7 +15,7 @@ public class DotbotAgent : AgentApplication
 {
     private readonly AdaptiveCardService _cardService;
     private readonly ResponseStorageService _responseStorage;
-    private readonly ConversationReferenceStore _convoStore;
+    private readonly IConversationReferenceStore _convoStore;
     private readonly UserResolverService _userResolver;
     private readonly ILogger<DotbotAgent> _logger;
 
@@ -39,7 +39,7 @@ public class DotbotAgent : AgentApplication
         AgentApplicationOptions options,
         AdaptiveCardService cardService,
         ResponseStorageService responseStorage,
-        ConversationReferenceStore convoStore,
+        IConversationReferenceStore convoStore,
         UserResolverService userResolver,
         ILogger<DotbotAgent> logger)
         : base(options)

--- a/server/src/Dotbot.Server/Pages/Respond.cshtml.cs
+++ b/server/src/Dotbot.Server/Pages/Respond.cshtml.cs
@@ -15,7 +15,7 @@ public class RespondModel : PageModel
     private const long MaxFileBytes = 15 * 1024 * 1024; // 15 MB
 
     private readonly InstanceStorageService _instances;
-    private readonly TemplateStorageService _templates;
+    private readonly ITemplateStorageService _templates;
     private readonly ResponseStorageService _responses;
     private readonly AttachmentStorageService _attachments;
     private readonly TokenStorageService _tokenStorage;
@@ -24,7 +24,7 @@ public class RespondModel : PageModel
 
     public RespondModel(
         InstanceStorageService instances,
-        TemplateStorageService templates,
+        ITemplateStorageService templates,
         ResponseStorageService responses,
         AttachmentStorageService attachments,
         TokenStorageService tokenStorage,

--- a/server/src/Dotbot.Server/Program.cs
+++ b/server/src/Dotbot.Server/Program.cs
@@ -58,8 +58,9 @@ try
 
     var builder = WebApplication.CreateBuilder(args);
 
-    // Prefer the hosting environment (set by IWebHostBuilder.UseEnvironment, respected by
-    // WebApplicationFactory) over the raw OS env var captured above for the bootstrap logger.
+    // Re-read environment from IWebHostEnvironment so the downstream auth and middleware
+    // branches honor IWebHostBuilder.UseEnvironment (e.g. WebApplicationFactory). The bootstrap
+    // logger above was already built from the OS env var and is not affected.
     environmentName = builder.Environment.EnvironmentName;
 
     // Clear default logging and wire Serilog

--- a/server/src/Dotbot.Server/Program.cs
+++ b/server/src/Dotbot.Server/Program.cs
@@ -58,6 +58,10 @@ try
 
     var builder = WebApplication.CreateBuilder(args);
 
+    // Prefer the hosting environment (set by IWebHostBuilder.UseEnvironment, respected by
+    // WebApplicationFactory) over the raw OS env var captured above for the bootstrap logger.
+    environmentName = builder.Environment.EnvironmentName;
+
     // Clear default logging and wire Serilog
     builder.Logging.ClearProviders();
     builder.Host.UseSerilog();

--- a/server/src/Dotbot.Server/Program.cs
+++ b/server/src/Dotbot.Server/Program.cs
@@ -114,12 +114,12 @@ try
 
     // Core application services
     builder.Services.AddSingleton<StoragePathResolver>();
-    builder.Services.AddSingleton<TemplateStorageService>();
+    builder.Services.AddSingleton<ITemplateStorageService, TemplateStorageService>();
     builder.Services.AddSingleton<QuestionTemplateValidator>();
     builder.Services.AddSingleton<InstanceStorageService>();
     builder.Services.AddSingleton<ResponseStorageService>();
     builder.Services.AddSingleton<AttachmentStorageService>();
-    builder.Services.AddSingleton<ConversationReferenceStore>();
+    builder.Services.AddSingleton<IConversationReferenceStore, ConversationReferenceStore>();
     builder.Services.AddSingleton<AdaptiveCardService>();
 
     // Auth services
@@ -161,7 +161,7 @@ try
     builder.Services.AddRazorPages();
 
     // Administrator service
-    builder.Services.AddSingleton<AdministratorService>();
+    builder.Services.AddSingleton<IAdministratorService, AdministratorService>();
 
     // Azure AD authentication for dashboard (reuses bot app registration)
     if (environmentName != "Development")
@@ -203,11 +203,11 @@ try
     app.UseMiddleware<DashboardAuthMiddleware>();
 
     // Seed administrator list
-    var adminService = app.Services.GetRequiredService<AdministratorService>();
+    var adminService = app.Services.GetRequiredService<IAdministratorService>();
     await adminService.SeedIfEmptyAsync();
 
     // Load persisted conversation references into memory cache
-    var convoStore = app.Services.GetRequiredService<ConversationReferenceStore>();
+    var convoStore = app.Services.GetRequiredService<IConversationReferenceStore>();
     await convoStore.LoadAsync();
     Log.Information("Conversation references loaded into memory cache");
 
@@ -222,7 +222,7 @@ try
     });
 
     // ── v1: Publish a question template ─────────────────────────────────────
-    app.MapPost("/api/templates", async (HttpRequest request, TemplateStorageService templates, QuestionTemplateValidator validator, ILogger<Program> logger) =>
+    app.MapPost("/api/templates", async (HttpRequest request, ITemplateStorageService templates, QuestionTemplateValidator validator, ILogger<Program> logger) =>
     {
         QuestionTemplate? template;
         try
@@ -254,7 +254,7 @@ try
     // ── v1: Create an instance and fan-out to recipients ────────────────────
     app.MapPost("/api/instances", async (
         HttpRequest request,
-        TemplateStorageService templates,
+        ITemplateStorageService templates,
         InstanceStorageService instances,
         DeliveryOrchestrator orchestrator,
         ILogger<Program> logger,
@@ -483,7 +483,7 @@ try
     // ── Dashboard API endpoints ────────────────────────────────────────────
     app.MapGet("/api/dashboard/instances", async (
         InstanceStorageService instances,
-        TemplateStorageService templates,
+        ITemplateStorageService templates,
         ResponseStorageService responses,
         ILogger<Program> logger) =>
     {
@@ -605,7 +605,7 @@ try
     app.MapPost("/api/dashboard/nudge", async (
         HttpRequest request,
         InstanceStorageService instances,
-        TemplateStorageService templates,
+        ITemplateStorageService templates,
         DeliveryOrchestrator orchestrator,
         ILogger<Program> logger,
         CancellationToken ct) =>
@@ -772,3 +772,6 @@ static void LogStartupConfiguration(WebApplicationBuilder builder)
 // Request models for minimal API endpoints
 record RevokeTokenRequest(string DeviceTokenId);
 record NudgeRequest(string ProjectId, string InstanceId, string RecipientEmail);
+
+// Exposes the implicit top-level Program class so WebApplicationFactory<Program> can reference it.
+public partial class Program { }

--- a/server/src/Dotbot.Server/Program.cs
+++ b/server/src/Dotbot.Server/Program.cs
@@ -85,21 +85,20 @@ try
     builder.AddAgent<DotbotAgent>();
     builder.Services.AddSingleton<IStorage, MemoryStorage>();
 
-    // Azure Blob Storage — Managed Identity in production, connection string fallback for local dev
-    var blobAccountUri = builder.Configuration["BlobStorage:AccountUri"];
-    var blobConnectionString = builder.Configuration["BlobStorage:ConnectionString"];
-    if (!string.IsNullOrEmpty(blobAccountUri))
+    // Azure Blob Storage — Managed Identity in production, connection string fallback for local dev.
+    // Factory delegate defers config reads to DI resolution time so test overrides apply.
+    builder.Services.AddSingleton(sp =>
     {
-        builder.Services.AddSingleton(new BlobServiceClient(new Uri(blobAccountUri), new DefaultAzureCredential()));
-    }
-    else if (!string.IsNullOrEmpty(blobConnectionString))
-    {
-        builder.Services.AddSingleton(new BlobServiceClient(blobConnectionString));
-    }
-    else
-    {
-        throw new InvalidOperationException("Either BlobStorage:AccountUri or BlobStorage:ConnectionString must be configured");
-    }
+        var config = sp.GetRequiredService<IConfiguration>();
+        var accountUri = config["BlobStorage:AccountUri"];
+        var connectionString = config["BlobStorage:ConnectionString"];
+        if (!string.IsNullOrEmpty(accountUri))
+            return new BlobServiceClient(new Uri(accountUri), new DefaultAzureCredential());
+        if (!string.IsNullOrEmpty(connectionString))
+            return new BlobServiceClient(connectionString);
+        throw new InvalidOperationException(
+            "Either BlobStorage:AccountUri or BlobStorage:ConnectionString must be configured");
+    });
 
     // Configuration bindings
     builder.Services.Configure<AuthSettings>(builder.Configuration.GetSection("Auth"));

--- a/server/src/Dotbot.Server/Program.cs
+++ b/server/src/Dotbot.Server/Program.cs
@@ -85,19 +85,21 @@ try
     builder.AddAgent<DotbotAgent>();
     builder.Services.AddSingleton<IStorage, MemoryStorage>();
 
-    // Azure Blob Storage — Managed Identity in production, connection string fallback for local dev.
-    // Factory delegate defers config reads to DI resolution time so test overrides are applied first.
-    builder.Services.AddSingleton(sp =>
+    // Azure Blob Storage — Managed Identity in production, connection string fallback for local dev
+    var blobAccountUri = builder.Configuration["BlobStorage:AccountUri"];
+    var blobConnectionString = builder.Configuration["BlobStorage:ConnectionString"];
+    if (!string.IsNullOrEmpty(blobAccountUri))
     {
-        var config = sp.GetRequiredService<IConfiguration>();
-        var accountUri = config["BlobStorage:AccountUri"];
-        var connectionString = config["BlobStorage:ConnectionString"];
-        if (!string.IsNullOrEmpty(accountUri))
-            return new BlobServiceClient(new Uri(accountUri), new DefaultAzureCredential());
-        if (!string.IsNullOrEmpty(connectionString))
-            return new BlobServiceClient(connectionString);
+        builder.Services.AddSingleton(new BlobServiceClient(new Uri(blobAccountUri), new DefaultAzureCredential()));
+    }
+    else if (!string.IsNullOrEmpty(blobConnectionString))
+    {
+        builder.Services.AddSingleton(new BlobServiceClient(blobConnectionString));
+    }
+    else
+    {
         throw new InvalidOperationException("Either BlobStorage:AccountUri or BlobStorage:ConnectionString must be configured");
-    });
+    }
 
     // Configuration bindings
     builder.Services.Configure<AuthSettings>(builder.Configuration.GetSection("Auth"));

--- a/server/src/Dotbot.Server/Program.cs
+++ b/server/src/Dotbot.Server/Program.cs
@@ -81,21 +81,19 @@ try
     builder.AddAgent<DotbotAgent>();
     builder.Services.AddSingleton<IStorage, MemoryStorage>();
 
-    // Azure Blob Storage — Managed Identity in production, connection string fallback for local dev
-    var blobAccountUri = builder.Configuration["BlobStorage:AccountUri"];
-    var blobConnectionString = builder.Configuration["BlobStorage:ConnectionString"];
-    if (!string.IsNullOrEmpty(blobAccountUri))
+    // Azure Blob Storage — Managed Identity in production, connection string fallback for local dev.
+    // Factory delegate defers config reads to DI resolution time so test overrides are applied first.
+    builder.Services.AddSingleton(sp =>
     {
-        builder.Services.AddSingleton(new BlobServiceClient(new Uri(blobAccountUri), new DefaultAzureCredential()));
-    }
-    else if (!string.IsNullOrEmpty(blobConnectionString))
-    {
-        builder.Services.AddSingleton(new BlobServiceClient(blobConnectionString));
-    }
-    else
-    {
+        var config = sp.GetRequiredService<IConfiguration>();
+        var accountUri = config["BlobStorage:AccountUri"];
+        var connectionString = config["BlobStorage:ConnectionString"];
+        if (!string.IsNullOrEmpty(accountUri))
+            return new BlobServiceClient(new Uri(accountUri), new DefaultAzureCredential());
+        if (!string.IsNullOrEmpty(connectionString))
+            return new BlobServiceClient(connectionString);
         throw new InvalidOperationException("Either BlobStorage:AccountUri or BlobStorage:ConnectionString must be configured");
-    }
+    });
 
     // Configuration bindings
     builder.Services.Configure<AuthSettings>(builder.Configuration.GetSection("Auth"));

--- a/server/src/Dotbot.Server/Services/AdministratorService.cs
+++ b/server/src/Dotbot.Server/Services/AdministratorService.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 
 namespace Dotbot.Server.Services;
 
-public class AdministratorService
+public class AdministratorService : IAdministratorService
 {
     private readonly BlobContainerClient _container;
     private readonly StoragePathResolver _paths;

--- a/server/src/Dotbot.Server/Services/ConversationReferenceStore.cs
+++ b/server/src/Dotbot.Server/Services/ConversationReferenceStore.cs
@@ -9,7 +9,7 @@ namespace Dotbot.Server.Services;
 /// Stores conversation references in Azure Blob Storage with an in-memory cache.
 /// Blobs are keyed by user AAD object ID in the "conversation-references" container.
 /// </summary>
-public class ConversationReferenceStore
+public class ConversationReferenceStore : IConversationReferenceStore
 {
     private readonly BlobContainerClient _container;
     private readonly ILogger<ConversationReferenceStore> _logger;

--- a/server/src/Dotbot.Server/Services/Delivery/TeamsDeliveryProvider.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/TeamsDeliveryProvider.cs
@@ -11,7 +11,7 @@ namespace Dotbot.Server.Services.Delivery;
 
 public class TeamsDeliveryProvider : IQuestionDeliveryProvider
 {
-    private readonly ConversationReferenceStore _convoStore;
+    private readonly IConversationReferenceStore _convoStore;
     private readonly AdaptiveCardService _cardService;
     private readonly GraphTokenService _graphTokenService;
     private readonly IAgentHttpAdapter _adapter;
@@ -21,7 +21,7 @@ public class TeamsDeliveryProvider : IQuestionDeliveryProvider
     public string ChannelName => "teams";
 
     public TeamsDeliveryProvider(
-        ConversationReferenceStore convoStore,
+        IConversationReferenceStore convoStore,
         AdaptiveCardService cardService,
         GraphTokenService graphTokenService,
         IAgentHttpAdapter adapter,

--- a/server/src/Dotbot.Server/Services/IAdministratorService.cs
+++ b/server/src/Dotbot.Server/Services/IAdministratorService.cs
@@ -1,0 +1,7 @@
+namespace Dotbot.Server.Services;
+
+public interface IAdministratorService
+{
+    Task SeedIfEmptyAsync();
+    Task<bool> IsAdministratorAsync(string email);
+}

--- a/server/src/Dotbot.Server/Services/IConversationReferenceStore.cs
+++ b/server/src/Dotbot.Server/Services/IConversationReferenceStore.cs
@@ -1,0 +1,10 @@
+using Microsoft.Agents.Core.Models;
+
+namespace Dotbot.Server.Services;
+
+public interface IConversationReferenceStore
+{
+    Task LoadAsync();
+    void AddOrUpdate(string userObjectId, ConversationReference reference);
+    ConversationReference? Get(string userObjectId);
+}

--- a/server/src/Dotbot.Server/Services/ITemplateStorageService.cs
+++ b/server/src/Dotbot.Server/Services/ITemplateStorageService.cs
@@ -1,0 +1,9 @@
+using Dotbot.Server.Models;
+
+namespace Dotbot.Server.Services;
+
+public interface ITemplateStorageService
+{
+    Task SaveTemplateAsync(QuestionTemplate template);
+    Task<QuestionTemplate?> GetTemplateAsync(string projectId, Guid questionId, int version);
+}

--- a/server/src/Dotbot.Server/Services/ReminderEscalationService.cs
+++ b/server/src/Dotbot.Server/Services/ReminderEscalationService.cs
@@ -46,7 +46,7 @@ public class ReminderEscalationService : BackgroundService
     {
         using var scope = _services.CreateScope();
         var instanceStorage = scope.ServiceProvider.GetRequiredService<InstanceStorageService>();
-        var templateStorage = scope.ServiceProvider.GetRequiredService<TemplateStorageService>();
+        var templateStorage = scope.ServiceProvider.GetRequiredService<ITemplateStorageService>();
         var responseStorage = scope.ServiceProvider.GetRequiredService<ResponseStorageService>();
         var orchestrator = scope.ServiceProvider.GetRequiredService<DeliveryOrchestrator>();
 

--- a/server/src/Dotbot.Server/Services/TemplateStorageService.cs
+++ b/server/src/Dotbot.Server/Services/TemplateStorageService.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 
 namespace Dotbot.Server.Services;
 
-public class TemplateStorageService
+public class TemplateStorageService : ITemplateStorageService
 {
     private readonly BlobContainerClient _container;
     private readonly StoragePathResolver _paths;

--- a/server/tests/Dotbot.Server.Tests/Integration/DotbotApiFactory.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/DotbotApiFactory.cs
@@ -13,6 +13,10 @@ public sealed class DotbotApiFactory : WebApplicationFactory<Program>
 {
     internal const string TestApiKey = "integration-test-key-abc123";
 
+    // Small non-default caps so cap-enforcement tests also catch options-binding regressions.
+    internal const int TestMaxAttachments = 2;
+    internal const int TestMaxReferenceLinks = 2;
+
     public InMemoryTemplateStorage Storage { get; } = new();
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -29,23 +33,31 @@ public sealed class DotbotApiFactory : WebApplicationFactory<Program>
                 ["Auth:JwtSigningKey"] = "integration-test-signing-key-32-chars!!",
                 ["Auth:JwtIssuer"] = "dotbot-test",
                 ["Auth:JwtAudience"] = "dotbot-test",
+                ["Validation:QuestionTemplate:MaxAttachments"] = TestMaxAttachments.ToString(),
+                ["Validation:QuestionTemplate:MaxReferenceLinks"] = TestMaxReferenceLinks.ToString(),
             });
         });
 
         builder.ConfigureServices(services =>
         {
-            // M365 Agents SDK's BackgroundQueue hosted services (HostedTaskService,
-            // HostedActivityService) recursively acquire a ReaderWriterLockSlim write
-            // lock during host shutdown, throwing LockRecursionException on Linux/macOS.
-            // The agent runtime is not exercised by these HTTP tests, so drop the
-            // hosted services before the host runs.
-            var backgroundQueueDescriptors = services
-                .Where(d => d.ServiceType == typeof(IHostedService)
-                    && (d.ImplementationType?.FullName?.StartsWith(
-                        "Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue.",
-                        StringComparison.Ordinal) ?? false))
+            // Drop hosted services that aren't exercised by these HTTP tests:
+            //  - M365 Agents BackgroundQueue.* (HostedTaskService, HostedActivityService) —
+            //    StopAsync recursively acquires a ReaderWriterLockSlim write lock,
+            //    throwing LockRecursionException on Linux/macOS during host shutdown.
+            //  - Dotbot.Server.Services.ReminderEscalationService — enumerates Azure
+            //    blobs on startup, triggering Azure SDK retry storms when storage is
+            //    unreachable in CI. Hides nondeterminism from test runs.
+            var hostedServicesToRemove = services
+                .Where(d => d.ServiceType == typeof(IHostedService))
+                .Where(d =>
+                {
+                    var name = d.ImplementationType?.FullName;
+                    return name != null
+                        && (name.StartsWith("Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue.", StringComparison.Ordinal)
+                            || name == "Dotbot.Server.Services.ReminderEscalationService");
+                })
                 .ToList();
-            foreach (var descriptor in backgroundQueueDescriptors)
+            foreach (var descriptor in hostedServicesToRemove)
                 services.Remove(descriptor);
 
             // Replace the three DI-blocking services with in-process test doubles.

--- a/server/tests/Dotbot.Server.Tests/Integration/DotbotApiFactory.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/DotbotApiFactory.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Hosting;
 
 namespace Dotbot.Server.Tests.Integration;
 
-public sealed class TemplatesApiFactory : WebApplicationFactory<Program>
+public sealed class DotbotApiFactory : WebApplicationFactory<Program>
 {
     internal const string TestApiKey = "integration-test-key-abc123";
 

--- a/server/tests/Dotbot.Server.Tests/Integration/DotbotApiFactory.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/DotbotApiFactory.cs
@@ -2,7 +2,6 @@ using Dotbot.Server.Services;
 using Dotbot.Server.Tests.Integration.TestDoubles;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -21,22 +20,16 @@ public sealed class DotbotApiFactory : WebApplicationFactory<Program>
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
-        // ConfigureAppConfiguration is guaranteed to run before the host builds its service
-        // container, so these values are visible to Program.cs and all middleware constructors
-        // regardless of ASPNETCORE_ENVIRONMENT (appsettings.Development.json is not loaded on CI).
-        builder.ConfigureAppConfiguration(config =>
-        {
-            config.AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["BlobStorage:ConnectionString"] = "UseDevelopmentStorage=true",
-                ["ApiSecurity:ApiKey"] = TestApiKey,
-                ["Auth:JwtSigningKey"] = "integration-test-signing-key-32-chars!!",
-                ["Auth:JwtIssuer"] = "dotbot-test",
-                ["Auth:JwtAudience"] = "dotbot-test",
-                ["Validation:QuestionTemplate:MaxAttachments"] = TestMaxAttachments.ToString(),
-                ["Validation:QuestionTemplate:MaxReferenceLinks"] = TestMaxReferenceLinks.ToString(),
-            });
-        });
+        // Provide minimum required configuration so the host boots without Azure resources.
+        builder.UseSetting("BlobStorage:ConnectionString", "UseDevelopmentStorage=true");
+        builder.UseSetting("ApiSecurity:ApiKey", TestApiKey);
+        builder.UseSetting("Validation:QuestionTemplate:MaxAttachments", TestMaxAttachments.ToString());
+        builder.UseSetting("Validation:QuestionTemplate:MaxReferenceLinks", TestMaxReferenceLinks.ToString());
+
+        // Stub required Auth config so JwtSigningKeyProvider and MagicLinkService don't fail to resolve.
+        builder.UseSetting("Auth:JwtSigningKey", "integration-test-signing-key-32-chars!!");
+        builder.UseSetting("Auth:JwtIssuer", "dotbot-test");
+        builder.UseSetting("Auth:JwtAudience", "dotbot-test");
 
         builder.ConfigureServices(services =>
         {

--- a/server/tests/Dotbot.Server.Tests/Integration/IntegrationTestBase.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/IntegrationTestBase.cs
@@ -1,0 +1,26 @@
+using Dotbot.Server.Tests.Integration.TestDoubles;
+
+namespace Dotbot.Server.Tests.Integration;
+
+public abstract class IntegrationTestBase : IClassFixture<TemplatesApiFactory>, IAsyncLifetime
+{
+    protected HttpClient Client { get; }
+    protected InMemoryTemplateStorage Storage { get; }
+
+    protected IntegrationTestBase(TemplatesApiFactory factory)
+    {
+        Client = factory.CreateClient();
+        Client.DefaultRequestHeaders.Add("X-Api-Key", TemplatesApiFactory.TestApiKey);
+        Storage = factory.Storage;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await Storage.ResetAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await Task.CompletedTask;
+    }
+}

--- a/server/tests/Dotbot.Server.Tests/Integration/IntegrationTestBase.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/IntegrationTestBase.cs
@@ -2,15 +2,15 @@ using Dotbot.Server.Tests.Integration.TestDoubles;
 
 namespace Dotbot.Server.Tests.Integration;
 
-public abstract class IntegrationTestBase : IClassFixture<TemplatesApiFactory>, IAsyncLifetime
+public abstract class IntegrationTestBase : IClassFixture<DotbotApiFactory>, IAsyncLifetime
 {
     protected HttpClient Client { get; }
     protected InMemoryTemplateStorage Storage { get; }
 
-    protected IntegrationTestBase(TemplatesApiFactory factory)
+    protected IntegrationTestBase(DotbotApiFactory factory)
     {
         Client = factory.CreateClient();
-        Client.DefaultRequestHeaders.Add("X-Api-Key", TemplatesApiFactory.TestApiKey);
+        Client.DefaultRequestHeaders.Add("X-Api-Key", DotbotApiFactory.TestApiKey);
         Storage = factory.Storage;
     }
 

--- a/server/tests/Dotbot.Server.Tests/Integration/IntegrationTestBase.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/IntegrationTestBase.cs
@@ -19,8 +19,5 @@ public abstract class IntegrationTestBase : IClassFixture<DotbotApiFactory>, IAs
         await Storage.ResetAsync();
     }
 
-    public async Task DisposeAsync()
-    {
-        await Task.CompletedTask;
-    }
+    public Task DisposeAsync() => Task.CompletedTask;
 }

--- a/server/tests/Dotbot.Server.Tests/Integration/PostTemplatesTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/PostTemplatesTests.cs
@@ -1,4 +1,5 @@
 using Dotbot.Server.Models;
+using Dotbot.Server.Tests.Integration.TestDoubles;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text;

--- a/server/tests/Dotbot.Server.Tests/Integration/PostTemplatesTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/PostTemplatesTests.cs
@@ -1,5 +1,4 @@
 using Dotbot.Server.Models;
-using Dotbot.Server.Tests.Integration.TestDoubles;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text;
@@ -7,19 +6,11 @@ using System.Text.Json;
 
 namespace Dotbot.Server.Tests.Integration;
 
-public class PostTemplatesTests : IClassFixture<TemplatesApiFactory>
+public class PostTemplatesTests : IntegrationTestBase
 {
     private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
 
-    private readonly HttpClient _client;
-    private readonly InMemoryTemplateStorage _storage;
-
-    public PostTemplatesTests(TemplatesApiFactory factory)
-    {
-        _client = factory.CreateClient();
-        _client.DefaultRequestHeaders.Add("X-Api-Key", TemplatesApiFactory.TestApiKey);
-        _storage = factory.Storage;
-    }
+    public PostTemplatesTests(TemplatesApiFactory factory) : base(factory) { }
 
     // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -63,10 +54,10 @@ public class PostTemplatesTests : IClassFixture<TemplatesApiFactory>
     {
         var template = ValidSingleChoice();
 
-        var response = await _client.PostAsync("/api/templates", Json(template));
+        var response = await Client.PostAsync("/api/templates", Json(template));
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        Assert.Single(_storage.Saved, t => t.QuestionId == template.QuestionId);
+        Assert.Single(Storage.Saved, t => t.QuestionId == template.QuestionId);
         var location = response.Headers.Location?.ToString();
         Assert.NotNull(location);
         Assert.Contains(template.QuestionId.ToString(), location);
@@ -77,10 +68,10 @@ public class PostTemplatesTests : IClassFixture<TemplatesApiFactory>
     {
         var template = ValidApproval();
 
-        var response = await _client.PostAsync("/api/templates", Json(template));
+        var response = await Client.PostAsync("/api/templates", Json(template));
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        Assert.Single(_storage.Saved, t => t.QuestionId == template.QuestionId);
+        Assert.Single(Storage.Saved, t => t.QuestionId == template.QuestionId);
         var location = response.Headers.Location?.ToString();
         Assert.NotNull(location);
         Assert.Contains(template.QuestionId.ToString(), location);
@@ -100,7 +91,7 @@ public class PostTemplatesTests : IClassFixture<TemplatesApiFactory>
             project = new { projectId = "" },
         };
 
-        var response = await _client.PostAsync("/api/templates", Json(payload));
+        var response = await Client.PostAsync("/api/templates", Json(payload));
         var body = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOpts);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -116,7 +107,7 @@ public class PostTemplatesTests : IClassFixture<TemplatesApiFactory>
     {
         var content = new StringContent("{ not valid json }", Encoding.UTF8, "application/json");
 
-        var response = await _client.PostAsync("/api/templates", content);
+        var response = await Client.PostAsync("/api/templates", content);
         var body = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOpts);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -138,7 +129,7 @@ public class PostTemplatesTests : IClassFixture<TemplatesApiFactory>
             project = (object?)null,
         };
 
-        var response = await _client.PostAsync("/api/templates", Json(payload));
+        var response = await Client.PostAsync("/api/templates", Json(payload));
         var body = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOpts);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -159,7 +150,7 @@ public class PostTemplatesTests : IClassFixture<TemplatesApiFactory>
             new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "file.pdf", BlobPath = blobPath }
         ];
 
-        var response = await _client.PostAsync("/api/templates", Json(template));
+        var response = await Client.PostAsync("/api/templates", Json(template));
         var body = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOpts);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -180,7 +171,7 @@ public class PostTemplatesTests : IClassFixture<TemplatesApiFactory>
             new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "file.pdf", Url = unsafeUrl }
         ];
 
-        var response = await _client.PostAsync("/api/templates", Json(template));
+        var response = await Client.PostAsync("/api/templates", Json(template));
         var body = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOpts);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -200,7 +191,7 @@ public class PostTemplatesTests : IClassFixture<TemplatesApiFactory>
             })
             .ToList();
 
-        var response = await _client.PostAsync("/api/templates", Json(template));
+        var response = await Client.PostAsync("/api/templates", Json(template));
         var body = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOpts);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -215,7 +206,7 @@ public class PostTemplatesTests : IClassFixture<TemplatesApiFactory>
             .Select(i => new ReferenceLink { Label = $"link{i}", Url = "https://docs.example.com/link" })
             .ToList();
 
-        var response = await _client.PostAsync("/api/templates", Json(template));
+        var response = await Client.PostAsync("/api/templates", Json(template));
         var body = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOpts);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);

--- a/server/tests/Dotbot.Server.Tests/Integration/PostTemplatesTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/PostTemplatesTests.cs
@@ -96,10 +96,10 @@ public class PostTemplatesTests : IntegrationTestBase
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         Assert.NotNull(body?.Errors);
-        Assert.Equal(3, body.Errors.Length);
         Assert.Contains(body.Errors, e => e.Contains("questionId"));
         Assert.Contains(body.Errors, e => e.Contains("project.projectId"));
         Assert.Contains(body.Errors, e => e.Contains("bogus"));
+        Assert.Equal(body.Errors.Length, body.Errors.Distinct().Count());
     }
 
     [Fact]
@@ -182,7 +182,7 @@ public class PostTemplatesTests : IntegrationTestBase
     public async Task AttachmentsOverCap_Returns400()
     {
         var template = ValidSingleChoice();
-        template.Attachments = Enumerable.Range(0, QuestionTemplateValidationSettings.DefaultMaxAttachments + 1)
+        template.Attachments = Enumerable.Range(0, DotbotApiFactory.TestMaxAttachments + 1)
             .Select(i => new QuestionAttachment
             {
                 AttachmentId = Guid.NewGuid(),
@@ -202,7 +202,7 @@ public class PostTemplatesTests : IntegrationTestBase
     public async Task ReferenceLinksOverCap_Returns400()
     {
         var template = ValidSingleChoice();
-        template.ReferenceLinks = Enumerable.Range(0, QuestionTemplateValidationSettings.DefaultMaxReferenceLinks + 1)
+        template.ReferenceLinks = Enumerable.Range(0, DotbotApiFactory.TestMaxReferenceLinks + 1)
             .Select(i => new ReferenceLink { Label = $"link{i}", Url = "https://docs.example.com/link" })
             .ToList();
 

--- a/server/tests/Dotbot.Server.Tests/Integration/PostTemplatesTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/PostTemplatesTests.cs
@@ -10,7 +10,7 @@ public class PostTemplatesTests : IntegrationTestBase
 {
     private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
 
-    public PostTemplatesTests(TemplatesApiFactory factory) : base(factory) { }
+    public PostTemplatesTests(DotbotApiFactory factory) : base(factory) { }
 
     // ── Helpers ──────────────────────────────────────────────────────────────
 

--- a/server/tests/Dotbot.Server.Tests/Integration/PostTemplatesTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/PostTemplatesTests.cs
@@ -1,0 +1,231 @@
+using Dotbot.Server.Models;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+namespace Dotbot.Server.Tests.Integration;
+
+public class PostTemplatesTests : IClassFixture<TemplatesApiFactory>
+{
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    private readonly HttpClient _client;
+    private readonly InMemoryTemplateStorage _storage;
+
+    public PostTemplatesTests(TemplatesApiFactory factory)
+    {
+        _client = factory.CreateClient();
+        _client.DefaultRequestHeaders.Add("X-Api-Key", TemplatesApiFactory.TestApiKey);
+        _storage = factory.Storage;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static QuestionTemplate ValidSingleChoice() => new()
+    {
+        QuestionId = Guid.NewGuid(),
+        Version = 1,
+        Title = "Which approach?",
+        Type = QuestionTypes.SingleChoice,
+        Options = [],
+        Project = new ProjectRef { ProjectId = "proj-123" },
+    };
+
+    private static QuestionTemplate ValidApproval() => new()
+    {
+        QuestionId = Guid.NewGuid(),
+        Version = 1,
+        Title = "Approve the deliverable?",
+        Type = QuestionTypes.Approval,
+        DeliverableSummary = "Implementation complete per spec.",
+        Options = [],
+        Project = new ProjectRef { ProjectId = "proj-456" },
+        Attachments =
+        [
+            new QuestionAttachment
+            {
+                AttachmentId = Guid.NewGuid(),
+                Name = "spec.pdf",
+                Url = "https://docs.example.com/spec.pdf",
+            }
+        ],
+    };
+
+    private static StringContent Json(object payload) =>
+        new(JsonSerializer.Serialize(payload, JsonOpts), Encoding.UTF8, "application/json");
+
+    // ── Scenarios ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ValidSingleChoice_Returns201AndPersists()
+    {
+        var template = ValidSingleChoice();
+
+        var response = await _client.PostAsync("/api/templates", Json(template));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.Single(_storage.Saved, t => t.QuestionId == template.QuestionId);
+        var location = response.Headers.Location?.ToString();
+        Assert.NotNull(location);
+        Assert.Contains(template.QuestionId.ToString(), location);
+    }
+
+    [Fact]
+    public async Task ValidApprovalWithAttachment_Returns201AndPersists()
+    {
+        var template = ValidApproval();
+
+        var response = await _client.PostAsync("/api/templates", Json(template));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.Single(_storage.Saved, t => t.QuestionId == template.QuestionId);
+        var location = response.Headers.Location?.ToString();
+        Assert.NotNull(location);
+        Assert.Contains(template.QuestionId.ToString(), location);
+    }
+
+    [Fact]
+    public async Task MultiFieldInvalidPayload_Returns400WithAllViolations()
+    {
+        // Exactly three violations: empty questionId, empty projectId, unknown type.
+        var payload = new
+        {
+            questionId = Guid.Empty,
+            version = 1,
+            title = "t",
+            type = "bogus",
+            options = Array.Empty<object>(),
+            project = new { projectId = "" },
+        };
+
+        var response = await _client.PostAsync("/api/templates", Json(payload));
+        var body = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOpts);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.NotNull(body?.Errors);
+        Assert.Equal(3, body.Errors.Length);
+        Assert.Contains(body.Errors, e => e.Contains("questionId"));
+        Assert.Contains(body.Errors, e => e.Contains("project.projectId"));
+        Assert.Contains(body.Errors, e => e.Contains("bogus"));
+    }
+
+    [Fact]
+    public async Task MalformedJson_Returns400()
+    {
+        var content = new StringContent("{ not valid json }", Encoding.UTF8, "application/json");
+
+        var response = await _client.PostAsync("/api/templates", content);
+        var body = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOpts);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.NotNull(body?.Error);
+        Assert.NotNull(body?.Errors);
+    }
+
+    [Fact]
+    public async Task NullProject_Returns400()
+    {
+        // Regression: validator must not throw NRE when project is null (commit 7aac214).
+        var payload = new
+        {
+            questionId = Guid.NewGuid(),
+            version = 1,
+            title = "t",
+            type = QuestionTypes.SingleChoice,
+            options = Array.Empty<object>(),
+            project = (object?)null,
+        };
+
+        var response = await _client.PostAsync("/api/templates", Json(payload));
+        var body = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOpts);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.NotNull(body?.Error);
+        Assert.Contains(body.Errors ?? [], e => e.Contains("project.projectId"));
+    }
+
+    [Theory]
+    [InlineData("projects/../secrets/config")]
+    [InlineData("./relative/path")]
+    [InlineData("/absolute/path")]
+    [InlineData("path\\with\\backslash")]
+    public async Task BlobPathTraversal_Returns400(string blobPath)
+    {
+        var template = ValidSingleChoice();
+        template.Attachments =
+        [
+            new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "file.pdf", BlobPath = blobPath }
+        ];
+
+        var response = await _client.PostAsync("/api/templates", Json(template));
+        var body = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOpts);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains(body?.Errors ?? [], e => e.Contains("blobPath"));
+    }
+
+    [Theory]
+    [InlineData("http://example.com/doc")]          // non-HTTPS scheme
+    [InlineData("https://user:pass@example.com/")]  // UserInfo present
+    [InlineData("https://127.0.0.1/doc")]            // loopback IP
+    [InlineData("https://localhost/doc")]             // loopback hostname
+    [InlineData("https://169.254.169.254/metadata")] // link-local / IMDS
+    public async Task UnsafeAttachmentUrl_Returns400(string unsafeUrl)
+    {
+        var template = ValidSingleChoice();
+        template.Attachments =
+        [
+            new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "file.pdf", Url = unsafeUrl }
+        ];
+
+        var response = await _client.PostAsync("/api/templates", Json(template));
+        var body = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOpts);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains(body?.Errors ?? [], e => e.Contains("url"));
+    }
+
+    [Fact]
+    public async Task AttachmentsOverCap_Returns400()
+    {
+        var template = ValidSingleChoice();
+        template.Attachments = Enumerable.Range(0, QuestionTemplateValidationSettings.DefaultMaxAttachments + 1)
+            .Select(i => new QuestionAttachment
+            {
+                AttachmentId = Guid.NewGuid(),
+                Name = $"doc{i}.pdf",
+                Url = "https://docs.example.com/doc.pdf",
+            })
+            .ToList();
+
+        var response = await _client.PostAsync("/api/templates", Json(template));
+        var body = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOpts);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains(body?.Errors ?? [], e => e.Contains("attachments"));
+    }
+
+    [Fact]
+    public async Task ReferenceLinksOverCap_Returns400()
+    {
+        var template = ValidSingleChoice();
+        template.ReferenceLinks = Enumerable.Range(0, QuestionTemplateValidationSettings.DefaultMaxReferenceLinks + 1)
+            .Select(i => new ReferenceLink { Label = $"link{i}", Url = "https://docs.example.com/link" })
+            .ToList();
+
+        var response = await _client.PostAsync("/api/templates", Json(template));
+        var body = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOpts);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains(body?.Errors ?? [], e => e.Contains("referenceLinks"));
+    }
+
+    // ── Response shape ───────────────────────────────────────────────────────
+
+    private sealed class ErrorResponse
+    {
+        public string? Error { get; set; }
+        public string[]? Errors { get; set; }
+    }
+}

--- a/server/tests/Dotbot.Server.Tests/Integration/PostTemplatesTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/PostTemplatesTests.cs
@@ -80,7 +80,9 @@ public class PostTemplatesTests : IntegrationTestBase
     [Fact]
     public async Task MultiFieldInvalidPayload_Returns400WithAllViolations()
     {
-        // Exactly three violations: empty questionId, empty projectId, unknown type.
+        // Payload triggers at least three known violations: empty questionId, empty projectId,
+        // unknown type. Assertions check those are present and that returned errors are unique;
+        // exact count is intentionally not asserted so new validator rules don't break this test.
         var payload = new
         {
             questionId = Guid.Empty,

--- a/server/tests/Dotbot.Server.Tests/Integration/TemplatesApiFactory.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/TemplatesApiFactory.cs
@@ -35,15 +35,18 @@ public sealed class TemplatesApiFactory : WebApplicationFactory<Program>
 
         builder.ConfigureServices(services =>
         {
-            // M365 Agents SDK's HostedTaskService.StopAsync recursively acquires a
-            // ReaderWriterLockSlim write lock during host shutdown, which throws
-            // LockRecursionException on Linux. The agent runtime is not exercised by
-            // these HTTP tests, so drop the hosted service before the host runs.
-            var hostedTaskDescriptors = services
+            // M365 Agents SDK's BackgroundQueue hosted services (HostedTaskService,
+            // HostedActivityService) recursively acquire a ReaderWriterLockSlim write
+            // lock during host shutdown, throwing LockRecursionException on Linux/macOS.
+            // The agent runtime is not exercised by these HTTP tests, so drop the
+            // hosted services before the host runs.
+            var backgroundQueueDescriptors = services
                 .Where(d => d.ServiceType == typeof(IHostedService)
-                    && (d.ImplementationType?.FullName?.Contains("HostedTaskService", StringComparison.Ordinal) ?? false))
+                    && (d.ImplementationType?.FullName?.StartsWith(
+                        "Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue.",
+                        StringComparison.Ordinal) ?? false))
                 .ToList();
-            foreach (var descriptor in hostedTaskDescriptors)
+            foreach (var descriptor in backgroundQueueDescriptors)
                 services.Remove(descriptor);
 
             // Replace the three DI-blocking services with in-process test doubles.

--- a/server/tests/Dotbot.Server.Tests/Integration/TemplatesApiFactory.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/TemplatesApiFactory.cs
@@ -1,6 +1,5 @@
-using Dotbot.Server.Models;
 using Dotbot.Server.Services;
-using Microsoft.Agents.Core.Models;
+using Dotbot.Server.Tests.Integration.TestDoubles;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
@@ -59,36 +58,4 @@ public sealed class TemplatesApiFactory : WebApplicationFactory<Program>
             services.AddSingleton<IConversationReferenceStore>(new NullConversationReferenceStore());
         });
     }
-}
-
-public sealed class InMemoryTemplateStorage : ITemplateStorageService
-{
-    private readonly List<QuestionTemplate> _saved = [];
-
-    public IReadOnlyList<QuestionTemplate> Saved => _saved;
-
-    public Task SaveTemplateAsync(QuestionTemplate template)
-    {
-        _saved.Add(template);
-        return Task.CompletedTask;
-    }
-
-    public Task<QuestionTemplate?> GetTemplateAsync(string projectId, Guid questionId, int version)
-        => Task.FromResult(_saved.FirstOrDefault(x =>
-            x.Project.ProjectId == projectId
-            && x.QuestionId == questionId
-            && x.Version == version));
-}
-
-internal sealed class NullAdministratorService : IAdministratorService
-{
-    public Task SeedIfEmptyAsync() => Task.CompletedTask;
-    public Task<bool> IsAdministratorAsync(string email) => Task.FromResult(false);
-}
-
-internal sealed class NullConversationReferenceStore : IConversationReferenceStore
-{
-    public Task LoadAsync() => Task.CompletedTask;
-    public void AddOrUpdate(string userObjectId, ConversationReference reference) { }
-    public ConversationReference? Get(string userObjectId) => null;
 }

--- a/server/tests/Dotbot.Server.Tests/Integration/TemplatesApiFactory.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/TemplatesApiFactory.cs
@@ -3,6 +3,7 @@ using Dotbot.Server.Services;
 using Microsoft.Agents.Core.Models;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -16,14 +17,20 @@ public sealed class TemplatesApiFactory : WebApplicationFactory<Program>
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
-        // Provide minimum required configuration so the host boots without Azure resources.
-        builder.UseSetting("BlobStorage:ConnectionString", "UseDevelopmentStorage=true");
-        builder.UseSetting("ApiSecurity:ApiKey", TestApiKey);
-
-        // Stub required Auth config so JwtSigningKeyProvider and MagicLinkService don't fail to resolve.
-        builder.UseSetting("Auth:JwtSigningKey", "integration-test-signing-key-32-chars!!");
-        builder.UseSetting("Auth:JwtIssuer", "dotbot-test");
-        builder.UseSetting("Auth:JwtAudience", "dotbot-test");
+        // ConfigureAppConfiguration is guaranteed to run before the host builds its service
+        // container, so these values are visible to Program.cs and all middleware constructors
+        // regardless of ASPNETCORE_ENVIRONMENT (appsettings.Development.json is not loaded on CI).
+        builder.ConfigureAppConfiguration(config =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["BlobStorage:ConnectionString"] = "UseDevelopmentStorage=true",
+                ["ApiSecurity:ApiKey"] = TestApiKey,
+                ["Auth:JwtSigningKey"] = "integration-test-signing-key-32-chars!!",
+                ["Auth:JwtIssuer"] = "dotbot-test",
+                ["Auth:JwtAudience"] = "dotbot-test",
+            });
+        });
 
         builder.ConfigureServices(services =>
         {

--- a/server/tests/Dotbot.Server.Tests/Integration/TemplatesApiFactory.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/TemplatesApiFactory.cs
@@ -1,0 +1,72 @@
+using Dotbot.Server.Models;
+using Dotbot.Server.Services;
+using Microsoft.Agents.Core.Models;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Dotbot.Server.Tests.Integration;
+
+public sealed class TemplatesApiFactory : WebApplicationFactory<Program>
+{
+    internal const string TestApiKey = "integration-test-key-abc123";
+
+    public InMemoryTemplateStorage Storage { get; } = new();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        // Provide minimum required configuration so the host boots without Azure resources.
+        builder.UseSetting("BlobStorage:ConnectionString", "UseDevelopmentStorage=true");
+        builder.UseSetting("ApiSecurity:ApiKey", TestApiKey);
+
+        // Stub required Auth config so JwtSigningKeyProvider and MagicLinkService don't fail to resolve.
+        builder.UseSetting("Auth:JwtSigningKey", "integration-test-signing-key-32-chars!!");
+        builder.UseSetting("Auth:JwtIssuer", "dotbot-test");
+        builder.UseSetting("Auth:JwtAudience", "dotbot-test");
+
+        builder.ConfigureServices(services =>
+        {
+            // Replace the three DI-blocking services with in-process test doubles.
+            services.RemoveAll<ITemplateStorageService>();
+            services.RemoveAll<IAdministratorService>();
+            services.RemoveAll<IConversationReferenceStore>();
+
+            services.AddSingleton<ITemplateStorageService>(Storage);
+            services.AddSingleton<IAdministratorService>(new NullAdministratorService());
+            services.AddSingleton<IConversationReferenceStore>(new NullConversationReferenceStore());
+        });
+    }
+}
+
+public sealed class InMemoryTemplateStorage : ITemplateStorageService
+{
+    private readonly List<QuestionTemplate> _saved = [];
+
+    public IReadOnlyList<QuestionTemplate> Saved => _saved;
+
+    public Task SaveTemplateAsync(QuestionTemplate template)
+    {
+        _saved.Add(template);
+        return Task.CompletedTask;
+    }
+
+    public Task<QuestionTemplate?> GetTemplateAsync(string projectId, Guid questionId, int version)
+        => Task.FromResult(_saved.FirstOrDefault(x =>
+            x.Project.ProjectId == projectId
+            && x.QuestionId == questionId
+            && x.Version == version));
+}
+
+internal sealed class NullAdministratorService : IAdministratorService
+{
+    public Task SeedIfEmptyAsync() => Task.CompletedTask;
+    public Task<bool> IsAdministratorAsync(string email) => Task.FromResult(false);
+}
+
+internal sealed class NullConversationReferenceStore : IConversationReferenceStore
+{
+    public Task LoadAsync() => Task.CompletedTask;
+    public void AddOrUpdate(string userObjectId, ConversationReference reference) { }
+    public ConversationReference? Get(string userObjectId) => null;
+}

--- a/server/tests/Dotbot.Server.Tests/Integration/TemplatesApiFactory.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/TemplatesApiFactory.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 
 namespace Dotbot.Server.Tests.Integration;
 
@@ -34,6 +35,17 @@ public sealed class TemplatesApiFactory : WebApplicationFactory<Program>
 
         builder.ConfigureServices(services =>
         {
+            // M365 Agents SDK's HostedTaskService.StopAsync recursively acquires a
+            // ReaderWriterLockSlim write lock during host shutdown, which throws
+            // LockRecursionException on Linux. The agent runtime is not exercised by
+            // these HTTP tests, so drop the hosted service before the host runs.
+            var hostedTaskDescriptors = services
+                .Where(d => d.ServiceType == typeof(IHostedService)
+                    && (d.ImplementationType?.FullName?.Contains("HostedTaskService", StringComparison.Ordinal) ?? false))
+                .ToList();
+            foreach (var descriptor in hostedTaskDescriptors)
+                services.Remove(descriptor);
+
             // Replace the three DI-blocking services with in-process test doubles.
             services.RemoveAll<ITemplateStorageService>();
             services.RemoveAll<IAdministratorService>();

--- a/server/tests/Dotbot.Server.Tests/Integration/TestDoubles/InMemoryTemplateStorage.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/TestDoubles/InMemoryTemplateStorage.cs
@@ -1,0 +1,23 @@
+using Dotbot.Server.Models;
+using Dotbot.Server.Services;
+
+namespace Dotbot.Server.Tests.Integration.TestDoubles;
+
+public sealed class InMemoryTemplateStorage : ITemplateStorageService
+{
+    private readonly List<QuestionTemplate> _saved = [];
+
+    public IReadOnlyList<QuestionTemplate> Saved => _saved;
+
+    public Task SaveTemplateAsync(QuestionTemplate template)
+    {
+        _saved.Add(template);
+        return Task.CompletedTask;
+    }
+
+    public Task<QuestionTemplate?> GetTemplateAsync(string projectId, Guid questionId, int version)
+        => Task.FromResult(_saved.FirstOrDefault(x =>
+            x.Project.ProjectId == projectId
+            && x.QuestionId == questionId
+            && x.Version == version));
+}

--- a/server/tests/Dotbot.Server.Tests/Integration/TestDoubles/InMemoryTemplateStorage.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/TestDoubles/InMemoryTemplateStorage.cs
@@ -9,6 +9,12 @@ public sealed class InMemoryTemplateStorage : ITemplateStorageService
 
     public IReadOnlyList<QuestionTemplate> Saved => _saved;
 
+    public Task ResetAsync()
+    {
+        _saved.Clear();
+        return Task.CompletedTask;
+    }
+
     public Task SaveTemplateAsync(QuestionTemplate template)
     {
         _saved.Add(template);

--- a/server/tests/Dotbot.Server.Tests/Integration/TestDoubles/NullAdministratorService.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/TestDoubles/NullAdministratorService.cs
@@ -1,0 +1,9 @@
+using Dotbot.Server.Services;
+
+namespace Dotbot.Server.Tests.Integration.TestDoubles;
+
+internal sealed class NullAdministratorService : IAdministratorService
+{
+    public Task SeedIfEmptyAsync() => Task.CompletedTask;
+    public Task<bool> IsAdministratorAsync(string email) => Task.FromResult(false);
+}

--- a/server/tests/Dotbot.Server.Tests/Integration/TestDoubles/NullConversationReferenceStore.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/TestDoubles/NullConversationReferenceStore.cs
@@ -1,0 +1,11 @@
+using Dotbot.Server.Services;
+using Microsoft.Agents.Core.Models;
+
+namespace Dotbot.Server.Tests.Integration.TestDoubles;
+
+internal sealed class NullConversationReferenceStore : IConversationReferenceStore
+{
+    public Task LoadAsync() => Task.CompletedTask;
+    public void AddOrUpdate(string userObjectId, ConversationReference reference) { }
+    public ConversationReference? Get(string userObjectId) => null;
+}


### PR DESCRIPTION
## Linked issue

Closes #395

## Summary of changes

Three concrete services (`TemplateStorageService`, `AdministratorService`, `ConversationReferenceStore`) were registered directly in DI with no interface, making it impossible to substitute them in a test host. `WebApplicationFactory` can only override registrations by key type — without interfaces, real Azure Blob SDK calls ran during test host startup and failed.

**Production changes (no behaviour change):**
- Extract `ITemplateStorageService`, `IAdministratorService`, `IConversationReferenceStore` interfaces
- Update DI registrations to `AddSingleton<IXxx, ConcreteXxx>()`
- Update all call sites: `Program.cs` (registrations, startup calls, 4 handler signatures), `DotbotAgent`, `TeamsDeliveryProvider`, `DashboardAuthMiddleware`, `ReminderEscalationService`, `Respond.cshtml.cs`
- Add `public partial class Program {}` so `WebApplicationFactory<Program>` can reference the top-level entry point

**Tests added:**
- `TemplatesApiFactory` — `WebApplicationFactory<Program>` subclass with 3 hand-written fakes (`InMemoryTemplateStorage`, `NullAdministratorService`, `NullConversationReferenceStore`) and minimum required config to boot without Azure
- `PostTemplatesTests` — 16 xUnit tests (8 scenarios × theory rows) covering all scenarios from the issue

## Testing notes

```bash
# Integration tests only
dotnet test server/dotbot.sln --filter "FullyQualifiedName~Integration"
# Passed: 16

# Full suite
dotnet test server/dotbot.sln
# Passed: 171, Failed: 0
```
## Checklist

- [x] Tests added or updated
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
