### PR TITLE
fix(runtime): detect org/monthly usage limits and park to needs-input

### DIFF
--- a/core/runtime/ClaudeCLI/ClaudeCLI.psm1
+++ b/core/runtime/ClaudeCLI/ClaudeCLI.psm1
@@ -697,17 +697,17 @@ function Invoke-ClaudeStream {
             $line = $raw.TrimStart()
             if ($line.Length -eq 0) { return }
             
-            # Check for rate limit in JSON responses
-            if ($line[0] -eq '{' -and $line -match "hit your limit|error.*rate_limit") {
+            # Check for rate limit in JSON responses (#391: includes org/monthly quota wording)
+            if ($line[0] -eq '{' -and $line -match "hit your.*?limit|out of extra usage|error.*?rate_limit") {
                 try {
                     $jsonObj = $line | ConvertFrom-Json -ErrorAction Stop
                     # Extract the actual message text from JSON
                     $rateLimitText = $null
-                    if ($jsonObj.result -and $jsonObj.result -match "resets?") {
+                    if ($jsonObj.result -and $jsonObj.result -match "hit your|out of extra usage|resets?") {
                         $rateLimitText = $jsonObj.result
                     } elseif ($jsonObj.message?.content -is [System.Array]) {
                         foreach ($c in $jsonObj.message.content) {
-                            if ($c.type -eq "text" -and $c.text -match "resets?") {
+                            if ($c.type -eq "text" -and $c.text -match "hit your|out of extra usage|resets?") {
                                 $rateLimitText = $c.text
                                 break
                             }
@@ -733,7 +733,7 @@ function Invoke-ClaudeStream {
             }
             
             # Check for plain text rate limit messages
-            if ($line[0] -ne '{' -and $line -match "hit your limit|resets?\s+\d{1,2}:?\d*\s*(am|pm)") {
+            if ($line[0] -ne '{' -and $line -match "hit your.*?limit|out of extra usage|resets?\s+\d{1,2}:?\d*\s*(am|pm)") {
                 [Console]::Error.WriteLine("")
                 [Console]::Error.WriteLine("$($t.Amber)⚠ RATE LIMIT: $line$($t.Reset)")
                 [Console]::Error.Flush()

--- a/core/runtime/ProviderCLI/parsers/Parse-ClaudeStream.ps1
+++ b/core/runtime/ProviderCLI/parsers/Parse-ClaudeStream.ps1
@@ -28,15 +28,28 @@ function Process-StreamLine {
 
     $t = $State.theme
 
-    # Check for rate limit
-    if ($Line -match "hit your limit|error.*rate_limit") {
+    # Check for rate limit (#391: includes org/monthly quota wording)
+    if ($Line -match "hit your.*?limit|out of extra usage|error.*?rate_limit") {
         try {
             $jsonObj = $Line | ConvertFrom-Json -ErrorAction Stop
-            if ($jsonObj.error -eq "rate_limit" -or ($jsonObj.result -and $jsonObj.result -match "resets?")) {
-                $State.rateLimitMessage = if ($jsonObj.result) { $jsonObj.result } else { "Rate limit hit" }
-                [Console]::Error.WriteLine("$($t.Amber)Rate limit: $($State.rateLimitMessage)$($t.Reset)")
+            $rateLimitText = $null
+            if ($jsonObj.result -and $jsonObj.result -match "hit your|out of extra usage|resets?") {
+                $rateLimitText = $jsonObj.result
+            } elseif ($jsonObj.message?.content -is [System.Array]) {
+                foreach ($c in $jsonObj.message.content) {
+                    if ($c.type -eq "text" -and $c.text -match "hit your|out of extra usage|resets?") {
+                        $rateLimitText = $c.text
+                        break
+                    }
+                }
+            } elseif ($jsonObj.error -eq "rate_limit") {
+                $rateLimitText = "Rate limit hit"
+            }
+            if ($rateLimitText) {
+                $State.rateLimitMessage = $rateLimitText
+                [Console]::Error.WriteLine("$($t.Amber)Rate limit: $rateLimitText$($t.Reset)")
                 [Console]::Error.Flush()
-                Write-ActivityLog -Type "rate_limit" -Message $State.rateLimitMessage
+                Write-ActivityLog -Type "rate_limit" -Message $rateLimitText
                 return 'rate_limit'
             }
         } catch { Write-BotLog -Level Debug -Message "Failed to parse data" -Exception $_ }

--- a/core/runtime/modules/OrgQuotaEscalation.psm1
+++ b/core/runtime/modules/OrgQuotaEscalation.psm1
@@ -1,0 +1,92 @@
+<#
+.SYNOPSIS
+    Shared helper for parking a task in needs-input/ when the provider returns
+    a non-resettable org/monthly usage quota event (#391).
+
+.DESCRIPTION
+    The org-quota wording ("You've hit your org's monthly usage limit") is
+    classified as kind='org_quota' by Get-RateLimitClassification. Unlike a
+    transient rate-limit, waiting will not unblock the task — admin/billing
+    action is required. This helper consolidates the analyse-phase and
+    execute-phase escalation paths so both write the same pending_question
+    shape and surface the same source-of-truth.
+#>
+
+function Move-TaskToOrgQuotaNeedsInput {
+    <#
+    .SYNOPSIS
+    Move a task from $SourceDir to needs-input/ with a provider-org-quota
+    pending_question. Returns a result hashtable; never throws on file ops.
+
+    .PARAMETER SourceDir
+    Directory under $TasksBaseDir to look in. 'analysing' for the analyse
+    phase, 'in-progress' for the execute phase.
+
+    .PARAMETER WorktreePath
+    Optional. When supplied, the worktree path is appended to the
+    pending_question.context so the operator knows the worktree is retained.
+
+    .OUTPUTS
+    @{ success; new_path; source_status; reason }
+    success=$false sets reason and leaves files untouched.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string] $TaskId,
+        [Parameter(Mandatory)] [string] $TasksBaseDir,
+        [Parameter(Mandatory)] [ValidateSet('analysing', 'in-progress')] [string] $SourceDir,
+        [Parameter(Mandatory)] [string] $RateLimitMessage,
+        [string] $WorktreePath
+    )
+
+    $sourcePath = Join-Path $TasksBaseDir $SourceDir
+    if (-not (Test-Path -LiteralPath $sourcePath)) {
+        return @{ success = $false; new_path = $null; source_status = $null; reason = "Source dir missing: $sourcePath" }
+    }
+
+    $taskFile = Get-ChildItem -LiteralPath $sourcePath -Filter "*.json" -File -ErrorAction SilentlyContinue | Where-Object {
+        try { (Get-Content $_.FullName -Raw | ConvertFrom-Json).id -eq $TaskId } catch { $false }
+    } | Select-Object -First 1
+
+    if (-not $taskFile) {
+        return @{ success = $false; new_path = $null; source_status = $SourceDir; reason = "Task $TaskId not found in $SourceDir/" }
+    }
+
+    $needsInputDir = Join-Path $TasksBaseDir "needs-input"
+    if (-not (Test-Path -LiteralPath $needsInputDir)) {
+        New-Item -ItemType Directory -Force -Path $needsInputDir | Out-Null
+    }
+
+    $taskData = Get-Content $taskFile.FullName -Raw | ConvertFrom-Json
+    $nowIso = (Get-Date).ToUniversalTime().ToString("o")
+    $taskData | Add-Member -NotePropertyName status -NotePropertyValue 'needs-input' -Force
+    $taskData | Add-Member -NotePropertyName updated_at -NotePropertyValue $nowIso -Force
+
+    $context = "Provider quota: $RateLimitMessage"
+    if ($WorktreePath) { $context += ". Worktree retained at: $WorktreePath" }
+
+    $taskData | Add-Member -NotePropertyName pending_question -NotePropertyValue @{
+        id             = "provider-org-quota"
+        question       = "Provider org/monthly usage quota exhausted — admin or billing action required before resume"
+        context        = $context
+        options        = @(
+            @{ key = "A"; label = "Wait for quota and resume"; rationale = "Admin tops up the org or waits for the next billing cycle, then move the task back to todo" }
+            @{ key = "B"; label = "Skip this task"; rationale = "Mark the task skipped and continue once quota returns" }
+        )
+        recommendation = "A"
+        asked_at       = $nowIso
+    } -Force
+
+    $newPath = Join-Path $needsInputDir $taskFile.Name
+    $taskData | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $newPath -Encoding UTF8
+    try {
+        Remove-Item -LiteralPath $taskFile.FullName -Force -ErrorAction Stop
+    } catch {
+        Remove-Item -LiteralPath $newPath -Force -ErrorAction SilentlyContinue
+        return @{ success = $false; new_path = $null; source_status = $SourceDir; reason = "Failed to remove source file: $($_.Exception.Message)" }
+    }
+
+    return @{ success = $true; new_path = $newPath; source_status = $SourceDir; reason = $null }
+}
+
+Export-ModuleMember -Function 'Move-TaskToOrgQuotaNeedsInput'

--- a/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
+++ b/core/runtime/modules/ProcessTypes/Invoke-WorkflowProcess.ps1
@@ -453,6 +453,54 @@ An interview-summary.md file exists in .bot/workspace/product/ containing the us
     return $fileRefs + $interviewContext
 }
 
+# Imports OrgQuotaEscalation.psm1, calls Move-TaskToOrgQuotaNeedsInput, emits
+# the corresponding activity-log message, and returns the helper's result
+# hashtable (success/reason/source_status/new_path). File-move semantics live
+# in core/runtime/modules/OrgQuotaEscalation.psm1.
+function Invoke-OrgQuotaEscalationStep {
+    param(
+        [Parameter(Mandatory)] [object] $Task,
+        [Parameter(Mandatory)] [string] $TasksBaseDir,
+        [Parameter(Mandatory)] [ValidateSet('analysing', 'in-progress')] [string] $SourceDir,
+        [Parameter(Mandatory)] [string] $RateLimitMessage,
+        [Parameter(Mandatory)] [string] $ProcId,
+        [string] $WorktreePath
+    )
+
+    $escalationModule = Join-Path (Split-Path $PSScriptRoot -Parent) 'OrgQuotaEscalation.psm1'
+    if (-not (Test-Path -LiteralPath $escalationModule)) {
+        Write-ProcessActivity -Id $ProcId -ActivityType "text" -Message "Org-quota escalation helper missing at $escalationModule; task '$($Task.name)' left in $SourceDir/"
+        return @{ success = $false; reason = "Helper module not found" }
+    }
+
+    Import-Module $escalationModule -Force
+
+    $params = @{
+        TaskId            = $Task.id
+        TasksBaseDir      = $TasksBaseDir
+        SourceDir         = $SourceDir
+        RateLimitMessage  = $RateLimitMessage
+    }
+    if ($WorktreePath) { $params['WorktreePath'] = $WorktreePath }
+
+    try {
+        $result = Move-TaskToOrgQuotaNeedsInput @params
+    } catch {
+        Write-BotLog -Level Warn -Message "Org-quota escalation failed" -Exception $_
+        Write-ProcessActivity -Id $ProcId -ActivityType "text" -Message "Org-quota escalation threw for task '$($Task.name)': $($_.Exception.Message)"
+        return @{ success = $false; reason = $_.Exception.Message }
+    }
+
+    if ($result.success) {
+        $tail = if ($WorktreePath) { "; worktree retained at $WorktreePath" } else { "" }
+        Write-ProcessActivity -Id $ProcId -ActivityType "text" -Message "Task '$($Task.name)' parked in needs-input/ — provider org quota; admin/billing action required before resume$tail"
+    } else {
+        Write-ProcessActivity -Id $ProcId -ActivityType "text" -Message "Org-quota escalation could not park task '$($Task.name)': $($result.reason)"
+    }
+
+    return $result
+}
+
 # Initialize session for execution phase tracking
 $sessionResult = Invoke-SessionInitialize -Arguments @{ session_type = "autonomous" }
 if ($sessionResult.success) {
@@ -1269,6 +1317,19 @@ Do NOT implement the task. Your job is research and preparation only.
             if ($rateLimitMsg) {
                 $rateLimitInfo = Get-RateLimitResetTime -Message $rateLimitMsg
                 if ($rateLimitInfo) {
+                    # Org/monthly quota is non-resettable — escalate to needs-input/
+                    # and treat the analyse phase as resolved with outcome=needs-input
+                    # regardless of whether the helper's file-move succeeded. Routing
+                    # via the failure path would re-enter the same quota wall on the
+                    # next loop. The helper's own activity-log message surfaces a
+                    # failed park for operator follow-up.
+                    if ($rateLimitInfo.kind -eq 'org_quota') {
+                        Write-ProcessActivity -Id $procId -ActivityType "rate_limit" -Message "Org quota: $rateLimitMsg"
+                        Invoke-OrgQuotaEscalationStep -Task $task -TasksBaseDir $tasksBaseDir -SourceDir 'analysing' -RateLimitMessage $rateLimitMsg -ProcId $procId | Out-Null
+                        $analysisSuccess = $true
+                        $analysisOutcome = 'needs-input'
+                        break
+                    }
                     $processData.heartbeat_status = "Rate limited - waiting..."
                     Write-ProcessFile -Id $procId -Data $processData
                     Write-ProcessActivity -Id $procId -ActivityType "rate_limit" -Message $rateLimitMsg
@@ -1552,6 +1613,19 @@ Work on this task autonomously. When complete, ensure you call task_mark_done vi
             if ($rateLimitMsg) {
                 $rateLimitInfo = Get-RateLimitResetTime -Message $rateLimitMsg
                 if ($rateLimitInfo) {
+                    # Org/monthly quota is non-resettable — escalate to needs-input/
+                    # and mark the task as parked unconditionally so the post-loop
+                    # branch retains the worktree instead of destroying it. If the
+                    # helper's file-move fails, the task will still be in in-progress/
+                    # but the worktree (which holds the agent's in-flight work) is
+                    # preserved for operator recovery. The helper's own activity-log
+                    # message surfaces a failed park.
+                    if ($rateLimitInfo.kind -eq 'org_quota') {
+                        Write-ProcessActivity -Id $procId -ActivityType "rate_limit" -Message "Org quota: $rateLimitMsg"
+                        Invoke-OrgQuotaEscalationStep -Task $task -TasksBaseDir $tasksBaseDir -SourceDir 'in-progress' -RateLimitMessage $rateLimitMsg -ProcId $procId -WorktreePath $worktreePath | Out-Null
+                        $taskParked = $true
+                        break
+                    }
                     $processData.heartbeat_status = "Rate limited - waiting..."
                     Write-ProcessFile -Id $procId -Data $processData
                     Write-ProcessActivity -Id $procId -ActivityType "rate_limit" -Message $rateLimitMsg

--- a/core/runtime/modules/rate-limit-handler.ps1
+++ b/core/runtime/modules/rate-limit-handler.ps1
@@ -1,19 +1,61 @@
+function Get-RateLimitClassification {
+    <#
+    .SYNOPSIS
+    Classify a provider quota / rate-limit message (#391).
+
+    .DESCRIPTION
+    Returns 'org_quota' for non-resettable org/monthly/weekly quota wording
+    (caller must escalate to needs-input/, not retry). Returns 'transient' for
+    everything else (caller waits and retries via Get-RateLimitResetTime).
+    A stated reset time means the limit is resettable even if the message also
+    mentions "org" — reset-time presence dominates so transient messages like
+    "Your organization has hit a rate limit, resets 3pm" stay transient.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Message
+    )
+
+    if ($Message -match "(?i)resets?\s+\d{1,2}:?\d*\s*(am|pm)") {
+        return 'transient'
+    }
+
+    # \b anchors avoid false-positives on substrings (organization, reorganization, organic).
+    if ($Message -match "(?i)\bmonthly\s+usage\s+limit\b|\bweekly\s+usage\s+limit\b|\bout\s+of\s+extra\s+usage\b|\borg'?s\s+(?:monthly|weekly|usage)\b|\badmin\s+(?:notified|aware|know|action)") {
+        return 'org_quota'
+    }
+    return 'transient'
+}
+
 function Get-RateLimitResetTime {
     <#
     .SYNOPSIS
     Parses a rate limit message and extracts the reset time
-    
+
     .PARAMETER Message
     The rate limit message to parse (e.g., "You've hit your limit · resets 10pm (Europe/Berlin)")
-    
+
     .OUTPUTS
-    Hashtable with parsed info or $null if not a rate limit message
+    Hashtable with parsed info or $null if not a rate limit message. The `kind`
+    field is 'org_quota' (caller must escalate, NOT retry) or 'transient'.
     #>
     param(
         [Parameter(Mandatory = $true)]
         [string]$Message
     )
-    
+
+    # #391: org/monthly quota — non-resettable, caller must escalate to needs-input.
+    if ((Get-RateLimitClassification -Message $Message) -eq 'org_quota') {
+        return @{
+            kind             = 'org_quota'
+            reset_time       = $null
+            wait_seconds     = $null
+            timezone         = 'n/a'
+            original_message = $Message
+        }
+    }
+
     # Pattern: "resets 10pm (Europe/Berlin)" or "resets 10:30pm (Europe/Berlin)"
     if ($Message -match "resets?\s+(\d{1,2}):?(\d{2})?\s*(am|pm)\s*\(([^)]+)\)") {
         $hour = [int]$matches[1]
@@ -68,6 +110,7 @@ function Get-RateLimitResetTime {
             }
             
             return @{
+                kind = 'transient'
                 reset_time = $resetLocal.DateTime
                 wait_seconds = $waitSeconds
                 timezone = $timezone
@@ -76,6 +119,7 @@ function Get-RateLimitResetTime {
         } catch {
             # If timezone conversion fails, wait 15 minutes as fallback
             return @{
+                kind = 'transient'
                 reset_time = (Get-Date).AddMinutes(15)
                 wait_seconds = 900
                 timezone = $timezone
@@ -84,10 +128,11 @@ function Get-RateLimitResetTime {
             }
         }
     }
-    
+
     # Check for simpler "hit your limit" patterns without specific time
     if ($Message -match "hit your limit|rate.?limit|too many requests|quota exceeded") {
         return @{
+            kind = 'transient'
             reset_time = (Get-Date).AddMinutes(15)
             wait_seconds = 900
             timezone = "unknown"

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -3115,6 +3115,154 @@ Export-ModuleMember -Function 'Close-SessionOnTask'
 }
 
 # ═══════════════════════════════════════════════════════════════════
+# RATE LIMIT HANDLER CLASSIFIER TESTS (issue #391)
+# ═══════════════════════════════════════════════════════════════════
+Write-Host ""
+Write-Host "--- RateLimitHandler Classifier ---" -ForegroundColor Cyan
+
+$rateLimitHandlerScript = Join-Path $botDir "core/runtime/modules/rate-limit-handler.ps1"
+
+if (Test-Path $rateLimitHandlerScript) {
+    . $rateLimitHandlerScript
+
+    Assert-Equal -Name "Org-monthly-limit wording classifies as org_quota" `
+        -Expected 'org_quota' `
+        -Actual (Get-RateLimitClassification -Message "You've hit your org's monthly usage limit")
+
+    Assert-Equal -Name "Org-monthly-limit (admin notified) classifies as org_quota" `
+        -Expected 'org_quota' `
+        -Actual (Get-RateLimitClassification -Message "Monthly usage limit reached — admin notified")
+
+    Assert-Equal -Name "Out-of-extra-usage classifies as org_quota" `
+        -Expected 'org_quota' `
+        -Actual (Get-RateLimitClassification -Message "You are out of extra usage for this billing period")
+
+    Assert-Equal -Name "Reset-time presence dominates org wording (transient)" `
+        -Expected 'transient' `
+        -Actual (Get-RateLimitClassification -Message "Your organization has hit a rate limit, resets 3pm")
+
+    Assert-Equal -Name "'organic' substring does not false-match (transient)" `
+        -Expected 'transient' `
+        -Actual (Get-RateLimitClassification -Message "This is organic produce")
+
+    Assert-Equal -Name "'organization' substring does not false-match (transient)" `
+        -Expected 'transient' `
+        -Actual (Get-RateLimitClassification -Message "Reorganization complete — usage normal")
+
+    Assert-Equal -Name "Empty message classifies as transient" `
+        -Expected 'transient' `
+        -Actual (Get-RateLimitClassification -Message "")
+
+    Assert-Equal -Name "Standard reset-time wording stays transient" `
+        -Expected 'transient' `
+        -Actual (Get-RateLimitClassification -Message "You've hit your limit · resets 10pm (UTC)")
+} else {
+    Write-TestResult -Name "rate-limit-handler.ps1 exists" -Status Fail -Message "Script not found at $rateLimitHandlerScript"
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# ORG QUOTA ESCALATION MODULE TESTS (issue #391)
+# ═══════════════════════════════════════════════════════════════════
+Write-Host ""
+Write-Host "--- OrgQuotaEscalation Module ---" -ForegroundColor Cyan
+
+$orgQuotaModule = Join-Path $botDir "core/runtime/modules/OrgQuotaEscalation.psm1"
+
+if (Test-Path $orgQuotaModule) {
+    Import-Module $orgQuotaModule -Force
+
+    $cmd = Get-Command Move-TaskToOrgQuotaNeedsInput -ErrorAction SilentlyContinue
+    Assert-True -Name "Move-TaskToOrgQuotaNeedsInput is exported" `
+        -Condition ($null -ne $cmd) `
+        -Message "Expected exported function"
+
+    $oqWorkspace = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-oq-$([System.Guid]::NewGuid().ToString().Substring(0,8))"
+
+    foreach ($phase in @('analysing', 'in-progress')) {
+        $sourceDir = Join-Path $oqWorkspace $phase
+        $needsInputDir = Join-Path $oqWorkspace "needs-input"
+        New-Item -ItemType Directory -Force -Path $sourceDir | Out-Null
+
+        $taskId = "oq" + ([System.Guid]::NewGuid().ToString().Substring(0, 6))
+        $taskJson = @{
+            id         = $taskId
+            name       = "Org-quota fixture ($phase)"
+            status     = if ($phase -eq 'analysing') { 'analysing' } else { 'in-progress' }
+            created_at = "2026-04-11T00:00:00.0000000Z"
+            updated_at = "2026-04-11T00:00:00.0000000Z"
+        } | ConvertTo-Json -Depth 10
+        $taskFile = Join-Path $sourceDir "$taskId.json"
+        Set-Content -Path $taskFile -Value $taskJson -Encoding UTF8
+
+        $worktreeArg = if ($phase -eq 'in-progress') { @{ WorktreePath = "C:\worktrees\dotbot\task-$taskId-fake" } } else { @{} }
+
+        $result = Move-TaskToOrgQuotaNeedsInput `
+            -TaskId $taskId `
+            -TasksBaseDir $oqWorkspace `
+            -SourceDir $phase `
+            -RateLimitMessage "You've hit your org's monthly usage limit" `
+            @worktreeArg
+
+        Assert-True -Name "[$phase] Move-TaskToOrgQuotaNeedsInput returns success" `
+            -Condition ($result.success -eq $true) `
+            -Message "Expected success=true, got reason=$($result.reason)"
+
+        Assert-True -Name "[$phase] source file removed" `
+            -Condition (-not (Test-Path $taskFile)) `
+            -Message "Source file still exists in $phase/"
+
+        $newPath = Join-Path $needsInputDir "$taskId.json"
+        Assert-True -Name "[$phase] file created in needs-input/" `
+            -Condition (Test-Path $newPath) `
+            -Message "Expected file at $newPath"
+
+        if (Test-Path $newPath) {
+            $written = Get-Content $newPath -Raw | ConvertFrom-Json
+            Assert-Equal -Name "[$phase] task status set to needs-input" `
+                -Expected 'needs-input' `
+                -Actual $written.status
+
+            Assert-Equal -Name "[$phase] pending_question.id is provider-org-quota" `
+                -Expected 'provider-org-quota' `
+                -Actual $written.pending_question.id
+
+            Assert-True -Name "[$phase] pending_question.context preserves provider message" `
+                -Condition ($written.pending_question.context -match "monthly usage limit") `
+                -Message "Expected provider wording in context, got: $($written.pending_question.context)"
+
+            if ($phase -eq 'in-progress') {
+                Assert-True -Name "[$phase] worktree path appended to context" `
+                    -Condition ($written.pending_question.context -match "Worktree retained at") `
+                    -Message "Expected worktree note in context, got: $($written.pending_question.context)"
+            } else {
+                Assert-True -Name "[$phase] no worktree note in context (analyse phase)" `
+                    -Condition (-not ($written.pending_question.context -match "Worktree retained at")) `
+                    -Message "Did not expect worktree note for analyse phase"
+            }
+        }
+    }
+
+    # Missing-task path: helper returns success=$false with a reason rather than throwing.
+    $missingTaskResult = Move-TaskToOrgQuotaNeedsInput `
+        -TaskId "does-not-exist" `
+        -TasksBaseDir $oqWorkspace `
+        -SourceDir 'analysing' `
+        -RateLimitMessage "any"
+
+    Assert-True -Name "Missing task returns success=false (no throw)" `
+        -Condition ($missingTaskResult.success -eq $false) `
+        -Message "Expected success=false for missing task"
+
+    Assert-True -Name "Missing task reason is descriptive" `
+        -Condition ([string]$missingTaskResult.reason -ne '') `
+        -Message "Expected non-empty reason"
+
+    Remove-Item -Path $oqWorkspace -Recurse -Force -ErrorAction SilentlyContinue
+} else {
+    Write-TestResult -Name "OrgQuotaEscalation module exists" -Status Fail -Message "Module not found at $orgQuotaModule"
+}
+
+# ═══════════════════════════════════════════════════════════════════
 # NOTIFICATION POLLER MODULE TESTS
 # ═══════════════════════════════════════════════════════════════════
 Write-Host ""

--- a/tests/Test-MockClaude.ps1
+++ b/tests/Test-MockClaude.ps1
@@ -318,6 +318,67 @@ try {
             # Reset mock mode
             if (Test-Path $modeFile) { Remove-Item $modeFile -Force }
         }
+
+        # #391: Org/monthly usage limit detection. The message arrives as a normal
+        # assistant text event (not an error envelope), so the original narrow regex
+        # missed it — verify the broader pattern catches it.
+        try {
+            "org-limit" | Set-Content -Path $modeFile
+
+            try {
+                Invoke-ClaudeStream -Prompt "Org limit test" -Model "opus" *>&1 | Out-Null
+            } catch {
+                $null = $_
+            }
+
+            $orgLimitInfo = Get-LastRateLimitInfo
+            Assert-True -Name "Org-limit detected by stream parser (#391)" `
+                -Condition ($null -ne $orgLimitInfo) `
+                -Message "Get-LastRateLimitInfo returned null for org-limit fixture"
+
+            if ($orgLimitInfo) {
+                Assert-True -Name "Org-limit message preserves text (#391)" `
+                    -Condition ($orgLimitInfo -match "monthly usage limit") `
+                    -Message "Expected 'monthly usage limit' wording, got: $orgLimitInfo"
+            }
+        } catch {
+            Write-TestResult -Name "Org-limit detection" -Status Fail -Message $_.Exception.Message
+        } finally {
+            if (Test-Path $modeFile) { Remove-Item $modeFile -Force }
+        }
+
+        # #391: end-to-end chain — mock-claude org-limit fixture -> Invoke-ClaudeStream
+        # surfaces the text -> Get-RateLimitResetTime classifies it as org_quota.
+        # Verifies the detection/classification gap the issue described is closed.
+        try {
+            "org-limit" | Set-Content -Path $modeFile
+
+            $rlHandlerPath = Join-Path $dotbotDir "core/runtime/modules/rate-limit-handler.ps1"
+            if (Test-Path $rlHandlerPath) {
+                . $rlHandlerPath
+
+                try {
+                    Invoke-ClaudeStream -Prompt "Integration chain" -Model "opus" *>&1 | Out-Null
+                } catch {
+                    $null = $_
+                }
+
+                $chainMsg = Get-LastRateLimitInfo
+                Assert-True -Name "Chain: org-limit text surfaced from mock (#391)" `
+                    -Condition ($null -ne $chainMsg) -Message "Get-LastRateLimitInfo returned null"
+
+                $chainInfo = Get-RateLimitResetTime -Message $chainMsg
+                Assert-Equal -Name "Chain: classified as org_quota (#391)" `
+                    -Expected 'org_quota' -Actual $chainInfo.kind
+            } else {
+                Write-TestResult -Name "Org-quota chain integration" -Status Skip `
+                    -Message "rate-limit-handler.ps1 not found"
+            }
+        } catch {
+            Write-TestResult -Name "Org-quota chain integration" -Status Fail -Message $_.Exception.Message
+        } finally {
+            if (Test-Path $modeFile) { Remove-Item $modeFile -Force }
+        }
     } else {
         Write-TestResult -Name "Rate limit detection tests" -Status Skip -Message "ClaudeCLI module not available"
     }

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1152,6 +1152,17 @@ Assert-True -Name "Paused branch does NOT increment tasks_completed" `
 Assert-True -Name "Paused branch emits 'Paused (needs-input)' heartbeat" `
     -Condition ($workflowSrc -match '"Paused\s*\(needs-input\):\s*\$\(\$task\.name\)"')
 
+# #391: execution-phase org-quota events must reuse the existing pending_question
+# pattern and set $taskParked = $true so the worktree is retained.
+Assert-True -Name "Workflow process branches on rateLimitInfo.kind -eq 'org_quota'" `
+    -Condition ($workflowSrc -match "rateLimitInfo\.kind\s+-eq\s+'org_quota'")
+
+$orgQuotaModulePath = Join-Path $repoRoot "core/runtime/modules/OrgQuotaEscalation.psm1"
+$orgQuotaSrc = if (Test-Path $orgQuotaModulePath) { Get-Content $orgQuotaModulePath -Raw } else { "" }
+Assert-True -Name "OrgQuotaEscalation helper sets provider-org-quota pending_question" `
+    -Condition ($orgQuotaSrc -match '"provider-org-quota"') `
+    -Message "Helper module not found at $orgQuotaModulePath, or provider-org-quota literal missing"
+
 Write-Host ""
 
 # ═══════════════════════════════════════════════════════════════════

--- a/tests/mock-claude.ps1
+++ b/tests/mock-claude.ps1
@@ -21,7 +21,7 @@ $argsFile = Join-Path $logDir "mock-claude-args.log"
 # Capture cwd so tests can assert WorkingDirectory plumbing (#314)
 (Get-Location).Path | Set-Content -Path (Join-Path $logDir "mock-claude-cwd.log") -Encoding UTF8
 
-# Determine mock mode (normal, rate-limit, error)
+# Determine mock mode (normal, rate-limit, org-limit, error)
 $mode = "normal"
 if (Test-Path $modeFile) {
     $mode = (Get-Content $modeFile -Raw).Trim()
@@ -87,6 +87,28 @@ switch ($mode) {
             }
         } | ConvertTo-Json -Depth 10 -Compress
         Write-Output $rateLimitJson
+    }
+
+    "org-limit" {
+        # #391: Org/monthly usage limit — non-resettable. Arrives as a normal
+        # assistant text message with no tool_use block (Claude CLI flattens
+        # the API error into the assistant stream).
+        $orgLimitJson = @{
+            type    = "assistant"
+            message = @{
+                content = @(
+                    @{
+                        type = "text"
+                        text = "You've hit your org's monthly usage limit"
+                    }
+                )
+                usage   = @{
+                    input_tokens  = 12
+                    output_tokens = 8
+                }
+            }
+        } | ConvertTo-Json -Depth 10 -Compress
+        Write-Output $orgLimitJson
     }
 
     "error" {


### PR DESCRIPTION
## Linked issue

Closes #391

## Summary of changes

- Broaden rate-limit detection in `ClaudeCLI.psm1` and `Parse-ClaudeStream.ps1` to match org/monthly/weekly quota wording (`"You've hit your org's monthly usage limit"`, `"out of extra usage"`, etc.) — previously only `"hit your limit"` and `error.*rate_limit` were matched, so the org-quota message was logged as ordinary assistant text.
- Add `Get-RateLimitClassification` in `rate-limit-handler.ps1` returning `org_quota` for non-resettable wording and `transient` otherwise. Reset-time presence dominates so transient messages that mention "organization" stay transient. `\b` anchors avoid `organization`/`organic` false-matches. `Get-RateLimitResetTime` now stamps a `kind` field on the result.
- New `core/runtime/modules/OrgQuotaEscalation.psm1` with `Move-TaskToOrgQuotaNeedsInput`: a pure file-move helper that parks a task in `needs-input/` with a `provider-org-quota` `pending_question`. Returns a result hashtable; never throws on file ops.
- Both analyse and execute branches in `Invoke-WorkflowProcess.ps1` now route `org_quota` events through the helper. Analyse phase sets `analysisSuccess = true` with `outcome = needs-input` so the post-loop check no longer emits a contradicting "Analysis failed" message after parking. Execute phase sets `taskParked = true` so the post-loop branch retains the worktree instead of destroying it. Both flags are set unconditionally on detection — if the helper's file move fails, the worktree (which holds in-flight work) is preserved for operator recovery.

## Screenshots / recordings

N/A — runtime / control-plane change, no UI surface affected.

## Testing notes

Tests landed in three places. All run on layers 1–3 with no external credentials.

- **`tests/mock-claude.ps1`** — new `org-limit` fixture mode emitting the Anthropic-shaped assistant-text envelope.
- **`tests/Test-MockClaude.ps1`** — stream-parser detection assertion, plus an end-to-end chain test (`mock` → `Invoke-ClaudeStream` → `Get-RateLimitResetTime` → `kind = 'org_quota'`).
- **`tests/Test-Components.ps1`** — direct unit tests for `Get-RateLimitClassification` (8 cases covering org/monthly, admin-notified, out-of-extra-usage, reset-time-dominates, `organic`/`organization` no-false-match, empty, transient-with-reset). Component tests for `Move-TaskToOrgQuotaNeedsInput` covering both source dirs (`analysing` and `in-progress`), pending_question shape, worktree-context inclusion/omission, and the missing-task non-throwing path.
- **`tests/Test-WorkflowManifest.ps1`** — source-string asserts that the workflow process branches on `rateLimitInfo.kind -eq 'org_quota'` and emits the `provider-org-quota` pending_question.

To verify locally:

```powershell
pwsh tests/Run-Tests.ps1
```

## Checklist

- [x] Tests added or updated
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
