### PR TITLE
fix(runtime): task worktrees always branch from main, not current HEAD (#317)

### DIFF
--- a/core/runtime/modules/WorktreeManager.psm1
+++ b/core/runtime/modules/WorktreeManager.psm1
@@ -89,19 +89,6 @@ function Invoke-Git {
     @($output | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] })
 }
 
-function Get-BaseBranch {
-    param([string]$ProjectRoot)
-    $branch = Invoke-Git -Arguments @('symbolic-ref', '--short', 'HEAD') -WorkingDirectory $ProjectRoot -SilentFail
-    if ($branch) {
-        $verify = Invoke-Git -Arguments @('rev-parse', '--verify', $branch.Trim()) -WorkingDirectory $ProjectRoot -SilentFail
-        if ($verify) { return $branch.Trim() }
-    }
-    foreach ($candidate in @('main', 'master')) {
-        $verify = Invoke-Git -Arguments @('rev-parse', '--verify', $candidate) -WorkingDirectory $ProjectRoot -SilentFail
-        if ($verify) { return $candidate }
-    }
-    return $null
-}
 
 function Initialize-WorktreeMap {
     param([string]$BotRoot)
@@ -497,8 +484,8 @@ function New-TaskWorktree {
     }
 
     try {
-        # Create branch from the repo's current branch and check it out in the worktree
-        $baseBranch = Get-BaseBranch -ProjectRoot $ProjectRoot
+        # Always branch from the canonical integration branch, not whatever HEAD happens to be checked out
+        $baseBranch = Resolve-MainBranch -ProjectRoot $ProjectRoot
         if (-not $baseBranch) {
             throw "Cannot create worktree: repository has no commits. Make an initial commit first."
         }

--- a/core/runtime/modules/WorktreeManager.psm1
+++ b/core/runtime/modules/WorktreeManager.psm1
@@ -487,7 +487,7 @@ function New-TaskWorktree {
         # Always branch from the canonical integration branch, not whatever HEAD happens to be checked out
         $baseBranch = Resolve-MainBranch -ProjectRoot $ProjectRoot
         if (-not $baseBranch) {
-            throw "Cannot create worktree: repository has no commits. Make an initial commit first."
+            throw "Cannot create worktree: no 'main' or 'master' branch found in $ProjectRoot. The repository may be empty (make an initial commit) or use a non-standard integration branch name (rename it to 'main' or 'master')."
         }
         $output = git -C $ProjectRoot worktree add -b $branchName $worktreePath $baseBranch 2>&1
         if ($LASTEXITCODE -ne 0) {

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -133,6 +133,100 @@ if (Test-Path $worktreeManagerModule) {
     Assert-True -Name "Get-GitignoredCopyPaths excludes noise dir caches" `
         -Condition (-not ($gitignoredCopyPaths -contains ".idea/cache/index.json")) `
         -Message "Noise directory cache contents should stay excluded from worktree copies"
+
+    # Regression guard for #317: New-TaskWorktree must always fork task branches
+    # from the canonical integration branch (main/master), never from whatever
+    # HEAD happens to be checked out. Resolve-MainBranch is the choke point —
+    # it must look up branches by explicit name and never read HEAD.
+    $resolveMainRepo = New-TestProject -Prefix 'dotbot-test-resolve-main'
+    try {
+        Push-Location $resolveMainRepo
+        & git branch -M main 2>&1 | Out-Null
+        & git checkout -b feature/scratch-branch --quiet 2>&1 | Out-Null
+        "scratch" | Set-Content -Path (Join-Path $resolveMainRepo "scratch.txt")
+        & git add scratch.txt 2>&1 | Out-Null
+        & git commit -m "Scratch commit on feature branch only" --quiet 2>&1 | Out-Null
+        $headBranch = (& git rev-parse --abbrev-ref HEAD 2>$null).Trim()
+        Pop-Location
+
+        Assert-Equal -Name "Regression #317 precondition: HEAD is on feature branch" `
+            -Expected "feature/scratch-branch" `
+            -Actual $headBranch
+
+        $resolvedBase = Resolve-MainBranch -ProjectRoot $resolveMainRepo
+        Assert-Equal -Name "Resolve-MainBranch returns 'main' when HEAD is on a non-main branch (#317 regression)" `
+            -Expected "main" `
+            -Actual $resolvedBase
+        Assert-True -Name "Resolve-MainBranch never returns the checked-out feature branch (#317 regression)" `
+            -Condition ($resolvedBase -ne 'feature/scratch-branch') `
+            -Message "Resolve-MainBranch returned the feature branch — it must look up main/master by name, not read HEAD"
+
+        # When neither main nor master exists, Resolve-MainBranch must return $null
+        # rather than fall back to HEAD.
+        Push-Location $resolveMainRepo
+        & git branch -m main legacy-trunk 2>&1 | Out-Null
+        Pop-Location
+        $missingBase = Resolve-MainBranch -ProjectRoot $resolveMainRepo
+        Assert-True -Name "Resolve-MainBranch returns null when neither main nor master exists" `
+            -Condition ($null -eq $missingBase) `
+            -Message "Expected null when no main/master branch exists, got '$missingBase'"
+    } finally {
+        Remove-TestProject -Path $resolveMainRepo
+    }
+
+    Assert-True -Name "WorktreeManager has no Get-BaseBranch function (replaced by Resolve-MainBranch for #317)" `
+        -Condition (-not (Select-String -Path $worktreeManagerModule -Pattern 'function Get-BaseBranch' -Quiet)) `
+        -Message "Get-BaseBranch read HEAD and caused #317 — it must remain deleted"
+
+    # End-to-end regression for #317: drive New-TaskWorktree through its real code
+    # path (the same call site fixed in commit c491166). The unit test above pins
+    # Resolve-MainBranch's contract; this test pins the integration — that the
+    # task worktree's HEAD ends up at main's tip even when the source repo's HEAD
+    # is on an unrelated feature branch with its own commits.
+    $e2eProj = New-TestProjectFromGolden -Flavor 'default' -Prefix 'dotbot-test-worktree-fork'
+    $e2eRoot = $e2eProj.ProjectRoot
+    $e2eBot  = $e2eProj.BotDir
+    $e2eResult = $null
+    try {
+        Push-Location $e2eRoot
+        & git branch -M main 2>&1 | Out-Null
+        & git checkout -b feature/scratch-branch --quiet 2>&1 | Out-Null
+        "feature-only" | Set-Content -Path (Join-Path $e2eRoot "scratch-feature-only.txt")
+        & git add scratch-feature-only.txt 2>&1 | Out-Null
+        & git commit -m "Commit only on feature branch" --quiet 2>&1 | Out-Null
+        $mainSha = (& git rev-parse main 2>$null).Trim()
+        $featureSha = (& git rev-parse HEAD 2>$null).Trim()
+        Pop-Location
+
+        Assert-True -Name "E2E #317 precondition: main and feature SHAs differ" `
+            -Condition ($mainSha -and $featureSha -and ($mainSha -ne $featureSha)) `
+            -Message "Test setup did not diverge feature from main"
+
+        $e2eTaskId = "deadbeef-1234-5678-9012-abcdef012345"
+        $e2eResult = New-TaskWorktree -TaskId $e2eTaskId -TaskName "regression-317" `
+                                      -ProjectRoot $e2eRoot -BotRoot $e2eBot
+
+        Assert-True -Name "E2E #317: New-TaskWorktree returns success" `
+            -Condition ($null -ne $e2eResult -and $e2eResult.success -eq $true) `
+            -Message "Expected New-TaskWorktree.success=true, got: $($e2eResult | ConvertTo-Json -Compress)"
+
+        if ($e2eResult -and $e2eResult.success -and $e2eResult.worktree_path -and (Test-Path $e2eResult.worktree_path)) {
+            $wtSha = (& git -C $e2eResult.worktree_path rev-parse HEAD 2>$null).Trim()
+            Assert-Equal -Name "E2E #317: task worktree HEAD == main's tip (forked from main)" `
+                -Expected $mainSha -Actual $wtSha
+            Assert-True -Name "E2E #317: feature-only file absent in task worktree" `
+                -Condition (-not (Test-Path (Join-Path $e2eResult.worktree_path "scratch-feature-only.txt"))) `
+                -Message "Worktree contains feature-branch-only file → task branch forked from feature, not main"
+        }
+    } finally {
+        if ($e2eResult -and $e2eResult.worktree_path -and (Test-Path $e2eResult.worktree_path)) {
+            & git -C $e2eRoot worktree remove -f $e2eResult.worktree_path 2>&1 | Out-Null
+        }
+        if ($e2eResult -and $e2eResult.branch_name) {
+            & git -C $e2eRoot branch -D $e2eResult.branch_name 2>&1 | Out-Null
+        }
+        Remove-TestProject -Path $e2eRoot
+    }
 } else {
     Write-TestResult -Name "WorktreeManager module exists" -Status Fail -Message "Module not found at $worktreeManagerModule"
 }


### PR DESCRIPTION
## Summary

- `New-TaskWorktree` was calling `Get-BaseBranch` which returned whatever branch the main repo had checked out at task start time, not the canonical integration branch
- If the repo was on a feature/scratch branch, the new task worktree inherited all unrelated commits from that branch — and those could silently land on `main` after squash-merge
- Fix: replace `Get-BaseBranch` with `Resolve-MainBranch`, which looks up `main`/`master` by explicit name and never reads HEAD
- Remove `Get-BaseBranch` entirely — it had one call site (now replaced) and its name implied correctness it didn't have

## Test plan

- [ ] All tests pass (layers 1-3 verified locally)
- [ ] With main repo checked out on a non-main branch, new task worktrees correctly fork from `main`
- [ ] `Get-BaseBranch` no longer exists in codebase

Closes #317