### PR TITLE
fix(mcp): remove § from metadata and force UTF-8 to fix tool-load failure on Windows

### DIFF
--- a/core/mcp/dotbot-mcp.ps1
+++ b/core/mcp/dotbot-mcp.ps1
@@ -25,6 +25,14 @@ $WarningPreference = 'SilentlyContinue'
 # Disable ANSI colors in error output
 $PSStyle.OutputRendering = 'PlainText'
 
+# Force UTF-8 on stdin/stdout. When pwsh is spawned as a subprocess (no
+# attached Windows console), it defaults to the OEM code page (CP437).
+# CP437 maps § (U+00A7) to byte 0x15 (NAK), which is an invalid control
+# character inside a JSON string and causes MCP clients to report
+# "Unterminated string" and fail to load tools.
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+[Console]::InputEncoding  = [System.Text.UTF8Encoding]::new($false)
+
 # Auto-detect project root. In a linked git worktree, walking up looking for
 # `.git` would stop at the worktree's gitfile rather than the main repo, so
 # Resolve-DotbotProjectRoot prefers `git rev-parse --git-common-dir`.

--- a/core/mcp/tools/task-answer-question/metadata.yaml
+++ b/core/mcp/tools/task-answer-question/metadata.yaml
@@ -15,7 +15,7 @@ inputSchema:
       description: "Question type. Determines which fields are required/validated."
     decision:
       type: string
-      description: "Required for approval/documentReview. Allowed values vary per type (PRD §4.1)."
+      description: "Required for approval/documentReview. Allowed values vary per type (PRD Section 4.1)."
     comment:
       type: string
       description: "Required when decision=rejected on an approval question."

--- a/core/mcp/tools/task-mark-needs-input/metadata.yaml
+++ b/core/mcp/tools/task-mark-needs-input/metadata.yaml
@@ -116,7 +116,7 @@ inputSchema:
       type: string
       enum: [singleChoice, approval, documentReview, freeText, priorityRanking]
       default: singleChoice
-      description: "Question type (PRD §4.6). Drives card rendering and response parsing."
+      description: "Question type (PRD Section 4.6). Drives card rendering and response parsing."
     deliverable_summary:
       type: string
       description: "1-3 line summary of what needs review (shown in channel notifications)"


### PR DESCRIPTION
Closes andresharpe/dotbot#424

## Summary

- Replace `§` (U+00A7) with `Section` in two MCP tool metadata descriptions (`task-answer-question` and `task-mark-needs-input`)
- Add `[Console]::OutputEncoding = UTF8` / `[Console]::InputEncoding = UTF8` in `dotbot-mcp.ps1` as a defensive measure

## Root cause

When `pwsh` is spawned as a subprocess without an attached Windows console, `[Console]::OutputEncoding` defaults to CP437. CP437 maps `§` (U+00A7) to byte `0x15` (NAK) — a C0 control character that must be escaped inside JSON strings per RFC 8259. The unescaped byte caused MCP clients to reject the entire `tools/list` response with `Unterminated string`, leaving Claude Code with zero registered tools.

## Test plan

- [ ] Edit verified: no `§` characters remain in any `metadata.yaml` under `core/mcp/tools/`
- [ ] Run `dotbot init --force` in a target project to propagate changes to `.bot/`
- [ ] Restart Claude Code and confirm dotbot MCP server lists all tools with no `Unterminated string` errors in `mcp-logs-dotbot/*.jsonl`
- [ ] Run `pwsh tests/Run-Tests.ps1` (layers 1–3) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)