### PR TITLE
fix(workflow): load recipes and skip analysis for start-from-prompt

### DIFF
--- a/workflows/start-from-prompt/workflow.yaml
+++ b/workflows/start-from-prompt/workflow.yaml
@@ -27,8 +27,9 @@ requires: {}
 
 tasks:
   - name: "Product Documents"
-    type: prompt
+    type: task_gen
     workflow: "01-plan-product.md"
+    skip_worktree: false
     outputs: ["mission.md", "tech-stack.md", "entity-model.md"]
     front_matter_docs: ["mission.md", "tech-stack.md", "entity-model.md"]
     commit:
@@ -37,8 +38,9 @@ tasks:
     priority: 0
 
   - name: "Generate Decisions"
-    type: prompt
+    type: task_gen
     workflow: "01b-generate-decisions.md"
+    skip_worktree: false
     depends_on: ["Product Documents"]
     commit:
       paths: ["workspace/decisions/"]
@@ -46,8 +48,9 @@ tasks:
     priority: 2
 
   - name: "Task Groups"
-    type: prompt
+    type: task_gen
     workflow: "03a-plan-task-groups.md"
+    skip_worktree: false
     depends_on: ["Generate Decisions"]
     outputs: ["task-groups.json"]
     post_script: "post-phase-task-groups.ps1"


### PR DESCRIPTION
## Summary

Closes #414 — `start-from-prompt` was burning ~30-45 min of empty-codebase analysis
per task and discarding the carefully-authored recipe files for spec generation.

Aligns `start-from-prompt` with the pattern already used by `start-from-jira` and
`start-from-pr`: `type: task_gen` with a `workflow:*.md` reference, which the
manifest hydrator at [workflow-manifest.ps1:568](core/runtime/modules/workflow-manifest.ps1:568)
maps to `prompt_template` — loading the recipe as the execution prompt and
skipping the analysis phase (since `task_gen` defaults `skip_analysis: true`).

`skip_worktree: false` is set explicitly to preserve the current isolation
behaviour (`task_gen`'s default would skip the worktree).

## What changes

Three tasks in [workflows/start-from-prompt/workflow.yaml](workflows/start-from-prompt/workflow.yaml)
flipped from `type: prompt` → `type: task_gen` + `skip_worktree: false`:

- `Product Documents` → loads `01-plan-product.md`
- `Generate Decisions` → loads `01b-generate-decisions.md`
- `Task Groups` → loads `03a-plan-task-groups.md`

No code changes — the runtime path is the same one `start-from-jira` and
`start-from-pr` already exercise in production.

## Effect

| Behaviour              | Before (`prompt`) | After (`task_gen`)                  |
|------------------------|-------------------|-------------------------------------|
| Pre-flight analysis    | Runs (3× wasted)  | Skipped (auto-promoted to analysed) |
| Recipe file loaded     | No (dead code)    | Yes (`prompt_template` mapping)     |
| Worktree isolation     | Yes               | Yes (explicit `skip_worktree: false`) |
| Commit / outputs hooks | Yes               | Yes (pass-through in hydration)     |

Net win on a brand-new project: ~30-45 min of Claude time and three redundant
analysis sessions eliminated, plus the spec output now follows the templates the
recipes specify instead of being inferred from scratch.