### PR TITLE
[PR-7/#288] Web form type handlers (approval, freeText, documentReview, priorityRanking)

### DIFF
--- a/server/src/Dotbot.Server/Models/ApprovalDecisions.cs
+++ b/server/src/Dotbot.Server/Models/ApprovalDecisions.cs
@@ -1,0 +1,24 @@
+namespace Dotbot.Server.Models;
+
+public static class ApprovalDecisions
+{
+    public const string Approve = "approve";
+    public const string Reject = "reject";
+    public const string Abstain = "abstain";
+
+    public const string RequestChanges = "request-changes";
+    public const string CommentOnly = "comment-only";
+
+    public static readonly string[] ApprovalAllowed = [Approve, Reject, Abstain];
+    public static readonly string[] DocumentReviewAllowed = [Approve, RequestChanges, CommentOnly];
+
+    public static string Label(string decision) => decision switch
+    {
+        Approve => "Approve",
+        Reject => "Reject",
+        Abstain => "Abstain",
+        RequestChanges => "Request Changes",
+        CommentOnly => "Comment Only",
+        _ => decision,
+    };
+}

--- a/server/src/Dotbot.Server/Models/QuestionTypes.cs
+++ b/server/src/Dotbot.Server/Models/QuestionTypes.cs
@@ -18,4 +18,12 @@ public static class QuestionTypes
         FreeText,
         PriorityRanking,
     ];
+
+    /// <summary>
+    /// True for the question types that render an attachment dropzone in
+    /// <c>Pages/Respond.cshtml</c>. Used to ignore files in adversarial POSTs
+    /// against types whose UI never offers an upload control.
+    /// </summary>
+    public static bool SupportsAttachments(string type) =>
+        type == SingleChoice || type == MultiChoice;
 }

--- a/server/src/Dotbot.Server/Pages/Respond.cshtml
+++ b/server/src/Dotbot.Server/Pages/Respond.cshtml
@@ -4,10 +4,10 @@
 @{
     ViewData["Title"] = "Respond to Question";
 
-    string ApprovalRadio(string value, string label, bool requireComment = false)
+    string ApprovalRadio(string value, string label, string shortKey, bool requireComment = false)
     {
         var requireAttr = requireComment ? "data-requires-comment=\"true\"" : "";
-        return $"<label class=\"btn-option approval-option\"><input type=\"radio\" name=\"approvalDecision\" value=\"{value}\" {requireAttr}/><span class=\"option-key\">{label[..1]}</span><span>{label}</span></label>";
+        return $"<label class=\"btn-option approval-option\"><input type=\"radio\" name=\"approvalDecision\" value=\"{value}\" {requireAttr}/><span class=\"option-key\">{shortKey}</span><span>{label}</span></label>";
     }
 }
 
@@ -52,9 +52,9 @@
             @switch (Model.Template.Type)
             {
                 case QuestionTypes.Approval:
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Approve, "Approve"))
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Reject, "Reject", requireComment: true))
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Abstain, "Abstain"))
+                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Approve, "Approve", "A"))
+                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Reject, "Reject", "R", requireComment: true))
+                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Abstain, "Abstain", "X"))
                     <div class="mt-1">
                         <label for="comment" class="label-text">Comment (required when rejecting):</label>
                         <textarea name="comment" id="comment" class="free-text"></textarea>
@@ -104,9 +104,9 @@
                             </ul>
                         </div>
                     }
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Approve, "Approve"))
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.RequestChanges, "Request Changes", requireComment: true))
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.CommentOnly, "Comment Only"))
+                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Approve, "Approve", "AP"))
+                    @Html.Raw(ApprovalRadio(ApprovalDecisions.RequestChanges, "Request Changes", "RC", requireComment: true))
+                    @Html.Raw(ApprovalRadio(ApprovalDecisions.CommentOnly, "Comment Only", "CO"))
                     <div class="mt-1">
                         <label for="comment" class="label-text">Feedback (required for "Request Changes"):</label>
                         <textarea name="comment" id="comment" class="free-text"></textarea>
@@ -229,6 +229,8 @@
                         dragged = li;
                         li.classList.add('dragging');
                         e.dataTransfer.effectAllowed = 'move';
+                        // Firefox requires a payload on dragstart or drag events never fire.
+                        e.dataTransfer.setData('text/plain', li.dataset.optionId);
                     });
                     li.addEventListener('dragend', () => {
                         if (dragged) dragged.classList.remove('dragging');

--- a/server/src/Dotbot.Server/Pages/Respond.cshtml
+++ b/server/src/Dotbot.Server/Pages/Respond.cshtml
@@ -1,7 +1,14 @@
 @page
 @model Dotbot.Server.Pages.RespondModel
+@using Dotbot.Server.Models
 @{
     ViewData["Title"] = "Respond to Question";
+
+    string ApprovalRadio(string value, string label, bool requireComment = false)
+    {
+        var requireAttr = requireComment ? "data-requires-comment=\"true\"" : "";
+        return $"<label class=\"btn-option approval-option\"><input type=\"radio\" name=\"approvalDecision\" value=\"{value}\" {requireAttr}/><span class=\"option-key\">{label[..1]}</span><span>{label}</span></label>";
+    }
 }
 
 <div class="card">
@@ -32,43 +39,137 @@
             <p class="context-text">@Model.Template.Context</p>
         }
 
-        <form method="post" enctype="multipart/form-data">
+        @if (!string.IsNullOrWhiteSpace(Model.Template.DeliverableSummary))
+        {
+            <p class="context-text"><strong>Deliverable: </strong>@Model.Template.DeliverableSummary</p>
+        }
+
+        <form method="post" enctype="multipart/form-data" data-question-type="@Model.Template.Type">
             <input type="hidden" name="instanceId" value="@Model.InstanceId" />
             <input type="hidden" name="projectId" value="@Model.ProjectId" />
             <input type="hidden" name="questionId" value="@Model.Template.QuestionId" />
 
-            @foreach (var option in Model.Template.Options)
+            @switch (Model.Template.Type)
             {
-                <label class="btn-option">
-                    <input type="radio" name="selectedKey" value="@option.Key" />
-                    <span class="option-key">@option.Key</span>
-                    <span>@option.Title
-                    @if (!string.IsNullOrWhiteSpace(option.Summary))
+                case QuestionTypes.Approval:
+                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Approve, "Approve"))
+                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Reject, "Reject", requireComment: true))
+                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Abstain, "Abstain"))
+                    <div class="mt-1">
+                        <label for="comment" class="label-text">Comment (required when rejecting):</label>
+                        <textarea name="comment" id="comment" class="free-text"></textarea>
+                    </div>
+                    break;
+
+                case QuestionTypes.FreeText:
+                    <div class="mt-1">
+                        <label for="freeText" class="label-text">Your response:</label>
+                        <textarea name="freeText" id="freeText" class="free-text" required></textarea>
+                    </div>
+                    break;
+
+                case QuestionTypes.DocumentReview:
+                    @if (Model.Template.Attachments is { Count: > 0 } docs)
                     {
-                        <span class="option-summary"> &mdash; @option.Summary</span>
+                        <div class="mt-1">
+                            <label class="label-text">Confirm the attachments you reviewed:</label>
+                            <ul class="doc-review-list">
+                                @foreach (var att in docs)
+                                {
+                                    var isUrl = !string.IsNullOrEmpty(att.Url);
+                                    string href;
+                                    if (isUrl)
+                                    {
+                                        href = att.Url!;
+                                    }
+                                    else if (!string.IsNullOrEmpty(att.BlobPath) && !string.IsNullOrEmpty(Model.AttachmentDownloadToken))
+                                    {
+                                        href = $"/api/attachments/{att.BlobPath}?token={Uri.EscapeDataString(Model.AttachmentDownloadToken!)}";
+                                    }
+                                    else
+                                    {
+                                        href = "#";
+                                    }
+                                    <li class="doc-review-item">
+                                        <label>
+                                            <input type="checkbox" name="reviewedAttachmentIds" value="@att.AttachmentId" />
+                                            <span class="doc-review-name">@att.Name</span>
+                                        </label>
+                                        @if (href != "#")
+                                        {
+                                            <a class="doc-review-link" href="@href" target="_blank" rel="noopener noreferrer">Open</a>
+                                        }
+                                    </li>
+                                }
+                            </ul>
+                        </div>
                     }
-                    </span>
-                </label>
-            }
+                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Approve, "Approve"))
+                    @Html.Raw(ApprovalRadio(ApprovalDecisions.RequestChanges, "Request Changes", requireComment: true))
+                    @Html.Raw(ApprovalRadio(ApprovalDecisions.CommentOnly, "Comment Only"))
+                    <div class="mt-1">
+                        <label for="comment" class="label-text">Feedback (required for "Request Changes"):</label>
+                        <textarea name="comment" id="comment" class="free-text"></textarea>
+                    </div>
+                    break;
 
-            @if (Model.AllowFreeText)
-            {
-                <div class="mt-1">
-                    <label for="freeText" class="label-text">Additional notes (optional):</label>
-                    <textarea name="freeText" id="freeText" class="free-text"></textarea>
-                </div>
-            }
+                case QuestionTypes.PriorityRanking:
+                    <p class="label-text">Drag to reorder. Position 1 = highest priority.</p>
+                    <ol id="rank-list" class="rank-list">
+                        @foreach (var option in Model.Template.Options)
+                        {
+                            <li class="rank-item" draggable="true" data-option-id="@option.OptionId">
+                                <span class="rank-handle">⋮⋮</span>
+                                <span class="rank-pos"></span>
+                                <span class="rank-title">@option.Title
+                                @if (!string.IsNullOrWhiteSpace(option.Summary))
+                                {
+                                    <span class="option-summary"> &mdash; @option.Summary</span>
+                                }
+                                </span>
+                            </li>
+                        }
+                    </ol>
+                    <input type="hidden" name="rankedItemsJson" id="rankedItemsJson" value="" />
+                    break;
 
-            <div class="mt-1 attachment-section">
-                <label class="label-text">Attach files (optional):</label>
-                <div class="attach-dropzone" id="attach-dropzone">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg>
-                    <span>Drop files here or <span class="attach-browse">browse</span></span>
-                    <span class="attach-hint">.md .docx .xlsx .pdf .txt &mdash; max 15 MB each</span>
-                </div>
-                <input type="file" name="attachments" id="attach-input" multiple accept=".md,.docx,.xlsx,.pdf,.txt" style="display:none" />
-                <ul id="attach-list" class="attach-list"></ul>
-            </div>
+                case QuestionTypes.SingleChoice:
+                case QuestionTypes.MultiChoice:
+                default:
+                    @foreach (var option in Model.Template.Options)
+                    {
+                        <label class="btn-option">
+                            <input type="radio" name="selectedKey" value="@option.Key" />
+                            <span class="option-key">@option.Key</span>
+                            <span>@option.Title
+                            @if (!string.IsNullOrWhiteSpace(option.Summary))
+                            {
+                                <span class="option-summary"> &mdash; @option.Summary</span>
+                            }
+                            </span>
+                        </label>
+                    }
+
+                    @if (Model.AllowFreeText)
+                    {
+                        <div class="mt-1">
+                            <label for="freeText" class="label-text">Additional notes (optional):</label>
+                            <textarea name="freeText" id="freeText" class="free-text"></textarea>
+                        </div>
+                    }
+
+                    <div class="mt-1 attachment-section">
+                        <label class="label-text">Attach files (optional):</label>
+                        <div class="attach-dropzone" id="attach-dropzone">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg>
+                            <span>Drop files here or <span class="attach-browse">browse</span></span>
+                            <span class="attach-hint">.md .docx .xlsx .pdf .txt &mdash; max 15 MB each</span>
+                        </div>
+                        <input type="file" name="attachments" id="attach-input" multiple accept=".md,.docx,.xlsx,.pdf,.txt" style="display:none" />
+                        <ul id="attach-list" class="attach-list"></ul>
+                    </div>
+                    break;
+            }
 
             <div class="mt-1-5 text-center">
                 <button type="submit" class="btn btn-primary">Submit Response</button>
@@ -77,93 +178,173 @@
 
         <script>
         (function () {
-            const dropzone = document.getElementById('attach-dropzone');
-            const input = document.getElementById('attach-input');
-            const list = document.getElementById('attach-list');
-            const form = dropzone.closest('form');
+            const form = document.querySelector('form[data-question-type]');
+            if (!form) return;
+            const type = form.dataset.questionType;
 
-            dropzone.addEventListener('click', () => input.click());
-            dropzone.addEventListener('dragover', e => { e.preventDefault(); dropzone.classList.add('dragover'); });
-            dropzone.addEventListener('dragleave', () => dropzone.classList.remove('dragover'));
-            dropzone.addEventListener('drop', e => {
-                e.preventDefault();
-                dropzone.classList.remove('dragover');
-                addFiles(e.dataTransfer.files);
-            });
-            input.addEventListener('change', () => {
-                addFiles(input.files);
-                input.value = '';
-            });
-
-            // Store files in memory — DataTransfer.files -> input.files assignment
-            // doesn't persist through native form submission in most browsers.
-            const stagedFiles = [];
-            const MAX = 15 * 1024 * 1024;
-            const ALLOWED = ['.md', '.docx', '.xlsx', '.pdf', '.txt'];
-
-            function addFiles(files) {
-                for (const f of files) {
-                    const ext = f.name.slice(f.name.lastIndexOf('.')).toLowerCase();
-                    if (!ALLOWED.includes(ext)) { alert('"' + f.name + '" is not allowed. Use .md, .docx, .xlsx, .pdf, or .txt'); continue; }
-                    if (f.size > MAX) { alert('"' + f.name + '" exceeds the 15 MB limit'); continue; }
-                    if (stagedFiles.some(x => x.name === f.name)) continue;
-                    stagedFiles.push(f);
-                }
-                renderList();
-            }
-
-            function renderList() {
-                list.innerHTML = '';
-                stagedFiles.forEach((f, i) => {
-                    const kb = Math.round(f.size / 1024);
-                    const li = document.createElement('li');
-                    li.className = 'attach-item';
-                    li.innerHTML = '<span class="attach-name">' + escHtml(f.name) + '</span><span class="attach-size">' + kb + ' KB</span><button type="button" class="attach-remove" data-i="' + i + '">&times;</button>';
-                    list.appendChild(li);
-                });
-                list.querySelectorAll('.attach-remove').forEach(btn => {
-                    btn.addEventListener('click', () => {
-                        stagedFiles.splice(+btn.dataset.i, 1);
-                        renderList();
-                    });
-                });
-            }
-
-            // Intercept form submit: use fetch + FormData so staged files are included
-            form.addEventListener('submit', async function (e) {
-                e.preventDefault();
-                const btn = form.querySelector('button[type=submit]');
-                if (btn) { btn.disabled = true; btn.textContent = 'Submitting…'; }
-
-                const fd = new FormData(form);
-                // Remove the empty file input value and re-add actual staged files
-                fd.delete('attachments');
-                stagedFiles.forEach(f => fd.append('attachments', f, f.name));
-
-                try {
-                    const resp = await fetch(form.action || window.location.href, {
-                        method: 'POST',
-                        body: fd
-                    });
-                    if (resp.redirected) {
-                        window.location.href = resp.url;
-                    } else if (resp.ok) {
-                        // Server returned the page (validation error) — full page replace to re-run scripts
-                        const html = await resp.text();
-                        document.open();
-                        document.write(html);
-                        document.close();
-                    } else {
-                        if (btn) { btn.disabled = false; btn.textContent = 'Submit Response'; }
-                        alert('Submission failed (' + resp.status + '). Please try again.');
+            // ── Approval / DocumentReview: comment required when destructive option selected ──
+            (function wireApproval() {
+                const radios = form.querySelectorAll('input[type="radio"][name="approvalDecision"]');
+                if (radios.length === 0) return;
+                const comment = form.querySelector('textarea[name="comment"]');
+                form.addEventListener('submit', function (e) {
+                    const checked = form.querySelector('input[type="radio"][name="approvalDecision"]:checked');
+                    if (!checked) {
+                        e.preventDefault();
+                        alert('Please choose one of the options.');
+                        return;
                     }
-                } catch (err) {
-                    if (btn) { btn.disabled = false; btn.textContent = 'Submit Response'; }
-                    alert('Submission failed. Please try again.');
-                }
-            });
+                    if (checked.dataset.requiresComment === 'true' && (!comment || !comment.value.trim())) {
+                        e.preventDefault();
+                        alert('A comment is required for this choice.');
+                        if (comment) comment.focus();
+                    }
+                });
+            })();
 
-            function escHtml(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+            // ── DocumentReview: at least one attachment confirmation ──
+            (function wireDocReview() {
+                if (type !== 'documentReview') return;
+                const checkboxes = form.querySelectorAll('input[type="checkbox"][name="reviewedAttachmentIds"]');
+                if (checkboxes.length === 0) return;
+                form.addEventListener('submit', function (e) {
+                    const any = Array.from(checkboxes).some(cb => cb.checked);
+                    if (!any) {
+                        e.preventDefault();
+                        alert('Please confirm you reviewed at least one attachment.');
+                    }
+                });
+            })();
+
+            // ── PriorityRanking: drag-and-drop sortable + serialise ──
+            (function wireRanking() {
+                if (type !== 'priorityRanking') return;
+                const list = document.getElementById('rank-list');
+                const hidden = document.getElementById('rankedItemsJson');
+                if (!list || !hidden) return;
+
+                let dragged = null;
+                list.querySelectorAll('.rank-item').forEach(li => {
+                    li.addEventListener('dragstart', e => {
+                        dragged = li;
+                        li.classList.add('dragging');
+                        e.dataTransfer.effectAllowed = 'move';
+                    });
+                    li.addEventListener('dragend', () => {
+                        if (dragged) dragged.classList.remove('dragging');
+                        dragged = null;
+                        renderPositions();
+                    });
+                    li.addEventListener('dragover', e => {
+                        e.preventDefault();
+                        if (!dragged || dragged === li) return;
+                        const rect = li.getBoundingClientRect();
+                        const before = e.clientY < rect.top + rect.height / 2;
+                        if (before) li.parentNode.insertBefore(dragged, li);
+                        else li.parentNode.insertBefore(dragged, li.nextSibling);
+                    });
+                });
+
+                function renderPositions() {
+                    Array.from(list.children).forEach((li, i) => {
+                        const pos = li.querySelector('.rank-pos');
+                        if (pos) pos.textContent = (i + 1).toString();
+                    });
+                }
+
+                form.addEventListener('submit', function (e) {
+                    const items = Array.from(list.children).map((li, i) => ({
+                        optionId: li.dataset.optionId,
+                        rank: i + 1
+                    }));
+                    hidden.value = JSON.stringify(items);
+                });
+
+                renderPositions();
+            })();
+
+            // ── SingleChoice / MultiChoice: attachments fetch-submit ──
+            (function wireAttachments() {
+                const dropzone = document.getElementById('attach-dropzone');
+                if (!dropzone) return;
+                const input = document.getElementById('attach-input');
+                const list = document.getElementById('attach-list');
+
+                dropzone.addEventListener('click', () => input.click());
+                dropzone.addEventListener('dragover', e => { e.preventDefault(); dropzone.classList.add('dragover'); });
+                dropzone.addEventListener('dragleave', () => dropzone.classList.remove('dragover'));
+                dropzone.addEventListener('drop', e => {
+                    e.preventDefault();
+                    dropzone.classList.remove('dragover');
+                    addFiles(e.dataTransfer.files);
+                });
+                input.addEventListener('change', () => {
+                    addFiles(input.files);
+                    input.value = '';
+                });
+
+                const stagedFiles = [];
+                const MAX = 15 * 1024 * 1024;
+                const ALLOWED = ['.md', '.docx', '.xlsx', '.pdf', '.txt'];
+
+                function addFiles(files) {
+                    for (const f of files) {
+                        const ext = f.name.slice(f.name.lastIndexOf('.')).toLowerCase();
+                        if (!ALLOWED.includes(ext)) { alert('"' + f.name + '" is not allowed. Use .md, .docx, .xlsx, .pdf, or .txt'); continue; }
+                        if (f.size > MAX) { alert('"' + f.name + '" exceeds the 15 MB limit'); continue; }
+                        if (stagedFiles.some(x => x.name === f.name)) continue;
+                        stagedFiles.push(f);
+                    }
+                    renderList();
+                }
+
+                function renderList() {
+                    list.innerHTML = '';
+                    stagedFiles.forEach((f, i) => {
+                        const kb = Math.round(f.size / 1024);
+                        const li = document.createElement('li');
+                        li.className = 'attach-item';
+                        li.innerHTML = '<span class="attach-name">' + escHtml(f.name) + '</span><span class="attach-size">' + kb + ' KB</span><button type="button" class="attach-remove" data-i="' + i + '">&times;</button>';
+                        list.appendChild(li);
+                    });
+                    list.querySelectorAll('.attach-remove').forEach(btn => {
+                        btn.addEventListener('click', () => {
+                            stagedFiles.splice(+btn.dataset.i, 1);
+                            renderList();
+                        });
+                    });
+                }
+
+                form.addEventListener('submit', async function (e) {
+                    e.preventDefault();
+                    const btn = form.querySelector('button[type=submit]');
+                    if (btn) { btn.disabled = true; btn.textContent = 'Submitting…'; }
+
+                    const fd = new FormData(form);
+                    fd.delete('attachments');
+                    stagedFiles.forEach(f => fd.append('attachments', f, f.name));
+
+                    try {
+                        const resp = await fetch(form.action || window.location.href, { method: 'POST', body: fd });
+                        if (resp.redirected) {
+                            window.location.href = resp.url;
+                        } else if (resp.ok) {
+                            const html = await resp.text();
+                            document.open();
+                            document.write(html);
+                            document.close();
+                        } else {
+                            if (btn) { btn.disabled = false; btn.textContent = 'Submit Response'; }
+                            alert('Submission failed (' + resp.status + '). Please try again.');
+                        }
+                    } catch (err) {
+                        if (btn) { btn.disabled = false; btn.textContent = 'Submit Response'; }
+                        alert('Submission failed. Please try again.');
+                    }
+                });
+
+                function escHtml(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+            })();
         })();
         </script>
     }

--- a/server/src/Dotbot.Server/Pages/Respond.cshtml
+++ b/server/src/Dotbot.Server/Pages/Respond.cshtml
@@ -345,6 +345,16 @@
 
                 function escHtml(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
             })();
+
+            // ── Disable Submit on click to prevent double-POST race against the magic-link JTI ──
+            // Registered last so it runs after every validation handler. If any earlier handler
+            // called preventDefault (validation failure, or the attachments fetch path which
+            // manages the button itself), this no-ops.
+            form.addEventListener('submit', function (e) {
+                if (e.defaultPrevented) return;
+                const btn = form.querySelector('button[type=submit]');
+                if (btn) { btn.disabled = true; btn.textContent = 'Submitting…'; }
+            });
         })();
         </script>
     }

--- a/server/src/Dotbot.Server/Pages/Respond.cshtml.cs
+++ b/server/src/Dotbot.Server/Pages/Respond.cshtml.cs
@@ -1,9 +1,11 @@
 using Dotbot.Server.Models;
 using Dotbot.Server.Services;
+using Dotbot.Server.Validation;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Options;
 using System.IdentityModel.Tokens.Jwt;
+using System.Text.Json;
 
 namespace Dotbot.Server.Pages;
 
@@ -13,6 +15,12 @@ public class RespondModel : PageModel
 {
     private static readonly string[] AllowedExtensions = [".md", ".docx", ".xlsx", ".pdf", ".txt", ".png", ".jpg", ".jpeg"];
     private const long MaxFileBytes = 15 * 1024 * 1024; // 15 MB
+
+    private static readonly JsonSerializerOptions RankedItemsJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
 
     private readonly InstanceStorageService _instances;
     private readonly TemplateStorageService _templates;
@@ -46,6 +54,13 @@ public class RespondModel : PageModel
     public bool AllowFreeText { get; set; }
     public string? ErrorMessage { get; set; }
 
+    /// <summary>
+    /// Magic-link JWT propagated from the GET query string, used by the page to construct
+    /// signed download URLs for blob-stored review attachments. Null when the user is on a
+    /// device cookie — PR-8 introduces a dedicated download-token mint for that path.
+    /// </summary>
+    public string? AttachmentDownloadToken { get; set; }
+
     public async Task<IActionResult> OnGetAsync([FromQuery] string? token, [FromQuery] string? instanceId, [FromQuery] string? projectId)
     {
         var email = HttpContext.Items["AuthenticatedEmail"] as string;
@@ -58,7 +73,6 @@ public class RespondModel : PageModel
         string? instanceIdStr = instanceId;
         string? projId = projectId;
 
-        // Extract claims from magic link JWT if present
         if (!string.IsNullOrEmpty(token))
         {
             try
@@ -67,10 +81,11 @@ public class RespondModel : PageModel
                 var jwt = handler.ReadJwtToken(token);
                 instanceIdStr ??= jwt.Claims.FirstOrDefault(c => c.Type == "questionInstanceId")?.Value;
                 projId ??= jwt.Claims.FirstOrDefault(c => c.Type == "projectId")?.Value;
+                AttachmentDownloadToken = token;
             }
             catch
             {
-                // Token was already consumed by middleware; fall through to query params
+                // Token unreadable; fall through to query params
             }
         }
 
@@ -102,11 +117,23 @@ public class RespondModel : PageModel
         return Page();
     }
 
-    public async Task<IActionResult> OnPostAsync(Guid instanceId, string projectId, Guid questionId, string? selectedKey, string? freeText)
+    public async Task<IActionResult> OnPostAsync(
+        Guid instanceId,
+        string projectId,
+        Guid questionId,
+        string? selectedKey,
+        string? freeText,
+        string? approvalDecision,
+        string? comment,
+        string? rankedItemsJson)
     {
         var attachments = Request.Form.Files;
-        _logger.LogDebug("POST Respond: instanceId={InstanceId}, selectedKey={SelectedKey}, attachmentCount={AttachmentCount}",
-            instanceId, selectedKey, attachments.Count);
+        var reviewedIds = ParseReviewedIds(Request.Form["reviewedAttachmentIds"]);
+        var rankedItems = ParseRankedItems(rankedItemsJson);
+
+        _logger.LogDebug(
+            "POST Respond: instanceId={InstanceId}, selectedKey={SelectedKey}, decision={Decision}, reviewed={ReviewedCount}, ranked={RankedCount}, attachmentCount={AttachmentCount}",
+            instanceId, selectedKey, approvalDecision, reviewedIds.Count, rankedItems.Count, attachments.Count);
 
         var email = HttpContext.Items["AuthenticatedEmail"] as string;
         if (string.IsNullOrEmpty(email))
@@ -129,28 +156,19 @@ public class RespondModel : PageModel
             return Page();
         }
 
-        _logger.LogInformation("Template option keys: [{Keys}]",
-            string.Join(", ", template.Options.Select(o => $"'{o.Key}'")));
+        var input = new RespondFormInput(
+            SelectedKey: selectedKey,
+            FreeText: freeText,
+            ApprovalDecision: approvalDecision,
+            Comment: comment,
+            ReviewedAttachmentIds: reviewedIds,
+            RankedItems: rankedItems,
+            UploadedAttachmentCount: attachments.Count);
 
-        // Resolve selected option (may be null for attachment-only submissions)
-        var selectedOption = string.IsNullOrEmpty(selectedKey)
-            ? null
-            : template.Options.FirstOrDefault(o => o.Key == selectedKey);
-
-        if (!string.IsNullOrEmpty(selectedKey) && selectedOption is null)
+        var validation = RespondFormHandler.Validate(template, input);
+        if (!validation.IsValid)
         {
-            ErrorMessage = "Invalid selection.";
-            InstanceId = instanceId;
-            ProjectId = projectId;
-            Template = template;
-            AllowFreeText = template.ResponseSettings?.AllowFreeText ?? false;
-            return Page();
-        }
-
-        var hasAttachments = attachments.Count > 0;
-        if (selectedOption is null && string.IsNullOrWhiteSpace(freeText) && !hasAttachments)
-        {
-            ErrorMessage = "Please select an option, type a response, or attach a file.";
+            ErrorMessage = validation.Error;
             InstanceId = instanceId;
             ProjectId = projectId;
             Template = template;
@@ -160,7 +178,6 @@ public class RespondModel : PageModel
 
         var responseId = Guid.NewGuid();
 
-        // Save attachments to blob storage
         var savedAttachments = new List<AttachmentRecord>();
         if (attachments.Count > 0)
         {
@@ -195,23 +212,51 @@ public class RespondModel : PageModel
             QuestionVersion = instance.QuestionVersion,
             ProjectId = instance.ProjectId,
             ResponderEmail = email,
-            SelectedOptionId = selectedOption?.OptionId,
-            SelectedKey = selectedKey,
-            SelectedOptionTitle = selectedOption?.Title,
-            FreeText = freeText,
+            SelectedOptionId = validation.SelectedOptionId,
+            SelectedKey = validation.SelectedKey,
+            SelectedOptionTitle = validation.SelectedOptionTitle,
+            FreeText = validation.FreeText,
+            ApprovalDecision = validation.ApprovalDecision,
+            Comment = validation.Comment,
+            ReviewedAttachmentIds = validation.ReviewedAttachmentIds?.ToList(),
+            RankedItems = validation.RankedItems?.ToList(),
             Attachments = savedAttachments.Count > 0 ? savedAttachments : null
         };
 
         await _responses.SaveResponseAsync(response);
-        _logger.LogInformation("Web response saved for {Email}, instance {InstanceId}, key {Key}", email, instanceId, selectedKey);
+        _logger.LogInformation(
+            "Web response saved: type={Type}, responder={Email}, instance={InstanceId}, decision={Decision}, key={Key}",
+            template.Type, email, instanceId, response.ApprovalDecision, response.SelectedKey);
 
-        // Consume the magic link token now that the response has been saved successfully
         await ConsumeMagicLinkAsync(email);
 
-        var selectionLabel = selectedOption is not null
-            ? $"{selectedKey}. {selectedOption.Title}"
-            : savedAttachments.Count > 0 ? $"{savedAttachments.Count} file(s) attached" : "Custom response";
+        var selectionLabel = validation.SelectionLabel ?? "Custom response";
         return RedirectToPage("Confirmation", new { question = template.Title, selection = selectionLabel });
+    }
+
+    private static List<Guid> ParseReviewedIds(Microsoft.Extensions.Primitives.StringValues raw)
+    {
+        var ids = new List<Guid>();
+        foreach (var value in raw)
+        {
+            if (string.IsNullOrWhiteSpace(value)) continue;
+            if (Guid.TryParse(value, out var id)) ids.Add(id);
+        }
+        return ids;
+    }
+
+    private static List<RankedItem> ParseRankedItems(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return new List<RankedItem>();
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<List<RankedItem>>(json, RankedItemsJsonOptions);
+            return parsed ?? new List<RankedItem>();
+        }
+        catch (JsonException)
+        {
+            return new List<RankedItem>();
+        }
     }
 
     /// <summary>

--- a/server/src/Dotbot.Server/Pages/Respond.cshtml.cs
+++ b/server/src/Dotbot.Server/Pages/Respond.cshtml.cs
@@ -131,9 +131,35 @@ public class RespondModel : PageModel
         var reviewedIds = ParseReviewedIds(Request.Form["reviewedAttachmentIds"]);
         var rankedItems = ParseRankedItems(rankedItemsJson);
 
+        // Filter uploads up front so validation, save loop, and confirmation label all see the
+        // same accepted set. Submitting only disallowed/oversized files must not pass an
+        // "attachment-only" check and consume the magic link with an empty response.
+        var acceptedFiles = new List<IFormFile>(attachments.Count);
+        foreach (var file in attachments)
+        {
+            var ext = Path.GetExtension(file.FileName).ToLowerInvariant();
+            var safeName = Path.GetFileName(file.FileName);
+            if (string.IsNullOrWhiteSpace(safeName))
+            {
+                _logger.LogWarning("Skipping attachment: empty filename");
+                continue;
+            }
+            if (!AllowedExtensions.Contains(ext))
+            {
+                _logger.LogWarning("Skipping attachment {Name}: unsupported extension {Ext}", safeName, ext);
+                continue;
+            }
+            if (file.Length > MaxFileBytes)
+            {
+                _logger.LogWarning("Skipping attachment {Name}: exceeds 15 MB limit ({Size} bytes)", safeName, file.Length);
+                continue;
+            }
+            acceptedFiles.Add(file);
+        }
+
         _logger.LogDebug(
-            "POST Respond: instanceId={InstanceId}, selectedKey={SelectedKey}, decision={Decision}, reviewed={ReviewedCount}, ranked={RankedCount}, attachmentCount={AttachmentCount}",
-            instanceId, selectedKey, approvalDecision, reviewedIds.Count, rankedItems.Count, attachments.Count);
+            "POST Respond: instanceId={InstanceId}, selectedKey={SelectedKey}, decision={Decision}, reviewed={ReviewedCount}, ranked={RankedCount}, uploadedCount={UploadedCount}, acceptedCount={AcceptedCount}",
+            instanceId, selectedKey, approvalDecision, reviewedIds.Count, rankedItems.Count, attachments.Count, acceptedFiles.Count);
 
         var email = HttpContext.Items["AuthenticatedEmail"] as string;
         if (string.IsNullOrEmpty(email))
@@ -163,7 +189,7 @@ public class RespondModel : PageModel
             Comment: comment,
             ReviewedAttachmentIds: reviewedIds,
             RankedItems: rankedItems,
-            UploadedAttachmentCount: attachments.Count);
+            UploadedAttachmentCount: acceptedFiles.Count);
 
         var validation = RespondFormHandler.Validate(template, input);
         if (!validation.IsValid)
@@ -179,29 +205,13 @@ public class RespondModel : PageModel
         var responseId = Guid.NewGuid();
 
         var savedAttachments = new List<AttachmentRecord>();
-        if (attachments.Count > 0)
+        foreach (var file in acceptedFiles)
         {
-            foreach (var file in attachments)
-            {
-                var ext = Path.GetExtension(file.FileName).ToLowerInvariant();
-                if (!AllowedExtensions.Contains(ext))
-                {
-                    _logger.LogWarning("Skipping attachment {Name}: unsupported extension {Ext}", file.FileName, ext);
-                    continue;
-                }
-                if (file.Length > MaxFileBytes)
-                {
-                    _logger.LogWarning("Skipping attachment {Name}: exceeds 15 MB limit ({Size} bytes)", file.FileName, file.Length);
-                    continue;
-                }
-
-                var safeFileName = Path.GetFileName(file.FileName);
-                if (string.IsNullOrWhiteSpace(safeFileName)) continue;
-                using var stream = file.OpenReadStream();
-                var record = await _attachments.SaveAsync(responseId, safeFileName, stream, file.Length);
-                savedAttachments.Add(record);
-                _logger.LogInformation("Attachment saved: {BlobPath} ({Size} bytes)", record.BlobPath, record.SizeBytes);
-            }
+            var safeFileName = Path.GetFileName(file.FileName);
+            using var stream = file.OpenReadStream();
+            var record = await _attachments.SaveAsync(responseId, safeFileName, stream, file.Length);
+            savedAttachments.Add(record);
+            _logger.LogInformation("Attachment saved: {BlobPath} ({Size} bytes)", record.BlobPath, record.SizeBytes);
         }
 
         var response = new ResponseRecordV2

--- a/server/src/Dotbot.Server/Pages/Respond.cshtml.cs
+++ b/server/src/Dotbot.Server/Pages/Respond.cshtml.cs
@@ -13,7 +13,7 @@ namespace Dotbot.Server.Pages;
 [RequestSizeLimit(35 * 1024 * 1024)]
 public class RespondModel : PageModel
 {
-    private static readonly string[] AllowedExtensions = [".md", ".docx", ".xlsx", ".pdf", ".txt", ".png", ".jpg", ".jpeg"];
+    private static readonly string[] AllowedExtensions = [".md", ".docx", ".xlsx", ".pdf", ".txt"];
     private const long MaxFileBytes = 15 * 1024 * 1024; // 15 MB
 
     private static readonly JsonSerializerOptions RankedItemsJsonOptions = new()
@@ -205,13 +205,22 @@ public class RespondModel : PageModel
         var responseId = Guid.NewGuid();
 
         var savedAttachments = new List<AttachmentRecord>();
-        foreach (var file in acceptedFiles)
+        if (QuestionTypes.SupportsAttachments(template.Type))
         {
-            var safeFileName = Path.GetFileName(file.FileName);
-            using var stream = file.OpenReadStream();
-            var record = await _attachments.SaveAsync(responseId, safeFileName, stream, file.Length);
-            savedAttachments.Add(record);
-            _logger.LogInformation("Attachment saved: {BlobPath} ({Size} bytes)", record.BlobPath, record.SizeBytes);
+            foreach (var file in acceptedFiles)
+            {
+                var safeFileName = Path.GetFileName(file.FileName);
+                using var stream = file.OpenReadStream();
+                var record = await _attachments.SaveAsync(responseId, safeFileName, stream, file.Length);
+                savedAttachments.Add(record);
+                _logger.LogInformation("Attachment saved: {BlobPath} ({Size} bytes)", record.BlobPath, record.SizeBytes);
+            }
+        }
+        else if (acceptedFiles.Count > 0)
+        {
+            _logger.LogWarning(
+                "Ignoring {Count} attachment(s) for question type {Type}: no upload UI is rendered for this type",
+                acceptedFiles.Count, template.Type);
         }
 
         var response = new ResponseRecordV2

--- a/server/src/Dotbot.Server/Pages/Shared/_Layout.cshtml
+++ b/server/src/Dotbot.Server/Pages/Shared/_Layout.cshtml
@@ -357,6 +357,16 @@
             background: var(--color-secondary); border-color: var(--color-secondary);
             box-shadow: inset 0 0 0 3px var(--bg-panel);
         }
+        .doc-review-item input[type="checkbox"]:focus-visible {
+            outline: none;
+            border-color: var(--color-secondary);
+            box-shadow: 0 0 8px var(--secondary-30);
+        }
+        input[type="radio"]:focus-visible {
+            outline: none;
+            border-color: var(--color-secondary);
+            box-shadow: 0 0 8px var(--secondary-30);
+        }
         .doc-review-name { color: var(--color-primary); font-size: 0.9rem; }
         .doc-review-link {
             color: var(--color-secondary); text-decoration: none;

--- a/server/src/Dotbot.Server/Pages/Shared/_Layout.cshtml
+++ b/server/src/Dotbot.Server/Pages/Shared/_Layout.cshtml
@@ -333,6 +333,58 @@
             line-height: 1; flex-shrink: 0;
         }
         .attach-remove:hover { color: var(--color-error); }
+
+        /* === Approval / DocReview options === */
+        .approval-option { font-family: var(--font-ui); }
+        .approval-option .option-key { font-family: var(--font-mono); text-transform: uppercase; }
+
+        /* === Document review list === */
+        .doc-review-list { list-style: none; display: flex; flex-direction: column; gap: 6px; margin: 8px 0; }
+        .doc-review-item {
+            display: flex; align-items: center; gap: 10px;
+            padding: 8px 10px; background: var(--bg-module);
+            border: 1px solid var(--primary-15); border-radius: 4px;
+        }
+        .doc-review-item label { display: flex; align-items: center; gap: 8px; flex: 1; cursor: pointer; }
+        .doc-review-item input[type="checkbox"] {
+            appearance: none; -webkit-appearance: none;
+            width: 16px; height: 16px; flex-shrink: 0;
+            border: 2px solid var(--color-primary-dim); border-radius: 3px;
+            background: transparent; cursor: pointer;
+            transition: all 150ms ease;
+        }
+        .doc-review-item input[type="checkbox"]:checked {
+            background: var(--color-secondary); border-color: var(--color-secondary);
+            box-shadow: inset 0 0 0 3px var(--bg-panel);
+        }
+        .doc-review-name { color: var(--color-primary); font-size: 0.9rem; }
+        .doc-review-link {
+            color: var(--color-secondary); text-decoration: none;
+            font-size: 0.8rem; padding: 2px 8px;
+            border: 1px solid var(--secondary-30); border-radius: 3px;
+        }
+        .doc-review-link:hover { background: var(--secondary-12); }
+
+        /* === Priority ranking list === */
+        .rank-list { list-style: none; display: flex; flex-direction: column; gap: 6px; margin: 12px 0; padding: 0; counter-reset: rank; }
+        .rank-item {
+            display: flex; align-items: center; gap: 10px;
+            padding: 10px 12px; background: var(--bg-module);
+            border: 1px solid var(--primary-15); border-radius: 4px;
+            cursor: grab; user-select: none;
+            transition: background 150ms ease, border-color 150ms ease;
+        }
+        .rank-item:hover { border-color: var(--primary-30); background: var(--primary-05); }
+        .rank-item.dragging { opacity: 0.4; cursor: grabbing; }
+        .rank-handle { color: var(--color-muted); font-size: 0.9rem; cursor: grab; flex-shrink: 0; letter-spacing: -2px; }
+        .rank-pos {
+            display: inline-flex; align-items: center; justify-content: center;
+            min-width: 24px; height: 24px;
+            background: var(--secondary-12); color: var(--color-secondary);
+            border-radius: 4px; font-weight: 700; font-size: 0.85rem;
+            flex-shrink: 0;
+        }
+        .rank-title { flex: 1; color: var(--color-primary); font-size: 0.9rem; }
     </style>
 </head>
 <body>

--- a/server/src/Dotbot.Server/Properties/launchSettings.json
+++ b/server/src/Dotbot.Server/Properties/launchSettings.json
@@ -7,7 +7,8 @@
       "launchBrowser": true,
       "applicationUrl": "http://localhost:5048",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTBOT_TEST_MODE": "true"
       }
     }
   }

--- a/server/src/Dotbot.Server/Properties/launchSettings.json
+++ b/server/src/Dotbot.Server/Properties/launchSettings.json
@@ -7,6 +7,15 @@
       "launchBrowser": true,
       "applicationUrl": "http://localhost:5048",
       "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "http-test": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5048",
+      "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTBOT_TEST_MODE": "true"
       }

--- a/server/src/Dotbot.Server/Services/Attachments/AzureBlobAttachmentStorage.cs
+++ b/server/src/Dotbot.Server/Services/Attachments/AzureBlobAttachmentStorage.cs
@@ -19,12 +19,12 @@ public class AzureBlobAttachmentStorage : IAttachmentStorage
     public async Task<AttachmentUploadResult> UploadAsync(
         string fileName, string contentType, Stream content, long sizeBytes, CancellationToken ct = default)
     {
-        var safeFileName = Path.GetFileName(fileName);
-        if (string.IsNullOrWhiteSpace(safeFileName))
+        var displayName = Path.GetFileName(fileName);
+        if (string.IsNullOrWhiteSpace(displayName))
             throw new ArgumentException("fileName must contain a valid file name.", nameof(fileName));
 
         var attachmentId = Guid.NewGuid();
-        var storageRef = $"{attachmentId}/{safeFileName}";
+        var storageRef = $"{attachmentId}/{FilenameSanitizer.ToBlobSafe(displayName)}";
 
         var blob = _container.GetBlobClient(storageRef);
         var uploadOptions = new BlobUploadOptions
@@ -33,7 +33,7 @@ public class AzureBlobAttachmentStorage : IAttachmentStorage
         };
         await blob.UploadAsync(content, uploadOptions, ct);
 
-        return new AttachmentUploadResult(attachmentId, storageRef, safeFileName, contentType, sizeBytes);
+        return new AttachmentUploadResult(attachmentId, storageRef, displayName, contentType, sizeBytes);
     }
 
     public async Task<(Stream Content, string ContentType)?> DownloadAsync(string storageRef, CancellationToken ct = default)

--- a/server/src/Dotbot.Server/Services/Attachments/FilenameSanitizer.cs
+++ b/server/src/Dotbot.Server/Services/Attachments/FilenameSanitizer.cs
@@ -1,0 +1,56 @@
+namespace Dotbot.Server.Services.Attachments;
+
+/// <summary>
+/// Produces a URL- and blob-storage-safe last-path-segment from a raw
+/// user-supplied filename. Original filenames are still kept on the
+/// <c>AttachmentRecord.Name</c> field for display and Content-Disposition
+/// fallback — this helper exists so paths embedded in URLs can't contain
+/// characters that break URI parsing (<c>?</c>, <c>#</c>, <c>%</c>, space,
+/// non-ASCII, control bytes, RTL overrides, etc.).
+/// </summary>
+public static class FilenameSanitizer
+{
+    private const int MaxLength = 200;
+    private const string Fallback = "file";
+
+    /// <summary>
+    /// Strips directory separators (defence-in-depth on top of
+    /// <c>Path.GetFileName</c>) and replaces any character that is not
+    /// ASCII letter, digit, dot, dash, or underscore with a single '_'.
+    /// Collapses runs of '_', trims leading/trailing '.' and '_',
+    /// caps length, and falls back to "file" when the result is empty.
+    /// </summary>
+    public static string ToBlobSafe(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return Fallback;
+
+        var name = Path.GetFileName(raw);
+        if (string.IsNullOrWhiteSpace(name)) return Fallback;
+
+        var sb = new System.Text.StringBuilder(name.Length);
+        var prevUnderscore = false;
+        foreach (var c in name)
+        {
+            var safe = char.IsAsciiLetterOrDigit(c) || c is '.' or '-' or '_';
+            if (safe)
+            {
+                sb.Append(c);
+                prevUnderscore = c == '_';
+            }
+            else if (!prevUnderscore)
+            {
+                sb.Append('_');
+                prevUnderscore = true;
+            }
+        }
+
+        // Trim only underscores so the extension (e.g. ".pdf") is preserved when the stem
+        // collapses entirely (all-non-ASCII filenames). Leading dots are kept — `Path.GetFileName`
+        // upstream already stripped directory traversal, and a single literal "." or ".." segment
+        // is rejected by AttachmentStorageHelpers.IsStorageRefSafe on the read path.
+        var result = sb.ToString().Trim('_');
+        if (result.Length == 0 || result == "." || result == "..") return Fallback;
+        if (result.Length > MaxLength) result = result[..MaxLength];
+        return result;
+    }
+}

--- a/server/src/Dotbot.Server/Services/Attachments/FilenameSanitizer.cs
+++ b/server/src/Dotbot.Server/Services/Attachments/FilenameSanitizer.cs
@@ -15,10 +15,14 @@ public static class FilenameSanitizer
 
     /// <summary>
     /// Strips directory separators (defence-in-depth on top of
-    /// <c>Path.GetFileName</c>) and replaces any character that is not
-    /// ASCII letter, digit, dot, dash, or underscore with a single '_'.
-    /// Collapses runs of '_', trims leading/trailing '.' and '_',
-    /// caps length, and falls back to "file" when the result is empty.
+    /// <c>Path.GetFileName</c>, with backslashes normalized first so the
+    /// behaviour is identical on Windows and Linux/macOS) and replaces any
+    /// character that is not ASCII letter, digit, dot, dash, or underscore
+    /// with a single '_'. Runs of '_' collapse to one. Trims leading and
+    /// trailing '_' only — dots are preserved so the extension survives
+    /// when the stem collapses entirely (e.g. "<paramref name="raw"/>" =
+    /// all-non-ASCII becomes ".pdf"). Caps length at 200. Falls back to
+    /// "file" when the result is empty, "." or "..".
     /// </summary>
     public static string ToBlobSafe(string? raw)
     {

--- a/server/src/Dotbot.Server/Services/Attachments/FilenameSanitizer.cs
+++ b/server/src/Dotbot.Server/Services/Attachments/FilenameSanitizer.cs
@@ -2,11 +2,15 @@ namespace Dotbot.Server.Services.Attachments;
 
 /// <summary>
 /// Produces a URL- and blob-storage-safe last-path-segment from a raw
-/// user-supplied filename. Original filenames are still kept on the
-/// <c>AttachmentRecord.Name</c> field for display and Content-Disposition
-/// fallback — this helper exists so paths embedded in URLs can't contain
-/// characters that break URI parsing (<c>?</c>, <c>#</c>, <c>%</c>, space,
-/// non-ASCII, control bytes, RTL overrides, etc.).
+/// user-supplied filename. The original filename is kept on
+/// <c>AttachmentRecord.Name</c> / <c>AttachmentUploadResult.Name</c> for UI
+/// display. The download endpoints currently derive the
+/// <c>Content-Disposition</c> filename from the sanitized blob path
+/// segment, not from the stored display name — wiring the stored name
+/// through to the download response is a separate UX improvement.
+/// This helper exists so paths embedded in URLs can't contain characters
+/// that break URI parsing (<c>?</c>, <c>#</c>, <c>%</c>, space, non-ASCII,
+/// control bytes, RTL overrides, etc.).
 /// </summary>
 public static class FilenameSanitizer
 {
@@ -21,7 +25,9 @@ public static class FilenameSanitizer
     /// with a single '_'. Runs of '_' collapse to one. Trims leading and
     /// trailing '_' only — dots are preserved so the extension survives
     /// when the stem collapses entirely (e.g. "<paramref name="raw"/>" =
-    /// all-non-ASCII becomes ".pdf"). Caps length at 200. Falls back to
+    /// all-non-ASCII becomes ".pdf"). Caps length at 200 while preserving
+    /// a short trailing extension (16 chars or fewer including the dot)
+    /// so the content-type cue isn't lost on long names. Falls back to
     /// "file" when the result is empty, "." or "..".
     /// </summary>
     public static string ToBlobSafe(string? raw)
@@ -58,7 +64,16 @@ public static class FilenameSanitizer
         // is rejected by AttachmentStorageHelpers.IsStorageRefSafe on the read path.
         var result = sb.ToString().Trim('_');
         if (result.Length == 0 || result == "." || result == "..") return Fallback;
-        if (result.Length > MaxLength) result = result[..MaxLength];
+        if (result.Length > MaxLength)
+        {
+            // Preserve a short extension (<=16 chars including the dot) so the truncated
+            // filename keeps its content-type cue. Anything longer gets a plain cut.
+            var dot = result.LastIndexOf('.');
+            var extLen = dot > 0 ? result.Length - dot : 0;
+            result = extLen > 0 && extLen <= 16 && extLen < MaxLength
+                ? result[..(MaxLength - extLen)] + result[dot..]
+                : result[..MaxLength];
+        }
         return result;
     }
 }

--- a/server/src/Dotbot.Server/Services/Attachments/FilenameSanitizer.cs
+++ b/server/src/Dotbot.Server/Services/Attachments/FilenameSanitizer.cs
@@ -24,7 +24,11 @@ public static class FilenameSanitizer
     {
         if (string.IsNullOrWhiteSpace(raw)) return Fallback;
 
-        var name = Path.GetFileName(raw);
+        // `Path.GetFileName` only treats the OS-native directory separator as a separator —
+        // on Linux/macOS `\` is a legal filename character, so `"..\\..\\boot.ini"` survives
+        // intact and bypasses the traversal strip. Normalize all backslashes to forward
+        // slashes first so the behaviour is identical across platforms.
+        var name = Path.GetFileName(raw.Replace('\\', '/'));
         if (string.IsNullOrWhiteSpace(name)) return Fallback;
 
         var sb = new System.Text.StringBuilder(name.Length);

--- a/server/src/Dotbot.Server/Services/Attachments/LocalFileAttachmentStorage.cs
+++ b/server/src/Dotbot.Server/Services/Attachments/LocalFileAttachmentStorage.cs
@@ -24,10 +24,11 @@ public class LocalFileAttachmentStorage : IAttachmentStorage
     public async Task<AttachmentUploadResult> UploadAsync(
         string fileName, string contentType, Stream content, long sizeBytes, CancellationToken ct = default)
     {
-        var safeFileName = Path.GetFileName(fileName);
-        if (string.IsNullOrWhiteSpace(safeFileName))
+        var displayName = Path.GetFileName(fileName);
+        if (string.IsNullOrWhiteSpace(displayName))
             throw new ArgumentException("fileName must contain a valid file name.", nameof(fileName));
 
+        var safeFileName = FilenameSanitizer.ToBlobSafe(displayName);
         var attachmentId = Guid.NewGuid();
         var dir = Path.Combine(_basePath, attachmentId.ToString());
         Directory.CreateDirectory(dir);
@@ -40,7 +41,7 @@ public class LocalFileAttachmentStorage : IAttachmentStorage
         var meta = JsonSerializer.Serialize(new { contentType }, JsonOptions);
         await File.WriteAllTextAsync(metaPath, meta, ct);
 
-        return new AttachmentUploadResult(attachmentId, $"{attachmentId}/{safeFileName}", safeFileName, contentType, sizeBytes);
+        return new AttachmentUploadResult(attachmentId, $"{attachmentId}/{safeFileName}", displayName, contentType, sizeBytes);
     }
 
     public async Task<(Stream Content, string ContentType)?> DownloadAsync(string storageRef, CancellationToken ct = default)

--- a/server/src/Dotbot.Server/Services/StoragePathResolver.cs
+++ b/server/src/Dotbot.Server/Services/StoragePathResolver.cs
@@ -1,3 +1,4 @@
+using Dotbot.Server.Services.Attachments;
 using Microsoft.Extensions.Configuration;
 using System.IO;
 
@@ -39,7 +40,7 @@ public class StoragePathResolver
         => $"{_env}/tokens/devices/{deviceTokenId}.json";
 
     public string AttachmentBlobPath(Guid responseId, string fileName)
-        => $"{_env}/attachments/{responseId}/{Path.GetFileName(fileName)}";
+        => $"{_env}/attachments/{responseId}/{FilenameSanitizer.ToBlobSafe(fileName)}";
 
     public string AdministratorsPath()
         => $"{_env}/config/administrators.json";

--- a/server/src/Dotbot.Server/Validation/RespondFormHandler.cs
+++ b/server/src/Dotbot.Server/Validation/RespondFormHandler.cs
@@ -1,0 +1,182 @@
+using Dotbot.Server.Models;
+
+namespace Dotbot.Server.Validation;
+
+public sealed record RespondFormInput(
+    string? SelectedKey = null,
+    string? FreeText = null,
+    string? ApprovalDecision = null,
+    string? Comment = null,
+    IReadOnlyList<Guid>? ReviewedAttachmentIds = null,
+    IReadOnlyList<RankedItem>? RankedItems = null,
+    int UploadedAttachmentCount = 0);
+
+public sealed class RespondFormResult
+{
+    public bool IsValid => Error is null;
+    public string? Error { get; init; }
+
+    public string? SelectedKey { get; init; }
+    public Guid? SelectedOptionId { get; init; }
+    public string? SelectedOptionTitle { get; init; }
+    public string? FreeText { get; init; }
+    public string? ApprovalDecision { get; init; }
+    public string? Comment { get; init; }
+    public IReadOnlyList<Guid>? ReviewedAttachmentIds { get; init; }
+    public IReadOnlyList<RankedItem>? RankedItems { get; init; }
+
+    public string? SelectionLabel { get; init; }
+
+    public static RespondFormResult Fail(string error) => new() { Error = error };
+}
+
+public static class RespondFormHandler
+{
+    public static RespondFormResult Validate(QuestionTemplate template, RespondFormInput input)
+    {
+        ArgumentNullException.ThrowIfNull(template);
+        ArgumentNullException.ThrowIfNull(input);
+
+        return template.Type switch
+        {
+            QuestionTypes.Approval => ValidateApproval(input),
+            QuestionTypes.FreeText => ValidateFreeText(input),
+            QuestionTypes.DocumentReview => ValidateDocumentReview(template, input),
+            QuestionTypes.PriorityRanking => ValidatePriorityRanking(template, input),
+            QuestionTypes.SingleChoice or QuestionTypes.MultiChoice
+                => ValidateSingleOrMultiChoice(template, input),
+            _ => RespondFormResult.Fail($"Unsupported question type '{template.Type}'."),
+        };
+    }
+
+    private static RespondFormResult ValidateApproval(RespondFormInput input)
+    {
+        var decision = input.ApprovalDecision?.Trim().ToLowerInvariant();
+        if (string.IsNullOrEmpty(decision) || !ApprovalDecisions.ApprovalAllowed.Contains(decision))
+            return RespondFormResult.Fail("Please choose Approve, Reject, or Abstain.");
+
+        if (decision == ApprovalDecisions.Reject && string.IsNullOrWhiteSpace(input.Comment))
+            return RespondFormResult.Fail("A comment is required when rejecting.");
+
+        return new RespondFormResult
+        {
+            ApprovalDecision = decision,
+            Comment = NullIfBlank(input.Comment),
+            SelectionLabel = ApprovalDecisions.Label(decision),
+        };
+    }
+
+    private static RespondFormResult ValidateFreeText(RespondFormInput input)
+    {
+        if (string.IsNullOrWhiteSpace(input.FreeText))
+            return RespondFormResult.Fail("Please type a response.");
+
+        return new RespondFormResult
+        {
+            FreeText = input.FreeText.Trim(),
+            SelectionLabel = "Free-text response",
+        };
+    }
+
+    private static RespondFormResult ValidateDocumentReview(QuestionTemplate template, RespondFormInput input)
+    {
+        var decision = input.ApprovalDecision?.Trim().ToLowerInvariant();
+        if (string.IsNullOrEmpty(decision) || !ApprovalDecisions.DocumentReviewAllowed.Contains(decision))
+            return RespondFormResult.Fail("Please choose Approve, Request Changes, or Comment Only.");
+
+        if (decision == ApprovalDecisions.RequestChanges && string.IsNullOrWhiteSpace(input.Comment))
+            return RespondFormResult.Fail("A comment is required when requesting changes.");
+
+        var templateAttachments = template.Attachments ?? new List<QuestionAttachment>();
+        if (templateAttachments.Count > 0)
+        {
+            var validIds = templateAttachments
+                .Where(a => a is not null)
+                .Select(a => a.AttachmentId)
+                .ToHashSet();
+
+            var reviewed = (input.ReviewedAttachmentIds ?? Array.Empty<Guid>())
+                .Where(id => validIds.Contains(id))
+                .Distinct()
+                .ToList();
+
+            if (reviewed.Count == 0)
+                return RespondFormResult.Fail("Please confirm you reviewed at least one attachment.");
+
+            return new RespondFormResult
+            {
+                ApprovalDecision = decision,
+                Comment = NullIfBlank(input.Comment),
+                ReviewedAttachmentIds = reviewed,
+                SelectionLabel = ApprovalDecisions.Label(decision),
+            };
+        }
+
+        return new RespondFormResult
+        {
+            ApprovalDecision = decision,
+            Comment = NullIfBlank(input.Comment),
+            SelectionLabel = ApprovalDecisions.Label(decision),
+        };
+    }
+
+    private static RespondFormResult ValidatePriorityRanking(QuestionTemplate template, RespondFormInput input)
+    {
+        var ranked = input.RankedItems?.Where(r => r is not null).ToList() ?? new List<RankedItem>();
+        var optionIds = template.Options.Where(o => o is not null).Select(o => o.OptionId).ToList();
+
+        if (optionIds.Count == 0)
+            return RespondFormResult.Fail("Question has no options to rank.");
+
+        if (ranked.Count != optionIds.Count)
+            return RespondFormResult.Fail("Please rank every option exactly once.");
+
+        var rankedIds = ranked.Select(r => r.OptionId).ToHashSet();
+        if (rankedIds.Count != optionIds.Count || !optionIds.All(rankedIds.Contains))
+            return RespondFormResult.Fail("Ranking must include every option exactly once.");
+
+        var ranks = ranked.Select(r => r.Rank).OrderBy(r => r).ToList();
+        for (var i = 0; i < ranks.Count; i++)
+        {
+            if (ranks[i] != i + 1)
+                return RespondFormResult.Fail($"Ranks must be 1..{optionIds.Count} with no gaps or duplicates.");
+        }
+
+        return new RespondFormResult
+        {
+            RankedItems = ranked,
+            SelectionLabel = $"{ranked.Count} option(s) ranked",
+        };
+    }
+
+    private static RespondFormResult ValidateSingleOrMultiChoice(QuestionTemplate template, RespondFormInput input)
+    {
+        var selected = string.IsNullOrEmpty(input.SelectedKey)
+            ? null
+            : template.Options.FirstOrDefault(o => o is not null && o.Key == input.SelectedKey);
+
+        if (!string.IsNullOrEmpty(input.SelectedKey) && selected is null)
+            return RespondFormResult.Fail("Invalid selection.");
+
+        var freeText = NullIfBlank(input.FreeText);
+        if (selected is null && freeText is null && input.UploadedAttachmentCount == 0)
+            return RespondFormResult.Fail("Please select an option, type a response, or attach a file.");
+
+        var label = selected is not null
+            ? $"{selected.Key}. {selected.Title}"
+            : input.UploadedAttachmentCount > 0
+                ? $"{input.UploadedAttachmentCount} file(s) attached"
+                : "Custom response";
+
+        return new RespondFormResult
+        {
+            SelectedKey = selected?.Key,
+            SelectedOptionId = selected?.OptionId,
+            SelectedOptionTitle = selected?.Title,
+            FreeText = freeText,
+            SelectionLabel = label,
+        };
+    }
+
+    private static string? NullIfBlank(string? s) => string.IsNullOrWhiteSpace(s) ? null : s.Trim();
+}

--- a/server/src/Dotbot.Server/Validation/RespondFormHandler.cs
+++ b/server/src/Dotbot.Server/Validation/RespondFormHandler.cs
@@ -159,6 +159,10 @@ public static class RespondFormHandler
             return RespondFormResult.Fail("Invalid selection.");
 
         var freeText = NullIfBlank(input.FreeText);
+        var allowFreeText = template.ResponseSettings?.AllowFreeText ?? false;
+        if (freeText is not null && !allowFreeText)
+            return RespondFormResult.Fail("Free-text response is not allowed for this question.");
+
         if (selected is null && freeText is null && input.UploadedAttachmentCount == 0)
             return RespondFormResult.Fail("Please select an option, type a response, or attach a file.");
 

--- a/server/tests/Dotbot.Server.Tests/Unit/FilenameSanitizerTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/FilenameSanitizerTests.cs
@@ -53,11 +53,31 @@ public class FilenameSanitizerTests
         => Assert.Equal("file", FilenameSanitizer.ToBlobSafe(input));
 
     [Fact]
-    public void Length_capped_at_200()
+    public void Length_capped_at_200_with_short_extension_preserved()
     {
         var input = new string('a', 500) + ".pdf";
         var result = FilenameSanitizer.ToBlobSafe(input);
         Assert.Equal(200, result.Length);
+        Assert.EndsWith(".pdf", result);
+    }
+
+    [Fact]
+    public void Length_capped_at_200_when_no_extension()
+    {
+        var input = new string('a', 500);
+        var result = FilenameSanitizer.ToBlobSafe(input);
+        Assert.Equal(200, result.Length);
+        Assert.DoesNotContain('.', result);
+    }
+
+    [Fact]
+    public void Length_capped_at_200_when_extension_too_long()
+    {
+        // 30-char "extension" looks more like a stem typo than a real extension — plain cut.
+        var input = new string('a', 300) + "." + new string('b', 30);
+        var result = FilenameSanitizer.ToBlobSafe(input);
+        Assert.Equal(200, result.Length);
+        Assert.StartsWith("aaa", result);
     }
 
     [Fact]

--- a/server/tests/Dotbot.Server.Tests/Unit/FilenameSanitizerTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/FilenameSanitizerTests.cs
@@ -1,0 +1,74 @@
+using Dotbot.Server.Services.Attachments;
+
+namespace Dotbot.Server.Tests.Unit;
+
+public class FilenameSanitizerTests
+{
+    [Theory]
+    [InlineData("report.pdf", "report.pdf")]
+    [InlineData("my-doc_v2.docx", "my-doc_v2.docx")]
+    [InlineData("README.md", "README.md")]
+    public void Allowed_characters_pass_through(string input, string expected)
+        => Assert.Equal(expected, FilenameSanitizer.ToBlobSafe(input));
+
+    [Theory]
+    [InlineData("my report.pdf", "my_report.pdf")]
+    [InlineData("what?.pdf", "what_.pdf")]
+    [InlineData("anchor#tag.pdf", "anchor_tag.pdf")]
+    [InlineData("100%.pdf", "100_.pdf")]
+    [InlineData("a&b.pdf", "a_b.pdf")]
+    public void Url_breaking_characters_replaced_with_underscore(string input, string expected)
+        => Assert.Equal(expected, FilenameSanitizer.ToBlobSafe(input));
+
+    [Theory]
+    [InlineData("отчёт.pdf", ".pdf")]
+    [InlineData("résumé.pdf", "r_sum_.pdf")]
+    [InlineData("日本語.pdf", ".pdf")]
+    public void Non_ascii_replaced_with_underscore(string input, string expected)
+        => Assert.Equal(expected, FilenameSanitizer.ToBlobSafe(input));
+
+    [Theory]
+    [InlineData("a   b.pdf", "a_b.pdf")]
+    [InlineData("a???b.pdf", "a_b.pdf")]
+    [InlineData("a !@# b.pdf", "a_b.pdf")]
+    public void Runs_of_unsafe_characters_collapse_to_single_underscore(string input, string expected)
+        => Assert.Equal(expected, FilenameSanitizer.ToBlobSafe(input));
+
+    [Theory]
+    [InlineData("../etc/passwd", "passwd")]
+    [InlineData("..\\..\\boot.ini", "boot.ini")]
+    [InlineData("/abs/path/file.txt", "file.txt")]
+    public void Directory_traversal_stripped_to_last_segment(string input, string expected)
+        => Assert.Equal(expected, FilenameSanitizer.ToBlobSafe(input));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    [InlineData("???")]
+    [InlineData("___")]
+    [InlineData(".")]
+    [InlineData("..")]
+    public void Empty_or_all_unsafe_falls_back_to_default(string? input)
+        => Assert.Equal("file", FilenameSanitizer.ToBlobSafe(input));
+
+    [Fact]
+    public void Length_capped_at_200()
+    {
+        var input = new string('a', 500) + ".pdf";
+        var result = FilenameSanitizer.ToBlobSafe(input);
+        Assert.Equal(200, result.Length);
+    }
+
+    [Fact]
+    public void Leading_and_trailing_underscores_trimmed()
+    {
+        Assert.Equal("a.pdf", FilenameSanitizer.ToBlobSafe("???a.pdf???"));
+    }
+
+    [Fact]
+    public void Dots_preserved_so_extension_survives_when_stem_collapses()
+    {
+        Assert.Equal(".pdf", FilenameSanitizer.ToBlobSafe("日本語.pdf"));
+    }
+}

--- a/server/tests/Dotbot.Server.Tests/Unit/RespondFormHandlerTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/RespondFormHandlerTests.cs
@@ -317,6 +317,51 @@ public class RespondFormHandlerTests
         Assert.Equal("2 file(s) attached", result.SelectionLabel);
     }
 
+    [Fact]
+    public void SingleChoice_FreeText_WhenNotAllowed_Fails()
+    {
+        var template = Template(QuestionTypes.SingleChoice, Option("A"));
+        // ResponseSettings null → AllowFreeText defaults to false.
+        var result = RespondFormHandler.Validate(
+            template,
+            new RespondFormInput(SelectedKey: "A", FreeText: "smuggled"));
+        Assert.False(result.IsValid);
+        Assert.Contains("not allowed", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SingleChoice_FreeText_OnlyAndNotAllowed_Fails()
+    {
+        var template = Template(QuestionTypes.SingleChoice, Option("A"));
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(FreeText: "hello"));
+        Assert.False(result.IsValid);
+        Assert.Contains("not allowed", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SingleChoice_FreeText_WhenAllowed_Succeeds()
+    {
+        var template = Template(QuestionTypes.SingleChoice, Option("A"));
+        template.ResponseSettings = new ResponseSettings { AllowFreeText = true };
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(FreeText: "hello"));
+        Assert.True(result.IsValid);
+        Assert.Equal("hello", result.FreeText);
+    }
+
+    [Fact]
+    public void SingleChoice_FreeText_WhenAllowed_AndSelected_BothPersist()
+    {
+        var opt = Option("A", "Alpha");
+        var template = Template(QuestionTypes.SingleChoice, opt);
+        template.ResponseSettings = new ResponseSettings { AllowFreeText = true };
+        var result = RespondFormHandler.Validate(
+            template,
+            new RespondFormInput(SelectedKey: "A", FreeText: "and a note"));
+        Assert.True(result.IsValid);
+        Assert.Equal("A", result.SelectedKey);
+        Assert.Equal("and a note", result.FreeText);
+    }
+
     // ── Unsupported type ───────────────────────────────────────────────────
 
     [Fact]

--- a/server/tests/Dotbot.Server.Tests/Unit/RespondFormHandlerTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/RespondFormHandlerTests.cs
@@ -1,0 +1,330 @@
+using Dotbot.Server.Models;
+using Dotbot.Server.Validation;
+
+namespace Dotbot.Server.Tests.Unit;
+
+public class RespondFormHandlerTests
+{
+    private static QuestionTemplate Template(string type, params TemplateOption[] options) => new()
+    {
+        QuestionId = Guid.NewGuid(),
+        Version = 1,
+        Title = "t",
+        Type = type,
+        Options = options.ToList(),
+        Project = new ProjectRef { ProjectId = "p1" },
+        DeliverableSummary = type is QuestionTypes.Approval or QuestionTypes.DocumentReview ? "deliverable" : null,
+    };
+
+    private static TemplateOption Option(string key = "A", string title = "Alpha")
+        => new() { OptionId = Guid.NewGuid(), Key = key, Title = title };
+
+    // ── Approval ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Approval_NoDecision_Fails()
+    {
+        var result = RespondFormHandler.Validate(Template(QuestionTypes.Approval), new RespondFormInput());
+        Assert.False(result.IsValid);
+        Assert.Contains("Approve, Reject, or Abstain", result.Error);
+    }
+
+    [Fact]
+    public void Approval_UnknownDecision_Fails()
+    {
+        var result = RespondFormHandler.Validate(
+            Template(QuestionTypes.Approval),
+            new RespondFormInput(ApprovalDecision: "maybe"));
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void Approval_Reject_RequiresComment()
+    {
+        var result = RespondFormHandler.Validate(
+            Template(QuestionTypes.Approval),
+            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Reject, Comment: "   "));
+        Assert.False(result.IsValid);
+        Assert.Contains("comment is required", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Approval_Reject_WithComment_Succeeds()
+    {
+        var result = RespondFormHandler.Validate(
+            Template(QuestionTypes.Approval),
+            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Reject, Comment: "needs work"));
+        Assert.True(result.IsValid);
+        Assert.Equal(ApprovalDecisions.Reject, result.ApprovalDecision);
+        Assert.Equal("needs work", result.Comment);
+        Assert.Equal("Reject", result.SelectionLabel);
+    }
+
+    [Fact]
+    public void Approval_Approve_NoCommentNeeded()
+    {
+        var result = RespondFormHandler.Validate(
+            Template(QuestionTypes.Approval),
+            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Approve));
+        Assert.True(result.IsValid);
+        Assert.Null(result.Comment);
+    }
+
+    [Fact]
+    public void Approval_Abstain_TrimsCommentNullIfBlank()
+    {
+        var result = RespondFormHandler.Validate(
+            Template(QuestionTypes.Approval),
+            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Abstain, Comment: "   "));
+        Assert.True(result.IsValid);
+        Assert.Null(result.Comment);
+    }
+
+    [Fact]
+    public void Approval_DecisionCaseInsensitive_Normalised()
+    {
+        var result = RespondFormHandler.Validate(
+            Template(QuestionTypes.Approval),
+            new RespondFormInput(ApprovalDecision: "APPROVE"));
+        Assert.True(result.IsValid);
+        Assert.Equal(ApprovalDecisions.Approve, result.ApprovalDecision);
+    }
+
+    // ── FreeText ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void FreeText_Empty_Fails()
+    {
+        var result = RespondFormHandler.Validate(
+            Template(QuestionTypes.FreeText),
+            new RespondFormInput(FreeText: "   "));
+        Assert.False(result.IsValid);
+        Assert.Contains("type a response", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void FreeText_Trimmed_Succeeds()
+    {
+        var result = RespondFormHandler.Validate(
+            Template(QuestionTypes.FreeText),
+            new RespondFormInput(FreeText: "  hello  "));
+        Assert.True(result.IsValid);
+        Assert.Equal("hello", result.FreeText);
+    }
+
+    // ── DocumentReview ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void DocumentReview_NoDecision_Fails()
+    {
+        var template = Template(QuestionTypes.DocumentReview);
+        var result = RespondFormHandler.Validate(template, new RespondFormInput());
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void DocumentReview_RequestChanges_RequiresComment()
+    {
+        var template = Template(QuestionTypes.DocumentReview);
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(
+            ApprovalDecision: ApprovalDecisions.RequestChanges));
+        Assert.False(result.IsValid);
+        Assert.Contains("comment is required", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DocumentReview_NoTemplateAttachments_AcceptsApproveWithoutReviewedIds()
+    {
+        var template = Template(QuestionTypes.DocumentReview);
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(
+            ApprovalDecision: ApprovalDecisions.Approve));
+        Assert.True(result.IsValid);
+        Assert.Null(result.ReviewedAttachmentIds);
+    }
+
+    [Fact]
+    public void DocumentReview_WithAttachments_RequiresAtLeastOneReviewed()
+    {
+        var template = Template(QuestionTypes.DocumentReview);
+        template.Attachments = [new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "spec", BlobPath = "x" }];
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(
+            ApprovalDecision: ApprovalDecisions.Approve,
+            ReviewedAttachmentIds: Array.Empty<Guid>()));
+        Assert.False(result.IsValid);
+        Assert.Contains("reviewed at least one", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DocumentReview_WithAttachments_FiltersUnknownIds()
+    {
+        var aid = Guid.NewGuid();
+        var template = Template(QuestionTypes.DocumentReview);
+        template.Attachments = [new QuestionAttachment { AttachmentId = aid, Name = "spec", BlobPath = "x" }];
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(
+            ApprovalDecision: ApprovalDecisions.Approve,
+            ReviewedAttachmentIds: new[] { aid, Guid.NewGuid() }));
+        Assert.True(result.IsValid);
+        Assert.Single(result.ReviewedAttachmentIds!);
+        Assert.Equal(aid, result.ReviewedAttachmentIds![0]);
+    }
+
+    [Fact]
+    public void DocumentReview_OnlyUnknownIds_Fails()
+    {
+        var template = Template(QuestionTypes.DocumentReview);
+        template.Attachments = [new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "spec", BlobPath = "x" }];
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(
+            ApprovalDecision: ApprovalDecisions.CommentOnly,
+            Comment: "ok",
+            ReviewedAttachmentIds: new[] { Guid.NewGuid() }));
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void DocumentReview_DuplicatesDeduped()
+    {
+        var aid = Guid.NewGuid();
+        var template = Template(QuestionTypes.DocumentReview);
+        template.Attachments = [new QuestionAttachment { AttachmentId = aid, Name = "spec", BlobPath = "x" }];
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(
+            ApprovalDecision: ApprovalDecisions.Approve,
+            ReviewedAttachmentIds: new[] { aid, aid, aid }));
+        Assert.True(result.IsValid);
+        Assert.Single(result.ReviewedAttachmentIds!);
+    }
+
+    // ── PriorityRanking ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Ranking_MissingItems_Fails()
+    {
+        var o1 = Option("A", "Alpha");
+        var o2 = Option("B", "Beta");
+        var template = Template(QuestionTypes.PriorityRanking, o1, o2);
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(
+            RankedItems: new[] { new RankedItem { OptionId = o1.OptionId, Rank = 1 } }));
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void Ranking_WrongOptionId_Fails()
+    {
+        var o1 = Option("A");
+        var o2 = Option("B");
+        var template = Template(QuestionTypes.PriorityRanking, o1, o2);
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(
+            RankedItems: new[]
+            {
+                new RankedItem { OptionId = o1.OptionId, Rank = 1 },
+                new RankedItem { OptionId = Guid.NewGuid(), Rank = 2 },
+            }));
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void Ranking_DuplicateRanks_Fails()
+    {
+        var o1 = Option("A");
+        var o2 = Option("B");
+        var template = Template(QuestionTypes.PriorityRanking, o1, o2);
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(
+            RankedItems: new[]
+            {
+                new RankedItem { OptionId = o1.OptionId, Rank = 1 },
+                new RankedItem { OptionId = o2.OptionId, Rank = 1 },
+            }));
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void Ranking_GapInRanks_Fails()
+    {
+        var o1 = Option("A");
+        var o2 = Option("B");
+        var template = Template(QuestionTypes.PriorityRanking, o1, o2);
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(
+            RankedItems: new[]
+            {
+                new RankedItem { OptionId = o1.OptionId, Rank = 1 },
+                new RankedItem { OptionId = o2.OptionId, Rank = 3 },
+            }));
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void Ranking_FullPermutation_Succeeds()
+    {
+        var o1 = Option("A");
+        var o2 = Option("B");
+        var o3 = Option("C");
+        var template = Template(QuestionTypes.PriorityRanking, o1, o2, o3);
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(
+            RankedItems: new[]
+            {
+                new RankedItem { OptionId = o2.OptionId, Rank = 1 },
+                new RankedItem { OptionId = o3.OptionId, Rank = 2 },
+                new RankedItem { OptionId = o1.OptionId, Rank = 3 },
+            }));
+        Assert.True(result.IsValid);
+        Assert.Equal(3, result.RankedItems!.Count);
+        Assert.Equal("3 option(s) ranked", result.SelectionLabel);
+    }
+
+    [Fact]
+    public void Ranking_NoOptionsTemplate_Fails()
+    {
+        var template = Template(QuestionTypes.PriorityRanking);
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(
+            RankedItems: Array.Empty<RankedItem>()));
+        Assert.False(result.IsValid);
+    }
+
+    // ── SingleChoice fallback ──────────────────────────────────────────────
+
+    [Fact]
+    public void SingleChoice_NothingProvided_Fails()
+    {
+        var template = Template(QuestionTypes.SingleChoice, Option("A"));
+        var result = RespondFormHandler.Validate(template, new RespondFormInput());
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void SingleChoice_KnownKey_Succeeds()
+    {
+        var opt = Option("A", "Alpha");
+        var template = Template(QuestionTypes.SingleChoice, opt);
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(SelectedKey: "A"));
+        Assert.True(result.IsValid);
+        Assert.Equal(opt.OptionId, result.SelectedOptionId);
+        Assert.Equal("A. Alpha", result.SelectionLabel);
+    }
+
+    [Fact]
+    public void SingleChoice_UnknownKey_Fails()
+    {
+        var template = Template(QuestionTypes.SingleChoice, Option("A"));
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(SelectedKey: "Z"));
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void SingleChoice_AttachmentOnly_Succeeds()
+    {
+        var template = Template(QuestionTypes.SingleChoice, Option("A"));
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(UploadedAttachmentCount: 2));
+        Assert.True(result.IsValid);
+        Assert.Equal("2 file(s) attached", result.SelectionLabel);
+    }
+
+    // ── Unsupported type ───────────────────────────────────────────────────
+
+    [Fact]
+    public void UnsupportedType_Fails()
+    {
+        var template = Template("bogus", Option("A"));
+        var result = RespondFormHandler.Validate(template, new RespondFormInput(SelectedKey: "A"));
+        Assert.False(result.IsValid);
+        Assert.Contains("Unsupported", result.Error);
+    }
+}


### PR DESCRIPTION
## Linked issue

Closes #288

## Summary of changes

Extends `Pages/Respond.cshtml` from singleChoice-only to render and submit the four new question types introduced by #29 (PR-7):

- **Approval** — Approve / Reject / Abstain. Reject requires a non-empty comment (server + client).
- **FreeText** — required textarea, server-side null-or-whitespace rejection.
- **DocumentReview** — per-attachment confirmation checkboxes (recorded in `ReviewedAttachmentIds`); Approve / Request Changes / Comment Only decision; feedback textarea required for Request Changes. When the template carries attachments, at least one must be confirmed. Blob-stored attachments render as `/api/attachments/{BlobPath}?token={magic-link-jwt}`; minting a fresh download token for the device-cookie path is deferred to PR-8 (#289).
- **PriorityRanking** — vanilla HTML5 drag-and-drop sortable list, integer ranks serialised to a hidden JSON field. Server validates the submission is a full `1..N` permutation over the template's options.

Validation lifted into `Validation/RespondFormHandler.cs` as a pure helper so per-type rules are unit-testable without spinning up the page model. `ApprovalDecisions` constants centralise the approval / docReview vocabularies.

Submit button is disabled on click for all four new types to prevent a double-POST race against the magic-link JTI consumption path.

The original singleChoice/multiChoice form (with attachment dropzone and async fetch submit) is unchanged.

## Screenshots / recordings

### Approval

<img width="887" height="628" alt="image" src="https://github.com/user-attachments/assets/8f82426e-a1be-4b82-b89c-cbc5c4c176e9" />

### FreeText

<img width="888" height="442" alt="free_text" src="https://github.com/user-attachments/assets/c934d53c-5022-4fda-90a1-51eb4e86557c" />

### DocumentReview

<img width="861" height="742" alt="deliverable approval" src="https://github.com/user-attachments/assets/55b96453-a1e6-4063-a4e0-3c2c8dab0ffe" />

<img width="858" height="835" alt="deliverable approval-error" src="https://github.com/user-attachments/assets/51428421-b0f6-4b3f-8a3a-1d5a8cfc0692" />

### PriorityRanking

<img width="1097" height="629" alt="ranking" src="https://github.com/user-attachments/assets/0e80e422-ba0a-4fea-8646-63964591b157" />

## Testing notes

- 27 unit tests in `RespondFormHandlerTests.cs` cover each type's validation paths (approve/reject/abstain, free-text empty, doc-review attachment-confirmation rules, ranking permutation invariants). Run: `dotnet test server/tests/Dotbot.Server.Tests/Dotbot.Server.Tests.csproj --filter "FullyQualifiedName~RespondFormHandler"`.
- Integration tests for the full POST roundtrip are not yet added — manual end-to-end verification was used instead. Set `DOTBOT_TEST_MODE=true`, seed templates+instances+magic-links via the test endpoints (`/api/test/magic-link`), then open `/respond?token=...` per type in a browser and confirm `ResponseRecordV2` lands correctly via `GET /api/instances/{projectId}/{questionId}/{instanceId}/responses`.
- Reject-requires-comment, Request-Changes-requires-comment, and at-least-one-attachment-confirmed validations all reject empty submissions on both client and server.
- Drag-and-drop ranking verified manually in Chromium-based browser; cross-browser check (Firefox + Safari) recommended before this lands.
- Batch state, `/api/attachments/*` middleware coverage, and JTI-consumption-on-batch-completion are out of scope and arrive in PR-8 (#289).

## Checklist

- [x] Tests added or updated
- [ ] Docs updated (if behaviour changed)
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)