### PR TITLE
fix(ui): unblock Auto Mode for Max users + correct plan-restriction signal

### DIFF
--- a/core/settings/providers/claude.json
+++ b/core/settings/providers/claude.json
@@ -18,10 +18,11 @@
     },
     "auto": {
       "display_name": "Auto Mode",
-      "description": "AI classifier approves or blocks actions. Requires Team, Enterprise, or API plan. Haiku not supported.",
+      "description": "AI classifier approves or blocks each action. Available on Max, Team, Enterprise, and API plans (not Pro). Anthropic API only. Haiku not supported.",
       "cli_args": ["--permission-mode", "auto"],
       "restrictions": {
-        "excluded_models": ["Haiku"]
+        "excluded_models": ["Haiku"],
+        "excluded_plans": ["pro"]
       }
     }
   },

--- a/core/ui/static/modules/controls.js
+++ b/core/ui/static/modules/controls.js
@@ -378,6 +378,26 @@ function selectExecutionModel(modelId, save = true) {
 }
 
 /**
+ * Returns true when modeConfig's restrictions explicitly exclude the given plan.
+ * The check is intentionally narrow: only restrictions.excluded_plans gates the UI on plan.
+ * Model-side restrictions (restrictions.excluded_models) are handled separately by
+ * filterModelsForPermissionMode and the runtime (launch-process.ps1).
+ */
+function isPlanRestricted(modeConfig, plan) {
+    return !!(modeConfig?.restrictions?.excluded_plans?.includes?.(plan));
+}
+
+/**
+ * Render the warning shown alongside a plan-restricted mode in the grid, or on the note
+ * below the grid. Phrasing is generic so it stays correct regardless of which plans a
+ * future mode lists in excluded_plans.
+ */
+function planRestrictionMessage(plan) {
+    const label = plan ? plan.charAt(0).toUpperCase() + plan.slice(1) : 'your';
+    return `Not available on the ${label} plan`;
+}
+
+/**
  * Initialize permission mode selector UI
  */
 function initPermissionModeSelector() {
@@ -399,23 +419,23 @@ function initPermissionModeSelector() {
     const modes = providerData.permission_modes;
     const planType = activeProvider?.plan_type;
 
-    // Compute effective mode — fall back to provider default if active mode is plan-restricted
+    // A mode is plan-restricted when its restrictions.excluded_plans list contains the user's
+    // plan. Model-side restrictions (excluded_models) are handled in the runtime
+    // (launch-process.ps1) and the filterModelsForPermissionMode helper below.
     let activeMode = providerData.active_permission_mode || providerData.default_permission_mode;
     const activeModeConfig = modes[activeMode];
-    if (activeModeConfig?.restrictions && planType && ['max', 'pro'].includes(planType)) {
+    if (isPlanRestricted(activeModeConfig, planType)) {
         activeMode = providerData.default_permission_mode;
     }
 
     grid.innerHTML = Object.entries(modes).map(([key, mode]) => {
-        // Determine if this mode is unavailable due to plan restrictions
-        const planRestricted = mode.restrictions && planType && ['max', 'pro'].includes(planType);
+        const planRestricted = isPlanRestricted(mode, planType);
         const disabledClass = planRestricted ? ' disabled' : '';
         const activeClass = (!planRestricted && key === activeMode) ? ' active' : '';
 
         let restrictionLine = '';
         if (planRestricted) {
-            const planLabel = planType.charAt(0).toUpperCase() + planType.slice(1);
-            restrictionLine = `<div class="model-option-description" style="color:var(--color-error);margin-top:4px;">Requires Team, Enterprise, or API plan</div>`;
+            restrictionLine = `<div class="model-option-description" style="color:var(--color-error);margin-top:4px;">${planRestrictionMessage(planType)}</div>`;
         }
 
         return `
@@ -513,15 +533,17 @@ function updatePermissionModeNote(modeKey) {
     const activeProvider = (providerData?.providers || []).find(p => p.name === providerData?.active);
     const planType = activeProvider?.plan_type;
 
-    // Check if any mode has plan restrictions that apply
-    const hasRestrictedModes = planType && ['max', 'pro'].includes(planType) &&
-        Object.values(providerData?.permission_modes || {}).some(m => m.restrictions);
+    // Note appears when at least one mode is plan-restricted for the active plan. Uses the
+    // same explicit excluded_plans signal as the grid, via isPlanRestricted, so the note
+    // and the grid never disagree about whether a mode is available.
+    const planRestrictsAnyMode = planType &&
+        Object.values(providerData?.permission_modes || {}).some(m => isPlanRestricted(m, planType));
 
-    if (hasRestrictedModes) {
+    if (planRestrictsAnyMode) {
         const planLabel = planType.charAt(0).toUpperCase() + planType.slice(1);
         note.style.display = '';
         note.className = 'settings-note primary';
-        note.innerHTML = `Some permission modes require a Team, Enterprise, or API plan. Your current plan: <strong>${planLabel}</strong>.`;
+        note.innerHTML = `Some permission modes are not available on the <strong>${planLabel}</strong> plan.`;
         return;
     }
 

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -2240,6 +2240,34 @@ if ($providerCliLoaded) {
         Assert-True -Name "Claude default_permission_mode is bypassPermissions" `
             -Condition ($claudeConfig.default_permission_mode -eq "bypassPermissions") `
             -Message "Expected bypassPermissions, got $($claudeConfig.default_permission_mode)"
+
+        # Claude auto mode plan eligibility per Anthropic's permission-mode docs (as of 2026-05):
+        # Max, Team, Enterprise, and API plans are supported; Pro is not.
+        # See https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode
+        # The UI in controls.js keys plan gating off restrictions.excluded_plans only, so the
+        # config must declare excluded_plans precisely. Asserting Pro is in the list and Max is
+        # NOT prevents both the previous bug (silent gate for Max users via excluded_models
+        # presence) and a regression that would let Pro users select a mode their plan rejects.
+        $autoMode = $claudeConfig.permission_modes.auto
+        Assert-True -Name "Claude auto permission mode is present in config" `
+            -Condition ($null -ne $autoMode) `
+            -Message "permission_modes.auto must exist; this test's later assertions are meaningful only when it does"
+
+        if ($autoMode) {
+            $excludedPlans = @($autoMode.restrictions.excluded_plans)
+            Assert-True -Name "Claude auto excluded_plans contains 'pro'" `
+                -Condition ($excludedPlans -contains "pro") `
+                -Message "auto must declare 'pro' in excluded_plans (Anthropic does not support auto on Pro). Got: $($excludedPlans -join ', ')"
+            Assert-True -Name "Claude auto excluded_plans does NOT contain 'max'" `
+                -Condition (-not ($excludedPlans -contains "max")) `
+                -Message "auto must not exclude 'max' (Max plans support auto). Got: $($excludedPlans -join ', ')"
+
+            $exclusiveTeamClaim = $autoMode.description -match "(Requires|requires).*(only|exclusively).*(Team|Enterprise|API).*plan" -or `
+                                  $autoMode.description -match "(Requires|requires).*(Team|Enterprise|API).*plan.*(only|exclusively)"
+            Assert-True -Name "Claude auto description does not falsely claim Team/Enterprise/API-only" `
+                -Condition (-not $exclusiveTeamClaim) `
+                -Message "auto description must not claim exclusive Team/Enterprise/API support — Max is also supported: '$($autoMode.description)'"
+        }
     }
 
     # Test Build-ProviderCliArgs with default permission mode (no PermissionMode param)


### PR DESCRIPTION
Closes #419

## Summary

dotbot's Settings tab disabled Auto Mode for Max-plan users with the message "Requires Team, Enterprise, or API plan." Per Anthropic's [permission-modes docs](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode):

> Auto mode is available only when your account meets all of these requirements:
> - **Plan**: Max, Team, Enterprise, or API. Not available on Pro.

Max IS supported. The dotbot UI was gating Max for the wrong reason — by inferring plan-restriction from the presence of any `restrictions` block, which `auto` had only for model gating (`excluded_models: ["Haiku"]`). Pro continued to be excluded (correctly), but with a misleading message and via the same buggy heuristic.

## Empirical evidence

```
$ claude auth status
{ "subscriptionType": "max", ... }

$ claude --permission-mode auto -p "Reply with exactly: PLAN_AUTO_OK" --model sonnet
PLAN_AUTO_OK
```

Auto Mode runs end-to-end on a Max plan via the CLI. The dotbot UI restriction was the only blocker.

## Changes

1. **`core/settings/providers/claude.json`** — describe Auto Mode's actual plan eligibility ("Available on Max, Team, Enterprise, and API plans (not Pro)") and declare `restrictions.excluded_plans = ["pro"]`. `excluded_models = ["Haiku"]` preserved.
2. **`core/ui/static/modules/controls.js`** — hoist a single `isPlanRestricted(modeConfig, plan)` helper that keys off `restrictions.excluded_plans`. Both `initPermissionModeSelector` (effective-mode override + per-mode grid render) and `updatePermissionModeNote` (explanatory note below the grid) now use the same signal so they can never disagree. Hardcoded `"Requires Team, Enterprise, or API plan"` message replaced by `planRestrictionMessage(plan)` — produces `"Not available on the <Plan> plan"` dynamically, so it stays correct for any future mode listing different plans in `excluded_plans`.
3. **`tests/Test-Components.ps1`** — assert the `auto` config matches Anthropic's policy: `excluded_plans` contains `"pro"`, does NOT contain `"max"`, the description does not falsely claim exclusive Team/Enterprise/API support. `auto`-mode existence asserted explicitly so a future removal/rename trips the gate rather than silently no-op'ing.

The runtime side (`launch-process.ps1`) already keys off `excluded_models` explicitly and is unaffected.

## Screenshots

Side-by-side rendering of the Settings → Permission Mode panel for a `plan_type = "max"` user. BEFORE: Auto Mode greyed out with "Requires Team, Enterprise, or API plan". AFTER: Auto Mode selectable. The screenshot's verdict box also notes that Pro-plan users will continue to see Auto disabled — now with a plan-aware "Not available on the Pro plan" message.

<img width="1232" height="1181" alt="image" src="https://github.com/user-attachments/assets/12e200e7-e49e-47de-b607-39def320dd2e" />

## Test plan

- [x] `pwsh tests/Run-Tests.ps1 -Layer 2` passes — `Layer 2 : ✓ PASSED (13m 23s)` / `RESULT: ALL PASSED` (Components 458/458, Workflow Integration 130/130, Task Actions 163/163, Server Startup 49/49, ProcessRegistry 20/20, Process Dispatch 26/26, StudioAPI 34/34).
- [x] New assertions visible in output: `Claude auto permission mode is present in config`, `Claude auto excluded_plans contains 'pro'`, `Claude auto excluded_plans does NOT contain 'max'`, `Claude auto description does not falsely claim Team/Enterprise/API-only`.
- [x] Pre-existing permission-mode tests still pass: `Auto permission mode uses --permission-mode auto`, `Auto permission mode does not include bypass flag`, `Default permission mode uses --dangerously-skip-permissions`.
- [x] No changes to `Build-ProviderCliArgs` output for either `auto` or `bypassPermissions` modes.
- [ ] (Manual) Settings tab on a Max plan: Auto Mode is selectable and persists across reload.
- [ ] (Manual) Settings tab on a Pro plan: Auto Mode stays disabled with the new "Not available on the Pro plan" message.
- [ ] (Manual) Settings tab on an API/Team/Enterprise plan: unchanged — Auto Mode remains selectable.

## Note on Layer 1

Layer 1's `Test-Structure.ps1` setup step `Rename-Item ~/dotbot` fails when a live dotbot runtime holds the directory open. Pre-existing, reproducible on `main`, unrelated to this PR.
