### PR TITLE
[PR-10/#29] Outpost MCP tools + NotificationClient

### DIFF
--- a/core/mcp/modules/NotificationClient.psm1
+++ b/core/mcp/modules/NotificationClient.psm1
@@ -264,6 +264,23 @@ function Send-TaskNotification {
     .PARAMETER Settings
     Optional notification settings. If not provided, reads from config.
 
+    .PARAMETER Type
+    PRD §4.6 question type — singleChoice (default) | approval | documentReview |
+    freeText | priorityRanking. Drives card rendering and response parsing.
+
+    .PARAMETER DeliverableSummary
+    Optional 1-3 line summary shown in channel notifications (PRD §5.2).
+
+    .PARAMETER Attachments
+    Optional array of pre-uploaded attachment metadata
+    (@{ name; description; storage_ref; size_bytes }) returned by
+    Invoke-AttachmentBatchUpload. Emitted on the template payload as camelCase
+    `attachments` with `storageRef` (PRD §5.2 wire shape).
+
+    .PARAMETER ReviewLinks
+    Optional array of @{ title; url; type } for reviewer context. Emitted as
+    template payload `reviewLinks`.
+
     .OUTPUTS
     Hashtable. On success: @{ success = $true; question_id; instance_id; channel; project_id }.
     On failure: @{ success = $false; reason = "..." } (reason is supplied by Send-ServerNotification).
@@ -275,7 +292,15 @@ function Send-TaskNotification {
         [Parameter(Mandatory)]
         [object]$PendingQuestion,
 
-        [object]$Settings
+        [object]$Settings,
+
+        [string]$Type = 'singleChoice',
+
+        [string]$DeliverableSummary,
+
+        [object[]]$Attachments,
+
+        [object[]]$ReviewLinks
     )
 
     $compositeKey = "$($TaskContent.id)-$($PendingQuestion.id)"
@@ -295,6 +320,39 @@ function Send-TaskNotification {
         context          = if ($PendingQuestion.context) { $PendingQuestion.context } else { $null }
         options          = $templateOptions
         responseSettings = @{ allowFreeText = $true }
+        type             = $Type
+    }
+
+    if ($DeliverableSummary) {
+        $template['deliverableSummary'] = $DeliverableSummary
+    }
+
+    if ($Attachments -and @($Attachments).Count -gt 0) {
+        $template['attachments'] = @(foreach ($att in @($Attachments)) {
+            $ref = if ($att -is [hashtable]) { $att['storage_ref'] } else { $att.storage_ref }
+            $name = if ($att -is [hashtable]) { $att['name'] } else { $att.name }
+            $size = if ($att -is [hashtable]) { $att['size_bytes'] } else { $att.size_bytes }
+            $desc = if ($att -is [hashtable]) { $att['description'] } else { $att.description }
+            @{
+                storageRef  = "$ref"
+                name        = "$name"
+                sizeBytes   = [int64]$size
+                description = if ($desc) { "$desc" } else { "" }
+            }
+        })
+    }
+
+    if ($ReviewLinks -and @($ReviewLinks).Count -gt 0) {
+        $template['reviewLinks'] = @(foreach ($link in @($ReviewLinks)) {
+            $title = if ($link -is [hashtable]) { $link['title'] } else { $link.title }
+            $url   = if ($link -is [hashtable]) { $link['url']   } else { $link.url   }
+            $type  = if ($link -is [hashtable]) { $link['type']  } else { $link.type  }
+            @{
+                title = "$title"
+                url   = "$url"
+                type  = if ($type) { "$type" } else { "other" }
+            }
+        })
     }
 
     return Send-ServerNotification -CompositeKey $compositeKey -Template $template -Settings $Settings
@@ -519,6 +577,246 @@ function Resolve-NotificationAnswer {
     }
 }
 
+function Send-AttachmentUpload {
+    <#
+    .SYNOPSIS
+    Uploads a single file to DotbotServer via POST /api/attachments (multipart/form-data).
+
+    .OUTPUTS
+    Hashtable: @{ success; storage_ref; size_bytes; name; description } on success,
+    @{ success = $false; reason } on failure.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [object]$Settings,
+
+        [Parameter(Mandatory)]
+        [string]$FilePath,
+
+        [string]$Description = ""
+    )
+
+    if (-not $Settings.server_url -or -not $Settings.api_key) {
+        return @{ success = $false; reason = "Notifications not configured" }
+    }
+    if (-not (Test-Path -LiteralPath $FilePath)) {
+        return @{ success = $false; reason = "File not found: $FilePath" }
+    }
+
+    $baseUrl = $Settings.server_url.TrimEnd('/')
+    $headers = @{ "X-Api-Key" = $Settings.api_key }
+    $uploadUrl = "$baseUrl/api/attachments"
+    $fileItem = Get-Item -LiteralPath $FilePath
+
+    try {
+        $form = @{
+            file        = $fileItem
+            description = $Description
+        }
+        $resp = Invoke-RestMethod -Uri $uploadUrl -Method Post -Headers $headers `
+            -Form $form -TimeoutSec 60 -ErrorAction Stop
+
+        $storageRef = if ($resp.storageRef) { "$($resp.storageRef)" }
+                      elseif ($resp.storage_ref) { "$($resp.storage_ref)" }
+                      else { $null }
+        if (-not $storageRef) {
+            return @{ success = $false; reason = "Server response missing storageRef" }
+        }
+        $sizeBytes = if ($resp.sizeBytes) { [int64]$resp.sizeBytes }
+                     elseif ($resp.size_bytes) { [int64]$resp.size_bytes }
+                     else { [int64]$fileItem.Length }
+        return @{
+            success     = $true
+            storage_ref = $storageRef
+            size_bytes  = $sizeBytes
+            name        = $fileItem.Name
+            description = $Description
+        }
+    } catch {
+        return @{ success = $false; reason = "Attachment upload failed: $($_.Exception.Message)" }
+    }
+}
+
+function Remove-Attachment {
+    <#
+    .SYNOPSIS
+    Deletes an attachment from DotbotServer via DELETE /api/attachments/{storageRef}.
+    Best-effort; logs warning on failure but does not throw.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [object]$Settings,
+
+        [Parameter(Mandatory)]
+        [string]$StorageRef
+    )
+
+    if (-not $Settings.server_url -or -not $Settings.api_key) { return $false }
+
+    $baseUrl = $Settings.server_url.TrimEnd('/')
+    $headers = @{ "X-Api-Key" = $Settings.api_key }
+    $encoded = [System.Uri]::EscapeDataString($StorageRef)
+    $url = "$baseUrl/api/attachments/$encoded"
+
+    try {
+        $null = Invoke-RestMethod -Uri $url -Method Delete -Headers $headers -TimeoutSec 15 -ErrorAction Stop
+        return $true
+    } catch {
+        if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
+            Write-BotLog -Level Warn -Message "Attachment cleanup failed for $StorageRef" -Exception $_
+        }
+        return $false
+    }
+}
+
+function Invoke-AttachmentBatchUpload {
+    <#
+    .SYNOPSIS
+    Uploads an array of attachments sequentially. On any single failure, rolls
+    back already-uploaded refs via Remove-Attachment, returns failure.
+
+    .PARAMETER Attachments
+    Array of objects/hashtables with { path; description? }.
+
+    .OUTPUTS
+    On full success: @{ success = $true; uploads = @(@{ name; description; storage_ref; size_bytes }, ...) }
+    On any failure : @{ success = $false; reason; uploaded = @(refs already cleaned) }
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [object]$Settings,
+
+        [object[]]$Attachments
+    )
+
+    if (-not $Attachments -or @($Attachments).Count -eq 0) {
+        return @{ success = $true; uploads = @() }
+    }
+
+    $uploaded = @()
+    foreach ($att in @($Attachments)) {
+        $path = if ($att -is [hashtable]) { $att['path'] } else { $att.path }
+        $desc = if ($att -is [hashtable]) { $att['description'] } else { $att.description }
+        if (-not $desc) { $desc = "" }
+
+        $result = Send-AttachmentUpload -Settings $Settings -FilePath $path -Description $desc
+        if (-not $result.success) {
+            # Roll back prior uploads
+            foreach ($prior in $uploaded) {
+                $null = Remove-Attachment -Settings $Settings -StorageRef $prior.storage_ref
+            }
+            return @{
+                success  = $false
+                reason   = $result.reason
+                uploaded = @()
+            }
+        }
+        $uploaded += @{
+            name        = $result.name
+            description = $result.description
+            storage_ref = $result.storage_ref
+            size_bytes  = $result.size_bytes
+        }
+    }
+
+    return @{ success = $true; uploads = $uploaded }
+}
+
+function ConvertTo-TypedResponse {
+    <#
+    .SYNOPSIS
+    Parses a notification response into PRD §5.4 typed fields. Metadata only —
+    does NOT download attachment bytes.
+
+    .PARAMETER Response
+    Raw response object from Get-TaskNotificationResponse.
+
+    .PARAMETER Type
+    Question type from the original template. Defaults to 'singleChoice' for
+    legacy responses (no template type metadata).
+
+    .OUTPUTS
+    Hashtable. Keys (only set when applicable):
+      answer_type        - the type string echoed back
+      answer             - resolved string for singleChoice (key) / freeText (string)
+      approval_decision  - approval / documentReview decision value
+      comment            - free-text comment
+      ranked_items       - array for priorityRanking
+      attachment_refs    - array of @{ name; size_bytes; storage_ref; description }
+    Returns $null when no meaningful payload found.
+    #>
+    param(
+        [Parameter(Mandatory)] $Response,
+        [string]$Type = 'singleChoice'
+    )
+
+    if (-not $Response) { return $null }
+
+    $out = @{ answer_type = $Type }
+
+    # Attachment metadata (no download)
+    $attachmentRefs = @()
+    if ($Response.PSObject.Properties['attachments'] -and $Response.attachments) {
+        foreach ($att in @($Response.attachments)) {
+            $ref = if ($att.PSObject.Properties['storageRef']) { "$($att.storageRef)" }
+                   elseif ($att.PSObject.Properties['storage_ref']) { "$($att.storage_ref)" }
+                   elseif ($att.PSObject.Properties['blobPath']) { "$($att.blobPath)" }
+                   else { $null }
+            $size = if ($att.PSObject.Properties['sizeBytes']) { [int64]$att.sizeBytes }
+                    elseif ($att.PSObject.Properties['size_bytes']) { [int64]$att.size_bytes }
+                    else { 0 }
+            $name = if ($att.PSObject.Properties['name']) { "$($att.name)" } else { "attachment" }
+            $desc = if ($att.PSObject.Properties['description']) { "$($att.description)" } else { "" }
+            $attachmentRefs += @{
+                name        = $name
+                size_bytes  = $size
+                storage_ref = $ref
+                description = $desc
+            }
+        }
+    }
+    if ($attachmentRefs.Count -gt 0) {
+        $out['attachment_refs'] = $attachmentRefs
+    }
+
+    $comment = if ($Response.PSObject.Properties['comment']) { "$($Response.comment)" } else { $null }
+    $decision = if ($Response.PSObject.Properties['approvalDecision']) { "$($Response.approvalDecision)" }
+                elseif ($Response.PSObject.Properties['decision']) { "$($Response.decision)" }
+                else { $null }
+    $selectedKey = if ($Response.PSObject.Properties['selectedKey']) { "$($Response.selectedKey)" } else { $null }
+    $freeText    = if ($Response.PSObject.Properties['freeText'])    { "$($Response.freeText)"    } else { $null }
+    $rankedItems = if ($Response.PSObject.Properties['rankedItems']) { @($Response.rankedItems) }
+                   elseif ($Response.PSObject.Properties['ranked_items']) { @($Response.ranked_items) }
+                   else { $null }
+
+    switch ($Type) {
+        'approval' {
+            if ($decision) { $out['approval_decision'] = $decision }
+            if ($comment)  { $out['comment']           = $comment  }
+        }
+        'documentReview' {
+            if ($decision) { $out['approval_decision'] = $decision }
+            if ($comment)  { $out['comment']           = $comment  }
+        }
+        'priorityRanking' {
+            if ($rankedItems) { $out['ranked_items'] = $rankedItems }
+        }
+        'freeText' {
+            if ($freeText) { $out['answer'] = $freeText }
+        }
+        default {
+            # singleChoice / legacy: prefer selectedKey, else freeText
+            if ($selectedKey)   { $out['answer'] = $selectedKey }
+            elseif ($freeText)  { $out['answer'] = $freeText    }
+        }
+    }
+
+    # Reject empty payloads (no fields beyond answer_type)
+    if ($out.Keys.Count -le 1) { return $null }
+
+    return $out
+}
+
 Export-ModuleMember -Function @(
     'Get-NotificationSettings'
     'Test-NotificationServer'
@@ -526,4 +824,8 @@ Export-ModuleMember -Function @(
     'Send-SplitProposalNotification'
     'Get-TaskNotificationResponse'
     'Resolve-NotificationAnswer'
+    'Send-AttachmentUpload'
+    'Remove-Attachment'
+    'Invoke-AttachmentBatchUpload'
+    'ConvertTo-TypedResponse'
 )

--- a/core/mcp/modules/NotificationClient.psm1
+++ b/core/mcp/modules/NotificationClient.psm1
@@ -850,7 +850,27 @@ function ConvertTo-TypedResponse {
             if ($comment)  { $out['comment']           = $comment  }
         }
         'priorityRanking' {
-            if ($rankedItems) { $out['ranked_items'] = $rankedItems }
+            if ($rankedItems) {
+                # Server emits RankedItem[] = [{ optionId: Guid, rank: int }]
+                # (Models/RankedItem.cs). Sort by rank and project to optionId
+                # strings so downstream `-join ', '` produces meaningful output
+                # instead of "System.Management.Automation.PSCustomObject".
+                # Legacy callers passing string arrays fall through the
+                # passthrough branch.
+                $normalized = @(@($rankedItems) |
+                    Where-Object { $_ } |
+                    Sort-Object -Property @{ Expression = {
+                        if ($_ -is [hashtable] -and $_.ContainsKey('rank')) { [int]$_['rank'] }
+                        elseif ($_.PSObject.Properties['rank']) { [int]$_.rank }
+                        else { [int]::MaxValue }
+                    } } |
+                    ForEach-Object {
+                        if ($_ -is [hashtable] -and $_.ContainsKey('optionId')) { "$($_['optionId'])" }
+                        elseif ($_.PSObject.Properties['optionId']) { "$($_.optionId)" }
+                        else { "$_" }
+                    })
+                if ($normalized.Count -gt 0) { $out['ranked_items'] = $normalized }
+            }
         }
         'freeText' {
             if ($freeText) { $out['answer'] = $freeText }

--- a/core/mcp/modules/NotificationClient.psm1
+++ b/core/mcp/modules/NotificationClient.psm1
@@ -353,14 +353,18 @@ function Send-TaskNotification {
         # Wire shape matches server ReferenceLink (Models/ReferenceLink.cs): { label, url }.
         # MCP input still uses review_links/{title,url,type} per PRD §4.6; type has no server
         # counterpart and is dropped at this wire boundary.
-        $template['referenceLinks'] = @(foreach ($link in @($ReviewLinks)) {
+        # Filter to safe HTTP/HTTPS URLs only — mirrors server IsSafeHttpsUrl validation and
+        # prevents SSRF via attacker-controlled task metadata reaching internal endpoints.
+        $safeLinks = @(foreach ($link in @($ReviewLinks)) {
             $title = if ($link -is [hashtable]) { $link['title'] } else { $link.title }
             $url   = if ($link -is [hashtable]) { $link['url']   } else { $link.url   }
-            @{
-                label = "$title"
-                url   = "$url"
+            if ("$url" -match '^https?://' -and "$url" -notmatch '[<>"''\\]') {
+                @{ label = "$title"; url = "$url" }
             }
         })
+        if ($safeLinks.Count -gt 0) {
+            $template['referenceLinks'] = $safeLinks
+        }
     }
 
     return Send-ServerNotification -CompositeKey $compositeKey -Template $template -Settings $Settings
@@ -609,26 +613,28 @@ function Send-AttachmentUpload {
     if (-not $Settings.server_url -or -not $Settings.api_key) {
         return @{ success = $false; reason = "Notifications not configured" }
     }
-    if (-not (Test-Path -LiteralPath $FilePath)) {
-        return @{ success = $false; reason = "File not found: $FilePath" }
-    }
 
     # Path-traversal guard: MCP tools are driven by untrusted LLM input. Reject
     # any FilePath that resolves outside the project root to prevent exfiltration
-    # of arbitrary host files
-    $projectRoot = if ($global:DotbotProjectRoot) { "$($global:DotbotProjectRoot)" } else { $null }
-    if ($projectRoot) {
-        try {
-            $resolvedFile = [System.IO.Path]::GetFullPath($FilePath)
-            $resolvedRoot = [System.IO.Path]::GetFullPath($projectRoot).TrimEnd([System.IO.Path]::DirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
-            # Linux paths are case-sensitive; Windows/macOS default to case-insensitive comparison.
-            $pathCmp = if ($IsLinux) { [System.StringComparison]::Ordinal } else { [System.StringComparison]::OrdinalIgnoreCase }
-            if (-not $resolvedFile.StartsWith($resolvedRoot, $pathCmp)) {
-                return @{ success = $false; reason = "FilePath outside project root: $FilePath" }
-            }
-        } catch {
-            return @{ success = $false; reason = "Invalid file path: $FilePath" }
+    # of arbitrary host files. Fail closed — no DotbotProjectRoot means no upload.
+    # Check authorization BEFORE file existence to avoid leaking whether a path exists.
+    if (-not (Test-Path Variable:global:DotbotProjectRoot) -or -not $global:DotbotProjectRoot) {
+        return @{ success = $false; reason = "Upload rejected: DotbotProjectRoot not set" }
+    }
+
+    if (-not (Test-Path -LiteralPath $FilePath)) {
+        return @{ success = $false; reason = "File not found: $FilePath" }
+    }
+    try {
+        $resolvedFile = [System.IO.Path]::GetFullPath($FilePath)
+        $resolvedRoot = [System.IO.Path]::GetFullPath("$($global:DotbotProjectRoot)").TrimEnd([System.IO.Path]::DirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+        # Windows is case-insensitive; Linux/macOS (including case-sensitive APFS) require Ordinal.
+        $pathCmp = if ($IsWindows) { [System.StringComparison]::OrdinalIgnoreCase } else { [System.StringComparison]::Ordinal }
+        if (-not $resolvedFile.StartsWith($resolvedRoot, $pathCmp)) {
+            return @{ success = $false; reason = "FilePath outside project root: $FilePath" }
         }
+    } catch {
+        return @{ success = $false; reason = "Invalid file path: $FilePath" }
     }
 
     $baseUrl = $Settings.server_url.TrimEnd('/')
@@ -687,6 +693,15 @@ function Remove-Attachment {
     )
 
     if (-not $Settings.server_url -or -not $Settings.api_key) { return $false }
+
+    # Reject path-traversal sequences — `..` after segment-encoding stays literal
+    # and would let a crafted storageRef escape the attachments route on the server.
+    if ($StorageRef -match '(^|/)\.\.(/|$)') {
+        if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
+            Write-BotLog -Level Warn -Message "Remove-Attachment rejected suspicious storageRef: $StorageRef"
+        }
+        return $false
+    }
 
     $baseUrl = $Settings.server_url.TrimEnd('/')
     $headers = @{ "X-Api-Key" = $Settings.api_key }

--- a/core/mcp/modules/NotificationClient.psm1
+++ b/core/mcp/modules/NotificationClient.psm1
@@ -591,8 +591,10 @@ function Send-AttachmentUpload {
     Uploads a single file to DotbotServer via POST /api/attachments (multipart/form-data).
 
     .OUTPUTS
-    Hashtable: @{ success; storage_ref; size_bytes; name; description } on success,
-    @{ success = $false; reason } on failure.
+    Hashtable on success: @{ success; attachment_id; storage_ref; size_bytes; name; description }.
+    attachment_id is the Guid returned by POST /api/attachments and is required
+    by the template wire shape (server QuestionAttachment).
+    On failure: @{ success = $false; reason }.
     #>
     param(
         [Parameter(Mandatory)]
@@ -717,8 +719,12 @@ function Invoke-AttachmentBatchUpload {
     Array of objects/hashtables with { path; description? }.
 
     .OUTPUTS
-    On full success: @{ success = $true; uploads = @(@{ name; description; storage_ref; size_bytes }, ...) }
-    On any failure : @{ success = $false; reason; uploaded = @(refs already cleaned) }
+    On full success: @{ success = $true; uploads = @(@{ name; description;
+    attachment_id; storage_ref; size_bytes }, ...) }. attachment_id is required
+    downstream by Send-TaskNotification when emitting the template wire payload
+    (server QuestionAttachment requires it).
+    On any failure : @{ success = $false; reason; uploaded = @(storage_refs of
+    the prior successful uploads that were rolled back via Remove-Attachment) }.
     #>
     param(
         [Parameter(Mandatory)]

--- a/core/mcp/modules/NotificationClient.psm1
+++ b/core/mcp/modules/NotificationClient.psm1
@@ -272,14 +272,18 @@ function Send-TaskNotification {
     Optional 1-3 line summary shown in channel notifications (PRD §5.2).
 
     .PARAMETER Attachments
-    Optional array of pre-uploaded attachment metadata
-    (@{ name; description; storage_ref; size_bytes }) returned by
-    Invoke-AttachmentBatchUpload. Emitted on the template payload as camelCase
-    `attachments` with `storageRef` (PRD §5.2 wire shape).
+    Optional array of pre-uploaded attachment metadata returned by
+    Invoke-AttachmentBatchUpload (@{ name; description; attachment_id;
+    storage_ref; size_bytes }). Emitted on the template payload as
+    `attachments[*] = { attachmentId, blobPath = storage_ref, name, sizeBytes }`
+    matching server `QuestionAttachment` (Models/QuestionAttachment.cs).
+    `storageRef`/`description` are client-side keys and not part of the wire shape.
 
     .PARAMETER ReviewLinks
-    Optional array of @{ title; url; type } for reviewer context. Emitted as
-    template payload `reviewLinks`.
+    Optional array of @{ title; url; type } for reviewer context. Emitted on
+    the template payload as `referenceLinks[*] = { label, url }` matching server
+    `ReferenceLink` (Models/ReferenceLink.cs). `title` → `label`; `type` has no
+    server counterpart and is dropped at the wire boundary.
 
     .OUTPUTS
     Hashtable. On success: @{ success = $true; question_id; instance_id; channel; project_id }.
@@ -685,10 +689,11 @@ function Remove-Attachment {
     $baseUrl = $Settings.server_url.TrimEnd('/')
     $headers = @{ "X-Api-Key" = $Settings.api_key }
     # storageRef is `{guid}/{filename}`. Server route is `{**storageRef}` catch-all and
-    # expects literal `/` separators. EscapeUriString preserves `/` while encoding any
-    # other special chars in the filename. EscapeDataString would percent-encode `/` and
-    # cause a 404 — same pattern Resolve-NotificationAnswer uses for downloads.
-    $encoded = [System.Uri]::EscapeUriString($StorageRef)
+    # expects literal `/` separators. Segment-encode (split on `/`, EscapeDataString
+    # each segment, rejoin) so `/` stays literal while `#`, `?`, spaces, and other
+    # reserved chars in filenames get percent-encoded — EscapeUriString alone leaves
+    # `#`/`?` unencoded and would truncate the request URI.
+    $encoded = ($StorageRef -split '/' | ForEach-Object { [System.Uri]::EscapeDataString($_) }) -join '/'
     $url = "$baseUrl/api/attachments/$encoded"
 
     try {

--- a/core/mcp/modules/NotificationClient.psm1
+++ b/core/mcp/modules/NotificationClient.psm1
@@ -603,6 +603,22 @@ function Send-AttachmentUpload {
         return @{ success = $false; reason = "File not found: $FilePath" }
     }
 
+    # Path-traversal guard: MCP tools are driven by untrusted LLM input. Reject
+    # any FilePath that resolves outside the project root to prevent exfiltration
+    # of arbitrary host files
+    $projectRoot = if ($global:DotbotProjectRoot) { "$($global:DotbotProjectRoot)" } else { $null }
+    if ($projectRoot) {
+        try {
+            $resolvedFile = [System.IO.Path]::GetFullPath($FilePath)
+            $resolvedRoot = [System.IO.Path]::GetFullPath($projectRoot).TrimEnd([System.IO.Path]::DirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+            if (-not $resolvedFile.StartsWith($resolvedRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+                return @{ success = $false; reason = "FilePath outside project root: $FilePath" }
+            }
+        } catch {
+            return @{ success = $false; reason = "Invalid file path: $FilePath" }
+        }
+    }
+
     $baseUrl = $Settings.server_url.TrimEnd('/')
     $headers = @{ "X-Api-Key" = $Settings.api_key }
     $uploadUrl = "$baseUrl/api/attachments"
@@ -701,14 +717,17 @@ function Invoke-AttachmentBatchUpload {
 
         $result = Send-AttachmentUpload -Settings $Settings -FilePath $path -Description $desc
         if (-not $result.success) {
-            # Roll back prior uploads
+            # Roll back prior uploads; return the refs we tried to clean up so
+            # callers/tests can introspect what was reverted (matches docstring).
+            $rolled = @()
             foreach ($prior in $uploaded) {
                 $null = Remove-Attachment -Settings $Settings -StorageRef $prior.storage_ref
+                $rolled += $prior.storage_ref
             }
             return @{
                 success  = $false
                 reason   = $result.reason
-                uploaded = @()
+                uploaded = $rolled
             }
         }
         $uploaded += @{
@@ -762,6 +781,9 @@ function ConvertTo-TypedResponse {
                    elseif ($att.PSObject.Properties['storage_ref']) { "$($att.storage_ref)" }
                    elseif ($att.PSObject.Properties['blobPath']) { "$($att.blobPath)" }
                    else { $null }
+            # Skip attachments without an identifier — a storage_ref=$null entry
+            # would confuse downstream readers (UI persists unusable metadata).
+            if (-not $ref) { continue }
             $size = if ($att.PSObject.Properties['sizeBytes']) { [int64]$att.sizeBytes }
                     elseif ($att.PSObject.Properties['size_bytes']) { [int64]$att.size_bytes }
                     else { 0 }

--- a/core/mcp/modules/NotificationClient.psm1
+++ b/core/mcp/modules/NotificationClient.psm1
@@ -328,29 +328,33 @@ function Send-TaskNotification {
     }
 
     if ($Attachments -and @($Attachments).Count -gt 0) {
+        # Wire shape matches server QuestionAttachment (Models/QuestionAttachment.cs):
+        # required attachmentId + name, exactly one of url/blobPath (we emit blobPath = storageRef).
+        # storage_ref/description are client-side keys; not part of the server schema.
         $template['attachments'] = @(foreach ($att in @($Attachments)) {
-            $ref = if ($att -is [hashtable]) { $att['storage_ref'] } else { $att.storage_ref }
-            $name = if ($att -is [hashtable]) { $att['name'] } else { $att.name }
-            $size = if ($att -is [hashtable]) { $att['size_bytes'] } else { $att.size_bytes }
-            $desc = if ($att -is [hashtable]) { $att['description'] } else { $att.description }
+            $aid  = if ($att -is [hashtable]) { $att['attachment_id'] } else { $att.attachment_id }
+            $ref  = if ($att -is [hashtable]) { $att['storage_ref']   } else { $att.storage_ref }
+            $name = if ($att -is [hashtable]) { $att['name'] }          else { $att.name }
+            $size = if ($att -is [hashtable]) { $att['size_bytes'] }    else { $att.size_bytes }
             @{
-                storageRef  = "$ref"
-                name        = "$name"
-                sizeBytes   = [int64]$size
-                description = if ($desc) { "$desc" } else { "" }
+                attachmentId = "$aid"
+                name         = "$name"
+                blobPath     = "$ref"
+                sizeBytes    = [int64]$size
             }
         })
     }
 
     if ($ReviewLinks -and @($ReviewLinks).Count -gt 0) {
-        $template['reviewLinks'] = @(foreach ($link in @($ReviewLinks)) {
+        # Wire shape matches server ReferenceLink (Models/ReferenceLink.cs): { label, url }.
+        # MCP input still uses review_links/{title,url,type} per PRD §4.6; type has no server
+        # counterpart and is dropped at this wire boundary.
+        $template['referenceLinks'] = @(foreach ($link in @($ReviewLinks)) {
             $title = if ($link -is [hashtable]) { $link['title'] } else { $link.title }
             $url   = if ($link -is [hashtable]) { $link['url']   } else { $link.url   }
-            $type  = if ($link -is [hashtable]) { $link['type']  } else { $link.type  }
             @{
-                title = "$title"
+                label = "$title"
                 url   = "$url"
-                type  = if ($type) { "$type" } else { "other" }
             }
         })
     }
@@ -611,7 +615,9 @@ function Send-AttachmentUpload {
         try {
             $resolvedFile = [System.IO.Path]::GetFullPath($FilePath)
             $resolvedRoot = [System.IO.Path]::GetFullPath($projectRoot).TrimEnd([System.IO.Path]::DirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
-            if (-not $resolvedFile.StartsWith($resolvedRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+            # Linux paths are case-sensitive; Windows/macOS default to case-insensitive comparison.
+            $pathCmp = if ($IsLinux) { [System.StringComparison]::Ordinal } else { [System.StringComparison]::OrdinalIgnoreCase }
+            if (-not $resolvedFile.StartsWith($resolvedRoot, $pathCmp)) {
                 return @{ success = $false; reason = "FilePath outside project root: $FilePath" }
             }
         } catch {
@@ -638,15 +644,22 @@ function Send-AttachmentUpload {
         if (-not $storageRef) {
             return @{ success = $false; reason = "Server response missing storageRef" }
         }
+        $attachmentId = if ($resp.attachmentId) { "$($resp.attachmentId)" }
+                        elseif ($resp.attachment_id) { "$($resp.attachment_id)" }
+                        else { $null }
+        if (-not $attachmentId) {
+            return @{ success = $false; reason = "Server response missing attachmentId" }
+        }
         $sizeBytes = if ($resp.sizeBytes) { [int64]$resp.sizeBytes }
                      elseif ($resp.size_bytes) { [int64]$resp.size_bytes }
                      else { [int64]$fileItem.Length }
         return @{
-            success     = $true
-            storage_ref = $storageRef
-            size_bytes  = $sizeBytes
-            name        = $fileItem.Name
-            description = $Description
+            success       = $true
+            attachment_id = $attachmentId
+            storage_ref   = $storageRef
+            size_bytes    = $sizeBytes
+            name          = $fileItem.Name
+            description   = $Description
         }
     } catch {
         return @{ success = $false; reason = "Attachment upload failed: $($_.Exception.Message)" }
@@ -671,7 +684,11 @@ function Remove-Attachment {
 
     $baseUrl = $Settings.server_url.TrimEnd('/')
     $headers = @{ "X-Api-Key" = $Settings.api_key }
-    $encoded = [System.Uri]::EscapeDataString($StorageRef)
+    # storageRef is `{guid}/{filename}`. Server route is `{**storageRef}` catch-all and
+    # expects literal `/` separators. EscapeUriString preserves `/` while encoding any
+    # other special chars in the filename. EscapeDataString would percent-encode `/` and
+    # cause a 404 — same pattern Resolve-NotificationAnswer uses for downloads.
+    $encoded = [System.Uri]::EscapeUriString($StorageRef)
     $url = "$baseUrl/api/attachments/$encoded"
 
     try {
@@ -731,10 +748,11 @@ function Invoke-AttachmentBatchUpload {
             }
         }
         $uploaded += @{
-            name        = $result.name
-            description = $result.description
-            storage_ref = $result.storage_ref
-            size_bytes  = $result.size_bytes
+            name          = $result.name
+            description   = $result.description
+            attachment_id = $result.attachment_id
+            storage_ref   = $result.storage_ref
+            size_bytes    = $result.size_bytes
         }
     }
 

--- a/core/mcp/tools/task-answer-question/metadata.yaml
+++ b/core/mcp/tools/task-answer-question/metadata.yaml
@@ -8,7 +8,22 @@ inputSchema:
       description: "The unique identifier of the task"
     answer:
       type: string
-      description: "The answer - either an option key (A, B, C, D, E) or a custom freeform answer"
+      description: "The answer - either an option key (A, B, C, D, E) or a custom freeform answer. Required for singleChoice/freeText types."
+    type:
+      type: string
+      enum: [singleChoice, approval, documentReview, freeText, priorityRanking]
+      description: "Question type. Determines which fields are required/validated."
+    decision:
+      type: string
+      description: "Required for approval/documentReview. Allowed values vary per type (PRD §4.1)."
+    comment:
+      type: string
+      description: "Required when decision=rejected on an approval question."
+    ranked_items:
+      type: array
+      description: "Required for priorityRanking. Ordered list of item identifiers."
+      items:
+        type: string
     question_id:
       type: string
       description: "Optional: the ID of the specific question to answer when task has pending_questions batch (e.g. 'q1'). Defaults to the first pending question."
@@ -26,4 +41,3 @@ inputSchema:
             type: string
   required:
     - task_id
-    - answer

--- a/core/mcp/tools/task-answer-question/script.ps1
+++ b/core/mcp/tools/task-answer-question/script.ps1
@@ -31,14 +31,53 @@ function Invoke-TaskAnswerQuestion {
     $answer = $Arguments['answer']
     $attachments = $Arguments['attachments']
     $questionId = $Arguments['question_id']  # Optional: which question to answer (for pending_questions batch)
+    $questionType = if ($Arguments['type']) { "$($Arguments['type'])" } else { $null }
+    $decision = if ($Arguments['decision']) { "$($Arguments['decision'])" } else { $null }
+    $comment = if ($Arguments['comment']) { "$($Arguments['comment'])" } else { $null }
+    $rankedItems = $Arguments['ranked_items']
 
     # Validate required fields
     if (-not $taskId) {
         throw "Task ID is required"
     }
 
+    # Type-specific validation (PRD §4.1, §4.6)
+    $validDecisions = @{
+        approval       = @('approved', 'rejected', 'abstained')
+        documentReview = @('approved', 'changes_requested', 'comment_only')
+    }
+    $validTypes = @('singleChoice', 'approval', 'documentReview', 'freeText', 'priorityRanking')
+    if ($questionType -and $questionType -notin $validTypes) {
+        throw "Invalid 'type' value '$questionType'. Allowed: $($validTypes -join ', ')"
+    }
+
+    if ($questionType -and $validDecisions.ContainsKey($questionType)) {
+        if (-not $decision) {
+            throw "'decision' is required for type '$questionType'"
+        }
+        if ($decision -notin $validDecisions[$questionType]) {
+            throw "Invalid 'decision' value '$decision' for type '$questionType'. Allowed: $($validDecisions[$questionType] -join ', ')"
+        }
+        if ($decision -eq 'rejected' -and -not $comment) {
+            throw "'comment' is required when decision='rejected'"
+        }
+    } elseif ($questionType -eq 'priorityRanking') {
+        if (-not $rankedItems -or @($rankedItems).Count -eq 0) {
+            throw "'ranked_items' is required for type 'priorityRanking'"
+        }
+    } else {
+        # singleChoice / freeText / unset (legacy) — answer required
+        if (-not $answer) {
+            throw "Answer is required"
+        }
+    }
+
+    # Synthesize an answer string for non-question types so downstream
+    # status-transition logic (skip detection, summary text) keeps working.
     if (-not $answer) {
-        throw "Answer is required"
+        $answer = if ($decision) { $decision }
+                  elseif ($rankedItems) { (@($rankedItems) -join ', ') }
+                  else { '' }
     }
 
     # Define tasks directories
@@ -119,13 +158,16 @@ function Invoke-TaskAnswerQuestion {
             id          = $targetQuestion.id
             question    = $targetQuestion.question
             answer      = $resolvedAnswer
-            answer_type = $answerType
+            answer_type = if ($questionType) { $questionType } else { $answerType }
             asked_at    = $targetQuestion.asked_at
             answered_at = $answeredAt
         }
         if ($attachments -and $attachments.Count -gt 0) {
             $resolvedEntry['attachments'] = $attachments
         }
+        if ($decision) { $resolvedEntry['approval_decision'] = $decision }
+        if ($comment)  { $resolvedEntry['comment']           = $comment  }
+        if ($rankedItems) { $resolvedEntry['ranked_items']  = @($rankedItems) }
 
         # Persist to interview-answers.json (survives task resets)
         $interviewEntry = @{
@@ -135,8 +177,12 @@ function Invoke-TaskAnswerQuestion {
             answer_key   = if ($answerType -eq 'option') { $answerKey } else { $null }
             answer_label = if ($answerType -eq 'option' -and $matchingOption) { $matchingOption.label } else { $null }
             answer       = $resolvedAnswer
+            answer_type  = if ($questionType) { $questionType } else { $answerType }
             answered_at  = $answeredAt
         }
+        if ($decision)    { $interviewEntry['approval_decision'] = $decision }
+        if ($comment)     { $interviewEntry['comment']           = $comment  }
+        if ($rankedItems) { $interviewEntry['ranked_items']      = @($rankedItems) }
         Write-InterviewAnswer -BotRoot (Join-Path $global:DotbotProjectRoot '.bot') -Entry $interviewEntry
 
         # Add to questions_resolved
@@ -276,7 +322,7 @@ function Invoke-TaskAnswerQuestion {
         id = $pendingQuestion.id
         question = $pendingQuestion.question
         answer = $resolvedAnswer
-        answer_type = $answerType
+        answer_type = if ($questionType) { $questionType } else { $answerType }
         asked_at = $pendingQuestion.asked_at
         answered_at = $answeredAt
     }
@@ -284,20 +330,28 @@ function Invoke-TaskAnswerQuestion {
     if ($attachments -and $attachments.Count -gt 0) {
         $resolvedEntry['attachments'] = $attachments
     }
+    if ($decision) { $resolvedEntry['approval_decision'] = $decision }
+    if ($comment)  { $resolvedEntry['comment']           = $comment  }
+    if ($rankedItems) { $resolvedEntry['ranked_items']  = @($rankedItems) }
 
     # Persist to interview-answers.json (survives task resets)
     $singularMatchingOption = if ($answerType -eq 'option') {
         $pendingQuestion.options | Where-Object { $_.key -eq $answerKey } | Select-Object -First 1
     } else { $null }
-    Write-InterviewAnswer -BotRoot (Join-Path $global:DotbotProjectRoot '.bot') -Entry @{
+    $singularInterviewEntry = @{
         question_id  = $pendingQuestion.id
         question     = $pendingQuestion.question
         context      = $pendingQuestion.context
         answer_key   = if ($answerType -eq 'option') { $answerKey } else { $null }
         answer_label = if ($singularMatchingOption) { $singularMatchingOption.label } else { $null }
         answer       = $resolvedAnswer
+        answer_type  = if ($questionType) { $questionType } else { $answerType }
         answered_at  = $answeredAt
     }
+    if ($decision)    { $singularInterviewEntry['approval_decision'] = $decision }
+    if ($comment)     { $singularInterviewEntry['comment']           = $comment  }
+    if ($rankedItems) { $singularInterviewEntry['ranked_items']      = @($rankedItems) }
+    Write-InterviewAnswer -BotRoot (Join-Path $global:DotbotProjectRoot '.bot') -Entry $singularInterviewEntry
 
     # Add to questions_resolved array
     if (-not $taskContent.PSObject.Properties['questions_resolved']) {

--- a/core/mcp/tools/task-answer-question/script.ps1
+++ b/core/mcp/tools/task-answer-question/script.ps1
@@ -58,8 +58,8 @@ function Invoke-TaskAnswerQuestion {
         if ($decision -notin $validDecisions[$questionType]) {
             throw "Invalid 'decision' value '$decision' for type '$questionType'. Allowed: $($validDecisions[$questionType] -join ', ')"
         }
-        if ($decision -eq 'rejected' -and -not $comment) {
-            throw "'comment' is required when decision='rejected'"
+        if ($decision -in @('rejected', 'changes_requested') -and -not $comment) {
+            throw "'comment' is required when decision='$decision'"
         }
     } elseif ($questionType -eq 'priorityRanking') {
         if (-not $rankedItems -or @($rankedItems).Count -eq 0) {
@@ -97,7 +97,18 @@ function Invoke-TaskAnswerQuestion {
     # status-transition logic (skip detection, summary text) keeps working.
     if (-not $answer) {
         $answer = if ($decision) { $decision }
-                  elseif ($rankedItems) { (@($rankedItems) -join ', ') }
+                  elseif ($rankedItems) {
+                      # Normalize each item: extract optionId string if Claude passed
+                      # PSCustomObject/hashtable items (e.g. from a prior response object)
+                      # so -join doesn't stringify to "System.Management.Automation.PSCustomObject".
+                      $normalized = @($rankedItems | ForEach-Object {
+                          if ($_ -is [string]) { $_ }
+                          elseif ($_ -is [hashtable] -and $_.ContainsKey('optionId')) { "$($_['optionId'])" }
+                          elseif ($_.PSObject.Properties['optionId']) { "$($_.optionId)" }
+                          else { "$_" }
+                      })
+                      $normalized -join ', '
+                  }
                   else { '' }
     }
 

--- a/core/mcp/tools/task-answer-question/script.ps1
+++ b/core/mcp/tools/task-answer-question/script.ps1
@@ -87,6 +87,11 @@ function Invoke-TaskAnswerQuestion {
     if ($rankedItems -and $effectiveType -ne 'priorityRanking') {
         throw "'ranked_items' is only valid for type 'priorityRanking', got type='$effectiveType'"
     }
+    # Reject 'answer' when caller passes it alongside a typed payload — would
+    # produce inconsistent resolvedEntry (e.g., answer='A' + approval_decision='approved').
+    if ($answer -and $effectiveType -notin @('singleChoice', 'freeText')) {
+        throw "'answer' is only valid for type 'singleChoice' or 'freeText', got type='$effectiveType'. Use 'decision' (approval/documentReview) or 'ranked_items' (priorityRanking)."
+    }
 
     # Synthesize an answer string for non-question types so downstream
     # status-transition logic (skip detection, summary text) keeps working.

--- a/core/mcp/tools/task-answer-question/script.ps1
+++ b/core/mcp/tools/task-answer-question/script.ps1
@@ -72,6 +72,21 @@ function Invoke-TaskAnswerQuestion {
         }
     }
 
+    # Cross-field validation: reject mutually-incompatible fields so callers
+    # can't smuggle approval semantics into a freeText/singleChoice answer
+    # (which would produce inconsistent questions_resolved entries).
+    if ($questionType) {
+        if ($decision -and $questionType -notin @('approval', 'documentReview')) {
+            throw "'decision' is only valid for type 'approval' or 'documentReview', got type='$questionType'"
+        }
+        if ($comment -and $questionType -notin @('approval', 'documentReview')) {
+            throw "'comment' is only valid for type 'approval' or 'documentReview', got type='$questionType'"
+        }
+        if ($rankedItems -and $questionType -ne 'priorityRanking') {
+            throw "'ranked_items' is only valid for type 'priorityRanking', got type='$questionType'"
+        }
+    }
+
     # Synthesize an answer string for non-question types so downstream
     # status-transition logic (skip detection, summary text) keeps working.
     if (-not $answer) {

--- a/core/mcp/tools/task-answer-question/script.ps1
+++ b/core/mcp/tools/task-answer-question/script.ps1
@@ -74,17 +74,18 @@ function Invoke-TaskAnswerQuestion {
 
     # Cross-field validation: reject mutually-incompatible fields so callers
     # can't smuggle approval semantics into a freeText/singleChoice answer
-    # (which would produce inconsistent questions_resolved entries).
-    if ($questionType) {
-        if ($decision -and $questionType -notin @('approval', 'documentReview')) {
-            throw "'decision' is only valid for type 'approval' or 'documentReview', got type='$questionType'"
-        }
-        if ($comment -and $questionType -notin @('approval', 'documentReview')) {
-            throw "'comment' is only valid for type 'approval' or 'documentReview', got type='$questionType'"
-        }
-        if ($rankedItems -and $questionType -ne 'priorityRanking') {
-            throw "'ranked_items' is only valid for type 'priorityRanking', got type='$questionType'"
-        }
+    # (would produce inconsistent questions_resolved entries). Runs even when
+    # 'type' is omitted — legacy callers default to singleChoice for this check
+    # so decision/comment/ranked_items can't sneak in alongside a plain answer.
+    $effectiveType = if ($questionType) { $questionType } else { 'singleChoice' }
+    if ($decision -and $effectiveType -notin @('approval', 'documentReview')) {
+        throw "'decision' is only valid for type 'approval' or 'documentReview', got type='$effectiveType'"
+    }
+    if ($comment -and $effectiveType -notin @('approval', 'documentReview')) {
+        throw "'comment' is only valid for type 'approval' or 'documentReview', got type='$effectiveType'"
+    }
+    if ($rankedItems -and $effectiveType -ne 'priorityRanking') {
+        throw "'ranked_items' is only valid for type 'priorityRanking', got type='$effectiveType'"
     }
 
     # Synthesize an answer string for non-question types so downstream

--- a/core/mcp/tools/task-answer-question/script.ps1
+++ b/core/mcp/tools/task-answer-question/script.ps1
@@ -230,7 +230,7 @@ function Invoke-TaskAnswerQuestion {
                 new_status                = 'needs-input'
                 question                  = $targetQuestion.question
                 answer                    = $resolvedAnswer
-                answer_type               = $answerType
+                answer_type               = if ($questionType) { $questionType } else { $answerType }
                 questions_resolved_count  = $taskContent.questions_resolved.Count
                 questions_remaining_count = $remaining.Count
                 file_path                 = $taskFile.FullName
@@ -293,7 +293,7 @@ function Invoke-TaskAnswerQuestion {
             new_status               = $newStatus
             question                 = $targetQuestion.question
             answer                   = $resolvedAnswer
-            answer_type              = $answerType
+            answer_type              = if ($questionType) { $questionType } else { $answerType }
             attachments_count        = if ($attachments) { @($attachments).Count } else { 0 }
             questions_resolved_count = $taskContent.questions_resolved.Count
             file_path                = $newFilePath
@@ -446,7 +446,7 @@ function Invoke-TaskAnswerQuestion {
         new_status = $newStatus
         question = $pendingQuestion.question
         answer = $resolvedAnswer
-        answer_type = $answerType
+        answer_type = if ($questionType) { $questionType } else { $answerType }
         attachments_count = if ($attachments) { @($attachments).Count } else { 0 }
         questions_resolved_count = $taskContent.questions_resolved.Count
         file_path = $newFilePath

--- a/core/mcp/tools/task-mark-needs-input/metadata.yaml
+++ b/core/mcp/tools/task-mark-needs-input/metadata.yaml
@@ -112,5 +112,42 @@ inputSchema:
       required:
         - reason
         - sub_tasks
+    type:
+      type: string
+      enum: [singleChoice, approval, documentReview, freeText, priorityRanking]
+      default: singleChoice
+      description: "Question type (PRD §4.6). Drives card rendering and response parsing."
+    deliverable_summary:
+      type: string
+      description: "1-3 line summary of what needs review (shown in channel notifications)"
+    attachments:
+      type: array
+      description: "Files to upload to Mothership before publishing the template"
+      items:
+        type: object
+        properties:
+          path:
+            type: string
+            description: "Local file path to upload"
+          description:
+            type: string
+        required:
+          - path
+    review_links:
+      type: array
+      description: "External URLs for reviewer context"
+      items:
+        type: object
+        properties:
+          title:
+            type: string
+          url:
+            type: string
+          type:
+            type: string
+            enum: [pull-request, document, design, other]
+        required:
+          - title
+          - url
   required:
     - task_id

--- a/core/mcp/tools/task-mark-needs-input/script.ps1
+++ b/core/mcp/tools/task-mark-needs-input/script.ps1
@@ -11,10 +11,19 @@ function Invoke-TaskMarkNeedsInput {
     $question = $Arguments['question']
     $questionsArg = $Arguments['questions']
     $splitProposal = $Arguments['split_proposal']
+    $questionType = if ($Arguments['type']) { "$($Arguments['type'])" } else { 'singleChoice' }
+    $deliverableSummary = $Arguments['deliverable_summary']
+    $attachmentsArg = $Arguments['attachments']
+    $reviewLinksArg = $Arguments['review_links']
 
     if (-not $taskId) { throw "Task ID is required" }
     if (-not $question -and -not $questionsArg -and -not $splitProposal) { throw "Either 'questions' array, 'question' object, or 'split_proposal' is required" }
     if (($question -or $questionsArg) -and $splitProposal) { throw "Cannot provide both questions and split_proposal - use one at a time" }
+
+    $validTypes = @('singleChoice', 'approval', 'documentReview', 'freeText', 'priorityRanking')
+    if ($questionType -notin $validTypes) {
+        throw "Invalid 'type' value '$questionType'. Allowed: $($validTypes -join ', ')"
+    }
 
     # Pre-read the task to build question data before the transition
     $found = Find-TaskFileById -TaskId $taskId -SearchStatuses @('analysing', 'in-progress', 'needs-input')
@@ -127,61 +136,110 @@ function Invoke-TaskMarkNeedsInput {
     }
 
     # --- External notification (opt-in) ---
+    $notificationError = $null
+    $uploadedAttachments = @()
+    $settings = $null   # init for StrictMode 3.0 (rollback path may run before try assigns it)
     try {
         $notifModule = Join-Path $global:DotbotProjectRoot ".bot/core/mcp/modules/NotificationClient.psm1"
-        if (Test-Path $notifModule) {
+        if (Test-Path -LiteralPath $notifModule) {
             Import-Module $notifModule -Force
             $settings = Get-NotificationSettings
-            if ($settings.enabled -and ($question -or $splitProposal)) {
-                $sendResult = if ($question) {
-                    Send-TaskNotification -TaskContent $taskContent -PendingQuestion $taskContent.pending_question -Settings $settings
-                } else {
-                    Send-SplitProposalNotification -TaskContent $taskContent -SplitProposal $taskContent.split_proposal -Settings $settings
-                }
-                if ($sendResult.success) {
-                    $taskContent | Add-Member -NotePropertyName 'notification' -NotePropertyValue @{
-                        question_id = $sendResult.question_id
-                        instance_id = $sendResult.instance_id
-                        channel     = $sendResult.channel
-                        project_id  = $sendResult.project_id
-                        sent_at     = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
-                    } -Force
-                    $taskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $result.file_path -Encoding UTF8
-                }
-            } elseif ($settings.enabled -and $newPendingQuestions.Count -gt 0) {
-                $sentAt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
-                $notificationsMap = @{}
-                if ($taskContent.PSObject.Properties['notifications']) {
-                    foreach ($prop in $taskContent.notifications.PSObject.Properties) {
-                        $notificationsMap[$prop.Name] = $prop.Value
+
+            if ($settings.enabled) {
+                # 1. Upload attachments (split proposals never carry attachments)
+                if ($attachmentsArg -and @($attachmentsArg).Count -gt 0 -and -not $splitProposal) {
+                    $batchResult = Invoke-AttachmentBatchUpload -Settings $settings -Attachments $attachmentsArg
+                    if (-not $batchResult.success) {
+                        $notificationError = "Attachment upload failed: $($batchResult.reason)"
+                    } else {
+                        $uploadedAttachments = $batchResult.uploads
                     }
                 }
-                foreach ($pq in $newPendingQuestions) {
-                    $maxAttempts = 3
-                    $sendResult  = $null
-                    for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
-                        $sendResult = Send-TaskNotification -TaskContent $taskContent -PendingQuestion $pq -Settings $settings
-                        if ($sendResult.success) { break }
-                        if ($attempt -lt $maxAttempts) { Start-Sleep -Milliseconds 500 }
+
+                # 2. Publish — single question / split / batch
+                if (-not $notificationError -and ($question -or $splitProposal)) {
+                    $sendResult = if ($question) {
+                        Send-TaskNotification -TaskContent $taskContent -PendingQuestion $taskContent.pending_question `
+                            -Settings $settings -Type $questionType -DeliverableSummary $deliverableSummary `
+                            -Attachments $uploadedAttachments -ReviewLinks $reviewLinksArg
+                    } else {
+                        Send-SplitProposalNotification -TaskContent $taskContent -SplitProposal $taskContent.split_proposal -Settings $settings
                     }
-                    if ($sendResult -and $sendResult.success) {
-                        $notificationsMap[$pq.id] = @{
-                            question_id = $sendResult.question_id
-                            instance_id = $sendResult.instance_id
-                            channel     = $sendResult.channel
-                            project_id  = $sendResult.project_id
-                            sent_at     = $sentAt
+                    if ($sendResult.success) {
+                        $taskContent | Add-Member -NotePropertyName 'notification' -NotePropertyValue @{
+                            question_id     = $sendResult.question_id
+                            instance_id     = $sendResult.instance_id
+                            channel         = $sendResult.channel
+                            project_id      = $sendResult.project_id
+                            sent_at         = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
+                            type            = $questionType
+                            attachment_refs = $uploadedAttachments
+                        } -Force
+                        $taskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $result.file_path -Encoding UTF8
+                    } else {
+                        $notificationError = $sendResult.reason
+                    }
+                } elseif (-not $notificationError -and $newPendingQuestions.Count -gt 0) {
+                    $sentAt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
+                    $notificationsMap = @{}
+                    if ($taskContent.PSObject.Properties['notifications']) {
+                        foreach ($prop in $taskContent.notifications.PSObject.Properties) {
+                            $notificationsMap[$prop.Name] = $prop.Value
                         }
                     }
+                    foreach ($pq in $newPendingQuestions) {
+                        $maxAttempts = 3
+                        $sendResult  = $null
+                        for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+                            $sendResult = Send-TaskNotification -TaskContent $taskContent -PendingQuestion $pq `
+                                -Settings $settings -Type $questionType -DeliverableSummary $deliverableSummary `
+                                -Attachments $uploadedAttachments -ReviewLinks $reviewLinksArg
+                            if ($sendResult.success) { break }
+                            if ($attempt -lt $maxAttempts) { Start-Sleep -Milliseconds 500 }
+                        }
+                        if ($sendResult -and $sendResult.success) {
+                            $notificationsMap[$pq.id] = @{
+                                question_id     = $sendResult.question_id
+                                instance_id     = $sendResult.instance_id
+                                channel         = $sendResult.channel
+                                project_id      = $sendResult.project_id
+                                sent_at         = $sentAt
+                                type            = $questionType
+                                attachment_refs = $uploadedAttachments
+                            }
+                        }
+                    }
+                    if ($notificationsMap.Count -gt 0) {
+                        $taskContent | Add-Member -NotePropertyName 'notifications' -NotePropertyValue $notificationsMap -Force
+                        $taskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $result.file_path -Encoding UTF8
+                    }
                 }
-                if ($notificationsMap.Count -gt 0) {
-                    $taskContent | Add-Member -NotePropertyName 'notifications' -NotePropertyValue $notificationsMap -Force
-                    $taskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $result.file_path -Encoding UTF8
-                }
+
             }
         }
     } catch {
-        # Never block the core flow
+        $notificationError = "Publish failed: $($_.Exception.Message)"
+    }
+
+    # --- Rollback on any notification failure ---
+    # Crash-safety guarantee: task JSON's `notification`/`notifications` fields
+    # are written ONLY after Send-* returns success, so a failure here leaves
+    # task JSON unchanged. Rollback only releases server-side attachment refs.
+    if ($notificationError) {
+        if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
+            Write-BotLog -Level Warn -Message "task-mark-needs-input notification failed: $notificationError"
+        }
+        try {
+            if ($uploadedAttachments -and @($uploadedAttachments).Count -gt 0 -and $settings -and $settings.enabled) {
+                foreach ($up in @($uploadedAttachments)) {
+                    if ($up.storage_ref) {
+                        $null = Remove-Attachment -Settings $settings -StorageRef $up.storage_ref
+                    }
+                }
+            }
+        } catch {
+            $null = $_  # best-effort cleanup; rollback errors must not mask the original $notificationError
+        }
     }
 
     # Build result
@@ -198,6 +256,8 @@ function Invoke-TaskMarkNeedsInput {
     if ($questionsArg) { $output['pending_questions'] = $taskContent.pending_questions; $output['questions_count'] = @($taskContent.pending_questions).Count }
     elseif ($question) { $output['pending_question'] = $taskContent.pending_question }
     elseif ($splitProposal) { $output['split_proposal'] = $taskContent.split_proposal }
+
+    if ($notificationError) { $output['notification_error'] = $notificationError }
 
     return $output
 }

--- a/core/mcp/tools/task-mark-needs-input/script.ps1
+++ b/core/mcp/tools/task-mark-needs-input/script.ps1
@@ -138,6 +138,7 @@ function Invoke-TaskMarkNeedsInput {
     # --- External notification (opt-in) ---
     $notificationError = $null
     $uploadedAttachments = @()
+    $attachmentsReferenced = $false   # set when any published notification persisted the attachment refs
     $settings = $null   # init for StrictMode 3.0 (rollback path may run before try assigns it)
     try {
         $notifModule = Join-Path $global:DotbotProjectRoot ".bot/core/mcp/modules/NotificationClient.psm1"
@@ -177,6 +178,7 @@ function Invoke-TaskMarkNeedsInput {
                             attachment_refs = $uploadedAttachments
                         } -Force
                         $taskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $result.file_path -Encoding UTF8
+                        $attachmentsReferenced = $true
                     } else {
                         $notificationError = $sendResult.reason
                     }
@@ -189,6 +191,7 @@ function Invoke-TaskMarkNeedsInput {
                         }
                     }
                     $newSuccessCount = 0
+                    $failedQuestionIds = @()
                     $lastBatchFailure = $null
                     foreach ($pq in $newPendingQuestions) {
                         $maxAttempts = 3
@@ -211,17 +214,26 @@ function Invoke-TaskMarkNeedsInput {
                                 type            = $questionType
                                 attachment_refs = $uploadedAttachments
                             }
-                        } elseif ($sendResult) {
-                            $lastBatchFailure = $sendResult.reason
+                        } else {
+                            $failedQuestionIds += $pq.id
+                            if ($sendResult) { $lastBatchFailure = $sendResult.reason }
                         }
                     }
                     if ($notificationsMap.Count -gt 0) {
                         $taskContent | Add-Member -NotePropertyName 'notifications' -NotePropertyValue $notificationsMap -Force
                         $taskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $result.file_path -Encoding UTF8
                     }
-                    # Zero successes across the batch — surface error so attachment rollback runs.
-                    if ($newSuccessCount -eq 0) {
-                        $notificationError = if ($lastBatchFailure) { "All batch publishes failed: $lastBatchFailure" } else { "All batch publishes failed" }
+                    if ($newSuccessCount -gt 0) { $attachmentsReferenced = $true }
+                    # Surface ANY per-question failure so caller knows the batch is incomplete.
+                    # Attachments stay on server (shared across batch — successes still reference them);
+                    # caller can retry the listed question IDs without re-uploading.
+                    if ($failedQuestionIds.Count -gt 0) {
+                        $idList = $failedQuestionIds -join ', '
+                        $notificationError = if ($newSuccessCount -eq 0) {
+                            "All batch publishes failed for: $idList. Reason: $lastBatchFailure"
+                        } else {
+                            "Batch publish failed for: $idList (of $($newPendingQuestions.Count)). Reason: $lastBatchFailure"
+                        }
                     }
                 }
 
@@ -240,7 +252,10 @@ function Invoke-TaskMarkNeedsInput {
             Write-BotLog -Level Warn -Message "task-mark-needs-input notification failed: $notificationError"
         }
         try {
-            if ($uploadedAttachments -and @($uploadedAttachments).Count -gt 0 -and $settings -and $settings.enabled) {
+            # Skip rollback when at least one published notification persisted the
+            # attachment refs — deleting them on the server would break successful
+            # entries (attachments are shared across the batch).
+            if (-not $attachmentsReferenced -and $uploadedAttachments -and @($uploadedAttachments).Count -gt 0 -and $settings -and $settings.enabled) {
                 foreach ($up in @($uploadedAttachments)) {
                     if ($up.storage_ref) {
                         $null = Remove-Attachment -Settings $settings -StorageRef $up.storage_ref

--- a/core/mcp/tools/task-mark-needs-input/script.ps1
+++ b/core/mcp/tools/task-mark-needs-input/script.ps1
@@ -150,7 +150,8 @@ function Invoke-TaskMarkNeedsInput {
                 if ($attachmentsArg -and @($attachmentsArg).Count -gt 0 -and -not $splitProposal) {
                     $batchResult = Invoke-AttachmentBatchUpload -Settings $settings -Attachments $attachmentsArg
                     if (-not $batchResult.success) {
-                        $notificationError = "Attachment upload failed: $($batchResult.reason)"
+                        # Reason already namespaces its own failure
+                        $notificationError = $batchResult.reason
                     } else {
                         $uploadedAttachments = $batchResult.uploads
                     }

--- a/core/mcp/tools/task-mark-needs-input/script.ps1
+++ b/core/mcp/tools/task-mark-needs-input/script.ps1
@@ -187,6 +187,8 @@ function Invoke-TaskMarkNeedsInput {
                             $notificationsMap[$prop.Name] = $prop.Value
                         }
                     }
+                    $newSuccessCount = 0
+                    $lastBatchFailure = $null
                     foreach ($pq in $newPendingQuestions) {
                         $maxAttempts = 3
                         $sendResult  = $null
@@ -198,6 +200,7 @@ function Invoke-TaskMarkNeedsInput {
                             if ($attempt -lt $maxAttempts) { Start-Sleep -Milliseconds 500 }
                         }
                         if ($sendResult -and $sendResult.success) {
+                            $newSuccessCount++
                             $notificationsMap[$pq.id] = @{
                                 question_id     = $sendResult.question_id
                                 instance_id     = $sendResult.instance_id
@@ -207,11 +210,17 @@ function Invoke-TaskMarkNeedsInput {
                                 type            = $questionType
                                 attachment_refs = $uploadedAttachments
                             }
+                        } elseif ($sendResult) {
+                            $lastBatchFailure = $sendResult.reason
                         }
                     }
                     if ($notificationsMap.Count -gt 0) {
                         $taskContent | Add-Member -NotePropertyName 'notifications' -NotePropertyValue $notificationsMap -Force
                         $taskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $result.file_path -Encoding UTF8
+                    }
+                    # Zero successes across the batch — surface error so attachment rollback runs.
+                    if ($newSuccessCount -eq 0) {
+                        $notificationError = if ($lastBatchFailure) { "All batch publishes failed: $lastBatchFailure" } else { "All batch publishes failed" }
                     }
                 }
 

--- a/core/ui/modules/NotificationPoller.psm1
+++ b/core/ui/modules/NotificationPoller.psm1
@@ -146,15 +146,19 @@ function Invoke-NotificationPollTick {
                         $taskContent | ConvertTo-Json -Depth 20 | Set-Content -Path $taskFile.FullName -Encoding UTF8
                     }
                 } else {
-                    # Question response: resolve answer and transition
+                    # Question response: parse typed fields (metadata only, no eager download)
                     $taskId    = $taskContent.id
                     $questionId = $taskContent.pending_question.id
-                    $attachDir = Join-Path $botRoot "workspace\attachments\$taskId\$questionId"
-                    $resolved  = Resolve-NotificationAnswer -Response $response -Settings $settings -AttachDir $attachDir
+                    $notifType = if ($notification.PSObject.Properties['type'] -and $notification.type) { "$($notification.type)" } else { 'singleChoice' }
+                    $typed = ConvertTo-TypedResponse -Response $response -Type $notifType
 
-                    if ($resolved) {
+                    if ($typed) {
+                        $answerStr = if ($typed.ContainsKey('answer')) { $typed.answer }
+                                     elseif ($typed.ContainsKey('approval_decision')) { $typed.approval_decision }
+                                     elseif ($typed.ContainsKey('ranked_items')) { (@($typed.ranked_items) -join ', ') }
+                                     else { '' }
                         Invoke-TaskTransitionFromNotification -TaskFile $taskFile -TaskContent $taskContent `
-                            -Answer $resolved.answer -Attachments $resolved.attachments -BotRoot $botRoot
+                            -Answer $answerStr -TypedFields $typed -BotRoot $botRoot
                     }
                 }
                 continue
@@ -179,16 +183,20 @@ function Invoke-NotificationPollTick {
                 $response = Get-TaskNotificationResponse -Notification $notifEntry -Settings $settings
                 if (-not $response) { continue }
 
-                $attachDir = Join-Path $botRoot "workspace\attachments\$taskId\$($pq.id)"
-                $resolved  = Resolve-NotificationAnswer -Response $response -Settings $settings -AttachDir $attachDir
-                if (-not $resolved) { continue }
+                $notifType = if ($notifEntry.PSObject.Properties['type'] -and $notifEntry.type) { "$($notifEntry.type)" } else { 'singleChoice' }
+                $typed = ConvertTo-TypedResponse -Response $response -Type $notifType
+                if (-not $typed) { continue }
 
                 # Re-read task file before mutating (first-write-wins)
                 if (-not (Test-Path $taskFile.FullName)) { break }
                 $taskContent = Get-Content -Path $taskFile.FullName -Raw | ConvertFrom-Json
 
+                $answerStr = if ($typed.ContainsKey('answer')) { $typed.answer }
+                             elseif ($typed.ContainsKey('approval_decision')) { $typed.approval_decision }
+                             elseif ($typed.ContainsKey('ranked_items')) { (@($typed.ranked_items) -join ', ') }
+                             else { '' }
                 Invoke-BatchQuestionTransitionFromNotification -TaskFile $taskFile -TaskContent $taskContent `
-                    -Question $pq -Answer $resolved.answer -Attachments $resolved.attachments -BotRoot $botRoot
+                    -Question $pq -Answer $answerStr -TypedFields $typed -BotRoot $botRoot
 
                 # Re-read after mutation to pick up updated pending_questions for next iteration
                 if (Test-Path $taskFile.FullName) {
@@ -223,7 +231,9 @@ function Invoke-TaskTransitionFromNotification {
         [Parameter(Mandatory)]
         [string]$BotRoot,
 
-        [array]$Attachments = @()
+        [array]$Attachments = @(),
+
+        [hashtable]$TypedFields
     )
 
     $tasksBaseDir = Join-Path $BotRoot "workspace\tasks"
@@ -259,6 +269,21 @@ function Invoke-TaskTransitionFromNotification {
 
     if ($Attachments -and $Attachments.Count -gt 0) {
         $resolvedEntry['attachments'] = $Attachments
+    }
+    if ($TypedFields) {
+        if ($TypedFields.ContainsKey('answer_type'))       { $resolvedEntry['answer_type']       = $TypedFields.answer_type }
+        if ($TypedFields.ContainsKey('approval_decision')) { $resolvedEntry['approval_decision'] = $TypedFields.approval_decision }
+        if ($TypedFields.ContainsKey('comment'))           { $resolvedEntry['comment']           = $TypedFields.comment }
+        if ($TypedFields.ContainsKey('ranked_items'))      { $resolvedEntry['ranked_items']      = $TypedFields.ranked_items }
+        if ($TypedFields.ContainsKey('attachment_refs')) {
+            $resolvedEntry['attachment_refs'] = $TypedFields.attachment_refs
+            # Mirror to 'attachments' so the dashboard UI (tasks.js reads qa.attachments)
+            # keeps rendering. attachment_refs is the PRD §5.4 canonical key; attachments
+            # is the UI-facing alias retained for compatibility with the existing reader.
+            if (-not $resolvedEntry.ContainsKey('attachments')) {
+                $resolvedEntry['attachments'] = $TypedFields.attachment_refs
+            }
+        }
     }
 
     # Add to questions_resolved
@@ -424,7 +449,9 @@ function Invoke-BatchQuestionTransitionFromNotification {
         [Parameter(Mandatory)]
         [string]$BotRoot,
 
-        [array]$Attachments = @()
+        [array]$Attachments = @(),
+
+        [hashtable]$TypedFields
     )
 
     $tasksBaseDir = Join-Path $BotRoot "workspace\tasks"
@@ -453,6 +480,21 @@ function Invoke-BatchQuestionTransitionFromNotification {
     }
     if ($Attachments -and $Attachments.Count -gt 0) {
         $resolvedEntry['attachments'] = $Attachments
+    }
+    if ($TypedFields) {
+        if ($TypedFields.ContainsKey('answer_type'))       { $resolvedEntry['answer_type']       = $TypedFields.answer_type }
+        if ($TypedFields.ContainsKey('approval_decision')) { $resolvedEntry['approval_decision'] = $TypedFields.approval_decision }
+        if ($TypedFields.ContainsKey('comment'))           { $resolvedEntry['comment']           = $TypedFields.comment }
+        if ($TypedFields.ContainsKey('ranked_items'))      { $resolvedEntry['ranked_items']      = $TypedFields.ranked_items }
+        if ($TypedFields.ContainsKey('attachment_refs')) {
+            $resolvedEntry['attachment_refs'] = $TypedFields.attachment_refs
+            # Mirror to 'attachments' so the dashboard UI (tasks.js reads qa.attachments)
+            # keeps rendering. attachment_refs is the PRD §5.4 canonical key; attachments
+            # is the UI-facing alias retained for compatibility with the existing reader.
+            if (-not $resolvedEntry.ContainsKey('attachments')) {
+                $resolvedEntry['attachments'] = $TypedFields.attachment_refs
+            }
+        }
     }
 
     # Append to questions_resolved

--- a/core/ui/modules/NotificationPoller.psm1
+++ b/core/ui/modules/NotificationPoller.psm1
@@ -150,7 +150,11 @@ function Invoke-NotificationPollTick {
                     $notifType = if ($notification.PSObject.Properties['type'] -and $notification.type) { "$($notification.type)" } else { 'singleChoice' }
                     $typed = ConvertTo-TypedResponse -Response $response -Type $notifType
 
-                    if ($typed) {
+                    if (-not $typed) {
+                        if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
+                            Write-BotLog -Level Warn -Message "Poller: ConvertTo-TypedResponse returned null for task $($taskContent.id), type='$notifType'. Skipping."
+                        }
+                    } else {
                         $answerStr = if ($typed.ContainsKey('answer')) { $typed.answer }
                                      elseif ($typed.ContainsKey('approval_decision')) { $typed.approval_decision }
                                      elseif ($typed.ContainsKey('ranked_items')) { (@($typed.ranked_items) -join ', ') }

--- a/core/ui/modules/NotificationPoller.psm1
+++ b/core/ui/modules/NotificationPoller.psm1
@@ -147,8 +147,6 @@ function Invoke-NotificationPollTick {
                     }
                 } else {
                     # Question response: parse typed fields (metadata only, no eager download)
-                    $taskId    = $taskContent.id
-                    $questionId = $taskContent.pending_question.id
                     $notifType = if ($notification.PSObject.Properties['type'] -and $notification.type) { "$($notification.type)" } else { 'singleChoice' }
                     $typed = ConvertTo-TypedResponse -Response $response -Type $notifType
 

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2463,7 +2463,7 @@ if (Test-Path $notifModule) {
         -Condition ($typedRank.ranked_items -and @($typedRank.ranked_items).Count -eq 3 -and $typedRank.ranked_items[0] -eq 'item-c') `
         -Message "Expected ranked_items[0]=item-c"
 
-    # Fix M: server emits RankedItem[] = [{ optionId, rank }] — sort by rank,
+    # Server emits RankedItem[] = [{ optionId, rank }] — sort by rank,
     # project to optionId strings so downstream -join produces meaningful output.
     $rankingObjResp = [PSCustomObject]@{
         rankedItems = @(
@@ -2473,7 +2473,7 @@ if (Test-Path $notifModule) {
         )
     }
     $typedRankObj = ConvertTo-TypedResponse -Response $rankingObjResp -Type 'priorityRanking'
-    Assert-True -Name "ConvertTo-TypedResponse normalizes server RankedItem objects (Fix M)" `
+    Assert-True -Name "ConvertTo-TypedResponse normalizes server RankedItem objects to optionId strings" `
         -Condition ($typedRankObj.ranked_items -and @($typedRankObj.ranked_items).Count -eq 3 -and
                     $typedRankObj.ranked_items[0] -eq 'opt-a' -and
                     $typedRankObj.ranked_items[1] -eq 'opt-b' -and
@@ -2652,6 +2652,60 @@ if (Test-Path $notifModule) {
         }
     }
 
+    # Upload rejected when DotbotProjectRoot is unset (fail-closed security guard)
+    $savedRootO = if (Test-Path Variable:global:DotbotProjectRoot) { $global:DotbotProjectRoot } else { $null }
+    Remove-Variable -Name DotbotProjectRoot -Scope Global -ErrorAction SilentlyContinue
+    try {
+        $resultO = Send-AttachmentUpload -Settings $enabledSettings -FilePath 'c:\anything.txt' -Description ''
+        Assert-True -Name "Send-AttachmentUpload rejects upload when DotbotProjectRoot unset" `
+            -Condition ($resultO.success -eq $false -and $resultO.reason -match 'DotbotProjectRoot not set') `
+            -Message "Expected fail-closed rejection, got: $($resultO | ConvertTo-Json -Compress)"
+    } finally {
+        if ($null -ne $savedRootO) { $global:DotbotProjectRoot = $savedRootO }
+    }
+
+    # Remove-Attachment rejects storageRef containing '..' path traversal segments
+    $script:traversalCallMade = $false
+    function global:Invoke-RestMethod {
+        param([string]$Uri, [string]$Method = 'Get', $Body, $Headers, $ContentType, $TimeoutSec, $Form, $OutFile, $ErrorAction)
+        $script:traversalCallMade = $true
+        return @{}
+    }
+    try {
+        $null = Remove-Attachment -Settings $enabledSettings -StorageRef 'guid/../../../etc/passwd'
+    } finally {
+        Remove-Item -Path 'function:global:Invoke-RestMethod' -ErrorAction SilentlyContinue
+    }
+    Assert-True -Name "Remove-Attachment rejects storageRef with '..' traversal segments" `
+        -Condition ($script:traversalCallMade -eq $false) `
+        -Message "Expected no HTTP call for traversal storageRef"
+
+    # review_links with unsafe URLs stripped before emitting wire payload (SSRF guard)
+    $global:templateCaptureV = $null
+    function global:Invoke-RestMethod {
+        param([string]$Uri, [string]$Method = 'Get', $Body, $Headers, $ContentType, $TimeoutSec, $Form, $OutFile, $ErrorAction)
+        if ($Uri -match '/api/templates$' -and $Method -eq 'Post') { $global:templateCaptureV = $Body | ConvertFrom-Json; return @{} }
+        if ($Uri -match '/api/instances$' -and $Method -eq 'Post') { return @{} }
+        throw "Unexpected: $Method $Uri"
+    }
+    try {
+        $taskV = [PSCustomObject]@{ id = 'task-v'; name = 'SSRF test' }
+        $qV    = [PSCustomObject]@{ id = 'q1'; question = 'Q?'; options = @([PSCustomObject]@{ key = 'A'; label = 'Yes' }); recommendation = 'A' }
+        $linksV = @(
+            @{ title = 'Safe';   url = 'https://example.com/spec'; type = 'document' }
+            @{ title = 'Evil';   url = 'javascript:alert(1)';       type = 'other' }
+            @{ title = 'Local';  url = 'file:///etc/passwd';         type = 'other' }
+        )
+        $null = Send-TaskNotification -TaskContent $taskV -PendingQuestion $qV `
+            -Settings $enabledSettings -Type 'singleChoice' -ReviewLinks $linksV
+    } finally {
+        Remove-Item -Path 'function:global:Invoke-RestMethod' -ErrorAction SilentlyContinue
+    }
+    $refLinksV = if ($global:templateCaptureV -and $global:templateCaptureV.PSObject.Properties['referenceLinks']) { @($global:templateCaptureV.referenceLinks) } else { @() }
+    Assert-True -Name "Send-TaskNotification strips unsafe review_links URLs (javascript:/file:)" `
+        -Condition ($refLinksV.Count -eq 1 -and $refLinksV[0].url -eq 'https://example.com/spec') `
+        -Message "Expected 1 safe link only, got $($refLinksV.Count): $($refLinksV | ConvertTo-Json -Compress)"
+
     # ── Remove-Attachment preserves '/' in URL ────
     $script:capturedDeleteUri = $null
     function global:Invoke-RestMethod {
@@ -2680,7 +2734,7 @@ if (Test-Path $notifModule) {
     } finally {
         Remove-Item -Path 'function:global:Invoke-RestMethod' -ErrorAction SilentlyContinue
     }
-    Assert-True -Name "Remove-Attachment encodes '#' and '?' in filename (Fix H)" `
+    Assert-True -Name "Remove-Attachment percent-encodes '#' and '?' in filename segment" `
         -Condition ($script:capturedDeleteUri -match '/api/attachments/guid-x/has%23hash%3Fq\.txt$') `
         -Message "Expected has%23hash%3Fq.txt segment, got: $script:capturedDeleteUri"
 
@@ -2800,6 +2854,66 @@ if (Test-Path $notifModule) {
             -Message "Expected zero -OutFile calls during poll tick"
 
         Remove-Item -Path $tempBot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # Poller logs warning and skips (does not throw) when typed response parsing returns null
+    if (Test-Path $pollerMod) {
+        $pollerUnknownId = "poll-unknown-type-" + [guid]::NewGuid().ToString('N').Substring(0,6)
+        $tempBotS = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-poller-s-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+        $tempBotDirS = Join-Path $tempBotS ".bot"
+        New-Item -ItemType Directory -Force -Path (Join-Path $tempBotDirS "settings")                      | Out-Null
+        New-Item -ItemType Directory -Force -Path (Join-Path $tempBotDirS "workspace/tasks/needs-input")   | Out-Null
+        New-Item -ItemType Directory -Force -Path (Join-Path $tempBotDirS "workspace/tasks/analysing")     | Out-Null
+        New-Item -ItemType Directory -Force -Path (Join-Path $tempBotDirS ".control")                      | Out-Null
+        $tempMcpS = Join-Path $tempBotDirS "core/mcp/modules"
+        $tempRtS  = Join-Path $tempBotDirS "core/runtime/modules"
+        New-Item -ItemType Directory -Force -Path $tempMcpS | Out-Null
+        New-Item -ItemType Directory -Force -Path $tempRtS  | Out-Null
+        Copy-Item -Path (Join-Path $botDir "core/mcp/modules/NotificationClient.psm1") -Destination $tempMcpS -Force
+        Copy-Item -Path (Join-Path $botDir "core/runtime/modules/SettingsLoader.psm1") -Destination $tempRtS  -Force
+        @'
+{ "instance_id": "55555555-5555-5555-5555-555555555555",
+  "mothership": { "enabled": true, "server_url": "http://localhost:9999", "api_key": "k",
+                  "channel": "teams", "recipients": ["x@y.com"], "poll_interval_seconds": 5 } }
+'@ | Set-Content (Join-Path $tempBotDirS ".control/settings.json") -Encoding UTF8
+        '{}' | Set-Content (Join-Path $tempBotDirS "settings/settings.default.json") -Encoding UTF8
+
+        @{
+            id = $pollerUnknownId; name = "Unknown type test"; status = "needs-input"
+            pending_question = @{ id = "q1"; question = "Q?"; options = @(@{ key = "A"; label = "Yes" }); recommendation = "A"; asked_at = "2026-05-12T00:00:00Z" }
+            notification = @{ question_id = "qid-s1"; instance_id = "iid-s1"; project_id = "pid-s1"; channel = "teams"; type = "unknown_future_type"; sent_at = "2026-05-12T00:00:00Z" }
+            questions_resolved = @(); updated_at = "2026-05-12T00:00:00Z"
+        } | ConvertTo-Json -Depth 20 | Set-Content (Join-Path $tempBotDirS "workspace/tasks/needs-input/$pollerUnknownId.json") -Encoding UTF8
+
+        $script:loggedWarnS = $false
+        function global:Invoke-RestMethod {
+            param([string]$Uri, [string]$Method = 'Get', $Body, $Headers, $ContentType, $TimeoutSec, $Form, $OutFile, $ErrorAction)
+            if ($Uri -match '/responses$') {
+                # No selectedKey/freeText/approvalDecision/rankedItems — unknown type falls into
+                # default branch of ConvertTo-TypedResponse, finds nothing, returns $null.
+                return @( [PSCustomObject]@{ selectedKey = $null; freeText = $null; approvalDecision = $null; attachments = @() } )
+            }
+            return @{}
+        }
+        function global:Write-BotLog { param($Level, $Message, $Exception) if ($Level -eq 'Warn' -and $Message -match 'ConvertTo-TypedResponse returned null') { $script:loggedWarnS = $true } }
+        $savedRootS = $global:DotbotProjectRoot
+        $global:DotbotProjectRoot = $tempBotS
+        try {
+            Import-Module $pollerMod -Force
+            Invoke-NotificationPollTick -BotRoot $tempBotDirS
+        } finally {
+            Remove-Item -Path 'function:global:Invoke-RestMethod' -ErrorAction SilentlyContinue
+            Remove-Item -Path 'function:global:Write-BotLog'      -ErrorAction SilentlyContinue
+            $global:DotbotProjectRoot = $savedRootS
+        }
+        $taskStillInNeedsInput = Test-Path (Join-Path $tempBotDirS "workspace/tasks/needs-input/$pollerUnknownId.json")
+        Assert-True -Name "Poller logs warn when ConvertTo-TypedResponse returns null for unknown type" `
+            -Condition $script:loggedWarnS `
+            -Message "Expected Write-BotLog Warn call about ConvertTo-TypedResponse returning null"
+        Assert-True -Name "Poller skips transition when typed response parsing yields no fields (task stays in needs-input)" `
+            -Condition $taskStillInNeedsInput `
+            -Message "Expected task to remain in needs-input when typed response returns null"
+        Remove-Item -Path $tempBotS -Recurse -Force -ErrorAction SilentlyContinue
     }
 
     # ── Crash-mid-publish leaves no partial state in task JSON (#291 acceptance)
@@ -3037,7 +3151,7 @@ if (Test-Path $notifModule) {
         Assert-True -Name "Partial batch: tool returns success=true (status transition succeeded)" `
             -Condition ($partialResult.success -eq $true) `
             -Message "Expected success=true, got: $($partialResult | ConvertTo-Json -Compress -Depth 5)"
-        Assert-True -Name "Partial batch: tool surfaces notification_error naming failed Q (Fix J)" `
+        Assert-True -Name "Partial batch: tool surfaces notification_error naming failed question IDs" `
             -Condition ($partialResult.notification_error -and $partialResult.notification_error -match 'Batch publish failed for') `
             -Message "Expected notification_error with 'Batch publish failed for', got: $($partialResult.notification_error)"
         Assert-True -Name "Partial batch: 2 successful notifications persisted in task JSON" `
@@ -3176,7 +3290,7 @@ if ((Test-Path $mniMeta) -and (Test-Path $aqMeta)) {
                 -Condition ($threw -and $msg -match "'ranked_items' is only valid") `
                 -Message "Expected throw on legacy caller smuggling ranked_items, got: $msg"
 
-            # Fix N: 'answer' rejected for typed payloads (would produce inconsistent resolvedEntry)
+            # 'answer' rejected for typed payloads — would produce inconsistent resolvedEntry with both answer and approval_decision set
             $threw = $false; $msg = ""
             try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='approval'; decision='approved'; answer='A' } } catch { $threw = $true; $msg = $_.Exception.Message }
             Assert-True -Name "task-answer-question rejects 'answer' alongside approval decision" `
@@ -3188,6 +3302,33 @@ if ((Test-Path $mniMeta) -and (Test-Path $aqMeta)) {
             Assert-True -Name "task-answer-question rejects 'answer' alongside priorityRanking" `
                 -Condition ($threw -and $msg -match "'answer' is only valid") `
                 -Message "Expected throw, got: $msg"
+
+            # changes_requested requires a comment — same requirement as rejected
+            $threw = $false; $msg = ""
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='documentReview'; decision='changes_requested' } } catch { $threw = $true; $msg = $_.Exception.Message }
+            Assert-True -Name "task-answer-question rejects changes_requested without comment" `
+                -Condition ($threw -and $msg -match "comment.*required") `
+                -Message "Expected throw on missing comment for changes_requested, got: $msg"
+
+            # priorityRanking synthesis must normalize PSCustomObject ranked_items to strings —
+            # (verify the synthesis-time -join stays safe even for PSCustomObject input)
+            # We test via answer synthesis path: the -join happens when $answer is empty
+            # and $rankedItems is set. Since the validation also blocks 'answer' for
+            # priorityRanking, this particular path is reached when the full tool processes
+            # a legitimate ranked submission. The normalization block converts PSCustomObject
+            # items to their optionId string, so the synthesized $answer should equal 'opt-x'.
+            # We can't call the full tool without a real task file, so test the normalization
+            # inline via a minimal replication of the synthesis block that mirrors the fix.
+            $rankedItemsTest = @([PSCustomObject]@{ optionId = 'opt-x'; rank = 1 })
+            $normalizedTest = @($rankedItemsTest | ForEach-Object {
+                if ($_ -is [string]) { $_ }
+                elseif ($_ -is [hashtable] -and $_.ContainsKey('optionId')) { "$($_['optionId'])" }
+                elseif ($_.PSObject.Properties['optionId']) { "$($_.optionId)" }
+                else { "$_" }
+            })
+            Assert-True -Name "priorityRanking synthesis normalizes PSCustomObject optionId to string" `
+                -Condition (@($normalizedTest).Count -eq 1 -and $normalizedTest[0] -eq 'opt-x') `
+                -Message "Expected ['opt-x'], got: $($normalizedTest -join ', ')"
         } finally {
             Remove-Item -Path $global:DotbotProjectRoot -Recurse -Force -ErrorAction SilentlyContinue
             $global:DotbotProjectRoot = $savedRoot

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2919,6 +2919,126 @@ if (Test-Path $notifModule) {
             Remove-Item -Path $controlSettingsFile -Force -ErrorAction SilentlyContinue
         }
     }
+
+    # Partial batch publish failure surfaces error ─
+    # 2 of 3 per-question publishes succeed, 1 fails → tool returns success=true
+    # but notification_error names the failed question ID, successful entries stay,
+    # and attachments are NOT rolled back (they're referenced by the 2 successes).
+    $mniScript2 = Join-Path $botDir "core/mcp/tools/task-mark-needs-input/script.ps1"
+    if (Test-Path $mniScript2) {
+        $partialTaskId = "partial-batch-" + [guid]::NewGuid().ToString('N').Substring(0,6)
+        $analysingDir2 = Join-Path $botDir "workspace/tasks/analysing"
+        $needsInputDir2 = Join-Path $botDir "workspace/tasks/needs-input"
+        if (-not (Test-Path $analysingDir2))  { New-Item -ItemType Directory -Force -Path $analysingDir2  | Out-Null }
+        if (-not (Test-Path $needsInputDir2)) { New-Item -ItemType Directory -Force -Path $needsInputDir2 | Out-Null }
+        $partialTaskFile = Join-Path $analysingDir2 "$partialTaskId.json"
+        @{
+            id = $partialTaskId
+            name = "Partial batch fixture"
+            status = "analysing"
+            created_at = "2026-05-11T00:00:00Z"
+            updated_at = "2026-05-11T00:00:00Z"
+        } | ConvertTo-Json -Depth 20 | Set-Content -Path $partialTaskFile -Encoding UTF8
+
+        $controlDir2 = Join-Path $botDir ".control"
+        if (-not (Test-Path $controlDir2)) { New-Item -ItemType Directory -Force -Path $controlDir2 | Out-Null }
+        $controlSettingsFile2 = Join-Path $controlDir2 "settings.json"
+        $controlBackup2 = $null
+        if (Test-Path $controlSettingsFile2) { $controlBackup2 = Get-Content $controlSettingsFile2 -Raw }
+        @'
+{
+  "instance_id": "44444444-4444-4444-4444-444444444444",
+  "mothership": {
+    "enabled": true,
+    "server_url": "http://localhost:9999",
+    "api_key": "test-key",
+    "channel": "teams",
+    "recipients": ["test@example.com"],
+    "project_name": "test-partial"
+  }
+}
+'@ | Set-Content $controlSettingsFile2 -Encoding UTF8
+
+        $partialAttDir = Join-Path $testProject (".partial-att-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+        New-Item -ItemType Directory -Force -Path $partialAttDir | Out-Null
+        $pf1 = Join-Path $partialAttDir 'doc.txt'; Set-Content -Path $pf1 -Value 'one' -Encoding UTF8
+
+        $script:partialUploadCount = 0
+        $script:partialTemplateCount = 0
+        $script:partialDeletedRefs = @()
+        function global:Invoke-RestMethod {
+            param([string]$Uri, [string]$Method = 'Get', $Body, $Headers, $ContentType, $TimeoutSec, $Form, $OutFile, $ErrorAction)
+            if ($Uri -match '/api/attachments$' -and $Method -eq 'Post') {
+                $script:partialUploadCount++
+                return @{ attachmentId = "partial-aid-$($script:partialUploadCount)"; storageRef = "partial-sref-$($script:partialUploadCount)"; sizeBytes = 3 }
+            }
+            if ($Uri -match '/api/attachments/(.+)$' -and $Method -eq 'Delete') {
+                $script:partialDeletedRefs += $matches[1]; return @{}
+            }
+            if ($Uri -match '/api/templates$' -and $Method -eq 'Post') {
+                $script:partialTemplateCount++
+                # First 2 questions succeed; 3rd throws on every retry (3 attempts).
+                if ($script:partialTemplateCount -le 2) { return @{} }
+                throw "publish q3 failed"
+            }
+            if ($Uri -match '/api/instances$' -and $Method -eq 'Post') { return @{} }
+            throw "Unexpected: $Method $Uri"
+        }
+        if (-not (Get-Command Write-BotLog -ErrorAction SilentlyContinue)) {
+            function global:Write-BotLog { param($Level, $Message, $Exception) }
+            $script:partialWroteBotLogStub = $true
+        }
+
+        $savedRoot3 = $global:DotbotProjectRoot
+        $global:DotbotProjectRoot = $testProject
+        $partialResult = $null
+        try {
+            . $mniScript2
+            $partialResult = Invoke-TaskMarkNeedsInput -Arguments @{
+                task_id  = $partialTaskId
+                type     = 'singleChoice'
+                attachments = @(@{ path = $pf1; description = 'shared' })
+                questions = @(
+                    @{ question = 'Q1?'; options = @(@{ key = 'A'; label = 'Yes' }); recommendation = 'A' }
+                    @{ question = 'Q2?'; options = @(@{ key = 'A'; label = 'Yes' }); recommendation = 'A' }
+                    @{ question = 'Q3?'; options = @(@{ key = 'A'; label = 'Yes' }); recommendation = 'A' }
+                )
+            }
+        } catch {
+            $partialResult = @{ success = $false; thrown = $_.Exception.Message }
+        } finally {
+            Remove-Item -Path 'function:global:Invoke-RestMethod' -ErrorAction SilentlyContinue
+            if ($script:partialWroteBotLogStub) { Remove-Item -Path 'function:global:Write-BotLog' -ErrorAction SilentlyContinue }
+            $global:DotbotProjectRoot = $savedRoot3
+        }
+
+        $movedPartial = Join-Path $needsInputDir2 "$partialTaskId.json"
+        $partialJson = if (Test-Path $movedPartial) { Get-Content $movedPartial -Raw | ConvertFrom-Json } else { $null }
+        $notifMap = if ($partialJson -and $partialJson.PSObject.Properties['notifications']) { $partialJson.notifications } else { $null }
+        $notifKeys = if ($notifMap) { @($notifMap.PSObject.Properties.Name) } else { @() }
+
+        Assert-True -Name "Partial batch: tool returns success=true (status transition succeeded)" `
+            -Condition ($partialResult.success -eq $true) `
+            -Message "Expected success=true, got: $($partialResult | ConvertTo-Json -Compress -Depth 5)"
+        Assert-True -Name "Partial batch: tool surfaces notification_error naming failed Q (Fix J)" `
+            -Condition ($partialResult.notification_error -and $partialResult.notification_error -match 'Batch publish failed for') `
+            -Message "Expected notification_error with 'Batch publish failed for', got: $($partialResult.notification_error)"
+        Assert-True -Name "Partial batch: 2 successful notifications persisted in task JSON" `
+            -Condition ($notifKeys.Count -eq 2) `
+            -Message "Expected 2 notifications entries, got $($notifKeys.Count): $($notifKeys -join ', ')"
+        Assert-True -Name "Partial batch: attachments NOT rolled back (referenced by successes)" `
+            -Condition (@($script:partialDeletedRefs).Count -eq 0) `
+            -Message "Expected zero DELETEs, got: $(@($script:partialDeletedRefs) -join ', ')"
+
+        Remove-Item -Path $partialTaskFile -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path $movedPartial -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path $partialAttDir -Recurse -Force -ErrorAction SilentlyContinue
+        if ($null -ne $controlBackup2) {
+            $controlBackup2 | Set-Content $controlSettingsFile2 -Encoding UTF8
+        } else {
+            Remove-Item -Path $controlSettingsFile2 -Force -ErrorAction SilentlyContinue
+        }
+    }
 } else {
     Write-TestResult -Name "NotificationClient module exists" -Status Fail -Message "Module not found at $notifModule"
 }

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2422,8 +2422,439 @@ if (Test-Path $notifModule) {
             -Condition ($templateCapture.responseSettings.allowFreeText -eq $false) `
             -Message "Expected allowFreeText=false for split proposal, got: $($templateCapture.responseSettings.allowFreeText)"
     }
+
+    # ── Outpost typed-response + attachment helpers (issue #291) ─────
+    # ConvertTo-TypedResponse: approval
+    $approvalResponse = [PSCustomObject]@{
+        approvalDecision = 'rejected'
+        comment          = 'needs more context'
+    }
+    $typedApproval = ConvertTo-TypedResponse -Response $approvalResponse -Type 'approval'
+    Assert-True -Name "ConvertTo-TypedResponse extracts approval decision" `
+        -Condition ($typedApproval -and $typedApproval.approval_decision -eq 'rejected') `
+        -Message "Expected approval_decision=rejected, got: $($typedApproval | ConvertTo-Json -Compress)"
+    Assert-True -Name "ConvertTo-TypedResponse extracts approval comment" `
+        -Condition ($typedApproval.comment -eq 'needs more context') `
+        -Message "Expected comment, got: $($typedApproval.comment)"
+    Assert-True -Name "ConvertTo-TypedResponse echoes answer_type" `
+        -Condition ($typedApproval.answer_type -eq 'approval') `
+        -Message "Expected answer_type=approval"
+
+    # ConvertTo-TypedResponse: documentReview with attachments (metadata only)
+    $docReviewResp = [PSCustomObject]@{
+        approvalDecision = 'changes_requested'
+        comment          = 'see notes'
+        attachments      = @(
+            [PSCustomObject]@{ name = 'notes.pdf'; sizeBytes = 1024; storageRef = 'sref-1'; description = 'reviewer notes' }
+        )
+    }
+    $typedDoc = ConvertTo-TypedResponse -Response $docReviewResp -Type 'documentReview'
+    Assert-True -Name "ConvertTo-TypedResponse documentReview includes attachment_refs metadata" `
+        -Condition ($typedDoc.attachment_refs -and @($typedDoc.attachment_refs).Count -eq 1 -and $typedDoc.attachment_refs[0].storage_ref -eq 'sref-1') `
+        -Message "Expected attachment_refs[0].storage_ref=sref-1"
+    Assert-True -Name "ConvertTo-TypedResponse does NOT eager-download (no path field)" `
+        -Condition (-not $typedDoc.attachment_refs[0].ContainsKey('path')) `
+        -Message "Expected metadata only, no local path"
+
+    # ConvertTo-TypedResponse: priorityRanking
+    $rankingResp = [PSCustomObject]@{ rankedItems = @('item-c', 'item-a', 'item-b') }
+    $typedRank = ConvertTo-TypedResponse -Response $rankingResp -Type 'priorityRanking'
+    Assert-True -Name "ConvertTo-TypedResponse extracts ranked_items" `
+        -Condition ($typedRank.ranked_items -and @($typedRank.ranked_items).Count -eq 3 -and $typedRank.ranked_items[0] -eq 'item-c') `
+        -Message "Expected ranked_items[0]=item-c"
+
+    # Invoke-AttachmentBatchUpload: empty input → success
+    $emptyBatch = Invoke-AttachmentBatchUpload -Settings $enabledSettings -Attachments @()
+    Assert-True -Name "Invoke-AttachmentBatchUpload empty input returns success" `
+        -Condition ($emptyBatch.success -eq $true -and @($emptyBatch.uploads).Count -eq 0) `
+        -Message "Expected success with empty uploads"
+
+    # Invoke-AttachmentBatchUpload: cleanup-on-failure.
+    # Mock at the HTTP boundary (Invoke-RestMethod) rather than overriding
+    # Send-AttachmentUpload/Remove-Attachment globally — module-internal calls
+    # in Invoke-AttachmentBatchUpload resolve via module scope and would bypass
+    # any global function override.
+    $tmpAttDir = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-att-test-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+    New-Item -ItemType Directory -Force -Path $tmpAttDir | Out-Null
+    $f1 = Join-Path $tmpAttDir 'a.txt'; Set-Content -Path $f1 -Value 'aaa' -Encoding UTF8
+    $f2 = Join-Path $tmpAttDir 'b.txt'; Set-Content -Path $f2 -Value 'bbb' -Encoding UTF8
+    $f3 = Join-Path $tmpAttDir 'c.txt'; Set-Content -Path $f3 -Value 'ccc' -Encoding UTF8
+
+    $script:postCount   = 0
+    $script:deletedRefs = @()
+    function global:Invoke-RestMethod {
+        param(
+            [string]$Uri,
+            [string]$Method = 'Get',
+            $Body, $Headers, $ContentType, $TimeoutSec, $Form, $OutFile, $ErrorAction
+        )
+        if ($Uri -match '/api/attachments/(.+)$' -and $Method -eq 'Delete') {
+            $script:deletedRefs += $matches[1]
+            return @{}
+        }
+        if ($Uri -match '/api/attachments$' -and $Method -eq 'Post') {
+            $script:postCount++
+            if ($script:postCount -le 2) {
+                return @{ storageRef = "sref-$($script:postCount)"; sizeBytes = 3 }
+            }
+            throw "simulated failure"
+        }
+        throw "Unexpected URI/method: $Method $Uri"
+    }
+    $batchFail = Invoke-AttachmentBatchUpload -Settings $enabledSettings -Attachments @(
+        @{ path = $f1 }; @{ path = $f2 }; @{ path = $f3 }
+    )
+    Remove-Item -Path 'function:global:Invoke-RestMethod' -ErrorAction SilentlyContinue
+    Remove-Item -Path $tmpAttDir -Recurse -Force -ErrorAction SilentlyContinue
+
+    Assert-True -Name "Invoke-AttachmentBatchUpload returns failure on partial-upload error" `
+        -Condition ($batchFail.success -eq $false) `
+        -Message "Expected success=false, got: $($batchFail | ConvertTo-Json -Compress)"
+    Assert-True -Name "Invoke-AttachmentBatchUpload exercised 3 POSTs (2 success + 1 fail)" `
+        -Condition ($script:postCount -eq 3) `
+        -Message "Expected 3 upload attempts, got $script:postCount"
+    Assert-True -Name "Invoke-AttachmentBatchUpload rolls back prior uploads via DELETE" `
+        -Condition (@($script:deletedRefs).Count -eq 2 -and $script:deletedRefs -contains 'sref-1' -and $script:deletedRefs -contains 'sref-2') `
+        -Message "Expected 2 DELETE calls (sref-1, sref-2), got: $(@($script:deletedRefs) -join ', ')"
+
+    # ── Poller persists typed-response fields without eager-download ─
+    # End-to-end: seed a needs-input task with an approval-typed notification,
+    # mock the responses GET to return decision/comment, run one poll tick,
+    # assert questions_resolved carries PRD §5.4 keys and no -OutFile call.
+    $pollerMod = Join-Path $botDir "core/ui/modules/NotificationPoller.psm1"
+    if (Test-Path $pollerMod) {
+        $tempBot = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-poller-test-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+        $tempBotDir = Join-Path $tempBot ".bot"
+        New-Item -ItemType Directory -Force -Path (Join-Path $tempBotDir "settings") | Out-Null
+        New-Item -ItemType Directory -Force -Path (Join-Path $tempBotDir "workspace/tasks/needs-input") | Out-Null
+        New-Item -ItemType Directory -Force -Path (Join-Path $tempBotDir "workspace/tasks/analysing") | Out-Null
+        New-Item -ItemType Directory -Force -Path (Join-Path $tempBotDir ".control") | Out-Null
+
+        # Highest-precedence layer: notifications enabled + recipient
+        @'
+{
+  "instance_id": "11111111-1111-1111-1111-111111111111",
+  "mothership": {
+    "enabled": true,
+    "server_url": "http://localhost:9999",
+    "api_key": "test-key",
+    "channel": "teams",
+    "recipients": ["test@example.com"],
+    "project_name": "test-poller",
+    "poll_interval_seconds": 5
+  }
+}
+'@ | Set-Content (Join-Path $tempBotDir ".control/settings.json") -Encoding UTF8
+        '{}' | Set-Content (Join-Path $tempBotDir "settings/settings.default.json") -Encoding UTF8
+
+        $taskId = "poll-typed-1"
+        $taskFile = Join-Path $tempBotDir "workspace/tasks/needs-input/$taskId.json"
+        @{
+            id = $taskId
+            name = "Approval test"
+            status = "needs-input"
+            pending_question = @{
+                id = "q1"
+                question = "Approve the artifact?"
+                options = @(@{ key = "A"; label = "Yes" })
+                recommendation = "A"
+                asked_at = "2026-05-07T00:00:00Z"
+            }
+            notification = @{
+                question_id = "qid-1"
+                instance_id = "iid-1"
+                project_id  = "pid-1"
+                channel     = "teams"
+                type        = "approval"
+                sent_at     = "2026-05-07T00:00:00Z"
+            }
+            questions_resolved = @()
+            updated_at = "2026-05-07T00:00:00Z"
+        } | ConvertTo-Json -Depth 20 | Set-Content -Path $taskFile -Encoding UTF8
+
+        $script:outFileCalled = $false
+        function global:Invoke-RestMethod {
+            param([string]$Uri, [string]$Method = 'Get', $Body, $Headers, $ContentType, $TimeoutSec, $Form, $OutFile, $ErrorAction)
+            if ($PSBoundParameters.ContainsKey('OutFile') -and $OutFile) { $script:outFileCalled = $true }
+            if ($Uri -match '/responses$' -and $Method -eq 'Get') {
+                return @(@{ approvalDecision = 'rejected'; comment = 'not yet'; selectedKey = $null; freeText = $null; attachments = @() })
+            }
+            return @{}
+        }
+        if (-not (Get-Command Write-BotLog -ErrorAction SilentlyContinue)) {
+            function global:Write-BotLog { param($Level, $Message, $Exception) }
+            $script:wroteBotLogStub = $true
+        }
+
+        $savedRoot = $global:DotbotProjectRoot
+        $global:DotbotProjectRoot = $tempBot
+        try {
+            Import-Module $pollerMod -Force
+            Invoke-NotificationPollTick -BotRoot $tempBotDir
+        } finally {
+            Remove-Item -Path 'function:global:Invoke-RestMethod' -ErrorAction SilentlyContinue
+            if ($script:wroteBotLogStub) { Remove-Item -Path 'function:global:Write-BotLog' -ErrorAction SilentlyContinue }
+            $global:DotbotProjectRoot = $savedRoot
+        }
+
+        $movedFile = Join-Path $tempBotDir "workspace/tasks/analysing/$taskId.json"
+        $movedExists = Test-Path $movedFile
+        $resolvedQA = $null
+        if ($movedExists) {
+            $movedTask = Get-Content $movedFile -Raw | ConvertFrom-Json
+            if ($movedTask.questions_resolved -and @($movedTask.questions_resolved).Count -gt 0) {
+                $resolvedQA = @($movedTask.questions_resolved)[0]
+            }
+        }
+
+        Assert-True -Name "Poller transitions needs-input → analysing on typed approval response" `
+            -Condition $movedExists -Message "Expected task moved to analysing/, missing: $movedFile"
+        Assert-True -Name "Poller persists approval_decision (PRD §5.4)" `
+            -Condition ($resolvedQA -and $resolvedQA.approval_decision -eq 'rejected') `
+            -Message "Expected approval_decision=rejected, got: $($resolvedQA | ConvertTo-Json -Compress)"
+        Assert-True -Name "Poller persists comment from typed response" `
+            -Condition ($resolvedQA -and $resolvedQA.comment -eq 'not yet') `
+            -Message "Expected comment='not yet'"
+        Assert-True -Name "Poller persists answer_type from notification metadata" `
+            -Condition ($resolvedQA -and $resolvedQA.answer_type -eq 'approval') `
+            -Message "Expected answer_type=approval, got: $($resolvedQA.answer_type)"
+        Assert-True -Name "Poller does NOT eager-download attachments (no -OutFile call)" `
+            -Condition ($script:outFileCalled -eq $false) `
+            -Message "Expected zero -OutFile calls during poll tick"
+
+        Remove-Item -Path $tempBot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # ── Crash-mid-publish leaves no partial state in task JSON (#291 acceptance)
+    # Seed a task in analysing/, mock attachment uploads to succeed but the
+    # template POST to throw. Assert the moved task in needs-input/ has no
+    # `notification` field, and uploaded refs were DELETE'd via Remove-Attachment.
+    $mniScript = Join-Path $botDir "core/mcp/tools/task-mark-needs-input/script.ps1"
+    if (Test-Path $mniScript) {
+        $crashTaskId = "crash-mid-publish-" + [guid]::NewGuid().ToString('N').Substring(0,6)
+        $analysingDir = Join-Path $botDir "workspace/tasks/analysing"
+        $needsInputDir = Join-Path $botDir "workspace/tasks/needs-input"
+        if (-not (Test-Path $analysingDir))  { New-Item -ItemType Directory -Force -Path $analysingDir  | Out-Null }
+        if (-not (Test-Path $needsInputDir)) { New-Item -ItemType Directory -Force -Path $needsInputDir | Out-Null }
+
+        $crashTaskFile = Join-Path $analysingDir "$crashTaskId.json"
+        @{
+            id = $crashTaskId
+            name = "Crash-mid-publish fixture"
+            status = "analysing"
+            created_at = "2026-05-07T00:00:00Z"
+            updated_at = "2026-05-07T00:00:00Z"
+        } | ConvertTo-Json -Depth 20 | Set-Content -Path $crashTaskFile -Encoding UTF8
+
+        # Enable mothership via .control/settings.json (highest precedence)
+        $controlDir = Join-Path $botDir ".control"
+        if (-not (Test-Path $controlDir)) { New-Item -ItemType Directory -Force -Path $controlDir | Out-Null }
+        $controlSettingsFile = Join-Path $controlDir "settings.json"
+        $controlBackup = $null
+        if (Test-Path $controlSettingsFile) { $controlBackup = Get-Content $controlSettingsFile -Raw }
+        @'
+{
+  "instance_id": "22222222-2222-2222-2222-222222222222",
+  "mothership": {
+    "enabled": true,
+    "server_url": "http://localhost:9999",
+    "api_key": "test-key",
+    "channel": "teams",
+    "recipients": ["test@example.com"],
+    "project_name": "test-crash"
+  }
+}
+'@ | Set-Content $controlSettingsFile -Encoding UTF8
+
+        # Stage attachment files
+        $crashAttDir = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-crash-att-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+        New-Item -ItemType Directory -Force -Path $crashAttDir | Out-Null
+        $cf1 = Join-Path $crashAttDir 'doc1.txt'; Set-Content -Path $cf1 -Value 'one' -Encoding UTF8
+        $cf2 = Join-Path $crashAttDir 'doc2.txt'; Set-Content -Path $cf2 -Value 'two' -Encoding UTF8
+
+        $script:crashUploadCount = 0
+        $script:crashDeletedRefs = @()
+        function global:Invoke-RestMethod {
+            param([string]$Uri, [string]$Method = 'Get', $Body, $Headers, $ContentType, $TimeoutSec, $Form, $OutFile, $ErrorAction)
+            if ($Uri -match '/api/attachments$' -and $Method -eq 'Post') {
+                $script:crashUploadCount++
+                return @{ storageRef = "crash-sref-$($script:crashUploadCount)"; sizeBytes = 3 }
+            }
+            if ($Uri -match '/api/attachments/(.+)$' -and $Method -eq 'Delete') {
+                $script:crashDeletedRefs += $matches[1]
+                return @{}
+            }
+            if ($Uri -match '/api/templates$' -and $Method -eq 'Post') {
+                throw "simulated mid-publish crash"
+            }
+            return @{}
+        }
+        if (-not (Get-Command Write-BotLog -ErrorAction SilentlyContinue)) {
+            function global:Write-BotLog { param($Level, $Message, $Exception) }
+            $script:crashWroteBotLogStub = $true
+        }
+
+        $savedRoot2 = $global:DotbotProjectRoot
+        $global:DotbotProjectRoot = $testProject
+        $crashResult = $null
+        try {
+            . $mniScript
+            $crashResult = Invoke-TaskMarkNeedsInput -Arguments @{
+                task_id             = $crashTaskId
+                type                = 'approval'
+                deliverable_summary = 'crash test artifact'
+                attachments         = @(
+                    @{ path = $cf1; description = 'first' }
+                    @{ path = $cf2; description = 'second' }
+                )
+                question = @{
+                    question = 'Approve?'
+                    options  = @(
+                        @{ key = 'A'; label = 'Yes' }
+                        @{ key = 'B'; label = 'No' }
+                    )
+                    recommendation = 'A'
+                }
+            }
+        } catch {
+            # Tool wraps publish in try/catch, should not bubble; capture for diagnostics
+            $crashResult = @{ success = $false; thrown = $_.Exception.Message }
+        } finally {
+            Remove-Item -Path 'function:global:Invoke-RestMethod' -ErrorAction SilentlyContinue
+            if ($script:crashWroteBotLogStub) { Remove-Item -Path 'function:global:Write-BotLog' -ErrorAction SilentlyContinue }
+            $global:DotbotProjectRoot = $savedRoot2
+        }
+
+        $movedCrashFile = Join-Path $needsInputDir "$crashTaskId.json"
+        $movedExists2 = Test-Path $movedCrashFile
+        $crashTaskJson = if ($movedExists2) { Get-Content $movedCrashFile -Raw | ConvertFrom-Json } else { $null }
+
+        Assert-True -Name "Crash mid-publish: tool reports success=true (status transition succeeded)" `
+            -Condition ($crashResult -and $crashResult.success -eq $true) `
+            -Message "Expected success=true, got: $($crashResult | ConvertTo-Json -Compress -Depth 5)"
+        Assert-True -Name "Crash mid-publish: tool surfaces notification_error" `
+            -Condition ($crashResult.notification_error -and $crashResult.notification_error -match 'crash') `
+            -Message "Expected notification_error containing 'crash', got: $($crashResult.notification_error)"
+        Assert-True -Name "Crash mid-publish: task moved to needs-input/" `
+            -Condition $movedExists2 -Message "Expected task at $movedCrashFile"
+        Assert-True -Name "Crash mid-publish: task JSON has pending_question (status state preserved)" `
+            -Condition ($crashTaskJson -and $crashTaskJson.pending_question -and $crashTaskJson.pending_question.question -eq 'Approve?') `
+            -Message "Expected pending_question populated"
+        $hasNotificationField = $crashTaskJson -and $crashTaskJson.PSObject.Properties['notification'] -and $crashTaskJson.notification
+        Assert-True -Name "Crash mid-publish: NO partial 'notification' state in task JSON (#291 acceptance)" `
+            -Condition (-not $hasNotificationField) `
+            -Message "Expected no notification field, got: $($crashTaskJson.notification | ConvertTo-Json -Compress)"
+        Assert-True -Name "Crash mid-publish: both uploaded attachments rolled back via DELETE" `
+            -Condition (@($script:crashDeletedRefs).Count -eq 2 -and $script:crashDeletedRefs -contains 'crash-sref-1' -and $script:crashDeletedRefs -contains 'crash-sref-2') `
+            -Message "Expected 2 DELETEs, got: $(@($script:crashDeletedRefs) -join ', ')"
+
+        # Cleanup
+        Remove-Item -Path $movedCrashFile -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path $crashTaskFile -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path $crashAttDir -Recurse -Force -ErrorAction SilentlyContinue
+        if ($null -ne $controlBackup) {
+            $controlBackup | Set-Content $controlSettingsFile -Encoding UTF8
+        } else {
+            Remove-Item -Path $controlSettingsFile -Force -ErrorAction SilentlyContinue
+        }
+    }
 } else {
     Write-TestResult -Name "NotificationClient module exists" -Status Fail -Message "Module not found at $notifModule"
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# OUTPOST MCP TOOLS — issue #291 schema & validation
+# ═══════════════════════════════════════════════════════════════════
+Write-Host ""
+Write-Host "--- Outpost MCP Tools (#291) ---" -ForegroundColor Cyan
+
+$mniMeta = Join-Path $botDir "core/mcp/tools/task-mark-needs-input/metadata.yaml"
+$aqMeta  = Join-Path $botDir "core/mcp/tools/task-answer-question/metadata.yaml"
+
+if ((Test-Path $mniMeta) -and (Test-Path $aqMeta)) {
+    $mniText = Get-Content $mniMeta -Raw
+    $aqText  = Get-Content $aqMeta  -Raw
+
+    Assert-True -Name "task-mark-needs-input schema declares 'type' enum" `
+        -Condition ($mniText -match '(?ms)\btype:\s*\r?\n\s+type:\s*string\s*\r?\n\s+enum:\s*\[singleChoice') `
+        -Message "Expected 'type' field with full PRD enum, got:`n$mniText"
+    Assert-True -Name "task-mark-needs-input schema declares 'deliverable_summary'" `
+        -Condition ($mniText -match 'deliverable_summary:') `
+        -Message "Expected deliverable_summary key"
+    Assert-True -Name "task-mark-needs-input schema declares 'attachments' array" `
+        -Condition ($mniText -match '(?ms)attachments:\s*\r?\n\s+type:\s*array') `
+        -Message "Expected attachments array"
+    Assert-True -Name "task-mark-needs-input schema declares 'review_links' with PRD enum" `
+        -Condition ($mniText -match '(?ms)review_links:.*?enum:\s*\[pull-request') `
+        -Message "Expected review_links with pull-request enum value"
+
+    Assert-True -Name "task-answer-question schema declares 'type' enum (full PRD)" `
+        -Condition ($aqText -match '(?ms)\btype:\s*\r?\n\s+type:\s*string\s*\r?\n\s+enum:\s*\[singleChoice') `
+        -Message "Expected type field with full PRD enum"
+    Assert-True -Name "task-answer-question schema declares 'decision'" `
+        -Condition ($aqText -match 'decision:') -Message "Expected decision key"
+    Assert-True -Name "task-answer-question schema declares 'comment'" `
+        -Condition ($aqText -match 'comment:') -Message "Expected comment key"
+    Assert-True -Name "task-answer-question schema declares 'ranked_items'" `
+        -Condition ($aqText -match 'ranked_items:') -Message "Expected ranked_items key"
+
+    # Validation: load script directly and test typed throws
+    $aqScript = Join-Path $botDir "core/mcp/tools/task-answer-question/script.ps1"
+    if (Test-Path $aqScript) {
+        # Stub deps loaded by tool's parent dot-source path; the script imports nothing,
+        # so we can dot-source it in a clean scope. Use a fake DotbotProjectRoot so any
+        # FS lookups fail predictably (we expect throws BEFORE any FS access).
+        $savedRoot = $global:DotbotProjectRoot
+        $global:DotbotProjectRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-aq-validate-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+        New-Item -ItemType Directory -Force -Path (Join-Path $global:DotbotProjectRoot ".bot/workspace/tasks/needs-input") | Out-Null
+        try {
+            . $aqScript
+
+            # Invalid decision for approval
+            $threw = $false; $msg = ""
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='approval'; decision='bogus' } } catch { $threw = $true; $msg = $_.Exception.Message }
+            Assert-True -Name "task-answer-question rejects invalid approval decision" `
+                -Condition ($threw -and $msg -match "Invalid 'decision'") `
+                -Message "Expected throw on bogus decision, got: $msg"
+
+            # decision=rejected without comment
+            $threw = $false; $msg = ""
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='approval'; decision='rejected' } } catch { $threw = $true; $msg = $_.Exception.Message }
+            Assert-True -Name "task-answer-question rejects rejected without comment" `
+                -Condition ($threw -and $msg -match "comment.*rejected") `
+                -Message "Expected throw on missing comment, got: $msg"
+
+            # priorityRanking without ranked_items
+            $threw = $false; $msg = ""
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='priorityRanking' } } catch { $threw = $true; $msg = $_.Exception.Message }
+            Assert-True -Name "task-answer-question rejects priorityRanking without ranked_items" `
+                -Condition ($threw -and $msg -match "ranked_items.*required") `
+                -Message "Expected throw on missing ranked_items, got: $msg"
+
+            # documentReview with allowed decision should NOT throw on validation —
+            # it will fail later at the task-not-found check, but only AFTER passing validation.
+            $threw = $false; $msg = ""
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='documentReview'; decision='approved' } } catch { $threw = $true; $msg = $_.Exception.Message }
+            Assert-True -Name "task-answer-question accepts documentReview decision=approved (passes validation)" `
+                -Condition ($threw -and $msg -match "not found in needs-input") `
+                -Message "Expected validation to pass and fail on task lookup, got: $msg"
+
+            # Invalid type
+            $threw = $false; $msg = ""
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='bogus'; answer='A' } } catch { $threw = $true; $msg = $_.Exception.Message }
+            Assert-True -Name "task-answer-question rejects unknown type" `
+                -Condition ($threw -and $msg -match "Invalid 'type'") `
+                -Message "Expected throw on bogus type, got: $msg"
+        } finally {
+            Remove-Item -Path $global:DotbotProjectRoot -Recurse -Force -ErrorAction SilentlyContinue
+            $global:DotbotProjectRoot = $savedRoot
+        }
+    } else {
+        Write-TestResult -Name "task-answer-question script.ps1 present" -Status Fail -Message "Missing $aqScript"
+    }
+} else {
+    Write-TestResult -Name "Outpost MCP tool metadata files exist" -Status Fail `
+        -Message "Missing $mniMeta or $aqMeta"
 }
 
 # ═══════════════════════════════════════════════════════════════════

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2456,12 +2456,29 @@ if (Test-Path $notifModule) {
         -Condition (-not $typedDoc.attachment_refs[0].ContainsKey('path')) `
         -Message "Expected metadata only, no local path"
 
-    # ConvertTo-TypedResponse: priorityRanking
+    # ConvertTo-TypedResponse: priorityRanking — legacy string passthrough
     $rankingResp = [PSCustomObject]@{ rankedItems = @('item-c', 'item-a', 'item-b') }
     $typedRank = ConvertTo-TypedResponse -Response $rankingResp -Type 'priorityRanking'
-    Assert-True -Name "ConvertTo-TypedResponse extracts ranked_items" `
+    Assert-True -Name "ConvertTo-TypedResponse extracts ranked_items (legacy strings)" `
         -Condition ($typedRank.ranked_items -and @($typedRank.ranked_items).Count -eq 3 -and $typedRank.ranked_items[0] -eq 'item-c') `
         -Message "Expected ranked_items[0]=item-c"
+
+    # Fix M: server emits RankedItem[] = [{ optionId, rank }] — sort by rank,
+    # project to optionId strings so downstream -join produces meaningful output.
+    $rankingObjResp = [PSCustomObject]@{
+        rankedItems = @(
+            [PSCustomObject]@{ optionId = 'opt-c'; rank = 3 }
+            [PSCustomObject]@{ optionId = 'opt-a'; rank = 1 }
+            [PSCustomObject]@{ optionId = 'opt-b'; rank = 2 }
+        )
+    }
+    $typedRankObj = ConvertTo-TypedResponse -Response $rankingObjResp -Type 'priorityRanking'
+    Assert-True -Name "ConvertTo-TypedResponse normalizes server RankedItem objects (Fix M)" `
+        -Condition ($typedRankObj.ranked_items -and @($typedRankObj.ranked_items).Count -eq 3 -and
+                    $typedRankObj.ranked_items[0] -eq 'opt-a' -and
+                    $typedRankObj.ranked_items[1] -eq 'opt-b' -and
+                    $typedRankObj.ranked_items[2] -eq 'opt-c') `
+        -Message "Expected sorted optionId strings ['opt-a','opt-b','opt-c'], got: $(@($typedRankObj.ranked_items) -join ', ')"
 
     # Invoke-AttachmentBatchUpload: empty input → success
     $emptyBatch = Invoke-AttachmentBatchUpload -Settings $enabledSettings -Attachments @()
@@ -3158,6 +3175,19 @@ if ((Test-Path $mniMeta) -and (Test-Path $aqMeta)) {
             Assert-True -Name "task-answer-question rejects 'ranked_items' when type is omitted (legacy)" `
                 -Condition ($threw -and $msg -match "'ranked_items' is only valid") `
                 -Message "Expected throw on legacy caller smuggling ranked_items, got: $msg"
+
+            # Fix N: 'answer' rejected for typed payloads (would produce inconsistent resolvedEntry)
+            $threw = $false; $msg = ""
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='approval'; decision='approved'; answer='A' } } catch { $threw = $true; $msg = $_.Exception.Message }
+            Assert-True -Name "task-answer-question rejects 'answer' alongside approval decision" `
+                -Condition ($threw -and $msg -match "'answer' is only valid") `
+                -Message "Expected throw, got: $msg"
+
+            $threw = $false; $msg = ""
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='priorityRanking'; ranked_items=@('a','b'); answer='A' } } catch { $threw = $true; $msg = $_.Exception.Message }
+            Assert-True -Name "task-answer-question rejects 'answer' alongside priorityRanking" `
+                -Condition ($threw -and $msg -match "'answer' is only valid") `
+                -Message "Expected throw, got: $msg"
         } finally {
             Remove-Item -Path $global:DotbotProjectRoot -Recurse -Force -ErrorAction SilentlyContinue
             $global:DotbotProjectRoot = $savedRoot

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2518,22 +2518,26 @@ if (Test-Path $notifModule) {
         -Message "Expected 2 DELETE calls (sref-1, sref-2), got: $(@($script:deletedRefs) -join ', ')"
 
     # ── Poller persists typed-response fields without eager-download ─
-    # End-to-end: seed a needs-input task with an approval-typed notification,
-    # mock the responses GET to return decision/comment, run one poll tick,
-    # assert questions_resolved carries PRD §5.4 keys and no -OutFile call.
+    # Reuse the layer-2 $botDir (which has the full module tree at
+    # core/mcp/modules/NotificationClient.psm1) — Invoke-NotificationPollTick
+    # silently no-ops if that module is missing under the BotRoot it receives.
     $pollerMod = Join-Path $botDir "core/ui/modules/NotificationPoller.psm1"
     if (Test-Path $pollerMod) {
-        $tempBot = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-poller-test-" + [guid]::NewGuid().ToString('N').Substring(0,8))
-        $tempBotDir = Join-Path $tempBot ".bot"
-        New-Item -ItemType Directory -Force -Path (Join-Path $tempBotDir "settings") | Out-Null
-        New-Item -ItemType Directory -Force -Path (Join-Path $tempBotDir "workspace/tasks/needs-input") | Out-Null
-        New-Item -ItemType Directory -Force -Path (Join-Path $tempBotDir "workspace/tasks/analysing") | Out-Null
-        New-Item -ItemType Directory -Force -Path (Join-Path $tempBotDir ".control") | Out-Null
+        $pollerTaskId = "poll-typed-" + [guid]::NewGuid().ToString('N').Substring(0,6)
+        $pollerNeedsInput = Join-Path $botDir "workspace/tasks/needs-input"
+        $pollerAnalysing  = Join-Path $botDir "workspace/tasks/analysing"
+        if (-not (Test-Path $pollerNeedsInput)) { New-Item -ItemType Directory -Force -Path $pollerNeedsInput | Out-Null }
+        if (-not (Test-Path $pollerAnalysing))  { New-Item -ItemType Directory -Force -Path $pollerAnalysing  | Out-Null }
 
-        # Highest-precedence layer: notifications enabled + recipient
+        # Enable mothership via .control/settings.json (highest precedence)
+        $pollerControlDir  = Join-Path $botDir ".control"
+        if (-not (Test-Path $pollerControlDir)) { New-Item -ItemType Directory -Force -Path $pollerControlDir | Out-Null }
+        $pollerControlFile = Join-Path $pollerControlDir "settings.json"
+        $pollerControlBackup = $null
+        if (Test-Path $pollerControlFile) { $pollerControlBackup = Get-Content $pollerControlFile -Raw }
         @'
 {
-  "instance_id": "11111111-1111-1111-1111-111111111111",
+  "instance_id": "33333333-3333-3333-3333-333333333333",
   "mothership": {
     "enabled": true,
     "server_url": "http://localhost:9999",
@@ -2544,13 +2548,11 @@ if (Test-Path $notifModule) {
     "poll_interval_seconds": 5
   }
 }
-'@ | Set-Content (Join-Path $tempBotDir ".control/settings.json") -Encoding UTF8
-        '{}' | Set-Content (Join-Path $tempBotDir "settings/settings.default.json") -Encoding UTF8
+'@ | Set-Content $pollerControlFile -Encoding UTF8
 
-        $taskId = "poll-typed-1"
-        $taskFile = Join-Path $tempBotDir "workspace/tasks/needs-input/$taskId.json"
+        $pollerTaskFile = Join-Path $pollerNeedsInput "$pollerTaskId.json"
         @{
-            id = $taskId
+            id = $pollerTaskId
             name = "Approval test"
             status = "needs-input"
             pending_question = @{
@@ -2570,14 +2572,15 @@ if (Test-Path $notifModule) {
             }
             questions_resolved = @()
             updated_at = "2026-05-07T00:00:00Z"
-        } | ConvertTo-Json -Depth 20 | Set-Content -Path $taskFile -Encoding UTF8
+        } | ConvertTo-Json -Depth 20 | Set-Content -Path $pollerTaskFile -Encoding UTF8
 
         $script:outFileCalled = $false
         function global:Invoke-RestMethod {
             param([string]$Uri, [string]$Method = 'Get', $Body, $Headers, $ContentType, $TimeoutSec, $Form, $OutFile, $ErrorAction)
             if ($PSBoundParameters.ContainsKey('OutFile') -and $OutFile) { $script:outFileCalled = $true }
             if ($Uri -match '/responses$' -and $Method -eq 'Get') {
-                return @(@{ approvalDecision = 'rejected'; comment = 'not yet'; selectedKey = $null; freeText = $null; attachments = @() })
+                # PSCustomObject mirrors what Invoke-RestMethod yields from JSON in production.
+                return @( [PSCustomObject]@{ approvalDecision = 'rejected'; comment = 'not yet'; selectedKey = $null; freeText = $null; attachments = @() } )
             }
             return @{}
         }
@@ -2587,17 +2590,17 @@ if (Test-Path $notifModule) {
         }
 
         $savedRoot = $global:DotbotProjectRoot
-        $global:DotbotProjectRoot = $tempBot
+        $global:DotbotProjectRoot = $testProject
         try {
             Import-Module $pollerMod -Force
-            Invoke-NotificationPollTick -BotRoot $tempBotDir
+            Invoke-NotificationPollTick -BotRoot $botDir
         } finally {
             Remove-Item -Path 'function:global:Invoke-RestMethod' -ErrorAction SilentlyContinue
             if ($script:wroteBotLogStub) { Remove-Item -Path 'function:global:Write-BotLog' -ErrorAction SilentlyContinue }
             $global:DotbotProjectRoot = $savedRoot
         }
 
-        $movedFile = Join-Path $tempBotDir "workspace/tasks/analysing/$taskId.json"
+        $movedFile = Join-Path $pollerAnalysing "$pollerTaskId.json"
         $movedExists = Test-Path $movedFile
         $resolvedQA = $null
         if ($movedExists) {
@@ -2622,7 +2625,14 @@ if (Test-Path $notifModule) {
             -Condition ($script:outFileCalled -eq $false) `
             -Message "Expected zero -OutFile calls during poll tick"
 
-        Remove-Item -Path $tempBot -Recurse -Force -ErrorAction SilentlyContinue
+        # Cleanup: remove fixture and restore .control/settings.json
+        Remove-Item -Path $pollerTaskFile -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path $movedFile -Force -ErrorAction SilentlyContinue
+        if ($null -ne $pollerControlBackup) {
+            $pollerControlBackup | Set-Content $pollerControlFile -Encoding UTF8
+        } else {
+            Remove-Item -Path $pollerControlFile -Force -ErrorAction SilentlyContinue
+        }
     }
 
     # ── Crash-mid-publish leaves no partial state in task JSON (#291 acceptance)

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2474,7 +2474,9 @@ if (Test-Path $notifModule) {
     # Send-AttachmentUpload/Remove-Attachment globally — module-internal calls
     # in Invoke-AttachmentBatchUpload resolve via module scope and would bypass
     # any global function override.
-    $tmpAttDir = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-att-test-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+    # Files must live under $global:DotbotProjectRoot (= $testProject) so
+    # path-traversal guard in Send-AttachmentUpload doesn't reject them.
+    $tmpAttDir = Join-Path $testProject (".attachments-test-" + [guid]::NewGuid().ToString('N').Substring(0,8))
     New-Item -ItemType Directory -Force -Path $tmpAttDir | Out-Null
     $f1 = Join-Path $tmpAttDir 'a.txt'; Set-Content -Path $f1 -Value 'aaa' -Encoding UTF8
     $f2 = Join-Path $tmpAttDir 'b.txt'; Set-Content -Path $f2 -Value 'bbb' -Encoding UTF8
@@ -2516,6 +2518,45 @@ if (Test-Path $notifModule) {
     Assert-True -Name "Invoke-AttachmentBatchUpload rolls back prior uploads via DELETE" `
         -Condition (@($script:deletedRefs).Count -eq 2 -and $script:deletedRefs -contains 'sref-1' -and $script:deletedRefs -contains 'sref-2') `
         -Message "Expected 2 DELETE calls (sref-1, sref-2), got: $(@($script:deletedRefs) -join ', ')"
+    # Failure return surfaces the rolled-back storage_refs
+    Assert-True -Name "Invoke-AttachmentBatchUpload failure surfaces rolled-back refs in 'uploaded'" `
+        -Condition (@($batchFail.uploaded).Count -eq 2 -and $batchFail.uploaded -contains 'sref-1' -and $batchFail.uploaded -contains 'sref-2') `
+        -Message "Expected uploaded=[sref-1, sref-2], got: $(@($batchFail.uploaded) -join ', ')"
+
+    # Send-AttachmentUpload rejects paths outside project root (security boundary)
+    $savedRootForPath = $global:DotbotProjectRoot
+    $pathTestRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-path-guard-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+    New-Item -ItemType Directory -Force -Path $pathTestRoot | Out-Null
+    $insideFile  = Join-Path $pathTestRoot 'inside.txt'
+    Set-Content -Path $insideFile -Value 'inside' -Encoding UTF8
+    $outsideDir  = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-path-guard-outside-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+    New-Item -ItemType Directory -Force -Path $outsideDir | Out-Null
+    $outsideFile = Join-Path $outsideDir 'outside.txt'
+    Set-Content -Path $outsideFile -Value 'outside' -Encoding UTF8
+    $global:DotbotProjectRoot = $pathTestRoot
+    try {
+        $outsideResult = Send-AttachmentUpload -Settings $enabledSettings -FilePath $outsideFile -Description 'evil'
+        Assert-True -Name "Send-AttachmentUpload rejects path outside project root" `
+            -Condition ($outsideResult.success -eq $false -and $outsideResult.reason -match 'outside project root') `
+            -Message "Expected outside-root rejection, got: $($outsideResult | ConvertTo-Json -Compress)"
+    } finally {
+        $global:DotbotProjectRoot = $savedRootForPath
+        Remove-Item -Path $pathTestRoot -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path $outsideDir   -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # ConvertTo-TypedResponse skips attachments without identifier
+    $missingRefResp = [PSCustomObject]@{
+        approvalDecision = 'approved'
+        attachments      = @(
+            [PSCustomObject]@{ name = 'ok.pdf';  sizeBytes = 100; storageRef = 'sref-good' }
+            [PSCustomObject]@{ name = 'bad.pdf'; sizeBytes = 200 }  # no storageRef / storage_ref / blobPath
+        )
+    }
+    $typedSkip = ConvertTo-TypedResponse -Response $missingRefResp -Type 'approval'
+    Assert-True -Name "ConvertTo-TypedResponse skips attachments without identifier" `
+        -Condition ($typedSkip.attachment_refs -and @($typedSkip.attachment_refs).Count -eq 1 -and $typedSkip.attachment_refs[0].storage_ref -eq 'sref-good') `
+        -Message "Expected single valid ref, got: $(@($typedSkip.attachment_refs) | ConvertTo-Json -Compress)"
 
     # ── Poller persists typed-response fields without eager-download ─
     # Use an isolated temp .bot to avoid contaminating the shared layer-2
@@ -2676,8 +2717,9 @@ if (Test-Path $notifModule) {
 }
 '@ | Set-Content $controlSettingsFile -Encoding UTF8
 
-        # Stage attachment files
-        $crashAttDir = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-crash-att-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+        # Stage attachment files under $testProject so path-traversal guard
+        # in Send-AttachmentUpload accepts them ($global:DotbotProjectRoot = $testProject below).
+        $crashAttDir = Join-Path $testProject (".crash-att-" + [guid]::NewGuid().ToString('N').Substring(0,8))
         New-Item -ItemType Directory -Force -Path $crashAttDir | Out-Null
         $cf1 = Join-Path $crashAttDir 'doc1.txt'; Set-Content -Path $cf1 -Value 'one' -Encoding UTF8
         $cf2 = Join-Path $crashAttDir 'doc2.txt'; Set-Content -Path $cf2 -Value 'two' -Encoding UTF8
@@ -2855,6 +2897,25 @@ if ((Test-Path $mniMeta) -and (Test-Path $aqMeta)) {
             Assert-True -Name "task-answer-question rejects unknown type" `
                 -Condition ($threw -and $msg -match "Invalid 'type'") `
                 -Message "Expected throw on bogus type, got: $msg"
+
+            # Cross-field validation: incompatible-field combinations
+            $threw = $false; $msg = ""
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='freeText'; answer='ok'; decision='approved' } } catch { $threw = $true; $msg = $_.Exception.Message }
+            Assert-True -Name "task-answer-question rejects 'decision' on freeText type" `
+                -Condition ($threw -and $msg -match "'decision' is only valid") `
+                -Message "Expected throw, got: $msg"
+
+            $threw = $false; $msg = ""
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='singleChoice'; answer='A'; comment='nope' } } catch { $threw = $true; $msg = $_.Exception.Message }
+            Assert-True -Name "task-answer-question rejects 'comment' on singleChoice type" `
+                -Condition ($threw -and $msg -match "'comment' is only valid") `
+                -Message "Expected throw, got: $msg"
+
+            $threw = $false; $msg = ""
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='approval'; decision='approved'; ranked_items=@('a','b') } } catch { $threw = $true; $msg = $_.Exception.Message }
+            Assert-True -Name "task-answer-question rejects 'ranked_items' on approval type" `
+                -Condition ($threw -and $msg -match "'ranked_items' is only valid") `
+                -Message "Expected throw, got: $msg"
         } finally {
             Remove-Item -Path $global:DotbotProjectRoot -Recurse -Force -ErrorAction SilentlyContinue
             $global:DotbotProjectRoot = $savedRoot

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2518,23 +2518,29 @@ if (Test-Path $notifModule) {
         -Message "Expected 2 DELETE calls (sref-1, sref-2), got: $(@($script:deletedRefs) -join ', ')"
 
     # ── Poller persists typed-response fields without eager-download ─
-    # Reuse the layer-2 $botDir (which has the full module tree at
-    # core/mcp/modules/NotificationClient.psm1) — Invoke-NotificationPollTick
-    # silently no-ops if that module is missing under the BotRoot it receives.
+    # Use an isolated temp .bot to avoid contaminating the shared layer-2
+    # $botDir. Invoke-NotificationPollTick resolves NotificationClient.psm1
+    # relative to its BotRoot and silently returns when missing, so copy the
+    # two needed modules into the temp tree.
     $pollerMod = Join-Path $botDir "core/ui/modules/NotificationPoller.psm1"
     if (Test-Path $pollerMod) {
-        $pollerTaskId = "poll-typed-" + [guid]::NewGuid().ToString('N').Substring(0,6)
-        $pollerNeedsInput = Join-Path $botDir "workspace/tasks/needs-input"
-        $pollerAnalysing  = Join-Path $botDir "workspace/tasks/analysing"
-        if (-not (Test-Path $pollerNeedsInput)) { New-Item -ItemType Directory -Force -Path $pollerNeedsInput | Out-Null }
-        if (-not (Test-Path $pollerAnalysing))  { New-Item -ItemType Directory -Force -Path $pollerAnalysing  | Out-Null }
+        $pollerTaskId = "poll-typed-1"
+        $tempBot = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-poller-test-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+        $tempBotDir = Join-Path $tempBot ".bot"
+        New-Item -ItemType Directory -Force -Path (Join-Path $tempBotDir "settings") | Out-Null
+        New-Item -ItemType Directory -Force -Path (Join-Path $tempBotDir "workspace/tasks/needs-input") | Out-Null
+        New-Item -ItemType Directory -Force -Path (Join-Path $tempBotDir "workspace/tasks/analysing") | Out-Null
+        New-Item -ItemType Directory -Force -Path (Join-Path $tempBotDir ".control") | Out-Null
 
-        # Enable mothership via .control/settings.json (highest precedence)
-        $pollerControlDir  = Join-Path $botDir ".control"
-        if (-not (Test-Path $pollerControlDir)) { New-Item -ItemType Directory -Force -Path $pollerControlDir | Out-Null }
-        $pollerControlFile = Join-Path $pollerControlDir "settings.json"
-        $pollerControlBackup = $null
-        if (Test-Path $pollerControlFile) { $pollerControlBackup = Get-Content $pollerControlFile -Raw }
+        # Copy the two modules the poller resolves relative to BotRoot.
+        $tempMcpModules = Join-Path $tempBotDir "core/mcp/modules"
+        $tempRtModules  = Join-Path $tempBotDir "core/runtime/modules"
+        New-Item -ItemType Directory -Force -Path $tempMcpModules | Out-Null
+        New-Item -ItemType Directory -Force -Path $tempRtModules  | Out-Null
+        Copy-Item -Path (Join-Path $botDir "core/mcp/modules/NotificationClient.psm1")     -Destination $tempMcpModules -Force
+        Copy-Item -Path (Join-Path $botDir "core/runtime/modules/SettingsLoader.psm1")     -Destination $tempRtModules  -Force
+
+        # Highest-precedence layer: notifications enabled + recipient
         @'
 {
   "instance_id": "33333333-3333-3333-3333-333333333333",
@@ -2548,9 +2554,10 @@ if (Test-Path $notifModule) {
     "poll_interval_seconds": 5
   }
 }
-'@ | Set-Content $pollerControlFile -Encoding UTF8
+'@ | Set-Content (Join-Path $tempBotDir ".control/settings.json") -Encoding UTF8
+        '{}' | Set-Content (Join-Path $tempBotDir "settings/settings.default.json") -Encoding UTF8
 
-        $pollerTaskFile = Join-Path $pollerNeedsInput "$pollerTaskId.json"
+        $pollerTaskFile = Join-Path $tempBotDir "workspace/tasks/needs-input/$pollerTaskId.json"
         @{
             id = $pollerTaskId
             name = "Approval test"
@@ -2590,17 +2597,17 @@ if (Test-Path $notifModule) {
         }
 
         $savedRoot = $global:DotbotProjectRoot
-        $global:DotbotProjectRoot = $testProject
+        $global:DotbotProjectRoot = $tempBot
         try {
             Import-Module $pollerMod -Force
-            Invoke-NotificationPollTick -BotRoot $botDir
+            Invoke-NotificationPollTick -BotRoot $tempBotDir
         } finally {
             Remove-Item -Path 'function:global:Invoke-RestMethod' -ErrorAction SilentlyContinue
             if ($script:wroteBotLogStub) { Remove-Item -Path 'function:global:Write-BotLog' -ErrorAction SilentlyContinue }
             $global:DotbotProjectRoot = $savedRoot
         }
 
-        $movedFile = Join-Path $pollerAnalysing "$pollerTaskId.json"
+        $movedFile = Join-Path $tempBotDir "workspace/tasks/analysing/$pollerTaskId.json"
         $movedExists = Test-Path $movedFile
         $resolvedQA = $null
         if ($movedExists) {
@@ -2625,14 +2632,7 @@ if (Test-Path $notifModule) {
             -Condition ($script:outFileCalled -eq $false) `
             -Message "Expected zero -OutFile calls during poll tick"
 
-        # Cleanup: remove fixture and restore .control/settings.json
-        Remove-Item -Path $pollerTaskFile -Force -ErrorAction SilentlyContinue
-        Remove-Item -Path $movedFile -Force -ErrorAction SilentlyContinue
-        if ($null -ne $pollerControlBackup) {
-            $pollerControlBackup | Set-Content $pollerControlFile -Encoding UTF8
-        } else {
-            Remove-Item -Path $pollerControlFile -Force -ErrorAction SilentlyContinue
-        }
+        Remove-Item -Path $tempBot -Recurse -Force -ErrorAction SilentlyContinue
     }
 
     # ── Crash-mid-publish leaves no partial state in task JSON (#291 acceptance)

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2497,7 +2497,7 @@ if (Test-Path $notifModule) {
         if ($Uri -match '/api/attachments$' -and $Method -eq 'Post') {
             $script:postCount++
             if ($script:postCount -le 2) {
-                return @{ storageRef = "sref-$($script:postCount)"; sizeBytes = 3 }
+                return @{ attachmentId = "aid-$($script:postCount)"; storageRef = "sref-$($script:postCount)"; sizeBytes = 3 }
             }
             throw "simulated failure"
         }
@@ -2557,6 +2557,99 @@ if (Test-Path $notifModule) {
     Assert-True -Name "ConvertTo-TypedResponse skips attachments without identifier" `
         -Condition ($typedSkip.attachment_refs -and @($typedSkip.attachment_refs).Count -eq 1 -and $typedSkip.attachment_refs[0].storage_ref -eq 'sref-good') `
         -Message "Expected single valid ref, got: $(@($typedSkip.attachment_refs) | ConvertTo-Json -Compress)"
+
+    # ── Server-schema wire shape (A + B) ────────
+    # A: Send-AttachmentUpload captures attachmentId; template emits
+    #    {attachmentId, name, blobPath, sizeBytes} (no storageRef/description).
+    # B: Template emits referenceLinks (not reviewLinks) with {label, url} (no type).
+    $tplCapture = $null
+    $uploadAttRoot = Join-Path $testProject (".att-wire-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+    New-Item -ItemType Directory -Force -Path $uploadAttRoot | Out-Null
+    $wireFile = Join-Path $uploadAttRoot 'attach.txt'
+    Set-Content -Path $wireFile -Value 'wire-test' -Encoding UTF8
+
+    function global:Invoke-RestMethod {
+        param([string]$Uri, [string]$Method = 'Get', $Body, $Headers, $ContentType, $TimeoutSec, $Form, $OutFile, $ErrorAction)
+        if ($Uri -match '/api/attachments$' -and $Method -eq 'Post') {
+            return @{ attachmentId = '00000000-0000-0000-0000-000000000aaa'; storageRef = 'guid-x/attach.txt'; sizeBytes = 9; name = 'attach.txt'; contentType = 'text/plain' }
+        }
+        if ($Uri -match '/api/templates$' -and $Method -eq 'Post') {
+            $global:templateCapture = $Body | ConvertFrom-Json
+            return @{}
+        }
+        if ($Uri -match '/api/instances$' -and $Method -eq 'Post') { return @{} }
+        throw "Unexpected URI: $Method $Uri"
+    }
+    try {
+        $upload = Send-AttachmentUpload -Settings $enabledSettings -FilePath $wireFile -Description 'desc'
+        Assert-True -Name "Send-AttachmentUpload captures attachment_id from server response" `
+            -Condition ($upload.success -and $upload.attachment_id -eq '00000000-0000-0000-0000-000000000aaa') `
+            -Message "Expected attachment_id='...0aaa', got: $($upload | ConvertTo-Json -Compress)"
+
+        $taskWire = [PSCustomObject]@{ id = 'task-wire-1'; name = 'Wire test' }
+        $qWire = [PSCustomObject]@{
+            id = 'q1'; question = 'Approve?'; options = @([PSCustomObject]@{ key = 'A'; label = 'Yes' }); recommendation = 'A'
+        }
+        $atts = @(@{ attachment_id = '00000000-0000-0000-0000-000000000aaa'; storage_ref = 'guid-x/attach.txt'; name = 'attach.txt'; size_bytes = 9; description = 'desc' })
+        $links = @(@{ title = 'Spec'; url = 'https://example.com/spec'; type = 'document' })
+        $null = Send-TaskNotification -TaskContent $taskWire -PendingQuestion $qWire -Settings $enabledSettings `
+            -Type 'approval' -DeliverableSummary 'short' -Attachments $atts -ReviewLinks $links
+    } finally {
+        Remove-Item -Path 'function:global:Invoke-RestMethod' -ErrorAction SilentlyContinue
+        Remove-Item -Path $uploadAttRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    $tplCapture = $global:templateCapture
+    Assert-True -Name "Template attachments[0] has attachmentId + blobPath (server schema)" `
+        -Condition ($tplCapture.attachments[0].attachmentId -eq '00000000-0000-0000-0000-000000000aaa' -and $tplCapture.attachments[0].blobPath -eq 'guid-x/attach.txt') `
+        -Message "Expected attachmentId + blobPath, got: $($tplCapture.attachments[0] | ConvertTo-Json -Compress)"
+    Assert-True -Name "Template attachments[0] omits storageRef/description (server has no counterpart)" `
+        -Condition (-not $tplCapture.attachments[0].PSObject.Properties['storageRef'] -and -not $tplCapture.attachments[0].PSObject.Properties['description']) `
+        -Message "Expected no storageRef/description keys"
+    Assert-True -Name "Template emits referenceLinks (not reviewLinks)" `
+        -Condition ($tplCapture.PSObject.Properties['referenceLinks'] -and -not $tplCapture.PSObject.Properties['reviewLinks']) `
+        -Message "Expected referenceLinks key, no reviewLinks"
+    Assert-True -Name "Template referenceLinks[0] has label (mapped from title)" `
+        -Condition ($tplCapture.referenceLinks[0].label -eq 'Spec' -and $tplCapture.referenceLinks[0].url -eq 'https://example.com/spec') `
+        -Message "Expected {label:Spec, url:...}, got: $($tplCapture.referenceLinks[0] | ConvertTo-Json -Compress)"
+    Assert-True -Name "Template referenceLinks[0] omits 'type' (no server field)" `
+        -Condition (-not $tplCapture.referenceLinks[0].PSObject.Properties['type']) `
+        -Message "Expected no type field"
+
+    # ── Round-2 Copilot fix C: Linux-only case-sensitivity guard ────────
+    if ($IsLinux) {
+        $caseRoot = Join-Path '/tmp' ("dotbot-case-" + [guid]::NewGuid().ToString('N').Substring(0,8) + 'a')
+        New-Item -ItemType Directory -Force -Path $caseRoot | Out-Null
+        $insideCase = Join-Path $caseRoot 'inside.txt'
+        Set-Content -Path $insideCase -Value 'x' -Encoding UTF8
+        $caseVariantPath = $insideCase -replace 'a/inside\.txt$', 'A/inside.txt'   # flip last char of root
+        $savedRootCase = $global:DotbotProjectRoot
+        $global:DotbotProjectRoot = $caseRoot
+        try {
+            $caseRes = Send-AttachmentUpload -Settings $enabledSettings -FilePath $caseVariantPath -Description ''
+            Assert-True -Name "Send-AttachmentUpload rejects case-variant path on Linux (case-sensitive FS)" `
+                -Condition ($caseRes.success -eq $false) `
+                -Message "Expected rejection on Linux, got: $($caseRes | ConvertTo-Json -Compress)"
+        } finally {
+            $global:DotbotProjectRoot = $savedRootCase
+            Remove-Item -Path $caseRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # ── Round-2 Copilot fix D: Remove-Attachment preserves '/' in URL ────
+    $script:capturedDeleteUri = $null
+    function global:Invoke-RestMethod {
+        param([string]$Uri, [string]$Method = 'Get', $Body, $Headers, $ContentType, $TimeoutSec, $Form, $OutFile, $ErrorAction)
+        if ($Method -eq 'Delete') { $script:capturedDeleteUri = $Uri; return @{} }
+        throw "Unexpected: $Method $Uri"
+    }
+    try {
+        $null = Remove-Attachment -Settings $enabledSettings -StorageRef 'guid-x/attach.txt'
+    } finally {
+        Remove-Item -Path 'function:global:Invoke-RestMethod' -ErrorAction SilentlyContinue
+    }
+    Assert-True -Name "Remove-Attachment preserves '/' separator in DELETE URI (no %2F)" `
+        -Condition ($script:capturedDeleteUri -match '/api/attachments/guid-x/attach\.txt$' -and $script:capturedDeleteUri -notmatch '%2F') `
+        -Message "Expected literal slash, got: $script:capturedDeleteUri"
 
     # ── Poller persists typed-response fields without eager-download ─
     # Use an isolated temp .bot to avoid contaminating the shared layer-2
@@ -2730,7 +2823,7 @@ if (Test-Path $notifModule) {
             param([string]$Uri, [string]$Method = 'Get', $Body, $Headers, $ContentType, $TimeoutSec, $Form, $OutFile, $ErrorAction)
             if ($Uri -match '/api/attachments$' -and $Method -eq 'Post') {
                 $script:crashUploadCount++
-                return @{ storageRef = "crash-sref-$($script:crashUploadCount)"; sizeBytes = 3 }
+                return @{ attachmentId = "crash-aid-$($script:crashUploadCount)"; storageRef = "crash-sref-$($script:crashUploadCount)"; sizeBytes = 3 }
             }
             if ($Uri -match '/api/attachments/(.+)$' -and $Method -eq 'Delete') {
                 $script:crashDeletedRefs += $matches[1]

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2615,7 +2615,7 @@ if (Test-Path $notifModule) {
         -Condition (-not $tplCapture.referenceLinks[0].PSObject.Properties['type']) `
         -Message "Expected no type field"
 
-    # ── Round-2 Copilot fix C: Linux-only case-sensitivity guard ────────
+    # ── Linux-only case-sensitivity guard ────────
     if ($IsLinux) {
         $caseRoot = Join-Path '/tmp' ("dotbot-case-" + [guid]::NewGuid().ToString('N').Substring(0,8) + 'a')
         New-Item -ItemType Directory -Force -Path $caseRoot | Out-Null
@@ -2635,7 +2635,7 @@ if (Test-Path $notifModule) {
         }
     }
 
-    # ── Round-2 Copilot fix D: Remove-Attachment preserves '/' in URL ────
+    # ── Remove-Attachment preserves '/' in URL ────
     $script:capturedDeleteUri = $null
     function global:Invoke-RestMethod {
         param([string]$Uri, [string]$Method = 'Get', $Body, $Headers, $ContentType, $TimeoutSec, $Form, $OutFile, $ErrorAction)
@@ -2650,6 +2650,22 @@ if (Test-Path $notifModule) {
     Assert-True -Name "Remove-Attachment preserves '/' separator in DELETE URI (no %2F)" `
         -Condition ($script:capturedDeleteUri -match '/api/attachments/guid-x/attach\.txt$' -and $script:capturedDeleteUri -notmatch '%2F') `
         -Message "Expected literal slash, got: $script:capturedDeleteUri"
+
+    # Segment-encode escapes # and ? in filename while keeping / literal
+    $script:capturedDeleteUri = $null
+    function global:Invoke-RestMethod {
+        param([string]$Uri, [string]$Method = 'Get', $Body, $Headers, $ContentType, $TimeoutSec, $Form, $OutFile, $ErrorAction)
+        if ($Method -eq 'Delete') { $script:capturedDeleteUri = $Uri; return @{} }
+        throw "Unexpected: $Method $Uri"
+    }
+    try {
+        $null = Remove-Attachment -Settings $enabledSettings -StorageRef 'guid-x/has#hash?q.txt'
+    } finally {
+        Remove-Item -Path 'function:global:Invoke-RestMethod' -ErrorAction SilentlyContinue
+    }
+    Assert-True -Name "Remove-Attachment encodes '#' and '?' in filename (Fix H)" `
+        -Condition ($script:capturedDeleteUri -match '/api/attachments/guid-x/has%23hash%3Fq\.txt$') `
+        -Message "Expected has%23hash%3Fq.txt segment, got: $script:capturedDeleteUri"
 
     # ── Poller persists typed-response fields without eager-download ─
     # Use an isolated temp .bot to avoid contaminating the shared layer-2
@@ -3009,6 +3025,19 @@ if ((Test-Path $mniMeta) -and (Test-Path $aqMeta)) {
             Assert-True -Name "task-answer-question rejects 'ranked_items' on approval type" `
                 -Condition ($threw -and $msg -match "'ranked_items' is only valid") `
                 -Message "Expected throw, got: $msg"
+
+            # Cross-field validation must also fire when 'type' is omitted (legacy callers)
+            $threw = $false; $msg = ""
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; answer='A'; decision='approved' } } catch { $threw = $true; $msg = $_.Exception.Message }
+            Assert-True -Name "task-answer-question rejects 'decision' when type is omitted (legacy)" `
+                -Condition ($threw -and $msg -match "'decision' is only valid") `
+                -Message "Expected throw on legacy caller smuggling decision, got: $msg"
+
+            $threw = $false; $msg = ""
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; answer='B'; ranked_items=@('a','b') } } catch { $threw = $true; $msg = $_.Exception.Message }
+            Assert-True -Name "task-answer-question rejects 'ranked_items' when type is omitted (legacy)" `
+                -Condition ($threw -and $msg -match "'ranked_items' is only valid") `
+                -Message "Expected throw on legacy caller smuggling ranked_items, got: $msg"
         } finally {
             Remove-Item -Path $global:DotbotProjectRoot -Recurse -Force -ErrorAction SilentlyContinue
             $global:DotbotProjectRoot = $savedRoot


### PR DESCRIPTION
## Linked issue

Closes #291

## Summary of changes

Implements PR-10/#29 — Outpost MCP tools + NotificationClient extensions for the new question types, attachment uploads, and typed responses defined in PRD-029 §4.6, §5.2, §5.4.

`core/mcp/modules/NotificationClient.psm1` adds `Send-AttachmentUpload` (multipart `POST /api/attachments`), `Remove-Attachment` (`DELETE`), `Invoke-AttachmentBatchUpload` (sequential upload with rollback-on-failure), and `ConvertTo-TypedResponse` — a metadata-only typed parser for the five PRD question types (`singleChoice`, `approval`, `documentReview`, `freeText`, `priorityRanking`). `Send-TaskNotification` gains `Type`, `DeliverableSummary`, `Attachments`, and `ReviewLinks` parameters, emitted on the template payload as camelCase (`deliverableSummary`, `reviewLinks`, `attachments[storageRef]`) per the §5.2 wire shape.

`core/mcp/tools/task-mark-needs-input` schema gains `type`, `deliverable_summary`, `attachments`, and `review_links`. The publish flow now uploads attachments before publishing the template; on any failure (upload or template POST), uploaded refs are rolled back via `Remove-Attachment` and the error surfaces in `notification_error`. Crash-mid-publish leaves task JSON without partial `notification` state because notification fields are written only after `Send-*` returns success.

`core/mcp/tools/task-answer-question` schema gains `type`, `decision`, `comment`, and `ranked_items`. Validation enforces per-type rules: approval and documentReview require `decision` from a fixed set; `decision=rejected` requires `comment`; `priorityRanking` requires `ranked_items`. PRD §5.4 keys (`approval_decision`, `comment`, `ranked_items`, `answer_type`) persist into both `questions_resolved` and `interview-answers.json`.

`core/ui/modules/NotificationPoller.psm1` replaces the eager-download `Resolve-NotificationAnswer` call with `ConvertTo-TypedResponse` so polling stays metadata-only (PRD §5.4: "bytes fetched on demand"). New typed fields land in `questions_resolved`; `attachment_refs` is mirrored to `attachments` so the existing dashboard reader (`tasks.js`) keeps rendering without UI changes.

Out of scope here, covered by sibling PRs: §5.5 dual-surface push-back (#292), §5.6 reminder/escalation (#290), ResponseId idempotency (#292).

## Testing notes

Layer 2 unit coverage added in `tests/Test-Components.ps1`. Schema regex assertions confirm the full PRD enum and new keys are present on both tool YAMLs. `task-answer-question` validation tests reject `decision=bogus`, missing `comment` on `rejected`, missing `ranked_items` on `priorityRanking`, and unknown `type`, while accepting a valid `documentReview decision=approved`. `ConvertTo-TypedResponse` is unit-tested for approval, documentReview-with-attachments (metadata only — no `path` field), and priorityRanking. `Invoke-AttachmentBatchUpload` cleanup-on-failure uses an HTTP-boundary mock that fails the third POST and asserts two prior `DELETE`s fire for `sref-1` and `sref-2`. The poller end-to-end test seeds an approval-typed task, mocks the `/responses` GET, and asserts `approval_decision`, `comment`, and `answer_type` persist with zero `-OutFile` calls during the poll tick. The crash-mid-publish test (issue acceptance criterion) seeds an analysing task, mocks `/api/templates` POST to throw after attachment uploads succeed, and asserts the task moves to `needs-input/` with `pending_question` populated, NO `notification` field, and both attachment refs `DELETE`'d.

```
pwsh install.ps1
pwsh tests/Run-Tests.ps1
```

For manual end-to-end verification, invoke task-mark-needs-input with type=documentReview, two attachments, and two review_links against a live Mothership, then respond via the web form and confirm the poller transitions the task with attachment metadata only — no auto-download.

## Checklist

- [x] Tests added or updated
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
