### PR TITLE
fix(ui): surface nested skills/agents in Workflows tab (#406)

### DIFF
--- a/core/runtime/modules/workflow-manifest.ps1
+++ b/core/runtime/modules/workflow-manifest.ps1
@@ -138,6 +138,66 @@ function Test-ValidWorkflowDir {
     }
 }
 
+function Get-RecipeFolders {
+    <#
+    .SYNOPSIS
+    Recursively discover recipe folders that contain a given marker file.
+
+    .DESCRIPTION
+    Walks $BaseDir looking for folders that directly contain $MarkerFile
+    (e.g. SKILL.md or AGENT.md). Returns each match as its forward-slash path
+    relative to $BaseDir, so nested folders like
+    `overrides/group-1/phase-x/SKILL.md` surface as `overrides/group-1/phase-x`.
+
+    Intermediate folders without their own marker file are not surfaced — only
+    leaf folders that genuinely contain a recipe show up. Recursion is
+    depth-capped so pathological trees don't impact response time.
+
+    Used by /api/workflows/installed in server.ps1 to expose registry-added
+    nested skills/agents in the Workflows tab. See issue #406.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$BaseDir,
+
+        [Parameter(Mandatory)]
+        [string]$MarkerFile,
+
+        [int]$MaxDepth = 4
+    )
+
+    if (-not (Test-Path -LiteralPath $BaseDir)) { return @() }
+
+    $results = [System.Collections.Generic.List[string]]::new()
+    $rootFull = (Resolve-Path -LiteralPath $BaseDir).ProviderPath.TrimEnd('\','/')
+
+    $stack = [System.Collections.Generic.Stack[object]]::new()
+    $stack.Push(@{ Path = $rootFull; Depth = 0 })
+
+    while ($stack.Count -gt 0) {
+        $frame = $stack.Pop()
+        $current = $frame.Path
+        $depth   = $frame.Depth
+
+        if ($depth -gt 0) {
+            $marker = Join-Path $current $MarkerFile
+            if (Test-Path -LiteralPath $marker -PathType Leaf) {
+                $rel = $current.Substring($rootFull.Length).TrimStart('\','/') -replace '\\','/'
+                if ($rel) { $results.Add($rel) }
+            }
+        }
+
+        if ($depth -ge $MaxDepth) { continue }
+
+        $children = Get-ChildItem -LiteralPath $current -Directory -ErrorAction SilentlyContinue
+        foreach ($child in $children) {
+            $stack.Push(@{ Path = $child.FullName; Depth = $depth + 1 })
+        }
+    }
+
+    return @($results | Sort-Object)
+}
+
 function Get-ActiveWorkflowManifest {
     <#
     .SYNOPSIS

--- a/core/ui/server.ps1
+++ b/core/ui/server.ps1
@@ -1931,13 +1931,13 @@ $docContext
                                 repository = if ($manifest['repository']) { "$($manifest['repository'])" } else { '' }
                                 homepage = if ($manifest['homepage']) { "$($manifest['homepage'])" } else { '' }
                                 agents = if ($manifest['agents'] -and $manifest['agents'].Count -gt 0) { @($manifest['agents'] | Where-Object { $_ }) } else {
-                                    # Fallback: discover from prompts directory
-                                    $wfAgentsDir = Join-Path $wfDir "recipes\agents"
-                                    if (Test-Path $wfAgentsDir) { @(Get-ChildItem $wfAgentsDir -Directory -ErrorAction SilentlyContinue | ForEach-Object { $_.Name }) } else { @() }
+                                    # Fallback: recursively discover folders containing AGENT.md.
+                                    # Non-recursive enumeration hid registry-added nested agents (#406).
+                                    @(Get-RecipeFolders -BaseDir (Join-Path $wfDir "recipes\agents") -MarkerFile "AGENT.md")
                                 }
                                 skills = if ($manifest['skills'] -and $manifest['skills'].Count -gt 0) { @($manifest['skills'] | Where-Object { $_ }) } else {
-                                    $wfSkillsDir = Join-Path $wfDir "recipes\skills"
-                                    if (Test-Path $wfSkillsDir) { @(Get-ChildItem $wfSkillsDir -Directory -ErrorAction SilentlyContinue | ForEach-Object { $_.Name }) } else { @() }
+                                    # Fallback: recursively discover folders containing SKILL.md (#406).
+                                    @(Get-RecipeFolders -BaseDir (Join-Path $wfDir "recipes\skills") -MarkerFile "SKILL.md")
                                 }
                                 tools = if ($manifest['tools'] -and $manifest['tools'].Count -gt 0) { @($manifest['tools'] | Where-Object { $_ }) } else { @() }
                                 status = if ($hasRunning) { 'running' } else { 'idle' }

--- a/core/ui/static/modules/workflow.js
+++ b/core/ui/static/modules/workflow.js
@@ -857,27 +857,33 @@ async function loadWfGroupItems(container, shortType, dirName) {
         const data = await response.json();
         const groups = data.groups || [];
 
-        // Flatten all items, using folder name as display name for subdirectory items
-        // e.g. agents/implementer/AGENT.md → display as "implementer"
-        const allItems = [];
-        const seen = new Set(); // Deduplicate: one entry per folder for single-file dirs
+        // One entry per marker-bearing folder. Identity is the full parent path
+        // (e.g. "overrides/group-1/phase-x"), so nested skills/agents added by
+        // registry extensions don't collapse into their top-level folder. When
+        // a folder contains both a marker (SKILL.md / AGENT.md) and helpers,
+        // prefer the marker as the click target. See issue #406.
+        const MARKER_RE = /^(SKILL|AGENT)\.md$/i;
+        const seen = new Map(); // folderPath -> { filename, displayName, isMarker }
         groups.forEach(g => {
             (g.items || []).forEach(item => {
-                const parts = (item.filename || '').split('/');
-                let displayName;
+                const filename = item.filename || '';
+                const parts = filename.split('/');
                 if (parts.length > 1) {
-                    // Subdirectory item: use the directory name as display name
-                    displayName = parts[0];
+                    const folderPath = parts.slice(0, -1).join('/');
+                    const basename   = parts[parts.length - 1];
+                    const isMarker   = MARKER_RE.test(basename);
+                    const existing   = seen.get(folderPath);
+                    if (!existing || (isMarker && !existing.isMarker)) {
+                        seen.set(folderPath, { filename, displayName: folderPath, isMarker });
+                    }
                 } else {
-                    // Root-level item: use the basename
-                    displayName = item.name || item.basename;
+                    if (!seen.has(filename)) {
+                        seen.set(filename, { filename, displayName: item.name || item.basename, isMarker: true });
+                    }
                 }
-                // Deduplicate by display name (one entry per agent/skill directory)
-                if (seen.has(displayName)) return;
-                seen.add(displayName);
-                allItems.push({ filename: item.filename, displayName });
             });
         });
+        const allItems = Array.from(seen.values()).map(v => ({ filename: v.filename, displayName: v.displayName }));
 
         if (allItems.length === 0) {
             container.innerHTML = '<div class="empty-state" style="font-size:10px">(empty)</div>';

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -5093,6 +5093,79 @@ if (Test-Path $workflowManifestScript) {
     Write-TestResult -Name "New-WorkflowTask optional propagation" -Status Skip -Message "workflow-manifest.ps1 not found"
 }
 
+# Get-RecipeFolders recursive discovery (issue #406)
+# Registry-installed workflows can layer skill folders nested several levels
+# deep under recipes/skills/. The /api/workflows/installed enumeration must
+# surface every leaf folder containing the marker file, not only top-level
+# children, and must not surface bare intermediate folders.
+if (Test-Path $workflowManifestScript) {
+    $recipesTmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-recipes-test-$(Get-Random)"
+    $skillsRoot = Join-Path $recipesTmpDir "recipes\skills"
+    try {
+        New-Item -Path $skillsRoot -ItemType Directory -Force | Out-Null
+
+        # Flat skills (top-level)
+        New-Item -Path (Join-Path $skillsRoot "default-skill-a") -ItemType Directory -Force | Out-Null
+        Set-Content -Path (Join-Path $skillsRoot "default-skill-a\SKILL.md") -Value "# A" -Encoding UTF8
+        New-Item -Path (Join-Path $skillsRoot "default-skill-b") -ItemType Directory -Force | Out-Null
+        Set-Content -Path (Join-Path $skillsRoot "default-skill-b\SKILL.md") -Value "# B" -Encoding UTF8
+
+        # Nested skills under an intermediate folder with no SKILL.md of its own
+        $nest1 = Join-Path $skillsRoot "overrides\group-1\phase-x"
+        $nest2 = Join-Path $skillsRoot "overrides\group-1\phase-y"
+        $nest3 = Join-Path $skillsRoot "overrides\group-2\phase-x"
+        New-Item -Path $nest1 -ItemType Directory -Force | Out-Null
+        Set-Content -Path (Join-Path $nest1 "SKILL.md") -Value "# x" -Encoding UTF8
+        New-Item -Path $nest2 -ItemType Directory -Force | Out-Null
+        Set-Content -Path (Join-Path $nest2 "SKILL.md") -Value "# y" -Encoding UTF8
+        New-Item -Path $nest3 -ItemType Directory -Force | Out-Null
+        Set-Content -Path (Join-Path $nest3 "SKILL.md") -Value "# x2" -Encoding UTF8
+
+        # Folder without a SKILL.md (must be filtered out)
+        New-Item -Path (Join-Path $skillsRoot "not-a-skill") -ItemType Directory -Force | Out-Null
+
+        . $workflowManifestScript
+        $found = Get-RecipeFolders -BaseDir $skillsRoot -MarkerFile "SKILL.md"
+
+        Assert-True -Name "Get-RecipeFolders surfaces top-level skills" `
+            -Condition (($found -contains 'default-skill-a') -and ($found -contains 'default-skill-b')) `
+            -Message "Expected default-skill-a and default-skill-b in results"
+
+        Assert-True -Name "Get-RecipeFolders surfaces nested skills with forward-slash paths" `
+            -Condition (($found -contains 'overrides/group-1/phase-x') -and ($found -contains 'overrides/group-1/phase-y') -and ($found -contains 'overrides/group-2/phase-x')) `
+            -Message "Expected nested overrides/group-N/phase-X entries with forward slashes"
+
+        Assert-True -Name "Get-RecipeFolders excludes intermediate folders without marker" `
+            -Condition (($found -notcontains 'overrides') -and ($found -notcontains 'overrides/group-1') -and ($found -notcontains 'overrides/group-2')) `
+            -Message "Bare intermediate folders should not be surfaced"
+
+        Assert-True -Name "Get-RecipeFolders excludes folders missing the marker file" `
+            -Condition ($found -notcontains 'not-a-skill') `
+            -Message "Folder without SKILL.md must be omitted"
+
+        # MaxDepth cap: a marker placed deeper than the cap must be ignored.
+        $deep = Join-Path $skillsRoot "a\b\c\d\e"
+        New-Item -Path $deep -ItemType Directory -Force | Out-Null
+        Set-Content -Path (Join-Path $deep "SKILL.md") -Value "# deep" -Encoding UTF8
+        $capped = Get-RecipeFolders -BaseDir $skillsRoot -MarkerFile "SKILL.md" -MaxDepth 2
+        Assert-True -Name "Get-RecipeFolders respects MaxDepth" `
+            -Condition ($capped -notcontains 'a/b/c/d/e') `
+            -Message "Marker beyond MaxDepth should not be surfaced"
+
+        # Missing base dir returns an empty array, not a crash.
+        $missing = Get-RecipeFolders -BaseDir (Join-Path $recipesTmpDir "no-such-dir") -MarkerFile "SKILL.md"
+        Assert-True -Name "Get-RecipeFolders returns empty for missing base dir" `
+            -Condition (@($missing).Count -eq 0) `
+            -Message "Missing base dir should yield an empty array"
+    } catch {
+        Write-TestResult -Name "Get-RecipeFolders recursive discovery" -Status Fail -Message $_.Exception.Message
+    } finally {
+        if (Test-Path $recipesTmpDir) { Remove-Item $recipesTmpDir -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+} else {
+    Write-TestResult -Name "Get-RecipeFolders recursive discovery" -Status Skip -Message "workflow-manifest.ps1 not found"
+}
+
 # ═══════════════════════════════════════════════════════════════════
 # CLEANUP
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Closes #406 — registry-installed workflows that organise skills/agents in nested folders (e.g. `recipes/skills/overrides/group-1/phase-x/SKILL.md`) had their nested entries hidden in the Workflows tab. The tab listed only top-level folders, including a misleading bare `overrides` entry that has no `SKILL.md` of its own.

This PR fixes both halves of the bug:

**Backend (`/api/workflows/installed`):**
- New `Get-RecipeFolders` helper in `core/runtime/modules/workflow-manifest.ps1` walks `recipes/skills/` (and `recipes/agents/`) recursively, surfacing only folders that directly contain a `SKILL.md` / `AGENT.md` marker. Returns forward-slash relative paths (`overrides/group-1/phase-x`).
- Bare intermediate folders without their own marker are no longer surfaced.
- Recursion is depth-capped at 4 to guard against pathological trees.
- The existing `skills:` array override in `workflow.yaml` continues to short-circuit the walk.

**Frontend (`workflow.js` lazy-load):**
- `loadWfGroupItems` previously deduplicated items by `parts[0]` of the file path, collapsing every nested skill under the same top-level folder (`overrides`) into a single entry. Dedup is now keyed on the full parent-folder path, so each nested skill renders as its own row.
- When a skill folder contains both `SKILL.md` and helpers (e.g. `README.md`), the click target now prefers the marker file.

## Changes

- `core/runtime/modules/workflow-manifest.ps1` — adds `Get-RecipeFolders` (iterative DFS, `-LiteralPath`, depth-capped, marker-aware).
- `core/ui/server.ps1` — `/api/workflows/installed` agents/skills enumeration calls `Get-RecipeFolders` instead of non-recursive `Get-ChildItem`.
- `core/ui/static/modules/workflow.js` — dedup keyed on full parent-folder path; marker-file preference for click target.
- `tests/Test-Components.ps1` — Layer 2 unit tests for `Get-RecipeFolders` covering top-level, nested, intermediate exclusion, missing-marker exclusion, MaxDepth cap, missing base dir.

## Test plan

- [x] Layer 2 unit tests pass (6 new assertions for `Get-RecipeFolders`)
- [x] Manual reproduction in dashboard with 3 flat + 6 nested skills + 1 helper README + 1 empty folder:
  - Skills badge count = 9
  - All 9 skills render with full nested paths (`overrides/group-1/phase-x`, etc.)
  - Bare `overrides` and `empty-folder` are not shown
  - Clicking `overrides/group-1/phase-x` opens `SKILL.md`, not the helper `README.md`
- [x] Default flat-skill workflows render unchanged (no regression)
- [x] Manifest-declared `skills:` array still short-circuits the recursive walk