### PR TITLE
[PR-12/#29] Notification polish — content-type filter + reminder OriginallySentAt

### DIFF
--- a/server/src/Dotbot.Server/Models/BlobStorageSettings.cs
+++ b/server/src/Dotbot.Server/Models/BlobStorageSettings.cs
@@ -5,4 +5,12 @@ public class BlobStorageSettings
     public string Backend { get; set; } = "AzureBlob";
     public int MaxAttachmentSizeMb { get; set; } = 15;
     public string LocalStoragePath { get; set; } = "attachments";
+
+    // Filename-extension blacklist applied at upload. Empty list → no filtering.
+    // PRD-029 §7 polish item: keep this minimal — attachments come from Claude-generated
+    // output in practice, so the risk is low; the list exists to block obvious foot-guns.
+    public List<string> AllowedExtensionsBlacklist { get; set; } = new()
+    {
+        ".exe", ".msi", ".dll", ".bat", ".sh", ".ps1", ".cmd", ".scr", ".vbs"
+    };
 }

--- a/server/src/Dotbot.Server/Program.cs
+++ b/server/src/Dotbot.Server/Program.cs
@@ -392,12 +392,33 @@ try
             return Results.StatusCode(413);
         }
 
+        var fileName = file.FileName ?? string.Empty;
+
+        // PRD-029 §7: filename-extension blacklist. Match the trailing extension only —
+        // never inspect the multipart Content-Type header, which is client-supplied and trivially spoofed.
+        var blacklist = blobSettings.Value.AllowedExtensionsBlacklist;
+        if (blacklist is { Count: > 0 })
+        {
+            var extension = Path.GetExtension(fileName);
+            if (!string.IsNullOrEmpty(extension) &&
+                blacklist.Any(b => string.Equals(b, extension, StringComparison.OrdinalIgnoreCase)))
+            {
+                logger.LogWarning(
+                    "Attachment upload rejected: extension {Extension} is on the blacklist (file: {FileName})",
+                    extension, fileName);
+                return Results.BadRequest(new
+                {
+                    error = $"File type '{extension}' is not allowed."
+                });
+            }
+        }
+
         var contentType = file.ContentType ?? "application/octet-stream";
         await using var stream = file.OpenReadStream();
         AttachmentUploadResult result;
         try
         {
-            result = await attachmentStorage.UploadAsync(file.FileName, contentType, stream, file.Length, ct);
+            result = await attachmentStorage.UploadAsync(fileName, contentType, stream, file.Length, ct);
         }
         catch (ArgumentException ex)
         {

--- a/server/src/Dotbot.Server/Services/AdaptiveCardService.cs
+++ b/server/src/Dotbot.Server/Services/AdaptiveCardService.cs
@@ -179,26 +179,41 @@ public class AdaptiveCardService
         // Reminder banner — sits above the project banner so re-deliveries are immediately visible
         if (summary.IsReminder)
         {
+            var reminderItems = new List<AdaptiveElement>
+            {
+                new AdaptiveRichTextBlock
+                {
+                    Inlines = new List<AdaptiveInline>
+                    {
+                        new AdaptiveTextRun
+                        {
+                            Text = "⏰ Reminder — this question is still awaiting your response.",
+                            Weight = AdaptiveTextWeight.Bolder,
+                            Color = AdaptiveTextColor.Warning
+                        }
+                    }
+                }
+            };
+
+            if (summary.OriginallySentAt.HasValue)
+            {
+                reminderItems.Add(new AdaptiveRichTextBlock
+                {
+                    Spacing = AdaptiveSpacing.None,
+                    Inlines = new List<AdaptiveInline>
+                    {
+                        new AdaptiveTextRun { Text = "Originally sent: ", Size = AdaptiveTextSize.Small, IsSubtle = true },
+                        new AdaptiveTextRun { Text = DeliveryFormatting.FormatUtc(summary.OriginallySentAt.Value), Size = AdaptiveTextSize.Small, IsSubtle = true }
+                    }
+                });
+            }
+
             body.Add(new AdaptiveContainer
             {
                 Style = AdaptiveContainerStyle.Warning,
                 Bleed = true,
                 Spacing = AdaptiveSpacing.None,
-                Items = new List<AdaptiveElement>
-                {
-                    new AdaptiveRichTextBlock
-                    {
-                        Inlines = new List<AdaptiveInline>
-                        {
-                            new AdaptiveTextRun
-                            {
-                                Text = "⏰ Reminder — this question is still awaiting your response.",
-                                Weight = AdaptiveTextWeight.Bolder,
-                                Color = AdaptiveTextColor.Warning
-                            }
-                        }
-                    }
-                }
+                Items = reminderItems
             });
         }
 

--- a/server/src/Dotbot.Server/Services/Delivery/DeliveryOrchestrator.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/DeliveryOrchestrator.cs
@@ -324,6 +324,7 @@ public class DeliveryOrchestrator
 
         var summary = _summaryBuilder.Build(template, instance, respondUrl: magicLinkUrl, isReminder: true);
         summary.DueBy = ComputeDueBy(template, instance, DateTime.UtcNow);
+        summary.OriginallySentAt = recipient.SentAt;
 
         var deliveryContext = new DeliveryContext
         {

--- a/server/src/Dotbot.Server/Services/Delivery/JiraDeliveryProvider.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/JiraDeliveryProvider.cs
@@ -121,6 +121,12 @@ public class JiraDeliveryProvider : IQuestionDeliveryProvider
         if (summary.IsReminder)
         {
             sb.AppendLine("{panel:borderColor=#f0ad4e|bgColor=#fff4ce}*Reminder:* This question is still awaiting a response.{panel}");
+
+            if (summary.OriginallySentAt.HasValue)
+            {
+                sb.AppendLine($"_Originally sent: {DeliveryFormatting.FormatUtc(summary.OriginallySentAt.Value)}_");
+                sb.AppendLine();
+            }
         }
 
         sb.AppendLine($"h3. {summary.QuestionTitle}");

--- a/server/src/Dotbot.Server/Services/Delivery/NotificationSummary.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/NotificationSummary.cs
@@ -20,6 +20,11 @@ public class NotificationSummary
     public required string RespondUrl { get; set; }
     public DateTime? DueBy { get; set; }
     public bool IsReminder { get; set; }
+
+    // Original send time for the recipient — populated by DeliveryOrchestrator on reminder
+    // deliveries from InstanceRecipient.SentAt. Providers render it as an "Originally sent:"
+    // line alongside the reminder marker (PRD-029 §7). Null on first-time deliveries.
+    public DateTime? OriginallySentAt { get; set; }
 }
 
 public class BatchQuestionRef

--- a/server/src/Dotbot.Server/Services/Delivery/SlackDeliveryProvider.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/SlackDeliveryProvider.cs
@@ -307,6 +307,18 @@ public class SlackDeliveryProvider : IQuestionDeliveryProvider
                 type = "context",
                 elements = new[] { new { type = "mrkdwn", text = ":alarm_clock: *Reminder* — this question is still awaiting your response." } }
             });
+
+            if (summary.OriginallySentAt.HasValue)
+            {
+                blocks.Add(new
+                {
+                    type = "context",
+                    elements = new[]
+                    {
+                        new { type = "mrkdwn", text = $"_Originally sent:_ {DeliveryFormatting.FormatUtc(summary.OriginallySentAt.Value)}" }
+                    }
+                });
+            }
         }
 
         blocks.Add(new

--- a/server/src/Dotbot.Server/appsettings.Example.json
+++ b/server/src/Dotbot.Server/appsettings.Example.json
@@ -44,7 +44,10 @@
     "AccountUri": "https://REPLACE-WITH-STORAGE-ACCOUNT.blob.core.windows.net",
     "ConnectionString": "",
     "Backend": "AzureBlob",
-    "MaxAttachmentSizeMb": 15
+    "MaxAttachmentSizeMb": 15,
+    "AllowedExtensionsBlacklist": [
+      ".exe", ".msi", ".dll", ".bat", ".sh", ".ps1", ".cmd", ".scr", ".vbs"
+    ]
   },
   "ApiSecurity": {
     "ApiKey": "<shared secret sent in X-Api-Key header by dotbot clients>"

--- a/server/tests/Dotbot.Server.Tests/Integration/DotbotApiFactory.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/DotbotApiFactory.cs
@@ -21,7 +21,12 @@ public sealed class DotbotApiFactory : WebApplicationFactory<Program>
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         // Provide minimum required configuration so the host boots without Azure resources.
+        // BlobStorage:Backend=Local routes IAttachmentStorage to LocalFileAttachmentStorage so
+        // upload tests run without a live Azurite. ConnectionString is still required because
+        // BlobServiceClient is unconditionally registered in Program.cs (resolved lazily).
         builder.UseSetting("BlobStorage:ConnectionString", "UseDevelopmentStorage=true");
+        builder.UseSetting("BlobStorage:Backend", "Local");
+        builder.UseSetting("BlobStorage:LocalStoragePath", Path.Combine(Path.GetTempPath(), "dotbot-test-attachments-" + Guid.NewGuid()));
         builder.UseSetting("ApiSecurity:ApiKey", TestApiKey);
         builder.UseSetting("Validation:QuestionTemplate:MaxAttachments", TestMaxAttachments.ToString());
         builder.UseSetting("Validation:QuestionTemplate:MaxReferenceLinks", TestMaxReferenceLinks.ToString());

--- a/server/tests/Dotbot.Server.Tests/Integration/PostAttachmentsTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/PostAttachmentsTests.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace Dotbot.Server.Tests.Integration;
+
+public class PostAttachmentsTests : IntegrationTestBase
+{
+    public PostAttachmentsTests(DotbotApiFactory factory) : base(factory) { }
+
+    private static MultipartFormDataContent FormWithFile(string fileName, string content = "data")
+    {
+        var bytes = Encoding.UTF8.GetBytes(content);
+        var fileContent = new ByteArrayContent(bytes);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        return new MultipartFormDataContent
+        {
+            { fileContent, "file", fileName }
+        };
+    }
+
+    [Theory]
+    [InlineData("payload.exe")]
+    [InlineData("installer.msi")]
+    [InlineData("library.dll")]
+    [InlineData("run.bat")]
+    [InlineData("install.sh")]
+    [InlineData("script.ps1")]
+    [InlineData("cmd.cmd")]
+    [InlineData("screen.scr")]
+    [InlineData("macro.vbs")]
+    public async Task BlacklistedExtension_ReturnsBadRequest(string fileName)
+    {
+        using var form = FormWithFile(fileName);
+
+        var response = await Client.PostAsync("/api/attachments", form);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var error = doc.RootElement.GetProperty("error").GetString();
+        Assert.NotNull(error);
+        Assert.Contains("not allowed", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task BlacklistedExtension_IsCaseInsensitive()
+    {
+        using var form = FormWithFile("Malware.EXE");
+
+        var response = await Client.PostAsync("/api/attachments", form);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MissingFileField_ReturnsBadRequest()
+    {
+        using var form = new MultipartFormDataContent
+        {
+            { new StringContent("not a file"), "other" }
+        };
+
+        var response = await Client.PostAsync("/api/attachments", form);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("design.pdf", "application/pdf")]
+    [InlineData("notes.txt", "text/plain")]
+    [InlineData("diagram.png", "image/png")]
+    public async Task AllowedExtension_UploadsAndReturnsMetadata(string fileName, string contentType)
+    {
+        const string body = "test file content";
+        var bytes = Encoding.UTF8.GetBytes(body);
+        var fileContent = new ByteArrayContent(bytes);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+
+        using var form = new MultipartFormDataContent
+        {
+            { fileContent, "file", fileName }
+        };
+
+        var response = await Client.PostAsync("/api/attachments", form);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(responseBody);
+        var root = doc.RootElement;
+
+        Assert.True(root.TryGetProperty("attachmentId", out var idProp));
+        Assert.True(Guid.TryParse(idProp.GetString(), out var attachmentId) && attachmentId != Guid.Empty);
+
+        Assert.True(root.TryGetProperty("storageRef", out var refProp));
+        Assert.False(string.IsNullOrWhiteSpace(refProp.GetString()));
+
+        Assert.Equal(fileName, root.GetProperty("name").GetString());
+        Assert.Equal(contentType, root.GetProperty("contentType").GetString());
+        Assert.Equal(bytes.Length, root.GetProperty("sizeBytes").GetInt64());
+    }
+}

--- a/server/tests/Dotbot.Server.Tests/Unit/JiraDeliveryProviderRenderingTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/JiraDeliveryProviderRenderingTests.cs
@@ -119,6 +119,34 @@ public class JiraDeliveryProviderRenderingTests
     }
 
     [Fact]
+    public void Summary_IsReminderTrue_WithOriginallySentAt_AddsOriginallySentLine()
+    {
+        var s = MakeFullSummary();
+        s.IsReminder = true;
+        s.OriginallySentAt = new DateTime(2026, 4, 28, 9, 15, 0, DateTimeKind.Utc);
+
+        var actual = Normalize(JiraDeliveryProvider.BuildJiraCommentFromSummary(s));
+
+        Assert.StartsWith(
+            "{panel:borderColor=#f0ad4e|bgColor=#fff4ce}*Reminder:* This question is still awaiting a response.{panel}\n" +
+            "_Originally sent: 2026-04-28 09:15 UTC_\n\n" +
+            "h3. Approve architecture v2\n",
+            actual);
+    }
+
+    [Fact]
+    public void Summary_IsReminderTrue_WithoutOriginallySentAt_OmitsOriginallySentLine()
+    {
+        var s = MakeFullSummary();
+        s.IsReminder = true;
+        s.OriginallySentAt = null;
+
+        var actual = Normalize(JiraDeliveryProvider.BuildJiraCommentFromSummary(s));
+
+        Assert.DoesNotContain("Originally sent", actual);
+    }
+
+    [Fact]
     public void NullSummary_LegacyFallback_RendersUnchanged()
     {
         var template = new QuestionTemplate

--- a/server/tests/Dotbot.Server.Tests/Unit/SlackSummaryBlocksTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/SlackSummaryBlocksTests.cs
@@ -21,7 +21,8 @@ public class SlackSummaryBlocksTests
         List<ReviewLinkRef>? reviewLinks = null,
         string respondUrl = "https://example/respond/abc",
         bool isReminder = false,
-        DateTime? dueBy = null)
+        DateTime? dueBy = null,
+        DateTime? originallySentAt = null)
         => new()
         {
             QuestionTitle = title,
@@ -35,6 +36,7 @@ public class SlackSummaryBlocksTests
             RespondUrl = respondUrl,
             IsReminder = isReminder,
             DueBy = dueBy,
+            OriginallySentAt = originallySentAt,
         };
 
     private static List<JsonElement> Render(NotificationSummary s)
@@ -188,6 +190,34 @@ public class SlackSummaryBlocksTests
     {
         var blocks = Render(Summary(isReminder: false));
         Assert.Equal("header", blocks[0].GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void Reminder_WithOriginallySentAt_RendersOriginallySentLineAfterBanner()
+    {
+        var sentAt = new DateTime(2026, 4, 28, 9, 15, 0, DateTimeKind.Utc);
+        var blocks = Render(Summary(isReminder: true, originallySentAt: sentAt));
+
+        var bannerText = blocks[0].GetProperty("elements")[0].GetProperty("text").GetString()!;
+        Assert.Contains("Reminder", bannerText);
+
+        var originallySentText = blocks[1].GetProperty("elements")[0].GetProperty("text").GetString()!;
+        Assert.Equal("context", blocks[1].GetProperty("type").GetString());
+        Assert.Contains("Originally sent:", originallySentText);
+        Assert.Contains("2026-04-28 09:15 UTC", originallySentText);
+    }
+
+    [Fact]
+    public void Reminder_WithoutOriginallySentAt_OmitsOriginallySentLine()
+    {
+        var blocks = Render(Summary(isReminder: true, originallySentAt: null));
+
+        Assert.DoesNotContain(blocks, b =>
+        {
+            if (b.GetProperty("type").GetString() != "context") return false;
+            var text = b.GetProperty("elements")[0].GetProperty("text").GetString() ?? string.Empty;
+            return text.Contains("Originally sent");
+        });
     }
 
     [Fact]

--- a/server/tests/Dotbot.Server.Tests/Unit/TeamsSummaryCardTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/TeamsSummaryCardTests.cs
@@ -19,7 +19,8 @@ public class TeamsSummaryCardTests
         List<ReviewLinkRef>? reviewLinks = null,
         string respondUrl = "https://example/respond/abc",
         bool isReminder = false,
-        DateTime? dueBy = null)
+        DateTime? dueBy = null,
+        DateTime? originallySentAt = null)
         => new()
         {
             QuestionTitle = title,
@@ -33,6 +34,7 @@ public class TeamsSummaryCardTests
             RespondUrl = respondUrl,
             IsReminder = isReminder,
             DueBy = dueBy,
+            OriginallySentAt = originallySentAt,
         };
 
     private static JsonElement Render(NotificationSummary s) =>
@@ -233,6 +235,35 @@ public class TeamsSummaryCardTests
             .Select(e => e.GetProperty("style").GetString())
             .ToList();
         Assert.DoesNotContain("warning", styles);
+    }
+
+    [Fact]
+    public void Reminder_WithOriginallySentAt_RendersOriginallySentInWarningContainer()
+    {
+        var sentAt = new DateTime(2026, 4, 28, 9, 15, 0, DateTimeKind.Utc);
+        var card = Render(Summary(isReminder: true, originallySentAt: sentAt));
+        var bodyArr = Body(card).ToList();
+
+        var warning = bodyArr[0];
+        Assert.Equal("warning", warning.GetProperty("style").GetString());
+
+        var items = warning.GetProperty("items").EnumerateArray().ToList();
+        Assert.Equal(2, items.Count);
+
+        var originallySentText = ConcatRichTextBlock(items[1]);
+        Assert.Contains("Originally sent:", originallySentText);
+        Assert.Contains("2026-04-28 09:15 UTC", originallySentText);
+    }
+
+    [Fact]
+    public void Reminder_WithoutOriginallySentAt_OmitsOriginallySentLine()
+    {
+        var card = Render(Summary(isReminder: true, originallySentAt: null));
+        var bodyArr = Body(card).ToList();
+
+        var warning = bodyArr[0];
+        var items = warning.GetProperty("items").EnumerateArray().ToList();
+        Assert.Single(items);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Implements two of the three polish items from #293 (PR-12/#29):

1. **Filename-extension blacklist on `POST /api/attachments`** — rejects executable extensions (`.exe`, `.msi`, `.dll`, `.bat`, `.sh`, `.ps1`, `.cmd`, `.scr`, `.vbs`) with `400 Bad Request` and a clear error message. Configurable via `BlobStorage:AllowedExtensionsBlacklist`.
2. **`NotificationSummary.OriginallySentAt`** populated from `InstanceRecipient.SentAt` on reminder deliveries; rendered as an "Originally sent: {timestamp}" line in the reminder header for Teams, Slack, and Jira providers.

`DueBy` derivation was already wired up in PR-6 (#413), so no work needed there.

## Changes

### Attachment blacklist
- `BlobStorageSettings.AllowedExtensionsBlacklist` — list, defaults to the 9 banned extensions; empty list disables filtering
- `POST /api/attachments` — extension check before stream is opened; case-insensitive compare; deliberately ignores client-supplied `Content-Type` header (spoofable) and only inspects the filename extension
- `appsettings.Example.json` — documents the new key

### Reminder "Originally sent" marker
- `NotificationSummary.OriginallySentAt` (nullable DateTime)
- `DeliveryOrchestrator.SendReminderAsync` — sets `OriginallySentAt = recipient.SentAt`
- `AdaptiveCardService` (Teams) — extra `RichTextBlock` inside the warning container
- `SlackDeliveryProvider` — extra `context` block after the reminder banner
- `JiraDeliveryProvider` — italic line beneath the reminder panel
- Email is intentionally not updated — issue spec lists "Originally sent" only for Teams/Slack/Jira; email already prefixes the subject

## Tests

- **Unit** — 6 new tests across `SlackSummaryBlocksTests`, `TeamsSummaryCardTests`, `JiraDeliveryProviderRenderingTests` covering reminder + with/without `OriginallySentAt`
- **Integration** — new `PostAttachmentsTests`:
  - `BlacklistedExtension_ReturnsBadRequest` — Theory over all 9 banned extensions
  - `BlacklistedExtension_IsCaseInsensitive` — `Malware.EXE`
  - `MissingFileField_ReturnsBadRequest`
  - `AllowedExtension_UploadsAndReturnsMetadata` — Theory for `.pdf`, `.txt`, `.png`, asserts full response shape
- **Test infra** — `DotbotApiFactory` now routes to `LocalFileAttachmentStorage` via `BlobStorage:Backend=Local` so attachment endpoints can be exercised without Azurite

## Acceptance Criteria

- [x] `.exe` upload → 400 with clear error
- [x] Allowed file types (PDF, images, text) upload successfully
- [x] `DueBy` renders in header for instances with `EscalateAfterDays` set _(already shipped in PR-6)_
- [x] Reminder fires → recipient sees `⏰ Reminder` marker + "Originally sent" line (Teams/Slack/Jira)

Closes #293