### PR TITLE
chore(server): ignore *.csproj.user files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ element-*.jpeg
 server/**/bin/
 server/**/obj/
 server/**/TestResults/
+server/**/*.csproj.user
 server/src/**/appsettings.Development.json
 server/terraform/.terraform/
 server/terraform/tfplan


### PR DESCRIPTION
## Summary
- Adds `server/**/*.csproj.user` to root `.gitignore` so Visual Studio per-user project state stops appearing as untracked.

Closes #429

## Test plan
- [x] `git status` no longer lists `server/src/Dotbot.Server/Dotbot.Server.csproj.user`
- [x] Pattern scoped to `server/` only (unchanged behavior elsewhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)