### PR TITLE
[PR-8/#289] Magic-link auth covers attachments + JWT lifetime from EscalateAfterDays

### DIFF
--- a/server/src/Dotbot.Server/MagicLinkAuthMiddleware.cs
+++ b/server/src/Dotbot.Server/MagicLinkAuthMiddleware.cs
@@ -7,14 +7,25 @@ using Microsoft.IdentityModel.Tokens;
 namespace Dotbot.Server;
 
 /// <summary>
-/// Intercepts requests to /respond* paths and enforces magic-link or device-cookie authentication.
+/// Intercepts requests that depend on magic-link or device-cookie authentication.
+///
+/// Covers:
+///   • /respond*                  — web response form (GET + POST)
+///   • GET /api/attachments/*     — template-attachment downloads rendered by the
+///                                  document-review form. Authorized by the same
+///                                  magic-link JWT as /respond; the middleware
+///                                  additionally verifies that the JWT's
+///                                  questionInstanceId owns the requested storageRef.
+///
 /// Flow:
-///   1. Check ?token= query param → validate JWT, check JTI blob exists and is unused
-///      - GET: authenticate without consuming (user is viewing the question)
-///      - POST: atomically mark used, create device token, set cookie (user is submitting answer)
-///   2. Else check dotbot_device cookie → load device blob, validate not expired/revoked
-///   3. If neither → 401
-/// Sets HttpContext.Items["AuthenticatedEmail"] for downstream use.
+///   1. Check ?token= query param → validate JWT, check JTI blob exists and is unused.
+///      - GET /respond and GET /api/attachments/*: authenticate without consuming.
+///      - POST /respond: validate; Respond page handler decides when to consume.
+///   2. Else check dotbot_device cookie (Respond only) → load device blob, validate.
+///   3. If neither → 401.
+///
+/// Expired JWTs (signature valid, exp in the past) return 410 Gone — abandoned
+/// partial-batch links should not look like an auth failure.
 /// </summary>
 public class MagicLinkAuthMiddleware
 {
@@ -29,11 +40,19 @@ public class MagicLinkAuthMiddleware
         HttpContext context,
         JwtSigningKeyProvider keyProvider,
         TokenStorageService tokenStorage,
+        InstanceStorageService instances,
+        ITemplateStorageService templates,
         IOptions<AuthSettings> authSettings,
         ILogger<MagicLinkAuthMiddleware> logger)
     {
         var path = context.Request.Path.Value ?? "";
-        if (!path.StartsWith("/respond", StringComparison.OrdinalIgnoreCase))
+        var method = context.Request.Method;
+
+        var isRespond = path.StartsWith("/respond", StringComparison.OrdinalIgnoreCase);
+        var isAttachmentGet = HttpMethods.IsGet(method)
+            && path.StartsWith("/api/attachments", StringComparison.OrdinalIgnoreCase);
+
+        if (!isRespond && !isAttachmentGet)
         {
             await _next(context);
             return;
@@ -41,7 +60,7 @@ public class MagicLinkAuthMiddleware
 
         // Teams (and other clients) send HEAD requests to preview URLs.
         // These must not consume the single-use magic link token.
-        if (HttpMethods.IsHead(context.Request.Method))
+        if (isRespond && HttpMethods.IsHead(method))
         {
             context.Response.StatusCode = 200;
             return;
@@ -52,54 +71,113 @@ public class MagicLinkAuthMiddleware
         // 1. Check for magic link token in query string
         if (context.Request.Query.TryGetValue("token", out var tokenValue) && !string.IsNullOrEmpty(tokenValue))
         {
+            JwtSecurityToken jwtToken;
             try
             {
                 var validationParams = await keyProvider.GetValidationParametersAsync();
                 var handler = new JwtSecurityTokenHandler();
-                var principal = handler.ValidateToken(tokenValue!, validationParams, out var validatedToken);
-                var jwtToken = (JwtSecurityToken)validatedToken;
-
-                var jti = jwtToken.Id;
-                var email = jwtToken.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Email)?.Value
-                    ?? jwtToken.Claims.FirstOrDefault(c => c.Type == "email")?.Value;
-
-                if (string.IsNullOrEmpty(jti) || string.IsNullOrEmpty(email))
-                {
-                    logger.LogWarning("Magic link token missing required claims (jti or email)");
-                    context.Response.StatusCode = 401;
-                    await context.Response.WriteAsync("Invalid token: missing required claims.");
-                    return;
-                }
-
-                // Verify the magic link hasn't already been used
-                var existingToken = await tokenStorage.GetMagicLinkTokenAsync(jti);
-                if (existingToken is null || existingToken.Used)
-                {
-                    logger.LogWarning("Magic link token {Jti} already used or not found", jti);
-                    context.Response.StatusCode = 401;
-                    await context.Response.WriteAsync("This link has already been used or has expired.");
-                    return;
-                }
-
-                // Store JTI so the page handler can consume after successful processing
-                context.Items["MagicLinkJti"] = jti;
-                logger.LogInformation("Magic link validated (not consumed) for {Email}, method {Method}", email, context.Request.Method);
-
-                context.Items["AuthenticatedEmail"] = email;
-                await _next(context);
+                handler.ValidateToken(tokenValue!, validationParams, out var validatedToken);
+                jwtToken = (JwtSecurityToken)validatedToken;
+            }
+            catch (SecurityTokenExpiredException ex)
+            {
+                logger.LogWarning(ex, "Magic link token expired (exp claim in the past)");
+                context.Response.StatusCode = StatusCodes.Status410Gone;
+                await context.Response.WriteAsync("This link has expired.");
                 return;
             }
-            catch (SecurityTokenException ex)
+            catch (Exception ex) when (
+                ex is SecurityTokenException ||      // signature, audience, issuer, malformed JWT structure
+                ex is ArgumentException)             // token string can't be parsed as JWT at all
             {
                 logger.LogWarning(ex, "Invalid magic link token");
-                context.Response.StatusCode = 401;
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
                 await context.Response.WriteAsync("Invalid or expired token.");
                 return;
             }
+
+            var jti = jwtToken.Id;
+            var email = jwtToken.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Email)?.Value
+                ?? jwtToken.Claims.FirstOrDefault(c => c.Type == "email")?.Value;
+            var instanceIdClaim = jwtToken.Claims.FirstOrDefault(c => c.Type == "questionInstanceId")?.Value;
+            var projectIdClaim = jwtToken.Claims.FirstOrDefault(c => c.Type == "projectId")?.Value;
+
+            if (string.IsNullOrEmpty(jti) || string.IsNullOrEmpty(email)
+                || string.IsNullOrEmpty(instanceIdClaim) || string.IsNullOrEmpty(projectIdClaim))
+            {
+                logger.LogWarning("Magic link token missing required claims");
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                await context.Response.WriteAsync("Invalid token: missing required claims.");
+                return;
+            }
+
+            // Verify the magic link blob is present and not expired/consumed
+            var existingToken = await tokenStorage.GetMagicLinkTokenAsync(jti);
+            if (existingToken is null)
+            {
+                logger.LogWarning("Magic link token {Jti} not found", jti);
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                await context.Response.WriteAsync("This link is not recognised.");
+                return;
+            }
+            if (existingToken.ExpiresAt <= DateTime.UtcNow)
+            {
+                logger.LogWarning("Magic link token {Jti} expired at {ExpiresAt}", jti, existingToken.ExpiresAt);
+                context.Response.StatusCode = StatusCodes.Status410Gone;
+                await context.Response.WriteAsync("This link has expired.");
+                return;
+            }
+            if (existingToken.Used)
+            {
+                logger.LogWarning("Magic link token {Jti} already used", jti);
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                await context.Response.WriteAsync("This link has already been used.");
+                return;
+            }
+
+            // Attachment downloads must come from the instance that owns the link
+            if (isAttachmentGet)
+            {
+                var storageRef = ExtractStorageRef(path);
+                if (string.IsNullOrEmpty(storageRef))
+                {
+                    await _next(context);
+                    return;
+                }
+
+                if (!Guid.TryParse(instanceIdClaim, out var instanceGuid))
+                {
+                    logger.LogWarning("Magic link token has non-GUID questionInstanceId claim");
+                    context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                    await context.Response.WriteAsync("Invalid token: questionInstanceId is malformed.");
+                    return;
+                }
+
+                if (!await StorageRefBelongsToInstanceAsync(storageRef, projectIdClaim!, instanceGuid, instances, templates))
+                {
+                    logger.LogWarning(
+                        "Attachment {StorageRef} not owned by instance {InstanceId} from token",
+                        storageRef, instanceGuid);
+                    context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                    await context.Response.WriteAsync("This link does not grant access to that attachment.");
+                    return;
+                }
+            }
+
+            // Store JTI so /respond's page handler can consume after the full batch is complete
+            context.Items["MagicLinkJti"] = jti;
+            context.Items["AuthenticatedEmail"] = email;
+            logger.LogInformation("Magic link validated (not consumed) for {Email}, method {Method}, path {Path}",
+                email, method, path);
+
+            await _next(context);
+            return;
         }
 
-        // 2. Check for device cookie
-        if (context.Request.Cookies.TryGetValue(settings.CookieName, out var cookieValue) && !string.IsNullOrEmpty(cookieValue))
+        // 2. Check for device cookie (only valid on /respond — attachment downloads always need the JWT)
+        if (isRespond
+            && context.Request.Cookies.TryGetValue(settings.CookieName, out var cookieValue)
+            && !string.IsNullOrEmpty(cookieValue))
         {
             var deviceToken = await tokenStorage.GetDeviceTokenAsync(cookieValue);
             if (deviceToken is not null && !deviceToken.Revoked && deviceToken.ExpiresAt > DateTime.UtcNow)
@@ -115,7 +193,54 @@ public class MagicLinkAuthMiddleware
         }
 
         // 3. No valid auth
-        context.Response.StatusCode = 401;
+        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
         await context.Response.WriteAsync("Authentication required. Please use a valid magic link.");
+    }
+
+    /// <summary>
+    /// Extracts the storage reference from a path like <c>/api/attachments/{**storageRef}</c>.
+    /// Returns null if the prefix is missing.
+    /// </summary>
+    private static string? ExtractStorageRef(string path)
+    {
+        const string prefix = "/api/attachments/";
+        if (!path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return null;
+        var tail = path[prefix.Length..];
+        return string.IsNullOrWhiteSpace(tail) ? null : tail;
+    }
+
+    /// <summary>
+    /// Verifies that the requested storageRef is referenced by the template owned by the
+    /// JWT's instance. Requires an exact <see cref="QuestionAttachment.BlobPath"/> match —
+    /// matching by the AttachmentId prefix alone would grant access to any object stored
+    /// under <c>{attachmentId}/*</c>, which on the local-file backend would include the
+    /// <c>.meta</c> companion next to the blob (and may include unrelated objects under
+    /// future storage layouts). Validator already enforces non-empty <c>BlobPath</c> on
+    /// blob-backed template attachments, so this loses no legitimate access.
+    /// </summary>
+    private static async Task<bool> StorageRefBelongsToInstanceAsync(
+        string storageRef,
+        string projectId,
+        Guid instanceId,
+        InstanceStorageService instances,
+        ITemplateStorageService templates)
+    {
+        var instance = await instances.GetInstanceAsync(projectId, instanceId);
+        if (instance is null)
+            return false;
+
+        var template = await templates.GetTemplateAsync(projectId, instance.QuestionId, instance.QuestionVersion);
+        if (template?.Attachments is null)
+            return false;
+
+        foreach (var att in template.Attachments)
+        {
+            if (att is null) continue;
+            if (!string.IsNullOrEmpty(att.BlobPath)
+                && string.Equals(att.BlobPath, storageRef, StringComparison.Ordinal))
+                return true;
+        }
+        return false;
     }
 }

--- a/server/src/Dotbot.Server/MagicLinkAuthMiddleware.cs
+++ b/server/src/Dotbot.Server/MagicLinkAuthMiddleware.cs
@@ -49,8 +49,12 @@ public class MagicLinkAuthMiddleware
         var method = context.Request.Method;
 
         var isRespond = path.StartsWith("/respond", StringComparison.OrdinalIgnoreCase);
+        // Require the trailing slash so the bare prefix (no storageRef) doesn't claim
+        // attachment-auth coverage and silently fall through. A request to
+        // /api/attachments or /api/attachmentsXYZ stays unhandled by this middleware
+        // and reaches routing / ApiKeyMiddleware as appropriate.
         var isAttachmentGet = HttpMethods.IsGet(method)
-            && path.StartsWith("/api/attachments", StringComparison.OrdinalIgnoreCase);
+            && path.StartsWith("/api/attachments/", StringComparison.OrdinalIgnoreCase);
 
         if (!isRespond && !isAttachmentGet)
         {
@@ -141,7 +145,12 @@ public class MagicLinkAuthMiddleware
                 var storageRef = ExtractStorageRef(path);
                 if (string.IsNullOrEmpty(storageRef))
                 {
-                    await _next(context);
+                    // isAttachmentGet only matches "/api/attachments/" + non-empty tail,
+                    // so this is theoretically unreachable. Belt-and-braces: refuse the
+                    // request rather than silently fall through past the ownership gate.
+                    logger.LogWarning("Attachment download rejected: missing storageRef on path {Path}", path);
+                    context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    await context.Response.WriteAsync("Attachment reference is required.");
                     return;
                 }
 

--- a/server/src/Dotbot.Server/MagicLinkAuthMiddleware.cs
+++ b/server/src/Dotbot.Server/MagicLinkAuthMiddleware.cs
@@ -39,8 +39,8 @@ public class MagicLinkAuthMiddleware
     public async Task InvokeAsync(
         HttpContext context,
         JwtSigningKeyProvider keyProvider,
-        TokenStorageService tokenStorage,
-        InstanceStorageService instances,
+        ITokenStorageService tokenStorage,
+        IInstanceStorageService instances,
         ITemplateStorageService templates,
         IOptions<AuthSettings> authSettings,
         ILogger<MagicLinkAuthMiddleware> logger)
@@ -223,7 +223,7 @@ public class MagicLinkAuthMiddleware
         string storageRef,
         string projectId,
         Guid instanceId,
-        InstanceStorageService instances,
+        IInstanceStorageService instances,
         ITemplateStorageService templates)
     {
         var instance = await instances.GetInstanceAsync(projectId, instanceId);

--- a/server/src/Dotbot.Server/MagicLinkAuthMiddleware.cs
+++ b/server/src/Dotbot.Server/MagicLinkAuthMiddleware.cs
@@ -24,8 +24,8 @@ namespace Dotbot.Server;
 ///   2. Else check dotbot_device cookie (Respond only) → load device blob, validate.
 ///   3. If neither → 401.
 ///
-/// Expired JWTs (signature valid, exp in the past) return 410 Gone — abandoned
-/// partial-batch links should not look like an auth failure.
+/// Expired JWTs (signature valid, exp in the past) return 410 Gone so an
+/// abandoned link does not look like an auth failure.
 /// </summary>
 public class MagicLinkAuthMiddleware
 {
@@ -173,7 +173,7 @@ public class MagicLinkAuthMiddleware
                 }
             }
 
-            // Store JTI so /respond's page handler can consume after the full batch is complete
+            // Store JTI so /respond's page handler can consume after a successful POST
             context.Items["MagicLinkJti"] = jti;
             context.Items["AuthenticatedEmail"] = email;
             logger.LogInformation("Magic link validated (not consumed) for {Email}, method {Method}, path {Path}",

--- a/server/src/Dotbot.Server/Models/AuthSettings.cs
+++ b/server/src/Dotbot.Server/Models/AuthSettings.cs
@@ -7,7 +7,6 @@ public class AuthSettings
     public string? JwtSigningKey { get; set; }
     public string JwtIssuer { get; set; } = "dotbot";
     public string JwtAudience { get; set; } = "dotbot-respond";
-    public int MagicLinkExpiryMinutes { get; set; } = 43200;
     public int DeviceTokenExpiryDays { get; set; } = 90;
     public string CookieName { get; set; } = "dotbot_device";
     public string[] SeedAdministrators { get; set; } = [];

--- a/server/src/Dotbot.Server/Models/QuestionTemplate.cs
+++ b/server/src/Dotbot.Server/Models/QuestionTemplate.cs
@@ -57,6 +57,14 @@ public class ResponseSettings
 
 public class DeliveryDefaults
 {
+    /// <summary>One year in hours - hard upper bound on <see cref="ReminderAfterHours"/>.</summary>
+    public const int MaxReminderAfterHours = 24 * 365;
+
+    /// <summary>One year in days - hard upper bound on <see cref="EscalateAfterDays"/>.
+    /// Magic-link JTI hard lifetime is fed by this; longer windows defeat its purpose
+    /// and would risk <see cref="DateTime.AddDays"/> overflow.</summary>
+    public const int MaxEscalateAfterDays = 365;
+
     public int? ReminderAfterHours { get; set; }
     public int? EscalateAfterDays { get; set; }
     public string? Priority { get; set; }

--- a/server/src/Dotbot.Server/Pages/Respond.cshtml.cs
+++ b/server/src/Dotbot.Server/Pages/Respond.cshtml.cs
@@ -22,20 +22,20 @@ public class RespondModel : PageModel
         PropertyNameCaseInsensitive = true,
     };
 
-    private readonly InstanceStorageService _instances;
+    private readonly IInstanceStorageService _instances;
     private readonly ITemplateStorageService _templates;
     private readonly ResponseStorageService _responses;
     private readonly AttachmentStorageService _attachments;
-    private readonly TokenStorageService _tokenStorage;
+    private readonly ITokenStorageService _tokenStorage;
     private readonly AuthSettings _authSettings;
     private readonly ILogger<RespondModel> _logger;
 
     public RespondModel(
-        InstanceStorageService instances,
+        IInstanceStorageService instances,
         ITemplateStorageService templates,
         ResponseStorageService responses,
         AttachmentStorageService attachments,
-        TokenStorageService tokenStorage,
+        ITokenStorageService tokenStorage,
         IOptions<AuthSettings> authSettings,
         ILogger<RespondModel> logger)
     {

--- a/server/src/Dotbot.Server/Program.cs
+++ b/server/src/Dotbot.Server/Program.cs
@@ -117,6 +117,7 @@ try
     builder.Services.AddSingleton<StoragePathResolver>();
     builder.Services.AddSingleton<ITemplateStorageService, TemplateStorageService>();
     builder.Services.AddSingleton<QuestionTemplateValidator>();
+    builder.Services.AddSingleton<QuestionInstanceValidator>();
     builder.Services.AddSingleton<IInstanceStorageService, InstanceStorageService>();
     builder.Services.AddSingleton<ResponseStorageService>();
     builder.Services.AddSingleton<AttachmentStorageService>();
@@ -258,6 +259,7 @@ try
         ITemplateStorageService templates,
         IInstanceStorageService instances,
         DeliveryOrchestrator orchestrator,
+        QuestionInstanceValidator instanceValidator,
         ILogger<Program> logger,
         CancellationToken ct) =>
     {
@@ -267,11 +269,18 @@ try
             logger.LogWarning("Instance creation rejected: invalid JSON");
             return Results.BadRequest(new { error = "Invalid JSON" });
         }
-        if (req.QuestionId == Guid.Empty)
+
+        // Pure-shape validation lives in QuestionInstanceValidator (questionId,
+        // jiraIssueKey, recipients, deliveryOverrides). Runtime-dependent checks
+        // (channel registration, template existence) stay below because they read
+        // mutable DI state and async storage respectively.
+        var instanceErrors = instanceValidator.Validate(req);
+        if (instanceErrors.Count > 0)
         {
-            logger.LogWarning("Instance creation rejected: questionId must be a GUID");
-            return Results.BadRequest(new { error = "questionId must be a GUID" });
+            logger.LogWarning("Instance creation rejected: {Reasons}", string.Join("; ", instanceErrors));
+            return Results.BadRequest(new { error = instanceErrors[0], errors = instanceErrors });
         }
+
         if (req.InstanceId == Guid.Empty) req.InstanceId = Guid.NewGuid();
 
         var channel = req.Channel ?? "teams";
@@ -280,31 +289,6 @@ try
             logger.LogWarning("Instance creation rejected: delivery channel '{Channel}' is not enabled. Available: {Available}",
                 channel, string.Join(", ", orchestrator.AvailableChannels));
             return Results.BadRequest(new { error = $"Delivery channel '{channel}' is not enabled. Available channels: {string.Join(", ", orchestrator.AvailableChannels)}" });
-        }
-
-        if (req.Channel == "jira" && string.IsNullOrEmpty(req.JiraIssueKey))
-        {
-            logger.LogWarning("Instance creation rejected: jiraIssueKey required for jira channel");
-            return Results.BadRequest(new { error = "jiraIssueKey is required when channel is 'jira'" });
-        }
-
-        // Validate recipients
-        var allEmails = req.Recipients?.Emails ?? [];
-        var allObjectIds = req.Recipients?.UserObjectIds ?? [];
-        var allSlackUserIds = req.Recipients?.SlackUserIds ?? [];
-        if (allEmails.Count == 0 && allObjectIds.Count == 0 && allSlackUserIds.Count == 0)
-        {
-            logger.LogWarning("Instance creation rejected: no recipients specified");
-            return Results.BadRequest(new { error = "At least one email, userObjectId, or slackUserId is required in recipients" });
-        }
-
-        var invalidEmails = allEmails
-            .Where(e => string.IsNullOrWhiteSpace(e) || !System.Text.RegularExpressions.Regex.IsMatch(e, @"^[^@\s]+@[^@\s]+\.[^@\s]+$"))
-            .ToList();
-        if (invalidEmails.Count > 0)
-        {
-            logger.LogWarning("Instance creation rejected: invalid emails {InvalidEmails}", invalidEmails);
-            return Results.BadRequest(new { error = $"Invalid email address(es): {string.Join(", ", invalidEmails)}" });
         }
 
         var template = await templates.GetTemplateAsync(req.ProjectId, req.QuestionId, req.QuestionVersion);

--- a/server/src/Dotbot.Server/Program.cs
+++ b/server/src/Dotbot.Server/Program.cs
@@ -117,7 +117,7 @@ try
     builder.Services.AddSingleton<StoragePathResolver>();
     builder.Services.AddSingleton<ITemplateStorageService, TemplateStorageService>();
     builder.Services.AddSingleton<QuestionTemplateValidator>();
-    builder.Services.AddSingleton<InstanceStorageService>();
+    builder.Services.AddSingleton<IInstanceStorageService, InstanceStorageService>();
     builder.Services.AddSingleton<ResponseStorageService>();
     builder.Services.AddSingleton<AttachmentStorageService>();
     builder.Services.AddSingleton<IConversationReferenceStore, ConversationReferenceStore>();
@@ -128,7 +128,7 @@ try
     builder.Services.AddSingleton<UserResolverService>();
     builder.Services.AddSingleton<BusinessHoursService>();
     builder.Services.AddSingleton<JwtSigningKeyProvider>();
-    builder.Services.AddSingleton<TokenStorageService>();
+    builder.Services.AddSingleton<ITokenStorageService, TokenStorageService>();
     builder.Services.AddSingleton<MagicLinkService>();
     builder.Services.AddSingleton<NotificationSummaryBuilder>();
 
@@ -256,7 +256,7 @@ try
     app.MapPost("/api/instances", async (
         HttpRequest request,
         ITemplateStorageService templates,
-        InstanceStorageService instances,
+        IInstanceStorageService instances,
         DeliveryOrchestrator orchestrator,
         ILogger<Program> logger,
         CancellationToken ct) =>
@@ -335,7 +335,7 @@ try
     });
 
     // ── v1: Get instance ────────────────────────────────────────────────────
-    app.MapGet("/api/instances/{projectId}/{instanceId}", async (string projectId, Guid instanceId, InstanceStorageService instances) =>
+    app.MapGet("/api/instances/{projectId}/{instanceId}", async (string projectId, Guid instanceId, IInstanceStorageService instances) =>
     {
         var inst = await instances.GetInstanceAsync(projectId, instanceId);
         return inst is not null ? Results.Ok(inst) : Results.NotFound();
@@ -448,7 +448,7 @@ try
     app.MapTestModeEndpoints();
 
     // ── Revoke a device token (API key protected) ───────────────────────────
-    app.MapPost("/tokens/revoke", async (HttpRequest request, TokenStorageService tokenStorage, ILogger<Program> logger) =>
+    app.MapPost("/tokens/revoke", async (HttpRequest request, ITokenStorageService tokenStorage, ILogger<Program> logger) =>
     {
         var body = await request.ReadFromJsonAsync<RevokeTokenRequest>();
         if (body is null || string.IsNullOrEmpty(body.DeviceTokenId))
@@ -470,7 +470,7 @@ try
 
     // ── Dashboard API endpoints ────────────────────────────────────────────
     app.MapGet("/api/dashboard/instances", async (
-        InstanceStorageService instances,
+        IInstanceStorageService instances,
         ITemplateStorageService templates,
         ResponseStorageService responses,
         ILogger<Program> logger) =>
@@ -574,7 +574,7 @@ try
 
     app.MapDelete("/api/dashboard/instances/{projectId}/{instanceId}", async (
         string projectId, Guid instanceId,
-        InstanceStorageService instances,
+        IInstanceStorageService instances,
         ResponseStorageService responses,
         ILogger<Program> logger) =>
     {
@@ -592,7 +592,7 @@ try
 
     app.MapPost("/api/dashboard/nudge", async (
         HttpRequest request,
-        InstanceStorageService instances,
+        IInstanceStorageService instances,
         ITemplateStorageService templates,
         DeliveryOrchestrator orchestrator,
         ILogger<Program> logger,

--- a/server/src/Dotbot.Server/Program.cs
+++ b/server/src/Dotbot.Server/Program.cs
@@ -690,7 +690,6 @@ static void LogStartupConfiguration(WebApplicationBuilder builder)
     Log.Information("  JwtSigningKey: {HasKey}", string.IsNullOrEmpty(config["Auth:JwtSigningKey"]) ? "(not set)" : "SET");
     Log.Information("  JwtIssuer: {Issuer}", config["Auth:JwtIssuer"] ?? "(not set)");
     Log.Information("  JwtAudience: {Audience}", config["Auth:JwtAudience"] ?? "(not set)");
-    Log.Information("  MagicLinkExpiryMinutes: {Expiry}", config["Auth:MagicLinkExpiryMinutes"] ?? "(not set)");
     Log.Information("  DeviceTokenExpiryDays: {Expiry}", config["Auth:DeviceTokenExpiryDays"] ?? "(not set)");
     Log.Information("");
 

--- a/server/src/Dotbot.Server/Program.cs
+++ b/server/src/Dotbot.Server/Program.cs
@@ -15,11 +15,8 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Identity.Web;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
 using Serilog;
 using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
 using System.Text.Json;
 
 // ── Bootstrap logger (captures startup errors before host is built) ─────────
@@ -416,29 +413,16 @@ try
         });
     });
 
-    // ── Template attachment download (JWT protected) ──────────────────────────
+    // ── Template attachment download ──────────────────────────────────────────
+    // Authorization (JWT validation + per-instance ownership) is handled upstream
+    // by MagicLinkAuthMiddleware. By the time this handler runs the token has been
+    // validated and the JWT's questionInstanceId is known to own this storageRef.
     app.MapGet("/api/attachments/{**storageRef}", async (
         string storageRef,
-        string? token,
         IAttachmentStorage attachmentStorage,
-        JwtSigningKeyProvider jwtKeyProvider,
         ILogger<Program> logger,
         CancellationToken ct) =>
     {
-        if (string.IsNullOrEmpty(token))
-            return Results.Unauthorized();
-
-        var validationParams = await jwtKeyProvider.GetValidationParametersAsync();
-        try
-        {
-            new JwtSecurityTokenHandler().ValidateToken(token, validationParams, out _);
-        }
-        catch (SecurityTokenException ex)
-        {
-            logger.LogWarning("Attachment download rejected: invalid token — {Message}", ex.Message);
-            return Results.Unauthorized();
-        }
-
         var result = await attachmentStorage.DownloadAsync(storageRef, ct);
         if (result is null)
         {

--- a/server/src/Dotbot.Server/Services/AdaptiveCardService.cs
+++ b/server/src/Dotbot.Server/Services/AdaptiveCardService.cs
@@ -290,39 +290,6 @@ public class AdaptiveCardService
             });
         }
 
-        if (summary.BatchQuestions.Count > 0)
-        {
-            body.Add(new AdaptiveTextBlock
-            {
-                Text = "Questions in this batch",
-                Weight = AdaptiveTextWeight.Bolder,
-                Size = AdaptiveTextSize.Small,
-                Spacing = AdaptiveSpacing.Medium,
-                Separator = true
-            });
-            foreach (var q in summary.BatchQuestions)
-            {
-                var inlines = new List<AdaptiveInline>
-                {
-                    new AdaptiveTextRun { Text = q.IsAnswered ? "✓ " : "⏳ ", Size = AdaptiveTextSize.Small },
-                    new AdaptiveTextRun { Text = q.Title, Size = AdaptiveTextSize.Small },
-                    new AdaptiveTextRun { Text = " (", Size = AdaptiveTextSize.Small },
-                    new AdaptiveTextRun { Text = q.Type, Size = AdaptiveTextSize.Small },
-                    new AdaptiveTextRun { Text = ")", Size = AdaptiveTextSize.Small }
-                };
-                if (!string.IsNullOrWhiteSpace(q.AnsweredSummary))
-                {
-                    inlines.Add(new AdaptiveTextRun { Text = " — ", Size = AdaptiveTextSize.Small });
-                    inlines.Add(new AdaptiveTextRun { Text = q.AnsweredSummary, Size = AdaptiveTextSize.Small });
-                }
-                body.Add(new AdaptiveRichTextBlock
-                {
-                    Spacing = AdaptiveSpacing.None,
-                    Inlines = inlines
-                });
-            }
-        }
-
         if (summary.Attachments.Count > 0)
         {
             body.Add(new AdaptiveTextBlock

--- a/server/src/Dotbot.Server/Services/Delivery/DeliveryOrchestrator.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/DeliveryOrchestrator.cs
@@ -114,7 +114,8 @@ public class DeliveryOrchestrator
 
                 // Generate magic link
                 var magicLinkUrl = await _magicLinkService.GenerateMagicLinkAsync(
-                    email, instance.InstanceId, instance.ProjectId, baseUrl);
+                    email, instance.InstanceId, instance.ProjectId, baseUrl,
+                    template.DeliveryDefaults?.EscalateAfterDays);
 
                 var sentAt = DateTime.UtcNow;
                 summary.RespondUrl = magicLinkUrl;
@@ -164,7 +165,8 @@ public class DeliveryOrchestrator
                 try
                 {
                     var magicLinkUrl = await _magicLinkService.GenerateMagicLinkAsync(
-                        slackUserId, instance.InstanceId, instance.ProjectId, baseUrl);
+                        slackUserId, instance.InstanceId, instance.ProjectId, baseUrl,
+                        template.DeliveryDefaults?.EscalateAfterDays);
 
                     var sentAt = DateTime.UtcNow;
                     summary.RespondUrl = magicLinkUrl;
@@ -220,7 +222,8 @@ public class DeliveryOrchestrator
                 }
 
                 var magicLinkUrl = await _magicLinkService.GenerateMagicLinkAsync(
-                    userId, instance.InstanceId, instance.ProjectId, baseUrl);
+                    userId, instance.InstanceId, instance.ProjectId, baseUrl,
+                    template.DeliveryDefaults?.EscalateAfterDays);
 
                 var sentAt = DateTime.UtcNow;
                 summary.RespondUrl = magicLinkUrl;
@@ -300,7 +303,8 @@ public class DeliveryOrchestrator
         var baseUrl = GetBaseUrl();
         var email = recipient.SlackUserId ?? recipient.Email ?? recipient.AadObjectId ?? "";
         var magicLinkUrl = await _magicLinkService.GenerateMagicLinkAsync(
-            email, instance.InstanceId, instance.ProjectId, baseUrl);
+            email, instance.InstanceId, instance.ProjectId, baseUrl,
+            template.DeliveryDefaults?.EscalateAfterDays);
 
         var recipientInfo = new RecipientInfo
         {
@@ -385,7 +389,8 @@ public class DeliveryOrchestrator
         }
 
         var magicLinkUrl = await _magicLinkService.GenerateMagicLinkAsync(
-            email, instance.InstanceId, instance.ProjectId, baseUrl);
+            email, instance.InstanceId, instance.ProjectId, baseUrl,
+            template.DeliveryDefaults?.EscalateAfterDays);
 
         var summary = _summaryBuilder.Build(template, instance, respondUrl: magicLinkUrl, isReminder: false);
         summary.DueBy = ComputeDueBy(template, instance, DateTime.UtcNow);

--- a/server/src/Dotbot.Server/Services/Delivery/EmailDeliveryProvider.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/EmailDeliveryProvider.cs
@@ -440,27 +440,6 @@ public class EmailDeliveryProvider : IQuestionDeliveryProvider
                 """);
         }
 
-        // Batch-question list (always render — single-question instance is a single-entry list)
-        if (summary.BatchQuestions.Count > 0)
-        {
-            sb.Append("""
-                <p style="font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 13px; font-weight: 700; color: #B87820; margin: 16px 0 8px; text-transform: uppercase; letter-spacing: 0.5px;">Questions in this batch</p>
-                <ul style="margin: 0 0 16px; padding-left: 20px;">
-                """);
-            foreach (var q in summary.BatchQuestions)
-            {
-                sb.Append("""<li style="font-family: Inter, Arial, sans-serif; font-size: 14px; color: #1A1B2E; margin: 4px 0;">""");
-                if (q.IsAnswered) sb.Append("&#10003; ");
-                sb.Append($"""<strong>{Encode(q.Title)}</strong> <span style="display: inline-block; padding: 1px 6px; background-color: #F5F4F0; border: 1px solid #E2E2EA; border-radius: 3px; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 10px; font-weight: 600; color: #666677; text-transform: uppercase; letter-spacing: 0.5px;">{Encode(q.Type)}</span>""");
-                if (q.IsAnswered && !string.IsNullOrWhiteSpace(q.AnsweredSummary))
-                {
-                    sb.Append($""" &mdash; <span style="color: #666677;">{Encode(q.AnsweredSummary)}</span>""");
-                }
-                sb.Append("</li>");
-            }
-            sb.Append("</ul>");
-        }
-
         // Attachments — table with name + size, no links.
         if (summary.Attachments.Count > 0)
         {

--- a/server/src/Dotbot.Server/Services/Delivery/JiraDeliveryProvider.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/JiraDeliveryProvider.cs
@@ -141,20 +141,6 @@ public class JiraDeliveryProvider : IQuestionDeliveryProvider
             sb.AppendLine();
         }
 
-        if (summary.BatchQuestions.Count > 0)
-        {
-            sb.AppendLine("*Questions in this batch:*");
-            foreach (var q in summary.BatchQuestions)
-            {
-                var prefix = q.IsAnswered ? "✓ " : string.Empty;
-                var suffix = (q.IsAnswered && !string.IsNullOrWhiteSpace(q.AnsweredSummary))
-                    ? $" — {q.AnsweredSummary}"
-                    : string.Empty;
-                sb.AppendLine($"* {prefix}{q.Title} _({q.Type})_{suffix}");
-            }
-            sb.AppendLine();
-        }
-
         if (summary.Attachments.Count > 0)
         {
             sb.AppendLine("*Attachments:*");

--- a/server/src/Dotbot.Server/Services/Delivery/NotificationSummary.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/NotificationSummary.cs
@@ -9,30 +9,12 @@ public class NotificationSummary
     public string? DeliverableSummary { get; set; }
     public string? Context { get; set; }
 
-    // All questions in the current instance's batch, each with its state.
-    // Outpost groups questions when calling task-mark-needs-input; single-question
-    // instance → one entry. No cross-instance lookup.
-    public List<BatchQuestionRef> BatchQuestions { get; set; } = new();
-
     public List<AttachmentRef> Attachments { get; set; } = new();
     public List<ReviewLinkRef> ReviewLinks { get; set; } = new();
 
     public required string RespondUrl { get; set; }
     public DateTime? DueBy { get; set; }
     public bool IsReminder { get; set; }
-}
-
-public class BatchQuestionRef
-{
-    public required Guid QuestionId { get; set; }
-    public required string Title { get; set; }
-    public required string Type { get; set; }
-
-    // Populated by the PR introducing multi-question batches (#289). Until then,
-    // builder leaves these at default — single-question instances never carry an
-    // already-answered question (reminders suppress those, see #290).
-    public bool IsAnswered { get; set; }
-    public string? AnsweredSummary { get; set; }
 }
 
 public class AttachmentRef

--- a/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
@@ -33,16 +33,6 @@ public class NotificationSummaryBuilder
             // documentReview, so this stays null only when intentional (PRD §8 line 651).
             DeliverableSummary = template.DeliverableSummary,
             Context = template.Context,
-            BatchQuestions = new List<BatchQuestionRef>
-            {
-                new()
-                {
-                    QuestionId = template.QuestionId,
-                    Title = template.Title,
-                    Type = template.Type,
-                    // IsAnswered / AnsweredSummary populated when multi-question batches land (#289).
-                }
-            },
             Attachments = template.Attachments?
                 .Select(a => new AttachmentRef
                 {

--- a/server/src/Dotbot.Server/Services/Delivery/SlackDeliveryProvider.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/SlackDeliveryProvider.cs
@@ -353,30 +353,6 @@ public class SlackDeliveryProvider : IQuestionDeliveryProvider
             });
         }
 
-        if (summary.BatchQuestions.Count > 0)
-        {
-            var sb = new StringBuilder("*Questions in this batch*\n");
-            foreach (var q in summary.BatchQuestions)
-            {
-                if (q.IsAnswered)
-                {
-                    var ans = !string.IsNullOrWhiteSpace(q.AnsweredSummary)
-                        ? $" — _{Escape(q.AnsweredSummary)}_"
-                        : "";
-                    sb.AppendLine($"✓ {Escape(q.Title)} (`{EscapeCodeSpan(q.Type)}`){ans}");
-                }
-                else
-                {
-                    sb.AppendLine($"• {Escape(q.Title)} (`{EscapeCodeSpan(q.Type)}`)");
-                }
-            }
-            blocks.Add(new
-            {
-                type = "section",
-                text = new { type = "mrkdwn", text = sb.ToString().TrimEnd() }
-            });
-        }
-
         if (summary.Attachments.Count > 0)
         {
             var sb = new StringBuilder("*Attachments*\n");

--- a/server/src/Dotbot.Server/Services/IInstanceStorageService.cs
+++ b/server/src/Dotbot.Server/Services/IInstanceStorageService.cs
@@ -1,0 +1,12 @@
+using Dotbot.Server.Models;
+
+namespace Dotbot.Server.Services;
+
+public interface IInstanceStorageService
+{
+    Task SaveInstanceAsync(QuestionInstance instance);
+    Task<QuestionInstance?> GetInstanceAsync(string projectId, Guid instanceId);
+    IAsyncEnumerable<QuestionInstance> ListActiveInstancesAsync();
+    IAsyncEnumerable<QuestionInstance> ListAllInstancesAsync();
+    Task<bool> DeleteInstanceAsync(string projectId, Guid instanceId);
+}

--- a/server/src/Dotbot.Server/Services/ITokenStorageService.cs
+++ b/server/src/Dotbot.Server/Services/ITokenStorageService.cs
@@ -1,0 +1,19 @@
+using Dotbot.Server.Models;
+
+namespace Dotbot.Server.Services;
+
+public interface ITokenStorageService
+{
+    Task SaveMagicLinkTokenAsync(MagicLinkToken token);
+    Task<MagicLinkToken?> GetMagicLinkTokenAsync(string jti);
+
+    /// <summary>
+    /// Atomically marks a magic link token as used via ETag-based optimistic concurrency.
+    /// Returns true if successfully marked, false if already used or not found.
+    /// </summary>
+    Task<bool> TryMarkMagicLinkUsedAsync(string jti, string deviceTokenId);
+
+    Task SaveDeviceTokenAsync(DeviceToken token);
+    Task<DeviceToken?> GetDeviceTokenAsync(string deviceTokenId);
+    Task<bool> RevokeDeviceTokenAsync(string deviceTokenId);
+}

--- a/server/src/Dotbot.Server/Services/InstanceAndResponseStorage.cs
+++ b/server/src/Dotbot.Server/Services/InstanceAndResponseStorage.cs
@@ -41,7 +41,7 @@ public class AttachmentStorageService
     }
 }
 
-public class InstanceStorageService
+public class InstanceStorageService : IInstanceStorageService
 {
     private readonly BlobContainerClient _container;
     private readonly StoragePathResolver _paths;

--- a/server/src/Dotbot.Server/Services/MagicLinkService.cs
+++ b/server/src/Dotbot.Server/Services/MagicLinkService.cs
@@ -38,8 +38,8 @@ public class MagicLinkService
     /// <param name="escalateAfterDays">
     /// Hard lifetime for the JTI in days, sourced from the question template's
     /// <c>DeliveryDefaults.EscalateAfterDays</c>. <see langword="null"/> falls back to
-    /// <see cref="DefaultEscalateAfterDays"/> so abandoned batches expire predictably even
-    /// when escalation is disabled (PRD-029 §5.3, §5.6).
+    /// <see cref="DefaultEscalateAfterDays"/> so abandoned links expire predictably even
+    /// when escalation is disabled (PRD-029 sec. 5.3, sec. 5.6).
     /// </param>
     public async Task<string> GenerateMagicLinkAsync(
         string email,

--- a/server/src/Dotbot.Server/Services/MagicLinkService.cs
+++ b/server/src/Dotbot.Server/Services/MagicLinkService.cs
@@ -8,6 +8,12 @@ namespace Dotbot.Server.Services;
 
 public class MagicLinkService
 {
+    /// <summary>
+    /// Fallback hard lifetime for a magic link when the template carries no
+    /// <c>DeliveryDefaults.EscalateAfterDays</c>. Aligns with PRD-029 §5.3.
+    /// </summary>
+    internal const int DefaultEscalateAfterDays = 30;
+
     private readonly JwtSigningKeyProvider _keyProvider;
     private readonly TokenStorageService _tokenStorage;
     private readonly AuthSettings _settings;
@@ -29,11 +35,22 @@ public class MagicLinkService
     /// Generates a magic link URL containing a signed JWT.
     /// The JWT contains the recipient email, instance ID, project ID, and a unique JTI for single-use enforcement.
     /// </summary>
-    public async Task<string> GenerateMagicLinkAsync(string email, Guid instanceId, string projectId, string baseUrl)
+    /// <param name="escalateAfterDays">
+    /// Hard lifetime for the JTI in days, sourced from the question template's
+    /// <c>DeliveryDefaults.EscalateAfterDays</c>. <see langword="null"/> falls back to
+    /// <see cref="DefaultEscalateAfterDays"/> so abandoned batches expire predictably even
+    /// when escalation is disabled (PRD-029 §5.3, §5.6).
+    /// </param>
+    public async Task<string> GenerateMagicLinkAsync(
+        string email,
+        Guid instanceId,
+        string projectId,
+        string baseUrl,
+        int? escalateAfterDays = null)
     {
         var jti = Guid.NewGuid().ToString();
         var now = DateTime.UtcNow;
-        var expires = now.AddMinutes(_settings.MagicLinkExpiryMinutes);
+        var expires = ComputeExpiry(now, escalateAfterDays);
 
         var credentials = await _keyProvider.GetSigningCredentialsAsync();
         var tokenDescriptor = new SecurityTokenDescriptor
@@ -68,5 +85,16 @@ public class MagicLinkService
         var url = $"{baseUrl.TrimEnd('/')}/respond?token={Uri.EscapeDataString(jwt)}";
         _logger.LogInformation("Generated magic link for {Email}, instance {InstanceId}", email, instanceId);
         return url;
+    }
+
+    /// <summary>
+    /// Derives the JTI hard expiry from the issue time and the template's escalation policy.
+    /// A non-positive value (zero or negative) falls back to <see cref="DefaultEscalateAfterDays"/>
+    /// the same way <see langword="null"/> does — neither is a valid lifetime.
+    /// </summary>
+    internal static DateTime ComputeExpiry(DateTime sentAt, int? escalateAfterDays)
+    {
+        var lifetimeDays = escalateAfterDays is > 0 ? escalateAfterDays.Value : DefaultEscalateAfterDays;
+        return sentAt.AddDays(lifetimeDays);
     }
 }

--- a/server/src/Dotbot.Server/Services/MagicLinkService.cs
+++ b/server/src/Dotbot.Server/Services/MagicLinkService.cs
@@ -15,13 +15,13 @@ public class MagicLinkService
     internal const int DefaultEscalateAfterDays = 30;
 
     private readonly JwtSigningKeyProvider _keyProvider;
-    private readonly TokenStorageService _tokenStorage;
+    private readonly ITokenStorageService _tokenStorage;
     private readonly AuthSettings _settings;
     private readonly ILogger<MagicLinkService> _logger;
 
     public MagicLinkService(
         JwtSigningKeyProvider keyProvider,
-        TokenStorageService tokenStorage,
+        ITokenStorageService tokenStorage,
         IOptions<AuthSettings> settings,
         ILogger<MagicLinkService> logger)
     {

--- a/server/src/Dotbot.Server/Services/ReminderEscalationService.cs
+++ b/server/src/Dotbot.Server/Services/ReminderEscalationService.cs
@@ -45,7 +45,7 @@ public class ReminderEscalationService : BackgroundService
     private async Task ProcessCycleAsync(CancellationToken ct)
     {
         using var scope = _services.CreateScope();
-        var instanceStorage = scope.ServiceProvider.GetRequiredService<InstanceStorageService>();
+        var instanceStorage = scope.ServiceProvider.GetRequiredService<IInstanceStorageService>();
         var templateStorage = scope.ServiceProvider.GetRequiredService<ITemplateStorageService>();
         var responseStorage = scope.ServiceProvider.GetRequiredService<ResponseStorageService>();
         var orchestrator = scope.ServiceProvider.GetRequiredService<DeliveryOrchestrator>();

--- a/server/src/Dotbot.Server/Services/TokenStorageService.cs
+++ b/server/src/Dotbot.Server/Services/TokenStorageService.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 
 namespace Dotbot.Server.Services;
 
-public class TokenStorageService
+public class TokenStorageService : ITokenStorageService
 {
     private readonly BlobContainerClient _container;
     private readonly StoragePathResolver _paths;

--- a/server/src/Dotbot.Server/Validation/QuestionInstanceValidator.cs
+++ b/server/src/Dotbot.Server/Validation/QuestionInstanceValidator.cs
@@ -1,0 +1,91 @@
+using Dotbot.Server.Models;
+using System.Text.RegularExpressions;
+
+namespace Dotbot.Server.Validation;
+
+/// <summary>
+/// Boundary validation for <see cref="CreateInstanceRequest"/>. Mirrors the shape of
+/// <see cref="QuestionTemplateValidator"/>: a list of pure rules emitting human-readable
+/// strings, no exceptions. Wired into <c>POST /api/instances</c>.
+///
+/// Runtime / side-effectful checks stay in the endpoint:
+///   - JSON parse success (before the validator runs)
+///   - <c>InstanceId</c> default-fill (mutation, not validation)
+///   - Channel availability (depends on registered <c>IQuestionDeliveryProvider</c> set)
+///   - Template existence (async storage lookup)
+/// </summary>
+public class QuestionInstanceValidator
+{
+    // Same lenient email shape the endpoint used before this validator existed.
+    // Kept here as the canonical regex so future producers (push-back, dual-surface)
+    // can share it via the validator instead of re-implementing.
+    private static readonly Regex EmailPattern = new(
+        @"^[^@\s]+@[^@\s]+\.[^@\s]+$",
+        RegexOptions.Compiled);
+
+    private delegate IEnumerable<string> Rule(CreateInstanceRequest request);
+
+    private readonly Rule[] _rules;
+
+    public QuestionInstanceValidator()
+    {
+        _rules =
+        [
+            CheckQuestionId,
+            CheckJiraIssueKey,
+            CheckRecipientsPresent,
+            CheckRecipientEmails,
+            CheckDeliveryOverrides,
+        ];
+    }
+
+    public IReadOnlyList<string> Validate(CreateInstanceRequest request) =>
+        _rules.SelectMany(rule => rule(request)).ToList();
+
+    private IEnumerable<string> CheckQuestionId(CreateInstanceRequest r)
+    {
+        if (r.QuestionId == Guid.Empty)
+            yield return "questionId must be a GUID";
+    }
+
+    private IEnumerable<string> CheckJiraIssueKey(CreateInstanceRequest r)
+    {
+        if (r.Channel == "jira" && string.IsNullOrEmpty(r.JiraIssueKey))
+            yield return "jiraIssueKey is required when channel is 'jira'";
+    }
+
+    private IEnumerable<string> CheckRecipientsPresent(CreateInstanceRequest r)
+    {
+        var emails = r.Recipients?.Emails?.Count ?? 0;
+        var objectIds = r.Recipients?.UserObjectIds?.Count ?? 0;
+        var slackUserIds = r.Recipients?.SlackUserIds?.Count ?? 0;
+        if (emails == 0 && objectIds == 0 && slackUserIds == 0)
+            yield return "At least one email, userObjectId, or slackUserId is required in recipients";
+    }
+
+    private IEnumerable<string> CheckRecipientEmails(CreateInstanceRequest r)
+    {
+        var emails = r.Recipients?.Emails;
+        if (emails is null || emails.Count == 0) yield break;
+
+        var invalid = emails
+            .Where(e => string.IsNullOrWhiteSpace(e) || !EmailPattern.IsMatch(e))
+            .ToList();
+        if (invalid.Count > 0)
+            yield return $"Invalid email address(es): {string.Join(", ", invalid)}";
+    }
+
+    private IEnumerable<string> CheckDeliveryOverrides(CreateInstanceRequest r)
+    {
+        if (r.DeliveryOverrides is null) yield break;
+
+        // Range bounds match DeliveryDefaults in QuestionTemplateValidator. Centralised
+        // upper bounds live on DeliveryDefaults so both validators reference the same
+        // numeric value without sharing validator code.
+        if (r.DeliveryOverrides.ReminderAfterHours is { } rah && (rah < 1 || rah > DeliveryDefaults.MaxReminderAfterHours))
+            yield return $"deliveryOverrides.reminderAfterHours must be between 1 and {DeliveryDefaults.MaxReminderAfterHours} (got {rah})";
+
+        if (r.DeliveryOverrides.EscalateAfterDays is { } ead && (ead < 1 || ead > DeliveryDefaults.MaxEscalateAfterDays))
+            yield return $"deliveryOverrides.escalateAfterDays must be between 1 and {DeliveryDefaults.MaxEscalateAfterDays} (got {ead})";
+    }
+}

--- a/server/src/Dotbot.Server/Validation/QuestionTemplateValidator.cs
+++ b/server/src/Dotbot.Server/Validation/QuestionTemplateValidator.cs
@@ -23,6 +23,7 @@ public class QuestionTemplateValidator
             CheckOptionUniqueness,
             CheckAttachments,
             CheckReferenceLinks,
+            CheckDeliveryDefaults,
         ];
     }
 
@@ -95,6 +96,20 @@ public class QuestionTemplateValidator
             if (hasBlobPath && !IsSafeBlobPath(a.BlobPath!))
                 yield return $"attachments[{i}].blobPath must be a relative path with no '..' segments";
         }
+    }
+
+    private IEnumerable<string> CheckDeliveryDefaults(QuestionTemplate t)
+    {
+        if (t.DeliveryDefaults is null) yield break;
+
+        // Range bounds match DeliveryOverrides in QuestionInstanceValidator. Centralised
+        // upper bounds live on DeliveryDefaults so both validators reference the same
+        // numeric value without sharing validator code.
+        if (t.DeliveryDefaults.ReminderAfterHours is { } rah && (rah < 1 || rah > DeliveryDefaults.MaxReminderAfterHours))
+            yield return $"deliveryDefaults.reminderAfterHours must be between 1 and {DeliveryDefaults.MaxReminderAfterHours} (got {rah})";
+
+        if (t.DeliveryDefaults.EscalateAfterDays is { } ead && (ead < 1 || ead > DeliveryDefaults.MaxEscalateAfterDays))
+            yield return $"deliveryDefaults.escalateAfterDays must be between 1 and {DeliveryDefaults.MaxEscalateAfterDays} (got {ead})";
     }
 
     private IEnumerable<string> CheckReferenceLinks(QuestionTemplate t)

--- a/server/src/Dotbot.Server/appsettings.Example.json
+++ b/server/src/Dotbot.Server/appsettings.Example.json
@@ -51,7 +51,6 @@
   },
   "Auth": {
     "JwtSigningKey": "dev-only-signing-key-do-not-use-in-production-32chars!",
-    "MagicLinkExpiryMinutes": 60,
     "SeedAdministrators": [ "your.email@example.com" ]
   },
   "DeliveryChannels": {

--- a/server/src/Dotbot.Server/appsettings.json
+++ b/server/src/Dotbot.Server/appsettings.json
@@ -45,7 +45,6 @@
     "JwtSigningKey": "",
     "JwtIssuer": "dotbot",
     "JwtAudience": "dotbot-respond",
-    "MagicLinkExpiryMinutes": 15,
     "DeviceTokenExpiryDays": 90,
     "CookieName": "dotbot_device",
     "SeedAdministrators": []

--- a/server/terraform/main.tf
+++ b/server/terraform/main.tf
@@ -107,7 +107,6 @@ resource "azurerm_linux_web_app" "bot" {
     "Auth__KeyName"                 = azurerm_key_vault_key.jwt_signing.name
     "Auth__JwtIssuer"               = "dotbot"
     "Auth__JwtAudience"             = "dotbot-respond"
-    "Auth__MagicLinkExpiryMinutes"  = var.magic_link_expiry_minutes
     "Auth__DeviceTokenExpiryDays"   = var.device_token_expiry_days
 
     # Delivery channels

--- a/server/terraform/variables.tf
+++ b/server/terraform/variables.tf
@@ -62,13 +62,6 @@ variable "bot_sku" {
   default     = "F0"
 }
 
-# --- Auth / Magic Link ---
-variable "magic_link_expiry_minutes" {
-  description = "Magic link token expiry in minutes"
-  type        = number
-  default     = 43200
-}
-
 variable "device_token_expiry_days" {
   description = "Device token expiry in days"
   type        = number

--- a/server/tests/Dotbot.Server.Tests/Integration/DotbotApiFactory.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/DotbotApiFactory.cs
@@ -16,7 +16,10 @@ public sealed class DotbotApiFactory : WebApplicationFactory<Program>
     internal const int TestMaxAttachments = 2;
     internal const int TestMaxReferenceLinks = 2;
 
-    public InMemoryTemplateStorage Storage { get; } = new();
+    public InMemoryTemplateStorage TemplateStorage { get; } = new();
+    public InMemoryInstanceStorage InstanceStorage { get; } = new();
+    public InMemoryTokenStorage TokenStorage { get; } = new();
+    public InMemoryAttachmentStorage AttachmentStorage { get; } = new();
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -30,6 +33,9 @@ public sealed class DotbotApiFactory : WebApplicationFactory<Program>
         builder.UseSetting("Auth:JwtSigningKey", "integration-test-signing-key-32-chars!!");
         builder.UseSetting("Auth:JwtIssuer", "dotbot-test");
         builder.UseSetting("Auth:JwtAudience", "dotbot-test");
+
+        // Enable test-mode endpoints (mint magic links etc.) for integration tests.
+        Environment.SetEnvironmentVariable("DOTBOT_TEST_MODE", "true");
 
         builder.ConfigureServices(services =>
         {
@@ -53,14 +59,20 @@ public sealed class DotbotApiFactory : WebApplicationFactory<Program>
             foreach (var descriptor in hostedServicesToRemove)
                 services.Remove(descriptor);
 
-            // Replace the three DI-blocking services with in-process test doubles.
+            // Replace DI-blocking services with in-process test doubles.
             services.RemoveAll<ITemplateStorageService>();
             services.RemoveAll<IAdministratorService>();
             services.RemoveAll<IConversationReferenceStore>();
+            services.RemoveAll<IInstanceStorageService>();
+            services.RemoveAll<ITokenStorageService>();
+            services.RemoveAll<Dotbot.Server.Services.Attachments.IAttachmentStorage>();
 
-            services.AddSingleton<ITemplateStorageService>(Storage);
+            services.AddSingleton<ITemplateStorageService>(TemplateStorage);
             services.AddSingleton<IAdministratorService>(new NullAdministratorService());
             services.AddSingleton<IConversationReferenceStore>(new NullConversationReferenceStore());
+            services.AddSingleton<IInstanceStorageService>(InstanceStorage);
+            services.AddSingleton<ITokenStorageService>(TokenStorage);
+            services.AddSingleton<Dotbot.Server.Services.Attachments.IAttachmentStorage>(AttachmentStorage);
         });
     }
 }

--- a/server/tests/Dotbot.Server.Tests/Integration/IntegrationTestBase.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/IntegrationTestBase.cs
@@ -5,18 +5,25 @@ namespace Dotbot.Server.Tests.Integration;
 public abstract class IntegrationTestBase : IClassFixture<DotbotApiFactory>, IAsyncLifetime
 {
     protected HttpClient Client { get; }
-    protected InMemoryTemplateStorage Storage { get; }
+    protected DotbotApiFactory Factory { get; }
 
     protected IntegrationTestBase(DotbotApiFactory factory)
     {
-        Client = factory.CreateClient();
+        // Browser-style client so cookie set by /respond consumption survives redirects.
+        Client = factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+        });
         Client.DefaultRequestHeaders.Add("X-Api-Key", DotbotApiFactory.TestApiKey);
-        Storage = factory.Storage;
+        Factory = factory;
     }
 
     public async Task InitializeAsync()
     {
-        await Storage.ResetAsync();
+        await Factory.TemplateStorage.ResetAsync();
+        await Factory.InstanceStorage.ResetAsync();
+        await Factory.TokenStorage.ResetAsync();
+        await Factory.AttachmentStorage.ResetAsync();
     }
 
     public Task DisposeAsync() => Task.CompletedTask;

--- a/server/tests/Dotbot.Server.Tests/Integration/IntegrationTestBase.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/IntegrationTestBase.cs
@@ -9,7 +9,9 @@ public abstract class IntegrationTestBase : IClassFixture<DotbotApiFactory>, IAs
 
     protected IntegrationTestBase(DotbotApiFactory factory)
     {
-        // Browser-style client so cookie set by /respond consumption survives redirects.
+        // Disable auto-redirect so middleware tests can assert the 302 + Set-Cookie that
+        // /respond returns on JTI consumption, rather than the redirected GET that follows.
+        // HttpClient still tracks Set-Cookie headers regardless of this flag.
         Client = factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
         {
             AllowAutoRedirect = false,

--- a/server/tests/Dotbot.Server.Tests/Integration/MagicLinkMiddlewareTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/MagicLinkMiddlewareTests.cs
@@ -1,0 +1,211 @@
+using Dotbot.Server.Models;
+using System.Net;
+using System.Net.Http.Json;
+
+namespace Dotbot.Server.Tests.Integration;
+
+/// <summary>
+/// End-to-end coverage of <see cref="Dotbot.Server.MagicLinkAuthMiddleware"/>.
+/// Exercises the four user-visible status codes the middleware emits, plus the
+/// happy path through to the attachment endpoint, against in-memory storage
+/// doubles registered by <see cref="DotbotApiFactory"/>.
+/// </summary>
+public sealed class MagicLinkMiddlewareTests(DotbotApiFactory factory)
+    : IntegrationTestBase(factory)
+{
+    private const string ProjectId = "p-mw";
+
+    // Both protected surfaces - shared by Theory data so endpoint-symmetric
+    // rejection rules are checked against each one.
+    private const string AttachmentPathStub = "/api/attachments/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/file.pdf";
+    private const string RespondPathStub = "/respond";
+
+    /// <summary>
+    /// Builds a published template (in InMemoryTemplateStorage) carrying one attachment,
+    /// an instance pointing at it (in InMemoryInstanceStorage), and seeds the attachment
+    /// bytes (in InMemoryAttachmentStorage). Returns the storageRef so callers can hit
+    /// <c>GET /api/attachments/{storageRef}</c> against the instance.
+    /// </summary>
+    private async Task<(Guid InstanceId, string StorageRef)> SeedAttachmentScenarioAsync(
+        byte[]? content = null, string suffix = "primary")
+    {
+        var questionId = Guid.NewGuid();
+        var attachmentId = Guid.NewGuid();
+        var storageRef = $"{attachmentId}/{suffix}.pdf";
+        var bytes = content ?? System.Text.Encoding.UTF8.GetBytes($"contents-of-{suffix}");
+
+        Factory.AttachmentStorage.Seed(storageRef, bytes, "application/pdf", name: $"{suffix}.pdf");
+
+        var template = new QuestionTemplate
+        {
+            QuestionId = questionId,
+            Version = 1,
+            Title = $"Review {suffix}",
+            Type = QuestionTypes.DocumentReview,
+            DeliverableSummary = "review",
+            Options = new(),
+            Project = new ProjectRef { ProjectId = ProjectId, Name = "MW" },
+            Attachments = new List<QuestionAttachment>
+            {
+                new() { AttachmentId = attachmentId, Name = $"{suffix}.pdf", BlobPath = storageRef, MediaType = "application/pdf" },
+            },
+        };
+        await Factory.TemplateStorage.SaveTemplateAsync(template);
+
+        var instanceId = Guid.NewGuid();
+        await Factory.InstanceStorage.SaveInstanceAsync(new QuestionInstance
+        {
+            InstanceId = instanceId,
+            QuestionId = questionId,
+            QuestionVersion = 1,
+            ProjectId = ProjectId,
+        });
+
+        return (instanceId, storageRef);
+    }
+
+    private async Task<string> MintTokenAsync(Guid instanceId, string email = "reviewer@example.com")
+    {
+        var resp = await Client.PostAsJsonAsync("/api/test/magic-link", new
+        {
+            projectId = ProjectId,
+            instanceId,
+            recipientEmail = email,
+        });
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<MintMagicLinkResponse>();
+        return body!.Token;
+    }
+
+    // ── Symmetric rejection rules: same outcome on /api/attachments + /respond ──
+    //
+    // The middleware short-circuits before any storage lookup for these three
+    // cases, so the URL only needs to be on a protected path. Theories collapse
+    // the (attachment-path, respond-path) duplication.
+
+    [Theory]
+    [InlineData(AttachmentPathStub)]
+    [InlineData(RespondPathStub)]
+    public async Task Middleware_NoToken_Returns401(string path)
+    {
+        var resp = await Client.GetAsync(path);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(AttachmentPathStub + "?token=garbage.garbage.garbage")]
+    [InlineData(RespondPathStub + "?token=garbage.garbage.garbage")]
+    public async Task Middleware_UnparseableToken_Returns401(string path)
+    {
+        // Pre-fix this returned 500: ArgumentException from JwtSecurityTokenHandler
+        // wasn't caught alongside SecurityTokenException.
+        var resp = await Client.GetAsync(path);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("/api/attachments/{ref}?token={token}")]
+    [InlineData("/respond?token={token}")]
+    public async Task Middleware_ExpiredJtiBlob_Returns410Gone(string urlTemplate)
+    {
+        // JWT exp is in the future (30-day default) but the persisted JTI blob's
+        // ExpiresAt is in the past. The middleware's belt-and-braces second check
+        // must trip and emit 410 Gone for BOTH protected surfaces, not 401.
+        var (instanceId, storageRef) = await SeedAttachmentScenarioAsync();
+        var token = await MintTokenAsync(instanceId);
+        var jti = Factory.TokenStorage.Jtis.Keys.Single();
+        Factory.TokenStorage.Jtis[jti].ExpiresAt = DateTime.UtcNow.AddDays(-1);
+
+        var url = urlTemplate.Replace("{ref}", storageRef).Replace("{token}", token);
+        var resp = await Client.GetAsync(url);
+
+        Assert.Equal(HttpStatusCode.Gone, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("expired", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── Attachment-specific cases (ownership + tampered sig + consumed JTI + happy) ──
+    //
+    // These only apply to /api/attachments. /respond's analogous "wrong instance"
+    // doesn't exist (any valid JWT for any instance is allowed to view its own
+    // /respond page), so they aren't symmetric.
+
+    [Fact]
+    public async Task GetAttachment_TamperedSignature_Returns401()
+    {
+        var (instanceId, storageRef) = await SeedAttachmentScenarioAsync();
+        var token = await MintTokenAsync(instanceId);
+        var tampered = token[..^5] + "XXXXX";
+
+        var resp = await Client.GetAsync($"/api/attachments/{storageRef}?token={tampered}");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAttachment_WrongInstanceJwt_Returns403()
+    {
+        // Two independent (instance, template, attachment) trios. Token for instance B
+        // hits instance A's storageRef - the middleware ownership check rejects it
+        // because the storageRef isn't referenced by instance B's template.
+        var (_, storageRefA) = await SeedAttachmentScenarioAsync(suffix: "a");
+        var (instanceB, _) = await SeedAttachmentScenarioAsync(suffix: "b");
+        var tokenB = await MintTokenAsync(instanceB);
+
+        var resp = await Client.GetAsync($"/api/attachments/{storageRefA}?token={tokenB}");
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("does not grant access", body);
+    }
+
+    [Fact]
+    public async Task GetAttachment_ConsumedJti_Returns401()
+    {
+        // Belt-and-braces: a consumed JTI must not be reusable for attachment downloads
+        // even before the JWT exp claim expires.
+        var (instanceId, storageRef) = await SeedAttachmentScenarioAsync();
+        var token = await MintTokenAsync(instanceId);
+        var jti = Factory.TokenStorage.Jtis.Keys.Single();
+        await Factory.TokenStorage.TryMarkMagicLinkUsedAsync(jti, "device-1");
+
+        var resp = await Client.GetAsync($"/api/attachments/{storageRef}?token={token}");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAttachment_ValidToken_Returns200WithBytes()
+    {
+        var content = System.Text.Encoding.UTF8.GetBytes("happy-path-bytes");
+        var (instanceId, storageRef) = await SeedAttachmentScenarioAsync(content: content);
+        var token = await MintTokenAsync(instanceId);
+
+        var resp = await Client.GetAsync($"/api/attachments/{storageRef}?token={token}");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("application/pdf", resp.Content.Headers.ContentType?.MediaType);
+        var streamed = await resp.Content.ReadAsByteArrayAsync();
+        Assert.Equal(content, streamed);
+    }
+
+    // ── /respond-only HEAD semantics ───────────────────────────────────────
+
+    [Fact]
+    public async Task HeadRespond_NeverConsumesToken_Returns200()
+    {
+        // Teams (and other clients) issue HEAD previews. Must not consume the JTI.
+        var (instanceId, _) = await SeedAttachmentScenarioAsync();
+        var token = await MintTokenAsync(instanceId);
+        var jti = Factory.TokenStorage.Jtis.Keys.Single();
+
+        var resp = await Client.SendAsync(new HttpRequestMessage(HttpMethod.Head, $"/respond?token={token}"));
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.False(Factory.TokenStorage.Jtis[jti].Used);
+    }
+
+    private sealed record MintMagicLinkResponse(string Token, string RedemptionUrl);
+}

--- a/server/tests/Dotbot.Server.Tests/Integration/PostTemplatesTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/PostTemplatesTests.cs
@@ -57,7 +57,7 @@ public class PostTemplatesTests : IntegrationTestBase
         var response = await Client.PostAsync("/api/templates", Json(template));
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        Assert.Single(Storage.Saved, t => t.QuestionId == template.QuestionId);
+        Assert.Single(Factory.TemplateStorage.Saved, t => t.QuestionId == template.QuestionId);
         var location = response.Headers.Location?.ToString();
         Assert.NotNull(location);
         Assert.Contains(template.QuestionId.ToString(), location);
@@ -71,7 +71,7 @@ public class PostTemplatesTests : IntegrationTestBase
         var response = await Client.PostAsync("/api/templates", Json(template));
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        Assert.Single(Storage.Saved, t => t.QuestionId == template.QuestionId);
+        Assert.Single(Factory.TemplateStorage.Saved, t => t.QuestionId == template.QuestionId);
         var location = response.Headers.Location?.ToString();
         Assert.NotNull(location);
         Assert.Contains(template.QuestionId.ToString(), location);

--- a/server/tests/Dotbot.Server.Tests/Integration/TestDoubles/InMemoryAttachmentStorage.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/TestDoubles/InMemoryAttachmentStorage.cs
@@ -1,0 +1,55 @@
+using Dotbot.Server.Services.Attachments;
+
+namespace Dotbot.Server.Tests.Integration.TestDoubles;
+
+/// <summary>
+/// In-memory <see cref="IAttachmentStorage"/> for integration tests. Storage refs are
+/// the canonical <c>{attachmentGuid}/{fileName}</c> shape so middleware path-matching
+/// against <see cref="Dotbot.Server.Models.QuestionAttachment.BlobPath"/> resolves correctly.
+/// </summary>
+public sealed class InMemoryAttachmentStorage : IAttachmentStorage
+{
+    private readonly Dictionary<string, (byte[] Content, string ContentType, string Name)> _store = new();
+
+    public IReadOnlyDictionary<string, (byte[] Content, string ContentType, string Name)> Saved => _store;
+
+    public Task ResetAsync()
+    {
+        _store.Clear();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Test seed helper - pre-populates an attachment with a known storageRef so a
+    /// matching <see cref="Dotbot.Server.Models.QuestionAttachment"/> can reference
+    /// it without going through the real upload path.
+    /// </summary>
+    public void Seed(string storageRef, byte[] content, string contentType = "text/plain", string? name = null)
+    {
+        _store[storageRef] = (content, contentType, name ?? Path.GetFileName(storageRef));
+    }
+
+    public Task<AttachmentUploadResult> UploadAsync(
+        string fileName, string contentType, Stream content, long sizeBytes, CancellationToken ct = default)
+    {
+        var attachmentId = Guid.NewGuid();
+        var storageRef = $"{attachmentId}/{fileName}";
+        using var ms = new MemoryStream();
+        content.CopyTo(ms);
+        _store[storageRef] = (ms.ToArray(), contentType, fileName);
+        return Task.FromResult(new AttachmentUploadResult(attachmentId, storageRef, fileName, contentType, sizeBytes));
+    }
+
+    public Task<(Stream Content, string ContentType)?> DownloadAsync(string storageRef, CancellationToken ct = default)
+    {
+        if (!_store.TryGetValue(storageRef, out var v))
+            return Task.FromResult<(Stream, string)?>(null);
+        return Task.FromResult<(Stream, string)?>((new MemoryStream(v.Content), v.ContentType));
+    }
+
+    public Task DeleteAsync(string storageRef, CancellationToken ct = default)
+    {
+        _store.Remove(storageRef);
+        return Task.CompletedTask;
+    }
+}

--- a/server/tests/Dotbot.Server.Tests/Integration/TestDoubles/InMemoryInstanceStorage.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/TestDoubles/InMemoryInstanceStorage.cs
@@ -1,0 +1,49 @@
+using Dotbot.Server.Models;
+using Dotbot.Server.Services;
+
+namespace Dotbot.Server.Tests.Integration.TestDoubles;
+
+/// <summary>
+/// In-memory <see cref="IInstanceStorageService"/> for integration tests.
+/// Stores <see cref="QuestionInstance"/> by (projectId, instanceId) so middleware /
+/// dashboard ownership lookups resolve without hitting Azurite.
+/// </summary>
+public sealed class InMemoryInstanceStorage : IInstanceStorageService
+{
+    private readonly Dictionary<(string ProjectId, Guid InstanceId), QuestionInstance> _store = new();
+
+    public IReadOnlyDictionary<(string ProjectId, Guid InstanceId), QuestionInstance> Saved => _store;
+
+    public Task ResetAsync()
+    {
+        _store.Clear();
+        return Task.CompletedTask;
+    }
+
+    public Task SaveInstanceAsync(QuestionInstance instance)
+    {
+        _store[(instance.ProjectId, instance.InstanceId)] = instance;
+        return Task.CompletedTask;
+    }
+
+    public Task<QuestionInstance?> GetInstanceAsync(string projectId, Guid instanceId)
+        => Task.FromResult(_store.TryGetValue((projectId, instanceId), out var v) ? v : null);
+
+    public async IAsyncEnumerable<QuestionInstance> ListActiveInstancesAsync()
+    {
+        foreach (var i in _store.Values)
+            if (i.OverallStatus == "active")
+                yield return i;
+        await Task.CompletedTask;
+    }
+
+    public async IAsyncEnumerable<QuestionInstance> ListAllInstancesAsync()
+    {
+        foreach (var i in _store.Values)
+            yield return i;
+        await Task.CompletedTask;
+    }
+
+    public Task<bool> DeleteInstanceAsync(string projectId, Guid instanceId)
+        => Task.FromResult(_store.Remove((projectId, instanceId)));
+}

--- a/server/tests/Dotbot.Server.Tests/Integration/TestDoubles/InMemoryTokenStorage.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/TestDoubles/InMemoryTokenStorage.cs
@@ -1,0 +1,72 @@
+using Dotbot.Server.Models;
+using Dotbot.Server.Services;
+
+namespace Dotbot.Server.Tests.Integration.TestDoubles;
+
+/// <summary>
+/// In-memory <see cref="ITokenStorageService"/> for integration tests. Holds magic-link
+/// JTI blobs and device-token blobs keyed by their respective ids; supports the
+/// atomic mark-used path the middleware relies on.
+/// </summary>
+public sealed class InMemoryTokenStorage : ITokenStorageService
+{
+    private readonly Dictionary<string, MagicLinkToken> _jtis = new();
+    private readonly Dictionary<string, DeviceToken> _devices = new();
+    private readonly object _gate = new();
+
+    public IReadOnlyDictionary<string, MagicLinkToken> Jtis => _jtis;
+    public IReadOnlyDictionary<string, DeviceToken> Devices => _devices;
+
+    public Task ResetAsync()
+    {
+        lock (_gate) { _jtis.Clear(); _devices.Clear(); }
+        return Task.CompletedTask;
+    }
+
+    public Task SaveMagicLinkTokenAsync(MagicLinkToken token)
+    {
+        lock (_gate) { _jtis[token.Jti] = token; }
+        return Task.CompletedTask;
+    }
+
+    public Task<MagicLinkToken?> GetMagicLinkTokenAsync(string jti)
+    {
+        lock (_gate) { return Task.FromResult(_jtis.TryGetValue(jti, out var v) ? v : null); }
+    }
+
+    public Task<bool> TryMarkMagicLinkUsedAsync(string jti, string deviceTokenId)
+    {
+        lock (_gate)
+        {
+            if (!_jtis.TryGetValue(jti, out var token) || token.Used)
+                return Task.FromResult(false);
+            token.Used = true;
+            token.UsedAt = DateTime.UtcNow;
+            token.UsedByDeviceTokenId = deviceTokenId;
+            return Task.FromResult(true);
+        }
+    }
+
+    public Task SaveDeviceTokenAsync(DeviceToken token)
+    {
+        lock (_gate) { _devices[token.DeviceTokenId] = token; }
+        return Task.CompletedTask;
+    }
+
+    public Task<DeviceToken?> GetDeviceTokenAsync(string deviceTokenId)
+    {
+        lock (_gate) { return Task.FromResult(_devices.TryGetValue(deviceTokenId, out var v) ? v : null); }
+    }
+
+    public Task<bool> RevokeDeviceTokenAsync(string deviceTokenId)
+    {
+        lock (_gate)
+        {
+            if (!_devices.TryGetValue(deviceTokenId, out var d) || d.Revoked)
+                return Task.FromResult(false);
+            d.Revoked = true;
+            d.RevokedAt = DateTime.UtcNow;
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/server/tests/Dotbot.Server.Tests/Unit/EmailDeliveryProviderRenderingTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/EmailDeliveryProviderRenderingTests.cs
@@ -15,24 +15,6 @@ public class EmailDeliveryProviderRenderingTests
         ProjectName = "Project One",
         DeliverableSummary = "Sign-off needed on the v2 architecture proposal.",
         Context = "We are choosing between two patterns; a third is out due to cost.",
-        BatchQuestions =
-        {
-            new BatchQuestionRef
-            {
-                QuestionId = Guid.NewGuid(),
-                Title = "Pick the migration strategy",
-                Type = "approval",
-                IsAnswered = true,
-                AnsweredSummary = "Approved",
-            },
-            new BatchQuestionRef
-            {
-                QuestionId = Guid.NewGuid(),
-                Title = "Confirm rollback window",
-                Type = "freeText",
-                IsAnswered = false,
-            },
-        },
         Attachments =
         {
             new AttachmentRef { Name = "diagram.pdf", ContentType = "application/pdf", SizeBytes = 245_678 },
@@ -61,12 +43,6 @@ public class EmailDeliveryProviderRenderingTests
         Assert.Contains("Sign-off needed on the v2 architecture proposal.", html);
         Assert.Contains("We are choosing between two patterns", html);
 
-        // Batch entries
-        Assert.Contains("Pick the migration strategy", html);
-        Assert.Contains("&#10003;", html);                 // ✓ marker on answered entry (Outlook-safe entity)
-        Assert.Contains("Approved", html);                 // AnsweredSummary text
-        Assert.Contains("Confirm rollback window", html);
-
         // Attachments — name + formatted size
         Assert.Contains("diagram.pdf", html);
         Assert.Contains("239.9 KB", html);                   // 245_678 / 1024 = 239
@@ -89,19 +65,17 @@ public class EmailDeliveryProviderRenderingTests
         Assert.Contains($"href=\"{DefaultRespondUrl}\"", html);
         Assert.Contains("Respond Now", html);
 
-        // Ordering — header → summary → context → batch → attachments → review-links → due-by → CTA
+        // Ordering — header → summary → context → attachments → review-links → due-by → CTA
         var idxTitle = html.IndexOf("Approve architecture v2", StringComparison.Ordinal);
         var idxDeliverable = html.IndexOf("Sign-off needed", StringComparison.Ordinal);
         var idxContext = html.IndexOf("two patterns", StringComparison.Ordinal);
-        var idxBatch = html.IndexOf("Pick the migration strategy", StringComparison.Ordinal);
         var idxAttach = html.IndexOf("diagram.pdf", StringComparison.Ordinal);
         var idxReview = html.IndexOf("Confluence design doc", StringComparison.Ordinal);
         var idxDue = html.IndexOf("Due by:", StringComparison.Ordinal);
         var idxCta = html.IndexOf("Respond Now</a>", StringComparison.Ordinal);
         Assert.True(idxTitle < idxDeliverable, "title before deliverable summary");
         Assert.True(idxDeliverable < idxContext, "deliverable before context");
-        Assert.True(idxContext < idxBatch, "context before batch");
-        Assert.True(idxBatch < idxAttach, "batch before attachments");
+        Assert.True(idxContext < idxAttach, "context before attachments");
         Assert.True(idxAttach < idxReview, "attachments before review links");
         Assert.True(idxReview < idxDue, "review links before due-by");
         Assert.True(idxDue < idxCta, "due-by before CTA");

--- a/server/tests/Dotbot.Server.Tests/Unit/JiraDeliveryProviderRenderingTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/JiraDeliveryProviderRenderingTests.cs
@@ -14,24 +14,6 @@ public class JiraDeliveryProviderRenderingTests
         ProjectName = "Project One",
         DeliverableSummary = "Sign-off needed on the v2 architecture proposal.",
         Context = "We are choosing between two patterns; a third is out due to cost.",
-        BatchQuestions =
-        {
-            new BatchQuestionRef
-            {
-                QuestionId = Guid.NewGuid(),
-                Title = "Pick the migration strategy",
-                Type = "approval",
-                IsAnswered = true,
-                AnsweredSummary = "Approved",
-            },
-            new BatchQuestionRef
-            {
-                QuestionId = Guid.NewGuid(),
-                Title = "Confirm rollback window",
-                Type = "freeText",
-                IsAnswered = false,
-            },
-        },
         Attachments =
         {
             new AttachmentRef { Name = "diagram.pdf", ContentType = "application/pdf", SizeBytes = 245_678 },
@@ -61,10 +43,6 @@ public class JiraDeliveryProviderRenderingTests
             "Sign-off needed on the v2 architecture proposal.\n" +
             "\n" +
             "_We are choosing between two patterns; a third is out due to cost._\n" +
-            "\n" +
-            "*Questions in this batch:*\n" +
-            "* ✓ Pick the migration strategy _(approval)_ — Approved\n" +
-            "* Confirm rollback window _(freeText)_\n" +
             "\n" +
             "*Attachments:*\n" +
             "* diagram.pdf _(239.9 KB)_\n" +
@@ -96,10 +74,6 @@ public class JiraDeliveryProviderRenderingTests
             "h3. Approve architecture v2\n" +
             "\n" +
             "*Project:* Project One | *Type:* approval\n" +
-            "\n" +
-            "*Questions in this batch:*\n" +
-            "* ✓ Pick the migration strategy _(approval)_ — Approved\n" +
-            "* Confirm rollback window _(freeText)_\n" +
             "\n" +
             "[Respond Now|https://example/respond/abc]\n";
 

--- a/server/tests/Dotbot.Server.Tests/Unit/MagicLinkExpiryTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/MagicLinkExpiryTests.cs
@@ -1,0 +1,47 @@
+using Dotbot.Server.Services;
+
+namespace Dotbot.Server.Tests.Unit;
+
+public class MagicLinkExpiryTests
+{
+    private static readonly DateTime SentAt = new(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void Null_FallsBackTo30Days()
+    {
+        var exp = MagicLinkService.ComputeExpiry(SentAt, escalateAfterDays: null);
+        Assert.Equal(SentAt.AddDays(MagicLinkService.DefaultEscalateAfterDays), exp);
+        Assert.Equal(SentAt.AddDays(30), exp);
+    }
+
+    [Fact]
+    public void Positive_HonouredVerbatim()
+    {
+        var exp = MagicLinkService.ComputeExpiry(SentAt, escalateAfterDays: 7);
+        Assert.Equal(SentAt.AddDays(7), exp);
+    }
+
+    [Fact]
+    public void Zero_FallsBackTo30Days()
+    {
+        // Zero is not a valid lifetime — treat the same as null. Catches misconfigured
+        // templates from being silently shrunk to "expires immediately".
+        var exp = MagicLinkService.ComputeExpiry(SentAt, escalateAfterDays: 0);
+        Assert.Equal(SentAt.AddDays(30), exp);
+    }
+
+    [Fact]
+    public void Negative_FallsBackTo30Days()
+    {
+        var exp = MagicLinkService.ComputeExpiry(SentAt, escalateAfterDays: -5);
+        Assert.Equal(SentAt.AddDays(30), exp);
+    }
+
+    [Fact]
+    public void DefaultEscalateAfterDays_Is30()
+    {
+        // Locked by PRD-029 §5.3. Surfaced as a constant so callers (and tests) can
+        // assert the contract instead of duplicating the number.
+        Assert.Equal(30, MagicLinkService.DefaultEscalateAfterDays);
+    }
+}

--- a/server/tests/Dotbot.Server.Tests/Unit/NotificationSummaryBuilderTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/NotificationSummaryBuilderTests.cs
@@ -94,27 +94,6 @@ public class NotificationSummaryBuilderTests
     }
 
     [Fact]
-    public void BatchQuestions_SingleEntryFromTemplate()
-    {
-        var qid = Guid.NewGuid();
-        var t = Template(questionId: qid, title: "Q1", type: "approval");
-        var bq = Assert.Single(Build(t).BatchQuestions);
-
-        Assert.Equal(qid, bq.QuestionId);
-        Assert.Equal("Q1", bq.Title);
-        Assert.Equal("approval", bq.Type);
-    }
-
-    [Fact]
-    public void BatchQuestions_AnsweredStateAtDefault()
-    {
-        // Locks the deferred-population contract — see #289.
-        var bq = Assert.Single(Build(Template()).BatchQuestions);
-        Assert.False(bq.IsAnswered);
-        Assert.Null(bq.AnsweredSummary);
-    }
-
-    [Fact]
     public void Attachments_MappedWithMediaTypeFallback()
     {
         var t = Template(attachments: new List<QuestionAttachment>

--- a/server/tests/Dotbot.Server.Tests/Unit/QuestionInstanceValidatorTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/QuestionInstanceValidatorTests.cs
@@ -1,0 +1,180 @@
+using Dotbot.Server.Models;
+using Dotbot.Server.Validation;
+
+namespace Dotbot.Server.Tests.Unit;
+
+public class QuestionInstanceValidatorTests
+{
+    private static readonly QuestionInstanceValidator Validator = new();
+
+    private static CreateInstanceRequest Request(
+        Guid? questionId = null,
+        string? channel = "teams",
+        string? jiraIssueKey = null,
+        Recipients? recipients = null,
+        DeliveryOverrides? overrides = null) => new()
+    {
+        ProjectId = "p1",
+        QuestionId = questionId ?? Guid.NewGuid(),
+        QuestionVersion = 1,
+        Channel = channel!,
+        JiraIssueKey = jiraIssueKey,
+        Recipients = recipients ?? new Recipients { Emails = new() { "a@b.co" } },
+        DeliveryOverrides = overrides,
+    };
+
+    [Fact]
+    public void Minimal_NoError()
+    {
+        Assert.Empty(Validator.Validate(Request()));
+    }
+
+    // ── QuestionId ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EmptyQuestionId_Error()
+    {
+        var errors = Validator.Validate(Request(questionId: Guid.Empty));
+        Assert.Single(errors);
+        Assert.Contains("questionId", errors[0]);
+    }
+
+    // ── JiraIssueKey ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void JiraChannel_NoIssueKey_Error()
+    {
+        var errors = Validator.Validate(Request(channel: "jira"));
+        Assert.Single(errors);
+        Assert.Contains("jiraIssueKey", errors[0]);
+    }
+
+    [Fact]
+    public void JiraChannel_WithIssueKey_NoError()
+    {
+        Assert.Empty(Validator.Validate(Request(channel: "jira", jiraIssueKey: "PROJ-1")));
+    }
+
+    [Theory]
+    [InlineData("teams")]
+    [InlineData("email")]
+    [InlineData("slack")]
+    public void NonJiraChannel_MissingIssueKey_NoError(string channel)
+    {
+        Assert.Empty(Validator.Validate(Request(channel: channel)));
+    }
+
+    // ── Recipients ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void NoRecipientsAtAll_Error()
+    {
+        var errors = Validator.Validate(Request(recipients: new Recipients()));
+        Assert.Single(errors);
+        Assert.Contains("recipients", errors[0]);
+    }
+
+    [Theory]
+    [InlineData("no-at-sign")]
+    [InlineData("@nouser.com")]
+    [InlineData("user@")]
+    [InlineData("user@nodot")]
+    [InlineData("  ")]
+    public void InvalidEmail_Error(string email)
+    {
+        var r = Request(recipients: new Recipients { Emails = new() { email } });
+        var errors = Validator.Validate(r);
+        Assert.Single(errors);
+        Assert.Contains("Invalid email", errors[0]);
+    }
+
+    [Fact]
+    public void InvalidEmailListed_ReportsAllOffenders()
+    {
+        var r = Request(recipients: new Recipients
+        {
+            Emails = new() { "ok@a.co", "bad", "alsobad" },
+        });
+        var errors = Validator.Validate(r);
+        Assert.Single(errors);
+        Assert.Contains("bad", errors[0]);
+        Assert.Contains("alsobad", errors[0]);
+    }
+
+    [Fact]
+    public void RecipientsWithOnlyObjectIds_NoError()
+    {
+        var r = Request(recipients: new Recipients { UserObjectIds = new() { "aad-123" } });
+        Assert.Empty(Validator.Validate(r));
+    }
+
+    [Fact]
+    public void RecipientsWithOnlySlackUserIds_NoError()
+    {
+        var r = Request(recipients: new Recipients { SlackUserIds = new() { "U123" } });
+        Assert.Empty(Validator.Validate(r));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(24)]
+    [InlineData(DeliveryDefaults.MaxReminderAfterHours)]
+    public void DeliveryOverrides_ReminderAfterHours_InRange_NoError(int value)
+    {
+        var r = Request(overrides: new DeliveryOverrides { ReminderAfterHours = value });
+        Assert.Empty(Validator.Validate(r));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(DeliveryDefaults.MaxReminderAfterHours + 1)]
+    [InlineData(int.MaxValue)]
+    public void DeliveryOverrides_ReminderAfterHours_OutOfRange_Error(int value)
+    {
+        var r = Request(overrides: new DeliveryOverrides { ReminderAfterHours = value });
+        var errors = Validator.Validate(r);
+        Assert.Single(errors);
+        Assert.Contains("reminderAfterHours", errors[0]);
+        Assert.Contains("deliveryOverrides", errors[0]);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(30)]
+    [InlineData(DeliveryDefaults.MaxEscalateAfterDays)]
+    public void DeliveryOverrides_EscalateAfterDays_InRange_NoError(int value)
+    {
+        var r = Request(overrides: new DeliveryOverrides { EscalateAfterDays = value });
+        Assert.Empty(Validator.Validate(r));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(DeliveryDefaults.MaxEscalateAfterDays + 1)]
+    [InlineData(int.MaxValue)]
+    public void DeliveryOverrides_EscalateAfterDays_OutOfRange_Error(int value)
+    {
+        var r = Request(overrides: new DeliveryOverrides { EscalateAfterDays = value });
+        var errors = Validator.Validate(r);
+        Assert.Single(errors);
+        Assert.Contains("escalateAfterDays", errors[0]);
+        Assert.Contains("deliveryOverrides", errors[0]);
+    }
+
+    [Fact]
+    public void DeliveryOverrides_BothFieldsBad_TwoErrors()
+    {
+        // Per-field error emission so callers see all reasons at once.
+        var r = Request(overrides: new DeliveryOverrides
+        {
+            ReminderAfterHours = int.MaxValue,
+            EscalateAfterDays = int.MaxValue,
+        });
+        var errors = Validator.Validate(r);
+        Assert.Equal(2, errors.Count);
+        Assert.Contains(errors, e => e.Contains("reminderAfterHours"));
+        Assert.Contains(errors, e => e.Contains("escalateAfterDays"));
+    }
+}

--- a/server/tests/Dotbot.Server.Tests/Unit/QuestionTemplateValidatorTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/QuestionTemplateValidatorTests.cs
@@ -484,6 +484,83 @@ public class QuestionTemplateValidatorTests
         Assert.Contains("null", errors[0]);
     }
 
+    // ── DeliveryDefaults bounds ────────────────────────────────────────────
+
+    [Fact]
+    public void DeliveryDefaults_Null_NoError()
+    {
+        var t = Template();
+        t.DeliveryDefaults = null;
+        Assert.Empty(Validate(t));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(24)]
+    [InlineData(DeliveryDefaults.MaxReminderAfterHours)]
+    public void DeliveryDefaults_ReminderAfterHours_InRange_NoError(int value)
+    {
+        var t = Template();
+        t.DeliveryDefaults = new DeliveryDefaults { ReminderAfterHours = value };
+        Assert.Empty(Validate(t));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(DeliveryDefaults.MaxReminderAfterHours + 1)]
+    [InlineData(int.MaxValue)]
+    public void DeliveryDefaults_ReminderAfterHours_OutOfRange_Error(int value)
+    {
+        var t = Template();
+        t.DeliveryDefaults = new DeliveryDefaults { ReminderAfterHours = value };
+        var errors = Validate(t);
+        Assert.Single(errors);
+        Assert.Contains("reminderAfterHours", errors[0]);
+        Assert.Contains("deliveryDefaults", errors[0]);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(30)]
+    [InlineData(DeliveryDefaults.MaxEscalateAfterDays)]
+    public void DeliveryDefaults_EscalateAfterDays_InRange_NoError(int value)
+    {
+        var t = Template();
+        t.DeliveryDefaults = new DeliveryDefaults { EscalateAfterDays = value };
+        Assert.Empty(Validate(t));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(DeliveryDefaults.MaxEscalateAfterDays + 1)]
+    [InlineData(int.MaxValue)]
+    public void DeliveryDefaults_EscalateAfterDays_OutOfRange_Error(int value)
+    {
+        var t = Template();
+        t.DeliveryDefaults = new DeliveryDefaults { EscalateAfterDays = value };
+        var errors = Validate(t);
+        Assert.Single(errors);
+        Assert.Contains("escalateAfterDays", errors[0]);
+    }
+
+    [Fact]
+    public void DeliveryDefaults_BothFieldsBad_TwoErrors()
+    {
+        // Locks the per-field error emission so callers see all reasons at once.
+        var t = Template();
+        t.DeliveryDefaults = new DeliveryDefaults
+        {
+            ReminderAfterHours = int.MaxValue,
+            EscalateAfterDays = int.MaxValue,
+        };
+        var errors = Validate(t);
+        Assert.Equal(2, errors.Count);
+        Assert.Contains(errors, e => e.Contains("reminderAfterHours"));
+        Assert.Contains(errors, e => e.Contains("escalateAfterDays"));
+    }
+
     [Fact]
     public void AllRulesFailSimultaneously_MultipleErrorsInRulesArrayOrder()
     {

--- a/server/tests/Dotbot.Server.Tests/Unit/SlackSummaryBlocksTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/SlackSummaryBlocksTests.cs
@@ -16,7 +16,6 @@ public class SlackSummaryBlocksTests
         string projectName = "Atlas",
         string? deliverableSummary = null,
         string? context = null,
-        List<BatchQuestionRef>? batchQuestions = null,
         List<AttachmentRef>? attachments = null,
         List<ReviewLinkRef>? reviewLinks = null,
         string respondUrl = "https://example/respond/abc",
@@ -29,7 +28,6 @@ public class SlackSummaryBlocksTests
             ProjectName = projectName,
             DeliverableSummary = deliverableSummary,
             Context = context,
-            BatchQuestions = batchQuestions ?? new List<BatchQuestionRef>(),
             Attachments = attachments ?? new List<AttachmentRef>(),
             ReviewLinks = reviewLinks ?? new List<ReviewLinkRef>(),
             RespondUrl = respondUrl,
@@ -76,24 +74,6 @@ public class SlackSummaryBlocksTests
 
         Assert.Contains(sectionTexts, t => t.Contains("Two diagrams + ADR"));
         Assert.Contains(sectionTexts, t => t == "Sign-off needed");
-    }
-
-    [Fact]
-    public void BatchQuestions_RenderWithAnsweredAndPendingMarkers()
-    {
-        var blocks = Render(Summary(batchQuestions: new()
-        {
-            new() { QuestionId = Guid.NewGuid(), Title = "Q1", Type = "approval", IsAnswered = false },
-            new() { QuestionId = Guid.NewGuid(), Title = "Q2", Type = "singleChoice", IsAnswered = true, AnsweredSummary = "A" },
-        }));
-
-        var section = blocks
-            .Where(b => b.GetProperty("type").GetString() == "section")
-            .Select(b => b.GetProperty("text").GetProperty("text").GetString()!)
-            .Single(t => t.Contains("Questions in this batch"));
-
-        Assert.Contains("• Q1 (`approval`)", section);
-        Assert.Contains("✓ Q2 (`singleChoice`) — _A_", section);
     }
 
     [Fact]

--- a/server/tests/Dotbot.Server.Tests/Unit/TeamsSummaryCardTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/TeamsSummaryCardTests.cs
@@ -14,7 +14,6 @@ public class TeamsSummaryCardTests
         string projectName = "Atlas",
         string? deliverableSummary = null,
         string? context = null,
-        List<BatchQuestionRef>? batchQuestions = null,
         List<AttachmentRef>? attachments = null,
         List<ReviewLinkRef>? reviewLinks = null,
         string respondUrl = "https://example/respond/abc",
@@ -27,7 +26,6 @@ public class TeamsSummaryCardTests
             ProjectName = projectName,
             DeliverableSummary = deliverableSummary,
             Context = context,
-            BatchQuestions = batchQuestions ?? new List<BatchQuestionRef>(),
             Attachments = attachments ?? new List<AttachmentRef>(),
             ReviewLinks = reviewLinks ?? new List<ReviewLinkRef>(),
             RespondUrl = respondUrl,
@@ -70,21 +68,6 @@ public class TeamsSummaryCardTests
 
         Assert.Contains("Two diagrams + ADR", texts);
         Assert.Contains("Sign-off needed", texts);
-    }
-
-    [Fact]
-    public void BatchQuestions_RenderEachAsRichTextBlockWithMarker()
-    {
-        var card = Render(Summary(batchQuestions: new()
-        {
-            new() { QuestionId = Guid.NewGuid(), Title = "Q1", Type = "approval", IsAnswered = false },
-            new() { QuestionId = Guid.NewGuid(), Title = "Q2", Type = "singleChoice", IsAnswered = true, AnsweredSummary = "A" },
-        }));
-
-        var texts = AllTexts(card);
-
-        Assert.Contains("⏳ Q1 (approval)", texts);
-        Assert.Contains("✓ Q2 (singleChoice) — A", texts);
     }
 
     [Fact]

--- a/specs/PRD-029-expand-question-service.md
+++ b/specs/PRD-029-expand-question-service.md
@@ -1,4 +1,4 @@
-# PRD-029: Expand QuestionService — Artifact Approvals and New Question Types
+# PRD-029: Expand QuestionService - Artifact Approvals and New Question Types
 
 | Field | Value |
 |-------|-------|
@@ -25,8 +25,8 @@ These gaps block the vision of dotbot as an autonomous agent that collaborates w
 
 Channel messages and the web form split responsibility deliberately:
 
-- **Channels (Teams, Email, Slack, Jira) are the *context surface*.** Every notification carries a rich human-in-the-loop summary: question title + type, a 1–3 line deliverable summary, the list of attachments to review, any external review links, and — for batched questions — the other questions in the same batch. A reviewer can judge urgency and scope from their inbox/chat, without clicking through.
-- **The Mothership web form is the *interaction surface*.** All actual submission — button clicks, comments, drag-and-drop ranking, document-review confirmation — happens here via a magic link. Keeping submission in one place means new question types don't multiply per-channel rendering work.
+- **Channels (Teams, Email, Slack, Jira) are the *context surface*.** Every notification carries a rich human-in-the-loop summary: question title + type, a 1-3 line deliverable summary, the list of attachments to review, and any external review links. A reviewer can judge urgency and scope from their inbox/chat, without clicking through.
+- **The Mothership web form is the *interaction surface*.** All actual submission - button clicks, comments, drag-and-drop ranking, document-review confirmation - happens here via a magic link. Keeping submission in one place means new question types don't multiply per-channel rendering work.
 
 Channels stay read-only. Interaction lives on the web form.
 
@@ -34,22 +34,22 @@ Channels stay read-only. Interaction lives on the web form.
 
 ## 2. Goals
 
-1. **Artifact approval workflow** — stakeholders can approve/reject generated documents with comments, via any delivery channel (notification → Mothership web form). Outpost Decisions tab push-back is P2 scope (see §7).
-2. **New question types** — approval (yes/no/abstain + comments), document review, free-text input, priority ranking
-3. **Attachment support** — generated artifacts (markdown→PDF, diagrams, code diffs) referenced inline with questions across all channels
-4. **Rich in-channel summaries** — every notification contains deliverable summary, attachment list, review links, and the batch's other questions (when the instance carries multiple), so a reviewer can triage in place
+1. **Artifact approval workflow** - stakeholders can approve/reject generated documents with comments, via any delivery channel (notification -> Mothership web form). Outpost Decisions tab push-back is P2 scope (see sec.7).
+2. **New question types** - approval (yes/no/abstain + comments), document review, free-text input, priority ranking
+3. **Attachment support** - generated artifacts (markdown->PDF, diagrams, code diffs) referenced inline with questions across all channels
+4. **Rich in-channel summaries** - every notification contains deliverable summary, attachment list, and review links, so a reviewer can triage in place
 
 ### Non-Goals
 
-- **Phase 13 (Multi-Channel Q&A) alignment** — out of scope. This PRD is independent; Phase 13 can adopt or extend these models when/if it is started.
-- **Role-based question routing** — targeting by role/domain requires the team registry (Phase 14, [#98](https://github.com/andresharpe/dotbot/issues/98)), not yet implemented. Deferred to Phase 14.
+- **Phase 13 (Multi-Channel Q&A) alignment** - out of scope. This PRD is independent; Phase 13 can adopt or extend these models when/if it is started.
+- **Role-based question routing** - targeting by role/domain requires the team registry (Phase 14, [#98](https://github.com/andresharpe/dotbot/issues/98)), not yet implemented. Deferred to Phase 14.
 - Full questionnaire/batched-question API (`POST /api/questionnaires`)
 - New delivery channels beyond the existing four (Teams, Email, Jira, Slack)
 - Per-recipient multi-channel fallback (if Teams fails, try email)
-- **Governance enforcement** — no quorum rules, no auto-approve policies. Approvals use **first-response-wins** semantics (later responses recorded with agreement/disagreement flags on the instance blob). Quorum belongs to a later governance phase alongside role support.
-- **In-channel interactive submission** — no Adaptive Card form posts, no Slack modals. Submission stays on the web form.
-- **Eager attachment download on the outpost** — the poller records attachment references only. If a tool needs the bytes, it fetches via `GET /api/attachments/{storageRef}` on demand.
-- **Attachment cleanup / orphan sweep** — not implemented in v1. Orphans from failed uploads, superseded templates, or deleted questions remain in storage; manual cleanup if ever needed. On known client-side upload failures the outpost calls `DELETE /api/attachments/{storageRef}` for already-uploaded files in the same publish, so successful-partial-then-failed publishes don't leak. Crash-mid-publish is accepted debt.
+- **Governance enforcement** - no quorum rules, no auto-approve policies. Approvals use **first-response-wins** semantics (later responses recorded with agreement/disagreement flags on the instance blob). Quorum belongs to a later governance phase alongside role support.
+- **In-channel interactive submission** - no Adaptive Card form posts, no Slack modals. Submission stays on the web form.
+- **Eager attachment download on the outpost** - the poller records attachment references only. If a tool needs the bytes, it fetches via `GET /api/attachments/{storageRef}` on demand.
+- **Attachment cleanup / orphan sweep** - not implemented in v1. Orphans from failed uploads, superseded templates, or deleted questions remain in storage; manual cleanup if ever needed. On known client-side upload failures the outpost calls `DELETE /api/attachments/{storageRef}` for already-uploaded files in the same publish, so successful-partial-then-failed publishes don't leak. Crash-mid-publish is accepted debt.
 
 ---
 
@@ -65,16 +65,16 @@ Channels stay read-only. Interaction lives on the web form.
 | `CreateInstanceRequest` | Single channel | One `Channel` field, flat `Recipients` |
 | Delivery providers | 4 channels | Teams (Adaptive Cards), Email (HTML), Jira (wiki tables), Slack (Block Kit) |
 | `DeliveryOrchestrator` | Basic routing | Channel validation, business hours, magic links, reminders/escalation |
-| Outpost MCP | Batch questions | `task-mark-needs-input` groups questions; `task-answer-question` handles batch responses; `NotificationPoller.psm1` tracks batch state |
+| Outpost MCP | Task-level question groups | `task-mark-needs-input` accepts `pending_questions[]` on the task; each question is published as its own template + instance. `task-answer-question` answers per question id. `NotificationPoller.psm1` reconciles each instance independently. |
 
 ### 3.2 What's Missing
 
-- No `Type` enum — the `"singleChoice"` string is the only known value
+- No `Type` enum - the `"singleChoice"` string is the only known value
 - No attachment support on `QuestionTemplate` (only on `ResponseRecordV2`)
 - No approval-specific response model (approve/reject/abstain + comments)
 - No dual-surface approval sync between Outpost and Mothership
 - No review link model to reference external artifacts for in-context review
-- **No shared notification-summary model** — each provider hand-rolls its own message, so adding a field (e.g. attachment list) today means editing four files with drift between them
+- **No shared notification-summary model** - each provider hand-rolls its own message, so adding a field (e.g. attachment list) today means editing four files with drift between them
 
 ---
 
@@ -82,7 +82,7 @@ Channels stay read-only. Interaction lives on the web form.
 
 ### 4.1 Question Type System
 
-Introduce a string-constant taxonomy for `Type` on `QuestionTemplate` (validated at the API boundary — see the `QuestionTypes` class below):
+Introduce a string-constant taxonomy for `Type` on `QuestionTemplate` (validated at the API boundary - see the `QuestionTypes` class below):
 
 | Type | Behavior | Options | Response Model |
 |------|----------|---------|----------------|
@@ -95,14 +95,14 @@ Introduce a string-constant taxonomy for `Type` on `QuestionTemplate` (validated
 **Server model changes:**
 
 ```csharp
-// QuestionTemplate.cs — extend
+// QuestionTemplate.cs - extend
 public class QuestionTemplate
 {
     // ... existing fields ...
     public string Type { get; set; } = "singleChoice";  // validated against QuestionTypes.AllowedTypes
     public List<Attachment>? Attachments { get; set; }   // NEW
     public List<ReviewLink>? ReviewLinks { get; set; }   // NEW
-    public string? DeliverableSummary { get; set; }      // NEW — 1-3 line summary for notifications
+    public string? DeliverableSummary { get; set; }      // NEW - 1-3 line summary for notifications
 }
 ```
 
@@ -112,12 +112,12 @@ A static `QuestionTypes` class (`Models/QuestionTypes.cs`) holds the five string
 
 `DeliverableSummary` is the author-supplied 1-3 sentence explanation of *what needs review*. It is rendered prominently in every channel notification. **Required** for `approval` and `documentReview` templates (validated at `POST /api/templates`; rejected with `400 Bad Request` if missing or blank); **optional** for `singleChoice`, `freeText`, and `priorityRanking` where the title + options carry enough context on their own.
 
-`priorityRanking` uses **ordinal ranks only** (1 = highest priority, 2 = next, …). No weighted scores in this release — a future enhancement could add an optional `Weight: double?` on `RankedItem` non-breakingly.
+`priorityRanking` uses **ordinal ranks only** (1 = highest priority, 2 = next, ...). No weighted scores in this release - a future enhancement could add an optional `Weight: double?` on `RankedItem` non-breakingly.
 
 ### 4.2 Attachment & Review Link Models
 
 ```csharp
-// Models/Attachment.cs — NEW
+// Models/Attachment.cs - NEW
 public class Attachment
 {
     public required string Name { get; set; }          // "architecture-v2.pdf"
@@ -127,10 +127,10 @@ public class Attachment
     public string? Description { get; set; }
 }
 
-// Models/ReviewLink.cs — NEW
+// Models/ReviewLink.cs - NEW
 public class ReviewLink
 {
-    public required string Title { get; set; }         // "PR #42 — Schema changes"
+    public required string Title { get; set; }         // "PR #42 - Schema changes"
     public required string Url { get; set; }           // external URL
     public string? Type { get; set; }                  // "pull-request"|"document"|"design"|"other"
     public string? Description { get; set; }
@@ -140,32 +140,32 @@ public class ReviewLink
 
 **Storage abstraction.** A single `IAttachmentStorage` interface with two implementations from day one:
 
-- **Azure Blob** — cloud deployments
-- **Local filesystem** — self-hosted deployments
+- **Azure Blob** - cloud deployments
+- **Local filesystem** - self-hosted deployments
 
-Selected via config. Interface surface: `UploadAsync`, `DownloadAsync`, `DeleteAsync`. `DownloadAsync` returns a stream; the Mothership proxies file content through `GET /api/attachments/{storageRef}`. Both backends present the same contract — clients never talk to Azure Blob or the filesystem directly. If bandwidth later becomes a concern for the Azure Blob case, `GetSignedUrlAsync` can be added non-breakingly and direct-to-storage downloads enabled per-backend.
+Selected via config. Interface surface: `UploadAsync`, `DownloadAsync`, `DeleteAsync`. `DownloadAsync` returns a stream; the Mothership proxies file content through `GET /api/attachments/{storageRef}`. Both backends present the same contract - clients never talk to Azure Blob or the filesystem directly. If bandwidth later becomes a concern for the Azure Blob case, `GetSignedUrlAsync` can be added non-breakingly and direct-to-storage downloads enabled per-backend.
 
 **Endpoints:**
 
 ```
 POST /api/attachments
 Content-Type: multipart/form-data
-→ { attachmentId, storageRef, name, contentType, sizeBytes }
+-> { attachmentId, storageRef, name, contentType, sizeBytes }
 
 GET  /api/attachments/{storageRef}?token={jwt}
-→ binary stream. Authorized by the same magic-link JWT that gates /respond.
-→ Middleware checks: JWT signature, JTI not consumed, storageRef owned by JWT's instanceId.
-→ Called by the web form only — channels do not carry download links.
+-> binary stream. Authorized by the same magic-link JWT that gates /respond.
+-> Middleware checks: JWT signature, JTI not consumed, storageRef owned by JWT's instanceId.
+-> Called by the web form only - channels do not carry download links.
 ```
 
-**`storageRef` format and validation.** `storageRef` is **server-issued only** — clients never construct one. Format: `{instanceId-guid}/{sanitized-filename}` where sanitized-filename matches `[A-Za-z0-9._-]+`. `GET /api/attachments/{storageRef}` validates the pattern on entry and rejects anything containing `..`, `/..`, `\`, null bytes, or absolute paths with `400 Bad Request`.
+**`storageRef` format and validation.** `storageRef` is **server-issued only** - clients never construct one. Format: `{instanceId-guid}/{sanitized-filename}` where sanitized-filename matches `[A-Za-z0-9._-]+`. `GET /api/attachments/{storageRef}` validates the pattern on entry and rejects anything containing `..`, `/..`, `\`, null bytes, or absolute paths with `400 Bad Request`.
 
 **Size limits** (both configurable):
 
-- `BlobStorage:MaxAttachmentSizeMb` — per-file cap, default **15 MB** (aligned with existing `Respond.cshtml`)
-- `BlobStorage:MaxTotalAttachmentsPerQuestionMb` — per-question total cap, default **50 MB**
+- `BlobStorage:MaxAttachmentSizeMb` - per-file cap, default **15 MB** (aligned with existing `Respond.cshtml`)
+- `BlobStorage:MaxTotalAttachmentsPerQuestionMb` - per-question total cap, default **50 MB**
 
-Channels show attachment **names and sizes only** as metadata — so the recipient knows what the review will contain. **No download URLs in the channel message.** All downloads happen on the Mothership web form (reached via the magic link), authorized by the same magic-link JWT. `GET /api/attachments/{storageRef}?token={jwt}` requires the JWT's `instanceId` to own the requested `storageRef`.
+Channels show attachment **names and sizes only** as metadata - so the recipient knows what the review will contain. **No download URLs in the channel message.** All downloads happen on the Mothership web form (reached via the magic link), authorized by the same magic-link JWT. `GET /api/attachments/{storageRef}?token={jwt}` requires the JWT's `instanceId` to own the requested `storageRef`.
 
 **Attachment download authorization.** `GET /api/attachments/{storageRef}` is covered by the same `MagicLinkAuthMiddleware` that gates `/respond`. The web form renders each download link as `/api/attachments/{storageRef}?token={jwt}`, reusing the magic-link JWT already present in the `/respond` URL. The middleware validates the JWT, verifies the JWT's `instanceId` owns the requested `storageRef`, and streams the file. No separate cookie or session mechanism is introduced. The existing **device cookie** (30-day lifetime, set at form POST time for recipient-email recognition across magic-link reissues) is unchanged and unrelated to attachment downloads.
 
@@ -178,7 +178,7 @@ public class ResponseRecordV2
 {
     // ... existing fields (SelectedOptionId, FreeText, etc.) ...
 
-    // NEW — approval/review responses
+    // NEW - approval/review responses
     // Values scoped by QuestionTemplate.Type:
     //   approval:       "approved" | "rejected" | "abstained"
     //   documentReview: "approved" | "changes_requested" | "comment_only"
@@ -202,22 +202,22 @@ Backwards-compatible: existing `singleChoice` responses continue using `Selected
 Per the whitepaper (section 6.2.1), approvals work on both the Outpost Decisions tab and via Mothership channels. For `approval` and `documentReview` question types:
 
 1. Outpost publishes template with `Type = "approval"` + attachments
-2. Mothership creates instance → delivers notifications to channels AND marks as pending in Decisions API
+2. Mothership creates instance -> delivers notifications to channels AND marks as pending in Decisions API
 3. Respondent approves via **either** surface:
-   - **Channel notification → Mothership web form:** reads full context from the rich notification, clicks magic link → opens question page → submits response
+   - **Channel notification -> Mothership web form:** reads full context from the rich notification, clicks magic link -> opens question page -> submits response
    - **Outpost:** approves in the Decisions tab locally
-4. **First response (by timestamp) is authoritative.** No quorum, no override — this is the governance posture for v1. Applies in the P0 single-surface flow (only the web form exists) and in the P2 dual-surface flow.
+4. **First response (by timestamp) is authoritative.** No quorum, no override - this is the governance posture for v1. Applies in the P0 single-surface flow (only the web form exists) and in the P2 dual-surface flow.
 5. Mothership syncs the decision back to the originating outpost
-6. **(P2 only)** With dual-surface enabled, a second response may arrive after the task has transitioned. The task state does not change. The second response is stored on the instance blob with its own timestamp and **flagged in the dashboard as agreement (same decision) or disagreement (different decision) for human review** — the flag is derived at read time by comparing to the first response's `ApprovalDecision`. Without dual-surface (P0 scope), only one response is possible per batch question.
+6. **(P2 only)** With dual-surface enabled, a second response may arrive after the task has transitioned. The task state does not change. The second response is stored on the instance blob with its own timestamp and **flagged in the dashboard as agreement (same decision) or disagreement (different decision) for human review** - the flag is derived at read time by comparing to the first response's `ApprovalDecision`. Without dual-surface (P0 scope), only one response is possible per question.
 
-**No new API endpoints needed** — the existing `POST /api/responses` and `ResponseRecordV2` accommodate this with the new `ApprovalDecision` field. The Outpost's Decisions tab needs a UI update to render approval-type questions (out of scope for this PRD — tracked separately).
+**No new API endpoints needed** - the existing `POST /api/responses` and `ResponseRecordV2` accommodate this with the new `ApprovalDecision` field. The Outpost's Decisions tab needs a UI update to render approval-type questions (out of scope for this PRD - tracked separately).
 
 ### 4.5 Channel Delivery Model: Rich Notification + Link
 
-**All channels render a shared `NotificationSummary`** — a single in-memory shape built **once per instance** by `DeliveryOrchestrator` (including the per-question answered-state lookup against `ResponseStorageService`). Only the magic-link URL (`RespondUrl`) is personalized per recipient before the summary is handed to the provider. Providers own only the *rendering* (Adaptive Card / HTML / Block Kit / wiki-format comment); they no longer compose message bodies from raw template fields.
+**All channels render a shared `NotificationSummary`** - a single in-memory shape built **once per instance** by `DeliveryOrchestrator`. Only the magic-link URL (`RespondUrl`) is personalized per recipient before the summary is handed to the provider. Providers own only the *rendering* (Adaptive Card / HTML / Block Kit / wiki-format comment); they no longer compose message bodies from raw template fields.
 
 ```csharp
-// Services/Delivery/NotificationSummary.cs — NEW
+// Services/Delivery/NotificationSummary.cs
 public class NotificationSummary
 {
     public required string QuestionTitle { get; set; }       // "Approve architecture v2"
@@ -227,11 +227,6 @@ public class NotificationSummary
     public string? DeliverableSummary { get; set; }          // 1-3 line "what needs review"
     public string? Context { get; set; }                     // longer context from template
 
-    // Batch questions — all questions in the current instance's batch, each with its state.
-    // The outpost groups questions when it calls task-mark-needs-input;
-    // single-question instance → one entry. No cross-instance lookup.
-    public List<BatchQuestionRef> BatchQuestions { get; set; } = new();
-
     public List<AttachmentRef> Attachments { get; set; } = new();
     public List<ReviewLinkRef> ReviewLinks { get; set; } = new();
 
@@ -240,25 +235,13 @@ public class NotificationSummary
     public bool IsReminder { get; set; }
 }
 
-public class BatchQuestionRef
-{
-    public required Guid QuestionId { get; set; }
-    public required string Title { get; set; }
-    public required string Type { get; set; }
-
-    // State — sourced from existing ResponseRecordV2 for (instanceId, questionId).
-    // NotificationSummaryBuilder queries ResponseStorageService to populate these.
-    public bool IsAnswered { get; set; }                     // true if a response exists
-    public string? AnsweredSummary { get; set; }             // e.g. "Approved", "Rank: 1,3,2"
-}
-
 public class AttachmentRef
 {
     public required string Name { get; set; }
     public required string ContentType { get; set; }
     public long? SizeBytes { get; set; }
-    // No DownloadUrl — channels do not link to files. Downloads happen on the web form
-    // after the magic link is followed. See §4.2.
+    // No DownloadUrl - channels do not link to files. Downloads happen on the web form
+    // after the magic link is followed. See sec. 4.2.
 }
 
 public class ReviewLinkRef
@@ -271,24 +254,23 @@ public class ReviewLinkRef
 
 **Every channel displays, in its own native format:**
 
-1. **Header** — question title + type badge + project name + reminder marker
+1. **Header** - question title + type badge + project name + reminder marker
 2. **Deliverable summary** (prominent)
-3. **Context** — optional longer block
-4. **Batch-question list** — all questions from the current instance's batch, bulleted with title + type (single-question instance = single entry). Already-answered questions are rendered with a ✓ marker and their `AnsweredSummary`; unanswered questions point to the Respond Now link. The notification is **one link per instance** — the web form opens showing every batch question with its current state.
-5. **Attachments** — name + size only (download happens on the web form after Respond Now)
-6. **Review links** — title + URL (+ "requires review" marker if set; external URLs are safe to link directly)
-7. **Respond Now** — the only action that leaves the channel; points at the web form
+3. **Context** - optional longer block
+4. **Attachments** - name + size only (download happens on the web form after Respond Now)
+5. **Review links** - title + URL (+ "requires review" marker if set; external URLs are safe to link directly)
+6. **Respond Now** - the only action that leaves the channel; points at the web form
 
 **Per-channel rendering notes:**
 
 | Channel | Format | Rendering notes |
 |---------|--------|-----------------|
-| Email | HTML (existing CRT theme) | Full sections, attachment list as a plain table (name + size, no links), batch-question bullets, single CTA button → Respond Now |
-| Teams | Adaptive Card | TextBlocks for header/summary/context, FactSet for batch questions, attachment list as TextBlocks (name + size), single Action.OpenUrl → Respond Now |
-| Slack | Block Kit | `section` blocks for summary + batch-question list; attachment list as mrkdwn bullets (name + size); `actions` block with a single Respond Now button |
+| Email | HTML (existing CRT theme) | Full sections, attachment list as a plain table (name + size, no links), single CTA button -> Respond Now |
+| Teams | Adaptive Card | TextBlocks for header/summary/context, attachment list as TextBlocks (name + size), single Action.OpenUrl -> Respond Now |
+| Slack | Block Kit | `section` blocks for summary; attachment list as mrkdwn bullets (name + size); `actions` block with a single Respond Now button |
 | Jira | Issue comment | Wiki-format: `h3.` header, paragraph summary, `*` bulleted lists, magic link URL inline as the only clickable element |
 
-**The Mothership web form (`Respond.cshtml`) remains the single rich interaction surface.** It handles all question types with full interactivity. **For batched instances, each question is rendered with its current state: answered questions appear as read-only summaries; unanswered questions render the input form for that type.** The form reflects the live state of the instance — reloading after submitting one question shows that question as done and the rest still pending.
+**The Mothership web form (`Respond.cshtml`) remains the single rich interaction surface.** It handles all question types with full interactivity. Each question is delivered as its own `QuestionInstance` with its own magic link; the form renders the type-specific input.
 
 | Type | Web Form Rendering |
 |------|--------------------|
@@ -299,14 +281,14 @@ public class ReviewLinkRef
 | `priorityRanking` | Drag-and-drop sortable list |
 
 **Benefits of this split (rich channel / interactive web form):**
-- **Zero per-channel work** for new question types — add the type to the web form only; every channel already displays the summary
-- **Consistent UX** — respondents always see the same form regardless of channel
-- **Simpler provider code** — each provider renders one shape; no conditional logic per question type
-- **Future-proof** — adding a new channel (Discord, WhatsApp, web) means implementing one renderer
+- **Zero per-channel work** for new question types - add the type to the web form only; every channel already displays the summary
+- **Consistent UX** - respondents always see the same form regardless of channel
+- **Simpler provider code** - each provider renders one shape; no conditional logic per question type
+- **Future-proof** - adding a new channel (Discord, WhatsApp, web) means implementing one renderer
 
 ### 4.6 Outpost-Side Changes
 
-**MCP tool: `task-mark-needs-input`** — extend metadata/script:
+**MCP tool: `task-mark-needs-input`** - extend metadata/script:
 
 ```yaml
 # New parameters
@@ -339,13 +321,13 @@ public class ReviewLinkRef
       type: { type: string, enum: [pull-request, document, design, other] }
 ```
 
-**`NotificationClient.psm1`** — extend to:
+**`NotificationClient.psm1`** - extend to:
 1. Upload attachments via `POST /api/attachments` before creating template
 2. Include `type`, `deliverable_summary`, `attachments`, `reviewLinks` on template
-3. Handle type-specific response parsing on poll (metadata only — no file download)
+3. Handle type-specific response parsing on poll (metadata only - no file download)
 
-**`task-answer-question`** — extend to handle approval/review responses:
-- Accept `decision` parameter — valid values vary by question type (see §4.1 table): `approval` accepts `approved` / `rejected` / `abstained`; `documentReview` accepts `approved` / `changes_requested` / `comment_only`
+**`task-answer-question`** - extend to handle approval/review responses:
+- Accept `decision` parameter - valid values vary by question type (see sec.4.1 table): `approval` accepts `approved` / `rejected` / `abstained`; `documentReview` accepts `approved` / `changes_requested` / `comment_only`
 - Accept `comment` parameter (required when `decision = rejected` on an `approval` question)
 - Accept `ranked_items` for priority ranking
 
@@ -353,13 +335,13 @@ public class ReviewLinkRef
 
 ## 5. Communication Flow
 
-The Outpost-Mothership integration uses **pull-based polling** — no persistent connection, no webhooks, no push. The Outpost polls every 30 seconds for responses.
+The Outpost-Mothership integration uses **pull-based polling** - no persistent connection, no webhooks, no push. The Outpost polls every 30 seconds for responses.
 
 ### 5.1 Current Integration Architecture
 
 ```
 OUTPOST (PowerShell)                    MOTHERSHIP (.NET Server)
-─────────────────────                   ─────────────────────────
+---------------------                   -------------------------
 
 NotificationClient.psm1                Program.cs (API endpoints)
 MothershipClient.psm1                   DeliveryOrchestrator
@@ -368,152 +350,145 @@ NotificationPoller.psm1                 ResponseStorageService
                                         NotificationSummaryBuilder (NEW)
                                         IAttachmentStorage (NEW, 2 impls)
 
-  ──── Push (Outpost → Mothership) ────
+  ---- Push (Outpost -> Mothership) ----
   POST /api/templates                   Store QuestionTemplate blob
   POST /api/instances                   Create QuestionInstance + deliver
   POST /api/attachments                 Upload file to blob store (NEW)
   POST /api/responses                   Push local approval (NEW, P2)
 
-  ──── Pull (Outpost ← Mothership) ────
+  ---- Pull (Outpost <- Mothership) ----
   GET  /api/instances/{p}/{q}/{i}/responses   Return ResponseRecordV2[]
   GET  /api/attachments/{storageRef}          Stream file (requires ?token={jwt}; middleware checks instanceId owns storageRef)
   GET  /api/health                            Server availability check
 ```
 
-### 5.2 Question Publication (Outpost → Mothership)
+### 5.2 Question Publication (Outpost -> Mothership)
 
 ```
  OUTPOST                                           MOTHERSHIP
- ──────                                            ──────────
+ ------                                            ----------
  Claude (analysis phase)
-   │
-   │ calls task-mark-needs-input
-   │   type: "approval"
-   │   deliverable_summary: "Architecture v2 introduces ..."
-   │   attachments: [architecture-v2.pdf]
-   │
-   ▼
+   |
+   | calls task-mark-needs-input
+   |   type: "approval"
+   |   deliverable_summary: "Architecture v2 introduces ..."
+   |   attachments: [architecture-v2.pdf]
+   |
+   v
  Invoke-TaskMarkNeedsInput
-   │
-   ├─1─ Upload attachments ──────────────────────► POST /api/attachments
-   │    (multipart/form-data)                      → IAttachmentStorage.UploadAsync()
-   │                                               ◄── { attachmentId, storageRef }
-   │
-   ├─2─ Publish template ───────────────────────► POST /api/templates
-   │    { questionId, type, title,                  → blob: /projects/{p}/questions/{q}/v{v}.json
-   │      deliverableSummary, options,
-   │      attachments, reviewLinks, project }
-   │
-   └─3─ Create instance ────────────────────────► POST /api/instances
-        { instanceId, questionId,                   │
-          channel, recipients }                     ▼
+   |
+   +-1- Upload attachments -----------------------> POST /api/attachments
+   |    (multipart/form-data)                      -> IAttachmentStorage.UploadAsync()
+   |                                               <--- { attachmentId, storageRef }
+   |
+   +-2- Publish template ------------------------> POST /api/templates
+   |    { questionId, type, title,                  -> blob: /projects/{p}/questions/{q}/v{v}.json
+   |      deliverableSummary, options,
+   |      attachments, reviewLinks, project }
+   |
+   +-3- Create instance -------------------------> POST /api/instances
+        { instanceId, questionId,                   |
+          channel, recipients }                     v
                                                   DeliveryOrchestrator.DeliverToAllAsync()
-                                                    │
-                                                    ├── NotificationSummaryBuilder.Build(instance)
-                                                    │   → merges template + instance batch +
-                                                    │     per-question answered state
-                                                    │     (from ResponseStorageService)
-                                                    │
-                                                    ├── For each recipient:
-                                                    │   ├── MagicLinkService.GenerateMagicLinkAsync()
-                                                    │   │   → JWT with {email, instanceId, projectId}
-                                                    │   │
-                                                    │   ├── Personalize(summary, magicLink)
-                                                    │   │   → fills RespondUrl for this recipient
-                                                    │   │
-                                                    │   └── Provider.DeliverAsync(personalizedSummary)
-                                                    │       → Teams:  Adaptive Card
-                                                    │       → Email:  HTML
-                                                    │       → Slack:  Block Kit
-                                                    │       → Jira:   wiki comment
-                                                    │
-                                                    └── Store instance blob with SentTo statuses
-                                                        → blob: /projects/{p}/instances/{i}.json
+                                                    |
+                                                    +-- NotificationSummaryBuilder.Build(instance)
+                                                    |   -> merges template + project context
+                                                    |     into the shared NotificationSummary
+                                                    |
+                                                    +-- For each recipient:
+                                                    |   +-- MagicLinkService.GenerateMagicLinkAsync()
+                                                    |   |   -> JWT with {email, instanceId, projectId}
+                                                    |   |
+                                                    |   +-- Personalize(summary, magicLink)
+                                                    |   |   -> fills RespondUrl for this recipient
+                                                    |   |
+                                                    |   +-- Provider.DeliverAsync(personalizedSummary)
+                                                    |       -> Teams:  Adaptive Card
+                                                    |       -> Email:  HTML
+                                                    |       -> Slack:  Block Kit
+                                                    |       -> Jira:   wiki comment
+                                                    |
+                                                    +-- Store instance blob with SentTo statuses
+                                                        -> blob: /projects/{p}/instances/{i}.json
 
  Task file updated:
    status: "needs-input"
    notification: { question_id, instance_id, channel, sent_at }
 ```
 
-### 5.3 Response Submission (User → Mothership)
+### 5.3 Response Submission (User -> Mothership)
 
 ```
  USER (any channel)                                MOTHERSHIP
- ──────────────────                                ──────────
+ ------------------                                ----------
 
  Receives rich notification
  (sees title, summary, attachments,
-  batch's other questions, all in-channel)
-   │
-   │ clicks magic link to submit
-   ▼
- GET /respond?token={jwt} ─────────────────────► MagicLinkAuthMiddleware
-                                                    │ validate JWT, check JTI expiry
-                                                    │   (expired → 410 Gone)
-                                                    │ extract email, instanceId
-                                                    ▼
+  review links, all in-channel)
+   |
+   | clicks magic link to submit
+   v
+ GET /respond?token={jwt} ----------------------> MagicLinkAuthMiddleware
+                                                    | validate JWT, check JTI expiry
+                                                    |   (expired -> 410 Gone)
+                                                    | extract email, instanceId
+                                                    v
                                                   Respond.cshtml.OnGetAsync()
-                                                    │ load QuestionTemplate + Instance
-                                                    │ query existing ResponseRecordV2 blobs
-                                                    │   → per-question state (answered/pending)
-                                                    │ render each batch question:
-                                                    │   answered   → read-only summary
-                                                    │   pending    → type-specific form:
-                                                    │     singleChoice → radio buttons
-                                                    │     approval → approve/reject/abstain + comment
-                                                    │     documentReview → per-attachment checklist + decision + feedback
-                                                    │     freeText → textarea
-                                                    │     priorityRanking → drag-and-drop list
-                                                    ▼
- User submits form ────────────────────────────► Respond.cshtml.OnPostAsync()
-   { questionId, selectedKey, freeText,             │
-     approvalDecision, comment,                     ├── Validate response vs template
-     rankedItems }                                  ├── Save ResponseRecordV2 blob for (instanceId, questionId)
-                                                    ├── Check batch completion:
-                                                    │   → all batch questions have responses?
-                                                    │     yes → mark magic link JTI consumed
-                                                    │     no  → JTI stays valid; reviewer can return
-                                                    └── Set device cookie (30 days); redirect back
-                                                        to form (now showing this question as done)
+                                                    | load QuestionTemplate + Instance
+                                                    | render type-specific form:
+                                                    |   singleChoice -> radio buttons
+                                                    |   approval -> approve/reject/abstain + comment
+                                                    |   documentReview -> per-attachment checklist + decision + feedback
+                                                    |   freeText -> textarea
+                                                    |   priorityRanking -> drag-and-drop list
+                                                    v
+ User submits form -----------------------------> Respond.cshtml.OnPostAsync()
+   { questionId, selectedKey, freeText,             |
+     approvalDecision, comment,                     +-- Validate response vs template
+     rankedItems }                                  +-- Save ResponseRecordV2 blob for (instanceId, questionId)
+                                                    +-- Consume magic-link JTI (single-use)
+                                                    +-- Set device cookie (30 days); redirect to
+                                                        Confirmation page
 
  Magic-link JTI hard expiry:
    SentAt + Template.DeliveryDefaults.EscalateAfterDays
    (default 30 days if EscalateAfterDays is null)
-   → after expiry, /respond?token=X returns 410 Gone;
-     abandoned partial batches naturally clean themselves up.
+   -> after expiry, /respond?token=X returns 410 Gone;
+     abandoned links expire predictably.
 ```
 
-### 5.4 Response Polling (Outpost ← Mothership)
+### 5.4 Response Polling (Outpost <- Mothership)
 
 ```
  OUTPOST                                           MOTHERSHIP
- ──────                                            ──────────
+ ------                                            ----------
 
  NotificationPoller.psm1
    (background runspace, every 30s)
-   │
-   │ For each task with notification metadata:
-   │
-   ├── GET /api/instances/{p}/{q}/{i}/responses ──► ResponseStorageService
-   │                                                  list blobs matching pattern
-   │   ◄── ResponseRecordV2[] (sorted by time) ◄──   return all responses
-   │
-   │ If response found:
-   │   │
-   │   │   (attachment references recorded in task JSON;
-   │   │    bytes fetched on demand, not during poll)
-   │   │
-   │   ├── Single question:      → move task needs-input → analysing
-   │   ├── Batch questions:      → mark answered; move only when ALL done
-   │   └── Split proposal:       → delegate to task-approve-split or mark rejected
-   │
-   ▼
+   |
+   | For each task with notification metadata:
+   |
+   +-- GET /api/instances/{p}/{q}/{i}/responses ---> ResponseStorageService
+   |                                                  list blobs matching pattern
+   |   <--- ResponseRecordV2[] (sorted by time) <---   return all responses
+   |
+   | If response found:
+   |   |
+   |   |   (attachment references recorded in task JSON;
+   |   |    bytes fetched on demand, not during poll)
+   |   |
+   |   +-- Single question:      -> move task needs-input -> analysing
+   |   +-- Task with pending_questions[] (task-level batch):
+   |   |                          -> mark answered per question; move when all done
+   |   +-- Split proposal:       -> delegate to task-approve-split or mark rejected
+   |
+   v
  Task JSON updated:
    questions_resolved: [{
      id, question, answer, answer_type,
-     approval_decision,          ← NEW for approval types
-     comment,                    ← NEW
-     attachment_refs,            ← NEW (refs only, not bytes)
+     approval_decision,          <- NEW for approval types
+     comment,                    <- NEW
+     attachment_refs,            <- NEW (refs only, not bytes)
      asked_at, answered_at,
      answered_via: "notification"
    }]
@@ -521,43 +496,43 @@ NotificationPoller.psm1                 ResponseStorageService
 
 ### 5.5 Dual-Surface Approval Sync
 
-Approvals can be submitted from two surfaces: the **Mothership web form** (via channel notification) and the **Outpost Decisions tab** (locally). The sync uses the existing pull-based architecture — no new push mechanism needed.
+Approvals can be submitted from two surfaces: the **Mothership web form** (via channel notification) and the **Outpost Decisions tab** (locally). The sync uses the existing pull-based architecture - no new push mechanism needed.
 
 ```
  OUTPOST Decisions Tab                  MOTHERSHIP Web Form
- ─────────────────────                  ────────────────────
-       │                                       │
-       │  User approves locally                │  User approves via magic link
-       ▼                                       ▼
+ ---------------------                  --------------------
+       |                                       |
+       |  User approves locally                |  User approves via magic link
+       v                                       v
  Save to local task JSON               Save ResponseRecordV2 blob
  approval_decision: "approved"         approvalDecision: "approved"
- answered_via: "outpost"               → available on next poll
-       │                                       │
-       ▼                                       ▼
- POST /api/responses ──────────►  Store as ResponseRecordV2
+ answered_via: "outpost"               -> available on next poll
+       |                                       |
+       v                                       v
+ POST /api/responses ----------->  Store as ResponseRecordV2
  (push local decision to server)
 
-                                   ┌────────────────────────────────────┐
-                                   │ RESOLUTION                         │
-                                   │  → First by timestamp wins         │
-                                   │  → Later responses recorded with   │
-                                   │    agreement/disagreement flag     │
-                                   │    (derived at read time)          │
-                                   │  → Never overrides the first       │
-                                   └────────────────────────────────────┘
+                                   +------------------------------------+
+                                   | RESOLUTION                         |
+                                   |  -> First by timestamp wins         |
+                                   |  -> Later responses recorded with   |
+                                   |    agreement/disagreement flag     |
+                                   |    (derived at read time)          |
+                                   |  -> Never overrides the first       |
+                                   +------------------------------------+
 ```
 
-**New Outpost-side requirement:** The Decisions tab needs a "push-back" path — when a user approves locally, `NotificationClient.psm1` must call `POST /api/responses` to write the decision to the Mothership so it's visible fleet-wide. This is a new capability (today the Outpost only pushes questions, never responses).
+**New Outpost-side requirement:** The Decisions tab needs a "push-back" path - when a user approves locally, `NotificationClient.psm1` must call `POST /api/responses` to write the decision to the Mothership so it's visible fleet-wide. This is a new capability (today the Outpost only pushes questions, never responses).
 
 **Idempotency.** The outpost generates a `ResponseId` (Guid) once per local approval. It includes this ID in the `POST /api/responses` body. The server treats the endpoint as an upsert: if a blob already exists for that `ResponseId`, it returns `200 OK` with the existing record; otherwise it stores a new one. This means transient-network retries never create duplicates. Different surfaces (web form vs outpost) generate different `ResponseId`s, so both are stored and first-wins applies on decision timestamp.
 
 ### 5.6 Reminder & Escalation (Server-Side Background)
 
-Mostly unchanged from current behavior. `ReminderEscalationService` scans active instances and triggers `DeliveryOrchestrator.DeliverReminderAsync()` at `ReminderAfterHours`; status transitions "sent" → "reminded" → "escalated" at `EscalateAfterDays`.
+Mostly unchanged from current behavior. `ReminderEscalationService` scans active instances and triggers `DeliveryOrchestrator.DeliverReminderAsync()` at `ReminderAfterHours`; status transitions "sent" -> "reminded" -> "escalated" at `EscalateAfterDays`.
 
-**Null-field handling:** If `ReminderAfterHours` is null, no reminder fires. If `EscalateAfterDays` is null, no escalation transition happens (status stays "reminded"). This is distinct from the JTI-expiry default in §5.3, which *does* fall back to 30 days when `EscalateAfterDays` is null — because the JTI must have a hard lifetime even when escalation is disabled.
+**Null-field handling:** If `ReminderAfterHours` is null, no reminder fires. If `EscalateAfterDays` is null, no escalation transition happens (status stays "reminded"). This is distinct from the JTI-expiry default in sec.5.3, which *does* fall back to 30 days when `EscalateAfterDays` is null - because the JTI must have a hard lifetime even when escalation is disabled.
 
-**New rule for batched instances:** before delivering a reminder, the service queries `ResponseStorageService` for existing responses on the instance. If every batch question already has a response, the reminder is **suppressed** (the instance is effectively complete and the outpost poller will reconcile on its next tick). If some questions are answered and others are not, the reminder is delivered; the `NotificationSummary` built for it naturally reflects per-question state via `IsAnswered` and `AnsweredSummary`, so the recipient sees a mix of ✓-marked (done) and pending items.
+**Suppression rule:** before delivering a reminder, the service queries `ResponseStorageService` for existing responses on the instance. If a response exists, the reminder is **suppressed** (the instance is effectively complete and the outpost poller will reconcile on its next tick).
 
 ---
 
@@ -574,8 +549,8 @@ Mostly unchanged from current behavior. `ReminderEscalationService` scans active
 | Create | `Services/IAttachmentStorage.cs` | Storage abstraction: Upload / Download (stream) / Delete |
 | Create | `Services/AzureBlobAttachmentStorage.cs` | Azure Blob implementation |
 | Create | `Services/LocalFileAttachmentStorage.cs` | Local filesystem implementation |
-| Create | `Services/Delivery/NotificationSummary.cs` | Shared summary DTO (see §4.5) |
-| Create | `Services/Delivery/NotificationSummaryBuilder.cs` | Builds summary from template + instance batch + per-question answered state (queries `ResponseStorageService`) |
+| Create | `Services/Delivery/NotificationSummary.cs` | Shared summary DTO (see sec.4.5) |
+| Create | `Services/Delivery/NotificationSummaryBuilder.cs` | Builds the shared `NotificationSummary` from template + project context |
 | Modify | `Models/QuestionTemplate.cs` | Add `Attachments`, `ReviewLinks`, `DeliverableSummary` |
 | Modify | `Models/ResponseRecordV2.cs` | Add `ApprovalDecision`, `Comment`, `ReviewedAttachmentIds`, `RankedItems` |
 | Modify | `Services/Delivery/IQuestionDeliveryProvider.cs` | `DeliveryContext` carries `NotificationSummary` |
@@ -585,7 +560,7 @@ Mostly unchanged from current behavior. `ReminderEscalationService` scans active
 | Modify | `Services/Delivery/SlackDeliveryProvider.cs` | Block Kit renders full `NotificationSummary` |
 | Modify | `Services/Delivery/JiraDeliveryProvider.cs` | Wiki comment renders full `NotificationSummary` |
 | Modify | `Pages/Respond.cshtml` | Full question-type handling: approval form, ranking drag-and-drop, document review, free text |
-| Create | API endpoint: `POST /api/attachments` | Multipart upload → `IAttachmentStorage` |
+| Create | API endpoint: `POST /api/attachments` | Multipart upload -> `IAttachmentStorage` |
 | Create | API endpoint: `GET /api/attachments/{storageRef}` | Stream blob content; middleware validates `?token={jwt}` and verifies JWT's `instanceId` owns the `storageRef` |
 
 ### Outpost-side (Client)
@@ -603,12 +578,12 @@ Mostly unchanged from current behavior. `ReminderEscalationService` scans active
 
 ## 7. Acceptance Criteria
 
-### P0 — Must Have
+### P0 - Must Have
 
 - [ ] `QuestionTemplate.Type` supports values: `singleChoice`, `approval`, `documentReview`, `freeText`, `priorityRanking`
-- [ ] `QuestionTemplate` accepts optional `Attachments` and `ReviewLinks`; `DeliverableSummary` is **required** for `approval` + `documentReview` (validated at `POST /api/templates`), optional for other types (see §4.1)
+- [ ] `QuestionTemplate` accepts optional `Attachments` and `ReviewLinks`; `DeliverableSummary` is **required** for `approval` + `documentReview` (validated at `POST /api/templates`), optional for other types (see sec.4.1)
 - [ ] `NotificationSummary` DTO + `NotificationSummaryBuilder` exist and are used by all four providers
-- [ ] All 4 channels (Teams, Email, Slack, Jira) render notifications containing: question title + type badge, deliverable summary, attachment list, review-link list, batch-question list (every question in the current instance's batch, each with its `IsAnswered` state), magic link to web form
+- [ ] All 4 channels (Teams, Email, Slack, Jira) render notifications containing: question title + type badge, deliverable summary, attachment list, review-link list, magic link to web form
 - [ ] Mothership web form (`Respond.cshtml`) supports all question types with full interactivity
 - [ ] `IAttachmentStorage` abstraction with **both** `AzureBlobAttachmentStorage` and `LocalFileAttachmentStorage` implementations; backend selectable via config
 - [ ] `POST /api/attachments` + `GET /api/attachments/{storageRef}` functional; per-file limit 15 MB, per-question total limit 50 MB (both configurable)
@@ -617,31 +592,31 @@ Mostly unchanged from current behavior. `ReminderEscalationService` scans active
 - [ ] `task-answer-question` MCP tool accepts `decision`, `comment` for approval responses
 - [ ] Outpost poller records attachment references only (no eager download)
 - [ ] Approval uses first-response-wins semantics (no quorum)
-- [ ] Reject on `approval` type requires a non-empty `Comment` — validated on server + web form
-- [ ] Batched instance web form: answered questions render as read-only summaries; unanswered render as input forms; magic-link JTI remains valid until every question in the batch has a response
+- [ ] Reject on `approval` type requires a non-empty `Comment` - validated on server + web form
+- [ ] `MagicLinkAuthMiddleware` covers `/respond*` AND `GET /api/attachments/*`; verifies the JWT's `questionInstanceId` owns the requested `storageRef`; returns 410 Gone (not 401) when the JWT or JTI blob is expired
+- [ ] Magic-link JTI lifetime sourced from `Template.DeliveryDefaults.EscalateAfterDays` with a 30-day fallback when null
+- [ ] Reminder suppression: if a response exists for the instance, the reminder is not delivered
 - [ ] Existing `singleChoice` behavior fully backwards-compatible
 
-### P1 — Should Have
+### P1 - Should Have
 
 - [ ] `documentReview` type with per-attachment confirmation checklist and decision buttons (Approve / Request Changes / Comment Only) in web form
 - [ ] `priorityRanking` type with drag-and-drop ranking in web form (ordinal only)
-- [ ] Batch-question list in notifications enumerates every question in the current instance's batch (relies on existing batching — no cross-instance queries)
-- [ ] Channel notifications (including reminders) mark already-answered batch questions with a ✓ and `AnsweredSummary`; unanswered questions point at the instance-scoped Respond Now link
 
-### P2 — Nice to Have
+### P2 - Nice to Have
 
-- [ ] Dual-surface approval sync: Outpost Decisions tab push-back via `POST /api/responses` (see §5.5)
+- [ ] Dual-surface approval sync: Outpost Decisions tab push-back via `POST /api/responses` (see sec.5.5)
 - [ ] Poller reads approval responses and updates Decisions tab state
 - [ ] Dual-surface conflict handling: first-by-timestamp wins, later responses recorded on instance blob with agreement/disagreement flag derived at read time
 - [ ] `ReviewLink.RequiresReview` enforcement (must confirm reviewed before submitting response)
 - [ ] Attachment inline preview in web form (PDF viewer, image preview, markdown render)
 
-### Polish (deferred — decide during implementation, not blocking plan)
+### Polish (deferred - decide during implementation, not blocking plan)
 
-- [ ] **Content-type filter on upload** (`POST /api/attachments`) — minimal blacklist of executable extensions (`.exe`, `.msi`, `.dll`, `.bat`, `.sh`, `.ps1`, `.cmd`, `.scr`, `.vbs`). Attachments in practice come from Claude-generated output, so risk is low.
-- [ ] **`NotificationSummary.DueBy` derivation** — default rule `Instance.SentAt + Template.DeliveryDefaults.EscalateAfterDays` (null if `EscalateAfterDays` not set); rendered as "Due by: {date}" in header.
-- [ ] **Reminder rendering convention** — `IsReminder=true` surfaces in each channel: email subject prefixed `"Reminder: "`; Teams/Slack/Jira show `⏰ REMINDER` marker + *"Originally sent: {timestamp}"* line in header.
-- [ ] **Consolidated configuration appendix (§10)** — one-page reference of all config keys and defaults (`BlobStorage:*`, any `NotificationSummary:*`).
+- [ ] **Content-type filter on upload** (`POST /api/attachments`) - minimal blacklist of executable extensions (`.exe`, `.msi`, `.dll`, `.bat`, `.sh`, `.ps1`, `.cmd`, `.scr`, `.vbs`). Attachments in practice come from Claude-generated output, so risk is low.
+- [ ] **`NotificationSummary.DueBy` derivation** - default rule `Instance.SentAt + Template.DeliveryDefaults.EscalateAfterDays` (null if `EscalateAfterDays` not set); rendered as "Due by: {date}" in header.
+- [ ] **Reminder rendering convention** - `IsReminder=true` surfaces in each channel: email subject prefixed `"Reminder: "`; Teams/Slack/Jira show ` REMINDER` marker + *"Originally sent: {timestamp}"* line in header.
+- [ ] **Consolidated configuration appendix (sec.10)** - one-page reference of all config keys and defaults (`BlobStorage:*`, any `NotificationSummary:*`).
 
 ---
 
@@ -657,8 +632,8 @@ Mostly unchanged from current behavior. `ReminderEscalationService` scans active
 
 ## 9. Related Issues & Documents
 
-- [#29](https://github.com/andresharpe/dotbot/issues/29) — This issue
-- [#30](https://github.com/andresharpe/dotbot/issues/30) — Jira approval channel
-- [#98](https://github.com/andresharpe/dotbot/issues/98) — Team registry (Phase 14) — role-based routing deferred to this issue
+- [#29](https://github.com/andresharpe/dotbot/issues/29) - This issue
+- [#30](https://github.com/andresharpe/dotbot/issues/30) - Jira approval channel
+- [#98](https://github.com/andresharpe/dotbot/issues/98) - Team registry (Phase 14) - role-based routing deferred to this issue
 - [Phase 14: Project Team & Roles](../docs/roadmap/DOTBOT-V4-phase-14-project-team-roles.md)
-- [UI & Domain Model Whitepaper v2](../docs/whitepapers/UI-AND-DOMAIN-MODEL-WHITEPAPER-v2.md) — section 6.2.1 (dual-surface approval)
+- [UI & Domain Model Whitepaper v2](../docs/whitepapers/UI-AND-DOMAIN-MODEL-WHITEPAPER-v2.md) - section 6.2.1 (dual-surface approval)


### PR DESCRIPTION
## Linked issue

Closes #289

## Summary of changes

Two threads, both sharing the magic-link surface:

**1. MagicLinkAuthMiddleware now covers `GET /api/attachments/*` in addition to `/respond*`.**
The inline JWT validation that previously lived at the attachment endpoint is removed - middleware owns it. Adds a per-instance ownership check: the JWT's `questionInstanceId` must own the requested `storageRef`, matched by exact `BlobPath` against the instance's question template. Wrong-instance JWT -> 403. Expired JWT (signature still valid, exp in the past) **or** JTI blob with `ExpiresAt <= UtcNow` -> **410 Gone** instead of the misleading 401. Unparseable token strings (`ArgumentException` from `JwtSecurityTokenHandler`) also return 401 - fixes a pre-existing gap where they would 500.

**2. Magic-link lifetime is sourced from the template's escalation policy.**
`MagicLinkService.GenerateMagicLinkAsync` gains an optional `escalateAfterDays` parameter. JWT `exp` claim and JTI blob `ExpiresAt` are both `now + (escalateAfterDays > 0 ? value : 30) days`. `DeliveryOrchestrator` passes `template.DeliveryDefaults?.EscalateAfterDays` at all 5 callsites (initial fan-out for email / Slack / AAD object-id, reminder delivery, scheduled re-delivery). Null / zero / negative falls back to 30 days per PRD-029 sec. 5.3.

**Test infrastructure**: extracted `IInstanceStorageService` and `ITokenStorageService` interfaces so the integration harness can swap in `InMemoryInstanceStorage` / `InMemoryTokenStorage` / `InMemoryAttachmentStorage` doubles. `DotbotApiFactory` exposes all four stubs; `IntegrationTestBase` reaches them through `Factory.X`. New `MagicLinkMiddlewareTests` exercises the full middleware behaviour end-to-end through HTTP.

### Note on scope - batch question state removed

Issue #289's original text included two bullets about "batch question state" on `/respond` (rendering each batch question with state, conditional JTI consumption when all batch questions answered). That work was pulled out of this PR because parent issue #29 itself never asks for multi-question-per-instance - the concept is invented by PRD-029 sec. 4.5, and no merged code today actually puts more than one question in an instance. Real support for it requires careful revision of the outpost-and-server data flow (template + instance shape, wizard UX, reminder semantics, migration) and will be tracked under a new sub-issue with its own PRD.

This PR's scope is therefore strictly the auth-middleware + JWT-lifetime half of #289. Single-question `/respond` behaviour is unchanged from main.

## Screenshots / recordings

Not applicable - middleware + lifetime change, no UI surface.

## Testing notes

**Unit tests** - 5 new in `MagicLinkExpiryTests`: null / positive / zero / negative `escalateAfterDays`, plus a guard locking `DefaultEscalateAfterDays = 30`.

**Integration tests** - 11 cases in new `MagicLinkMiddlewareTests` against the in-memory storage doubles. Theory-grouped where the two protected paths (`/api/attachments/*` and `/respond*`) share the same expected outcome.

| Probe | Endpoint | Expected |
|---|---|---|
| No token | both | 401 |
| Unparseable token | both | 401 |
| Tampered signature | `/api/attachments` | 401 |
| Consumed JTI | `/api/attachments` | 401 |
| Expired JTI blob | both | **410 Gone** |
| Wrong-instance JWT (token for B, blob owned by A) | `/api/attachments` | **403** |
| Valid token | `/api/attachments` | 200, content bytes match |
| HEAD request | `/respond` | 200, JTI not consumed |

## Checklist

- [x] Tests added or updated
- [ ] Docs updated (if behaviour changed) - no doc surface today; PRD-029 describes the target behaviour
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)