### PR TITLE
[PR-6/#29] DeliveryOrchestrator wires NotificationSummaryBuilder

### DIFF
--- a/server/src/Dotbot.Server/Services/Delivery/DeliveryOrchestrator.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/DeliveryOrchestrator.cs
@@ -116,8 +116,9 @@ public class DeliveryOrchestrator
                 var magicLinkUrl = await _magicLinkService.GenerateMagicLinkAsync(
                     email, instance.InstanceId, instance.ProjectId, baseUrl);
 
+                var sentAt = DateTime.UtcNow;
                 summary.RespondUrl = magicLinkUrl;
-                summary.DueBy = ComputeDueBy(template, instance, DateTime.UtcNow);
+                summary.DueBy = ComputeDueBy(template, instance, sentAt);
 
                 var deliveryContext = new DeliveryContext
                 {
@@ -136,7 +137,7 @@ public class DeliveryOrchestrator
                     Email = email,
                     AadObjectId = recipientInfo.AadObjectId,
                     Channel = channel,
-                    SentAt = result.Success ? DateTime.UtcNow : null,
+                    SentAt = result.Success ? sentAt : null,
                     Status = result.Success ? "sent" : "failed"
                 });
             }
@@ -165,8 +166,9 @@ public class DeliveryOrchestrator
                     var magicLinkUrl = await _magicLinkService.GenerateMagicLinkAsync(
                         slackUserId, instance.InstanceId, instance.ProjectId, baseUrl);
 
+                    var sentAt = DateTime.UtcNow;
                     summary.RespondUrl = magicLinkUrl;
-                    summary.DueBy = ComputeDueBy(template, instance, DateTime.UtcNow);
+                    summary.DueBy = ComputeDueBy(template, instance, sentAt);
 
                     var deliveryContext = new DeliveryContext
                     {
@@ -184,7 +186,7 @@ public class DeliveryOrchestrator
                     {
                         SlackUserId = slackUserId,
                         Channel = channel,
-                        SentAt = result.Success ? DateTime.UtcNow : null,
+                        SentAt = result.Success ? sentAt : null,
                         Status = result.Success ? "sent" : "failed"
                     });
                 }
@@ -220,8 +222,9 @@ public class DeliveryOrchestrator
                 var magicLinkUrl = await _magicLinkService.GenerateMagicLinkAsync(
                     userId, instance.InstanceId, instance.ProjectId, baseUrl);
 
+                var sentAt = DateTime.UtcNow;
                 summary.RespondUrl = magicLinkUrl;
-                summary.DueBy = ComputeDueBy(template, instance, DateTime.UtcNow);
+                summary.DueBy = ComputeDueBy(template, instance, sentAt);
 
                 var deliveryContext = new DeliveryContext
                 {
@@ -239,7 +242,7 @@ public class DeliveryOrchestrator
                 {
                     AadObjectId = userId,
                     Channel = channel,
-                    SentAt = result.Success ? DateTime.UtcNow : null,
+                    SentAt = result.Success ? sentAt : null,
                     Status = result.Success ? "sent" : "failed"
                 });
             }
@@ -400,9 +403,11 @@ public class DeliveryOrchestrator
         return result.Success;
     }
 
-    private static DateTime? ComputeDueBy(QuestionTemplate template, QuestionInstance instance, DateTime sentAt)
+    private DateTime? ComputeDueBy(QuestionTemplate template, QuestionInstance instance, DateTime sentAt)
     {
-        var days = instance.DeliveryOverrides?.EscalateAfterDays ?? template.DeliveryDefaults?.EscalateAfterDays;
+        var days = instance.DeliveryOverrides?.EscalateAfterDays
+            ?? template.DeliveryDefaults?.EscalateAfterDays
+            ?? _config.GetValue<int?>("Reminders:DefaultEscalateAfterDays");
         return days.HasValue ? sentAt.AddDays(days.Value) : null;
     }
 

--- a/server/src/Dotbot.Server/Services/Delivery/DeliveryOrchestrator.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/DeliveryOrchestrator.cs
@@ -8,6 +8,7 @@ public class DeliveryOrchestrator
     private readonly UserResolverService _userResolver;
     private readonly MagicLinkService _magicLinkService;
     private readonly BusinessHoursService _businessHours;
+    private readonly NotificationSummaryBuilder _summaryBuilder;
     private readonly IConfiguration _config;
     private readonly ILogger<DeliveryOrchestrator> _logger;
 
@@ -16,6 +17,7 @@ public class DeliveryOrchestrator
         UserResolverService userResolver,
         MagicLinkService magicLinkService,
         BusinessHoursService businessHours,
+        NotificationSummaryBuilder summaryBuilder,
         IConfiguration config,
         ILogger<DeliveryOrchestrator> logger)
     {
@@ -23,6 +25,7 @@ public class DeliveryOrchestrator
         _userResolver = userResolver;
         _magicLinkService = magicLinkService;
         _businessHours = businessHours;
+        _summaryBuilder = summaryBuilder;
         _config = config;
         _logger = logger;
     }
@@ -57,6 +60,9 @@ public class DeliveryOrchestrator
 
         var baseUrl = GetBaseUrl();
         var recipients = new List<InstanceRecipient>();
+
+        // Build summary once per instance; RespondUrl and DueBy are personalized per recipient below.
+        var summary = _summaryBuilder.Build(template, instance, respondUrl: string.Empty, isReminder: false);
 
         // Collect all target emails
         var emails = new List<string>(request.Recipients?.Emails ?? []);
@@ -110,13 +116,17 @@ public class DeliveryOrchestrator
                 var magicLinkUrl = await _magicLinkService.GenerateMagicLinkAsync(
                     email, instance.InstanceId, instance.ProjectId, baseUrl);
 
+                summary.RespondUrl = magicLinkUrl;
+                summary.DueBy = ComputeDueBy(template, instance, DateTime.UtcNow);
+
                 var deliveryContext = new DeliveryContext
                 {
                     Instance = instance,
                     Template = template,
                     Recipient = recipientInfo,
                     MagicLinkUrl = magicLinkUrl,
-                    JiraIssueKey = request.JiraIssueKey
+                    JiraIssueKey = request.JiraIssueKey,
+                    Summary = summary
                 };
 
                 var result = await provider.DeliverAsync(deliveryContext, ct);
@@ -155,13 +165,17 @@ public class DeliveryOrchestrator
                     var magicLinkUrl = await _magicLinkService.GenerateMagicLinkAsync(
                         slackUserId, instance.InstanceId, instance.ProjectId, baseUrl);
 
+                    summary.RespondUrl = magicLinkUrl;
+                    summary.DueBy = ComputeDueBy(template, instance, DateTime.UtcNow);
+
                     var deliveryContext = new DeliveryContext
                     {
                         Instance = instance,
                         Template = template,
                         Recipient = recipientInfo,
                         MagicLinkUrl = magicLinkUrl,
-                        JiraIssueKey = request.JiraIssueKey
+                        JiraIssueKey = request.JiraIssueKey,
+                        Summary = summary
                     };
 
                     var result = await provider.DeliverAsync(deliveryContext, ct);
@@ -206,13 +220,17 @@ public class DeliveryOrchestrator
                 var magicLinkUrl = await _magicLinkService.GenerateMagicLinkAsync(
                     userId, instance.InstanceId, instance.ProjectId, baseUrl);
 
+                summary.RespondUrl = magicLinkUrl;
+                summary.DueBy = ComputeDueBy(template, instance, DateTime.UtcNow);
+
                 var deliveryContext = new DeliveryContext
                 {
                     Instance = instance,
                     Template = template,
                     Recipient = recipientInfo,
                     MagicLinkUrl = magicLinkUrl,
-                    JiraIssueKey = request.JiraIssueKey
+                    JiraIssueKey = request.JiraIssueKey,
+                    Summary = summary
                 };
 
                 var result = await provider.DeliverAsync(deliveryContext, ct);
@@ -301,13 +319,17 @@ public class DeliveryOrchestrator
             }
         }
 
+        var summary = _summaryBuilder.Build(template, instance, respondUrl: magicLinkUrl, isReminder: true);
+        summary.DueBy = ComputeDueBy(template, instance, DateTime.UtcNow);
+
         var deliveryContext = new DeliveryContext
         {
             Instance = instance,
             Template = template,
             Recipient = recipientInfo,
             IsReminder = true,
-            MagicLinkUrl = magicLinkUrl
+            MagicLinkUrl = magicLinkUrl,
+            Summary = summary
         };
 
         return await provider.DeliverAsync(deliveryContext, ct);
@@ -362,16 +384,26 @@ public class DeliveryOrchestrator
         var magicLinkUrl = await _magicLinkService.GenerateMagicLinkAsync(
             email, instance.InstanceId, instance.ProjectId, baseUrl);
 
+        var summary = _summaryBuilder.Build(template, instance, respondUrl: magicLinkUrl, isReminder: false);
+        summary.DueBy = ComputeDueBy(template, instance, DateTime.UtcNow);
+
         var deliveryContext = new DeliveryContext
         {
             Instance = instance,
             Template = template,
             Recipient = recipientInfo,
-            MagicLinkUrl = magicLinkUrl
+            MagicLinkUrl = magicLinkUrl,
+            Summary = summary
         };
 
         var result = await provider.DeliverAsync(deliveryContext, ct);
         return result.Success;
+    }
+
+    private static DateTime? ComputeDueBy(QuestionTemplate template, QuestionInstance instance, DateTime sentAt)
+    {
+        var days = instance.DeliveryOverrides?.EscalateAfterDays ?? template.DeliveryDefaults?.EscalateAfterDays;
+        return days.HasValue ? sentAt.AddDays(days.Value) : null;
     }
 
     private string GetBaseUrl()


### PR DESCRIPTION
## Summary
Closes #287
- Injected `NotificationSummaryBuilder` into `DeliveryOrchestrator`
- `DeliverToAllAsync` builds `NotificationSummary` once per instance; personalizes `RespondUrl` and `DueBy` per recipient before passing to each provider
- `DeliverReminderAsync` and `DeliverScheduledAsync` each build a personalized summary with correct `isReminder` flag
- Added `ComputeDueBy` helper — resolves escalation days from instance override, falling back to `template.DeliveryDefaults`
- `Summary` field wired into every `DeliveryContext` across all three delivery paths (email/Teams/objectId, Slack, scheduled)

## Test plan

- [ ] End-to-end smoke test: publish template with attachments → notification delivered per channel → summary sections present
- [ ] Existing `singleChoice` behavior unchanged for legacy templates
- [ ] Null-summary fallback still compiles and runs (providers check `context.Summary != null`)
- [ ] All 195 unit tests pass

## Notes

- No feature flag needed — before this merges providers received null summaries and used fallback rendering; after, they receive real summaries. Natural cutover.
- Depends on PR-3 (NotificationSummaryBuilder), PR-4 (Email+Jira providers), PR-5 (Teams+Slack providers)
- Unblocks reminder-suppression behavior (PR-9)