### PR TITLE
fix(workflow-manifest): loud schema errors for malformed env_vars (#319)

### DIFF
--- a/core/runtime/modules/workflow-manifest.ps1
+++ b/core/runtime/modules/workflow-manifest.ps1
@@ -189,6 +189,130 @@ function Get-ActiveWorkflowManifest {
     return $null
 }
 
+function Get-ManifestEntryField {
+    param([object]$Entry, [string]$Field)
+    if ($null -eq $Entry) { return $null }
+    if ($Entry -is [System.Collections.IDictionary]) { return $Entry[$Field] }
+    return $Entry.$Field
+}
+
+function Format-ManifestEntryForError {
+    <#
+    .SYNOPSIS
+    Render a manifest entry as a compact "{ key: value, ... }" string for error messages.
+    #>
+    param([object]$Entry)
+    if ($null -eq $Entry) { return '<null>' }
+    if ($Entry -is [System.Collections.IDictionary]) {
+        $pairs = @()
+        foreach ($k in $Entry.Keys) {
+            $v = $Entry[$k]
+            $vRendered = if ($null -eq $v) { 'null' } elseif ($v -is [string]) { '"' + $v + '"' } else { [string]$v }
+            $pairs += "$k`: $vRendered"
+        }
+        return '{ ' + ($pairs -join ', ') + ' }'
+    }
+    $pairs = @()
+    foreach ($p in $Entry.PSObject.Properties) {
+        $vRendered = if ($null -eq $p.Value) { 'null' } elseif ($p.Value -is [string]) { '"' + $p.Value + '"' } else { [string]$p.Value }
+        $pairs += "$($p.Name): $vRendered"
+    }
+    return '{ ' + ($pairs -join ', ') + ' }'
+}
+
+function Test-WorkflowManifestSchema {
+    <#
+    .SYNOPSIS
+    Validate a parsed workflow manifest against the requires.* schema.
+
+    .DESCRIPTION
+    Returns an array of human-readable error strings — one per malformed entry.
+    Empty array means the manifest is valid for the requires.* sections.
+
+    Validates that every entry in:
+      - requires.env_vars     has a non-empty 'var' field
+      - requires.mcp_servers  has a non-empty 'name' field
+      - requires.cli_tools    has a non-empty 'name' field
+
+    Used at install time by `dotbot init` and `dotbot workflow add` to surface
+    schema mistakes before any scaffolding runs, so the author gets a clear
+    error at the point they can act on it instead of a null-key crash from
+    New-EnvLocalScaffold or a silently-dropped preflight check at runtime.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [object]$Manifest,
+
+        [string]$WorkflowName
+    )
+
+    $errors = @()
+    if (-not $WorkflowName) {
+        $WorkflowName = Get-ManifestEntryField -Entry $Manifest -Field 'name'
+        if (-not $WorkflowName) { $WorkflowName = '<unknown>' }
+    }
+
+    $requires = Get-ManifestEntryField -Entry $Manifest -Field 'requires'
+    if (-not $requires) { return @() }
+
+    # env_vars: each entry must have 'var'
+    $envVars = Get-ManifestEntryField -Entry $requires -Field 'env_vars'
+    if ($envVars) {
+        $i = 0
+        foreach ($ev in @($envVars)) {
+            $varName = Get-ManifestEntryField -Entry $ev -Field 'var'
+            if (-not $varName) {
+                $rendered = Format-ManifestEntryForError -Entry $ev
+                $errors += @"
+env_vars entry [$i] in workflow '$WorkflowName' is missing the required 'var' field.
+Entry: $rendered
+Expected schema: { var: <IDENTIFIER>, name: <DISPLAY NAME>, message: <TEXT>, hint: <TEXT> }
+Note: 'var' is the env var identifier (e.g. GITHUB_TOKEN). 'name' is the human-readable label (e.g. "GitHub Personal Access Token").
+"@
+            }
+            $i++
+        }
+    }
+
+    # mcp_servers: each entry must have 'name'
+    $mcpServers = Get-ManifestEntryField -Entry $requires -Field 'mcp_servers'
+    if ($mcpServers) {
+        $i = 0
+        foreach ($ms in @($mcpServers)) {
+            $srvName = Get-ManifestEntryField -Entry $ms -Field 'name'
+            if (-not $srvName) {
+                $rendered = Format-ManifestEntryForError -Entry $ms
+                $errors += @"
+mcp_servers entry [$i] in workflow '$WorkflowName' is missing the required 'name' field.
+Entry: $rendered
+Expected schema: { name: <SERVER NAME>, message: <TEXT>, hint: <TEXT> }
+"@
+            }
+            $i++
+        }
+    }
+
+    # cli_tools: each entry must have 'name'
+    $cliTools = Get-ManifestEntryField -Entry $requires -Field 'cli_tools'
+    if ($cliTools) {
+        $i = 0
+        foreach ($ct in @($cliTools)) {
+            $toolName = Get-ManifestEntryField -Entry $ct -Field 'name'
+            if (-not $toolName) {
+                $rendered = Format-ManifestEntryForError -Entry $ct
+                $errors += @"
+cli_tools entry [$i] in workflow '$WorkflowName' is missing the required 'name' field.
+Entry: $rendered
+Expected schema: { name: <TOOL NAME>, message: <TEXT>, hint: <TEXT> }
+"@
+            }
+            $i++
+        }
+    }
+
+    return $errors
+}
+
 function Convert-ManifestRequiresToPreflightChecks {
     <#
     .SYNOPSIS
@@ -197,10 +321,18 @@ function Convert-ManifestRequiresToPreflightChecks {
     .DESCRIPTION
     Maps requires.env_vars, requires.mcp_servers, requires.cli_tools into the
     array-of-hashtable format expected by Get-PreflightResults and the UI.
+
+    Throws a clear schema error when an entry is missing its required
+    identifier field. Install-time validation via Test-WorkflowManifestSchema
+    catches this earlier; this throw is a defense-in-depth backstop for
+    hand-edited manifests so the failure is loud instead of silently dropping
+    checks (which previously masked auth/401 failures at runtime).
     #>
     param(
         [Parameter(Mandatory)]
-        [object]$Requires
+        [object]$Requires,
+
+        [string]$WorkflowName = '<unknown>'
     )
 
     $checks = @()
@@ -208,40 +340,52 @@ function Convert-ManifestRequiresToPreflightChecks {
     # env_vars
     $envVars = if ($Requires -is [System.Collections.IDictionary]) { $Requires['env_vars'] } else { $Requires.env_vars }
     if ($envVars) {
+        $i = 0
         foreach ($ev in @($envVars)) {
             $varName = if ($ev -is [System.Collections.IDictionary]) { $ev['var'] } else { $ev.var }
             $name = if ($ev -is [System.Collections.IDictionary]) { $ev['name'] } else { $ev.name }
             $message = if ($ev -is [System.Collections.IDictionary]) { $ev['message'] } else { $ev.message }
             $hint = if ($ev -is [System.Collections.IDictionary]) { $ev['hint'] } else { $ev.hint }
-            if ($varName) {
-                $checks += @{ type = 'env_var'; var = $varName; name = if ($name) { $name } else { $varName }; message = $message; hint = $hint }
+            if (-not $varName) {
+                $rendered = Format-ManifestEntryForError -Entry $ev
+                throw "env_vars entry [$i] in workflow '$WorkflowName' is missing the required 'var' field.`nEntry: $rendered`nExpected schema: { var: <IDENTIFIER>, name: <DISPLAY NAME>, message: <TEXT>, hint: <TEXT> }`nNote: 'var' is the env var identifier (e.g. GITHUB_TOKEN). 'name' is the human-readable label (e.g. `"GitHub Personal Access Token`")."
             }
+            $checks += @{ type = 'env_var'; var = $varName; name = if ($name) { $name } else { $varName }; message = $message; hint = $hint }
+            $i++
         }
     }
 
     # mcp_servers
     $mcpServers = if ($Requires -is [System.Collections.IDictionary]) { $Requires['mcp_servers'] } else { $Requires.mcp_servers }
     if ($mcpServers) {
+        $i = 0
         foreach ($ms in @($mcpServers)) {
             $srvName = if ($ms -is [System.Collections.IDictionary]) { $ms['name'] } else { $ms.name }
             $message = if ($ms -is [System.Collections.IDictionary]) { $ms['message'] } else { $ms.message }
             $hint = if ($ms -is [System.Collections.IDictionary]) { $ms['hint'] } else { $ms.hint }
-            if ($srvName) {
-                $checks += @{ type = 'mcp_server'; name = $srvName; message = $message; hint = $hint }
+            if (-not $srvName) {
+                $rendered = Format-ManifestEntryForError -Entry $ms
+                throw "mcp_servers entry [$i] in workflow '$WorkflowName' is missing the required 'name' field.`nEntry: $rendered`nExpected schema: { name: <SERVER NAME>, message: <TEXT>, hint: <TEXT> }"
             }
+            $checks += @{ type = 'mcp_server'; name = $srvName; message = $message; hint = $hint }
+            $i++
         }
     }
 
     # cli_tools
     $cliTools = if ($Requires -is [System.Collections.IDictionary]) { $Requires['cli_tools'] } else { $Requires.cli_tools }
     if ($cliTools) {
+        $i = 0
         foreach ($ct in @($cliTools)) {
             $toolName = if ($ct -is [System.Collections.IDictionary]) { $ct['name'] } else { $ct.name }
             $message = if ($ct -is [System.Collections.IDictionary]) { $ct['message'] } else { $ct.message }
             $hint = if ($ct -is [System.Collections.IDictionary]) { $ct['hint'] } else { $ct.hint }
-            if ($toolName) {
-                $checks += @{ type = 'cli_tool'; name = $toolName; message = $message; hint = $hint }
+            if (-not $toolName) {
+                $rendered = Format-ManifestEntryForError -Entry $ct
+                throw "cli_tools entry [$i] in workflow '$WorkflowName' is missing the required 'name' field.`nEntry: $rendered`nExpected schema: { name: <TOOL NAME>, message: <TEXT>, hint: <TEXT> }"
             }
+            $checks += @{ type = 'cli_tool'; name = $toolName; message = $message; hint = $hint }
+            $i++
         }
     }
 
@@ -567,13 +711,21 @@ function New-EnvLocalScaffold {
     <#
     .SYNOPSIS
     Create or update .env.local with required variables from workflow manifests.
+
+    .DESCRIPTION
+    Throws a clear schema error when any entry is missing 'var'. Install-time
+    validation via Test-WorkflowManifestSchema catches this earlier; this throw
+    is a defense-in-depth backstop replacing the previous null-key crash from
+    Hashtable.ContainsKey($null), which gave authors no actionable signal.
     #>
     param(
         [Parameter(Mandatory)]
         [string]$EnvLocalPath,
 
         [Parameter(Mandatory)]
-        [array]$EnvVars             # array of @{ var, name, hint }
+        [array]$EnvVars,            # array of @{ var, name, hint }
+
+        [string]$WorkflowName = '<unknown>'
     )
 
     # Read existing values
@@ -588,11 +740,17 @@ function New-EnvLocalScaffold {
 
     # Build content: preserve existing values, add missing with hints
     $lines = @()
+    $i = 0
     foreach ($ev in $EnvVars) {
-        $varName = $ev.var
-        if (-not $varName) { $varName = $ev['var'] }
-        $hint = if ($ev.hint) { $ev.hint } elseif ($ev['hint']) { $ev['hint'] } else { "" }
-        $displayName = if ($ev.name) { $ev.name } elseif ($ev['name']) { $ev['name'] } else { $varName }
+        $varName = if ($ev -is [System.Collections.IDictionary]) { $ev['var'] } else { $ev.var }
+        if (-not $varName) {
+            $rendered = Format-ManifestEntryForError -Entry $ev
+            throw "env_vars entry [$i] in workflow '$WorkflowName' is missing the required 'var' field.`nEntry: $rendered`nExpected schema: { var: <IDENTIFIER>, name: <DISPLAY NAME>, message: <TEXT>, hint: <TEXT> }`nNote: 'var' is the env var identifier (e.g. GITHUB_TOKEN). 'name' is the human-readable label (e.g. `"GitHub Personal Access Token`")."
+        }
+        $hint = if ($ev -is [System.Collections.IDictionary]) { $ev['hint'] } else { $ev.hint }
+        if (-not $hint) { $hint = "" }
+        $displayName = if ($ev -is [System.Collections.IDictionary]) { $ev['name'] } else { $ev.name }
+        if (-not $displayName) { $displayName = $varName }
 
         if ($existing.ContainsKey($varName)) {
             $lines += "$varName=$($existing[$varName])"
@@ -600,6 +758,7 @@ function New-EnvLocalScaffold {
             if ($hint) { $lines += "# $displayName — $hint" }
             $lines += "$varName="
         }
+        $i++
     }
 
     # Preserve any extra vars not in the manifest

--- a/core/ui/modules/ProductAPI.psm1
+++ b/core/ui/modules/ProductAPI.psm1
@@ -337,14 +337,18 @@ function Get-PreflightResults {
         try {
             $preflightChecks = @(Convert-ManifestRequiresToPreflightChecks -Requires $manifest.requires -WorkflowName $manifestName)
         } catch {
+            # Keep `message` short — the UI renders it as the main label
+            # (workflow-launch.js: `check.message || check.name`). Full
+            # multiline schema details go in `hint`, which only shows on a
+            # failed check.
             return @{
                 success = $false
                 checks = @(@{
                     type = 'manifest_schema'
                     name = "workflow.yaml schema error"
                     passed = $false
-                    message = $_.Exception.Message
-                    hint = "Fix the workflow.yaml manifest schema. See issue #319."
+                    message = "Manifest validation failed"
+                    hint = $_.Exception.Message
                 })
             }
         }

--- a/core/ui/modules/ProductAPI.psm1
+++ b/core/ui/modules/ProductAPI.psm1
@@ -330,7 +330,24 @@ function Get-PreflightResults {
     $preflightChecks = @()
     $manifest = Get-ActiveWorkflowManifest -BotRoot $botRoot
     if ($manifest -and $manifest.requires) {
-        $preflightChecks = @(Convert-ManifestRequiresToPreflightChecks -Requires $manifest.requires)
+        # Convert-ManifestRequiresToPreflightChecks throws on schema errors
+        # (issue #319). Surface the error as a single failed check rather
+        # than crashing the dashboard render.
+        $manifestName = if ($manifest -is [System.Collections.IDictionary]) { $manifest['name'] } else { $manifest.name }
+        try {
+            $preflightChecks = @(Convert-ManifestRequiresToPreflightChecks -Requires $manifest.requires -WorkflowName $manifestName)
+        } catch {
+            return @{
+                success = $false
+                checks = @(@{
+                    type = 'manifest_schema'
+                    name = "workflow.yaml schema error"
+                    passed = $false
+                    message = $_.Exception.Message
+                    hint = "Fix the workflow.yaml manifest schema. See issue #319."
+                })
+            }
+        }
     }
 
     # Legacy settings.workflow.preflight fallback removed in PR-3 (engine deletion).

--- a/scripts/init-project.ps1
+++ b/scripts/init-project.ps1
@@ -489,6 +489,21 @@ if ($Workflow) {
             # Parse manifest for env vars and MCP servers
             $manifest = Read-WorkflowManifest -WorkflowDir $wfTargetDir
 
+            # Validate manifest schema before any scaffolding so authors see
+            # a clear error at the point they can fix it (issue #319).
+            $schemaErrors = Test-WorkflowManifestSchema -Manifest $manifest -WorkflowName $displayName
+            if ($schemaErrors.Count -gt 0) {
+                Write-DotbotError "Workflow '$displayName' has manifest schema errors:"
+                foreach ($err in $schemaErrors) {
+                    Write-DotbotError $err
+                }
+                Write-DotbotError "Skipping '$displayName'; fix workflow.yaml and re-run."
+                if (Test-Path $wfTargetDir) {
+                    Remove-Item -Path $wfTargetDir -Recurse -Force
+                }
+                continue
+            }
+
             # Scaffold .env.local from requires.env_vars
             $envVars = @()
             if ($manifest.requires -and $manifest.requires.env_vars) {
@@ -498,7 +513,7 @@ if ($Workflow) {
             }
             if ($envVars.Count -gt 0) {
                 $envLocalPath = Join-Path $ProjectDir ".env.local"
-                New-EnvLocalScaffold -EnvLocalPath $envLocalPath -EnvVars $envVars
+                New-EnvLocalScaffold -EnvLocalPath $envLocalPath -EnvVars $envVars -WorkflowName $displayName
                 # Ensure .env.local is gitignored
                 $gi = Join-Path $ProjectDir ".gitignore"
                 if (Test-Path $gi) {

--- a/scripts/workflow-add.ps1
+++ b/scripts/workflow-add.ps1
@@ -115,12 +115,31 @@ if (-not (Test-ValidWorkflowDir -Dir $wfTargetDir)) {
 # Parse manifest
 $manifest = Read-WorkflowManifest -WorkflowDir $wfTargetDir
 
+# Validate manifest schema before any scaffolding so authors see a clear
+# error at the point they can fix it (issue #319).
+$schemaErrors = Test-WorkflowManifestSchema -Manifest $manifest -WorkflowName $displayName
+if ($schemaErrors.Count -gt 0) {
+    Write-DotbotError "Workflow '$displayName' has manifest schema errors:"
+    foreach ($err in $schemaErrors) {
+        Write-DotbotError $err
+    }
+    Write-DotbotError "Aborting; fix workflow.yaml and re-run."
+    if (Test-Path $wfTargetDir) {
+        try {
+            Remove-Item -Path $wfTargetDir -Recurse -Force
+        } catch {
+            Write-DotbotError "Failed to clean up partially installed workflow directory '$wfTargetDir': $($_.Exception.Message)"
+        }
+    }
+    exit 1
+}
+
 # Scaffold .env.local
 $envVars = @()
 if ($manifest.requires -and $manifest.requires.env_vars) { $envVars = @($manifest.requires.env_vars) }
 elseif ($manifest.requires -and $manifest.requires['env_vars']) { $envVars = @($manifest.requires['env_vars']) }
 if ($envVars.Count -gt 0) {
-    New-EnvLocalScaffold -EnvLocalPath (Join-Path $ProjectDir ".env.local") -EnvVars $envVars
+    New-EnvLocalScaffold -EnvLocalPath (Join-Path $ProjectDir ".env.local") -EnvVars $envVars -WorkflowName $displayName
 }
 
 # Merge MCP servers

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -386,6 +386,116 @@ $envOnlyChecks = @(Convert-ManifestRequiresToPreflightChecks -Requires @{
 })
 Assert-Equal -Name "env_vars-only requires returns 1 check" -Expected 1 -Actual $envOnlyChecks.Count
 
+# Schema error path: missing 'var' in env_vars now throws (issue #319) instead
+# of silently dropping the entry.
+$throwCaught = $false
+try {
+    Convert-ManifestRequiresToPreflightChecks -Requires @{
+        env_vars = @(@{ name = "GITHUB_TOKEN"; message = "required" })
+    } -WorkflowName "test-wf" | Out-Null
+} catch {
+    $throwCaught = $true
+    Assert-True -Name "env_vars missing 'var' throws naming the field" `
+        -Condition ($_.Exception.Message -match "missing the required 'var' field") `
+        -Message "Error message did not name the missing field. Got: $($_.Exception.Message)"
+    Assert-True -Name "env_vars missing 'var' throws naming the workflow" `
+        -Condition ($_.Exception.Message -match "test-wf") `
+        -Message "Error message did not name the workflow"
+}
+Assert-True -Name "env_vars missing 'var' throws (was silent skip)" `
+    -Condition $throwCaught `
+    -Message "Convert-ManifestRequiresToPreflightChecks should throw on missing 'var', not silent-skip"
+
+# Schema error: missing 'name' in mcp_servers
+$throwCaught = $false
+try {
+    Convert-ManifestRequiresToPreflightChecks -Requires @{
+        mcp_servers = @(@{ message = "required" })
+    } | Out-Null
+} catch { $throwCaught = $true }
+Assert-True -Name "mcp_servers missing 'name' throws" -Condition $throwCaught
+
+# Schema error: missing 'name' in cli_tools
+$throwCaught = $false
+try {
+    Convert-ManifestRequiresToPreflightChecks -Requires @{
+        cli_tools = @(@{ message = "required" })
+    } | Out-Null
+} catch { $throwCaught = $true }
+Assert-True -Name "cli_tools missing 'name' throws" -Condition $throwCaught
+
+Write-Host ""
+
+# ═══════════════════════════════════════════════════════════════════
+# TEST-WORKFLOWMANIFESTSCHEMA
+# ═══════════════════════════════════════════════════════════════════
+
+Write-Host "  TEST-WORKFLOWMANIFESTSCHEMA" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+# Valid manifest produces no errors
+$validManifest = @{
+    name = "valid-wf"
+    requires = @{
+        env_vars = @(@{ var = "API_KEY"; name = "API Key"; message = "required" })
+        mcp_servers = @(@{ name = "dotbot"; message = "required" })
+        cli_tools = @(@{ name = "git"; message = "required" })
+    }
+}
+$validErrors = @(Test-WorkflowManifestSchema -Manifest $validManifest)
+Assert-Equal -Name "Valid manifest returns 0 errors" -Expected 0 -Actual $validErrors.Count
+
+# Manifest with no requires returns 0 errors
+$noReqErrors = @(Test-WorkflowManifestSchema -Manifest @{ name = "x" })
+Assert-Equal -Name "Manifest without requires returns 0 errors" -Expected 0 -Actual $noReqErrors.Count
+
+# env_vars missing 'var' (the original bug from issue #319): one error
+$badEnvVars = @{
+    name = "bad-wf"
+    requires = @{
+        env_vars = @(@{ name = "GITHUB_TOKEN"; message = "required" })
+    }
+}
+$badErrors = @(Test-WorkflowManifestSchema -Manifest $badEnvVars)
+Assert-Equal -Name "env_vars missing 'var' produces 1 error" -Expected 1 -Actual $badErrors.Count
+Assert-True -Name "Error names the workflow" `
+    -Condition ($badErrors[0] -match "bad-wf") `
+    -Message "Workflow name not in error: $($badErrors[0])"
+Assert-True -Name "Error names the missing field" `
+    -Condition ($badErrors[0] -match "'var'") `
+    -Message "Field name not in error"
+Assert-True -Name "Error shows the offending entry" `
+    -Condition ($badErrors[0] -match "GITHUB_TOKEN") `
+    -Message "Offending entry not shown"
+Assert-True -Name "Error shows the expected schema" `
+    -Condition ($badErrors[0] -match "Expected schema:") `
+    -Message "Expected schema line missing"
+
+# Multiple bad entries each produce their own error
+$multiBad = @{
+    name = "multi-bad"
+    requires = @{
+        env_vars = @(
+            @{ name = "ENTRY_ONE" },
+            @{ var = "OK_VAR" },
+            @{ name = "ENTRY_TWO" }
+        )
+        mcp_servers = @(@{ message = "missing name" })
+        cli_tools = @(@{ message = "missing name" })
+    }
+}
+$multiErrors = @(Test-WorkflowManifestSchema -Manifest $multiBad)
+Assert-Equal -Name "Multiple bad entries produce 4 errors (2 env + 1 mcp + 1 cli)" `
+    -Expected 4 -Actual $multiErrors.Count
+
+# WorkflowName param overrides manifest.name in error output
+$overrideErrors = @(Test-WorkflowManifestSchema -Manifest @{
+    requires = @{ env_vars = @(@{ name = "X" }) }
+} -WorkflowName "override-name")
+Assert-True -Name "WorkflowName param appears in error" `
+    -Condition ($overrideErrors[0] -match "override-name") `
+    -Message "Override name not honored"
+
 Write-Host ""
 
 # ═══════════════════════════════════════════════════════════════════
@@ -757,6 +867,38 @@ try {
         Assert-True -Name ".env.local adds missing SECRET=" `
             -Condition ($content2 -match "SECRET=") `
             -Message "Missing var not added"
+    }
+
+    # Schema error: missing 'var' now throws a clear error (issue #319) instead
+    # of crashing with "Value cannot be null" from Hashtable.ContainsKey($null).
+    Remove-Item $envLocalPath -Force -ErrorAction SilentlyContinue
+    $throwCaught = $false
+    $errMsg = ""
+    try {
+        New-EnvLocalScaffold -EnvLocalPath $envLocalPath `
+            -EnvVars @(@{ name = "GITHUB_TOKEN"; message = "required" }) `
+            -WorkflowName "test-wf"
+    } catch {
+        $throwCaught = $true
+        $errMsg = $_.Exception.Message
+    }
+    Assert-True -Name "New-EnvLocalScaffold throws on missing 'var'" -Condition $throwCaught
+    if ($throwCaught) {
+        Assert-True -Name "Throw message names the workflow" `
+            -Condition ($errMsg -match "test-wf") `
+            -Message "Workflow name missing from error: $errMsg"
+        Assert-True -Name "Throw message names the 'var' field" `
+            -Condition ($errMsg -match "'var'") `
+            -Message "Field name missing from error"
+        Assert-True -Name "Throw message shows the offending entry" `
+            -Condition ($errMsg -match "GITHUB_TOKEN") `
+            -Message "Offending entry not shown"
+        Assert-True -Name "Throw message shows expected schema" `
+            -Condition ($errMsg -match "Expected schema:") `
+            -Message "Expected schema line missing"
+        Assert-True -Name "Throw is NOT the legacy null-key crash" `
+            -Condition ($errMsg -notmatch "Value cannot be null") `
+            -Message "Still hitting the legacy ContainsKey(`$null) crash"
     }
 
 } finally {


### PR DESCRIPTION
Closes #319.

`requires.env_vars` entries missing a `var` field hit two different bad failure modes — both fixed:

1. **Crash path** — `New-EnvLocalScaffold` called `Hashtable.ContainsKey($null)` and threw `Value cannot be null` with no workflow, entry, or field info.
2. **Silent-skip path** — `Convert-ManifestRequiresToPreflightChecks` quietly dropped the entry, so the env var was never validated and the agent later 401'd at runtime.

## Changes

- **New `Test-WorkflowManifestSchema` helper** (`core/runtime/modules/workflow-manifest.ps1`) — validates `requires.env_vars` (must have `var`), `requires.mcp_servers` (must have `name`), `requires.cli_tools` (must have `name`). Returns one human-readable error per malformed entry, naming the workflow, the offending entry contents, and the expected schema. Includes the note that `var` is the identifier vs. `name` is the display label, since that's the most common author confusion.
- **Install-time gate** — `dotbot init` (`scripts/init-project.ps1`) and `dotbot workflow add` (`scripts/workflow-add.ps1`) run the validator after parsing the manifest and halt before any scaffolding, so authors see the error at the point they can fix it instead of deep into a run.
- **Defense-in-depth throws** — `New-EnvLocalScaffold` and `Convert-ManifestRequiresToPreflightChecks` now throw a clear schema error on malformed entries instead of crashing or silently dropping. `WorkflowName` flows through both for traceability.
- **Dashboard graceful handling** — `Get-PreflightResults` (`core/ui/modules/ProductAPI.psm1`) catches the throw and surfaces it as a single failed `manifest_schema` check rather than crashing the Product tab render.
- **No implicit fallback to `ev.name`** — per the issue, treating one field as the other would hide schema errors and produce odd identifiers in `.env.local`. The fix is the loud error, not coercion.

## Tests

`tests/Test-WorkflowManifest.ps1`:
- `Test-WorkflowManifestSchema`: valid manifest, no `requires`, missing `var`, multiple bad entries across all three sections, `WorkflowName` override
- `Convert-ManifestRequiresToPreflightChecks`: throws on missing `var` (env_vars), missing `name` (mcp_servers, cli_tools), with workflow and field named in the message
- `New-EnvLocalScaffold`: throws on missing `var` with the full schema-error format, and explicitly asserts the legacy `Value cannot be null` crash is no longer hit