### PR TITLE
chore(security): allowlist test API key constant in gitleaks (#411)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,18 @@
+title = "dotbot gitleaks config"
+
+# Inherit gitleaks' built-in rules; only the allowlist below is project-specific.
+[extend]
+useDefault = true
+
+# Test fixtures that look like secrets to gitleaks' generic-api-key rule but
+# are local-only values used by the in-process integration test factory.
+# Keep entries narrow (one file, with the specific value as the regex) so a
+# real secret accidentally landing nearby still gets flagged.
+[[allowlists]]
+description = "Test API key constant used only by WebApplicationFactory-based integration tests"
+paths = [
+    '''server/tests/Dotbot\.Server\.Tests/Integration/DotbotApiFactory\.cs''',
+]
+regexes = [
+    '''integration-test-key-abc123''',
+]


### PR DESCRIPTION
## Summary

- Adds a minimal `.gitleaks.toml` that extends the default ruleset
- Allowlists the test API key constant in `server/tests/Dotbot.Server.Tests/Integration/DotbotApiFactory.cs`
- Narrow allowlist (one file, one regex) so a real secret accidentally landing nearby still gets flagged

Closes #411

## Why

The integration-test scaffolding introduced by #398 uses `TestApiKey = "integration-test-key-abc123"` as a local-only constant that `WebApplicationFactory` hands to the in-process test host. Gitleaks generic-api-key rule (entropy 3.88) flags it on every pwsh-review run.

## Test plan

- [x] `gitleaks detect --config .gitleaks.toml` reports `no leaks found`
- [x] pwsh-review static layer reports `GitleaksFindings: 0`
- [x] Pre-commit hook (which also runs gitleaks) passed on the commit