### PR TITLE
fix: dashboard date format

### DIFF
--- a/core/ui/static/modules/actions.js
+++ b/core/ui/static/modules/actions.js
@@ -548,7 +548,7 @@ function renderReviewItem(item) {
         if (item.commit_sha) parts.push(`<span class="review-meta-commit">commit <code>${escapeHtml(item.commit_sha.substring(0, 8))}</code></span>`);
         if (item.review_requested_at) {
             const d = new Date(item.review_requested_at);
-            const label = isNaN(d) ? item.review_requested_at : d.toLocaleString();
+            const label = isNaN(d) ? item.review_requested_at : formatFriendlyDate(item.review_requested_at);
             parts.push(`<span class="review-meta-time">${escapeHtml(label)}</span>`);
         }
         return parts.length ? `<div class="review-meta">${parts.join('')}</div>` : '';

--- a/core/ui/static/modules/aether.js
+++ b/core/ui/static/modules/aether.js
@@ -837,7 +837,7 @@ const Aether = (function() {
 
         if (lastEventEl && _lastEvent) {
             const _t = _lastEvent.time;
-            const timeStr = `${_t.getHours().toString().padStart(2,'0')}:${_t.getMinutes().toString().padStart(2,'0')}`;
+            const timeStr = `${_t.getHours().toString().padStart(2,'0')}:${_t.getMinutes().toString().padStart(2,'0')}:${_t.getSeconds().toString().padStart(2,'0')}`;
             const colorVar = _lastEvent.type === 'START' ? '--color-success' :
                              _lastEvent.type === 'COMPLETE' ? '--color-secondary' : '--color-primary';
             lastEventEl.innerHTML = `<span class="event-type" style="color: var(${colorVar})">${_lastEvent.type}</span><span class="event-time">${timeStr}</span>`;

--- a/core/ui/static/modules/aether.js
+++ b/core/ui/static/modules/aether.js
@@ -836,7 +836,8 @@ const Aether = (function() {
         if (errorEl) errorEl.textContent = _stats.errors;
 
         if (lastEventEl && _lastEvent) {
-            const timeStr = _lastEvent.time.toLocaleTimeString();
+            const _t = _lastEvent.time;
+            const timeStr = `${_t.getHours().toString().padStart(2,'0')}:${_t.getMinutes().toString().padStart(2,'0')}`;
             const colorVar = _lastEvent.type === 'START' ? '--color-success' :
                              _lastEvent.type === 'COMPLETE' ? '--color-secondary' : '--color-primary';
             lastEventEl.innerHTML = `<span class="event-type" style="color: var(${colorVar})">${_lastEvent.type}</span><span class="event-time">${timeStr}</span>`;

--- a/core/ui/static/modules/decisions.js
+++ b/core/ui/static/modules/decisions.js
@@ -191,6 +191,7 @@ function _friendlyDate(iso) {
     if (!iso) return '';
     try {
         const d = new Date(iso);
+        if (isNaN(d.getTime())) return iso;
         const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
         return `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
     } catch { return iso; }

--- a/core/ui/static/modules/decisions.js
+++ b/core/ui/static/modules/decisions.js
@@ -190,7 +190,9 @@ function _renderList() {
 function _friendlyDate(iso) {
     if (!iso) return '';
     try {
-        return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+        const d = new Date(iso);
+        const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+        return `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
     } catch { return iso; }
 }
 

--- a/core/ui/static/modules/processes.js
+++ b/core/ui/static/modules/processes.js
@@ -295,7 +295,7 @@ function toggleProcessExpand(processId) {
 function renderOutputHtml(events) {
     let html = '';
     for (const evt of events) {
-        const ts = evt.timestamp ? new Date(evt.timestamp).toLocaleTimeString() : '';
+        const ts = evt.timestamp ? formatCompactTime(evt.timestamp) : '';
         const typeClass = evt.type === 'rate_limit' ? 'warning' : (evt.type === 'text' ? 'text' : 'tool');
         const messageText = stripConsoleSequences(evt.message || '');
         html += `<div class="process-output-line ${typeClass}">`;

--- a/core/ui/static/modules/ui-updates.js
+++ b/core/ui/static/modules/ui-updates.js
@@ -65,7 +65,7 @@ function updateUI(state) {
  */
 function updateTimestamp(instanceId) {
     const _now = new Date();
-    setElementText('last-update', `${_now.getHours().toString().padStart(2,'0')}:${_now.getMinutes().toString().padStart(2,'0')}`);
+    setElementText('last-update', `${_now.getHours().toString().padStart(2,'0')}:${_now.getMinutes().toString().padStart(2,'0')}:${_now.getSeconds().toString().padStart(2,'0')}`);
     setElementText('instance-id', instanceId || '--');
     // Update footer mission on each poll to ensure it's current
     updateFooterMission();
@@ -144,7 +144,7 @@ function updateSessionInfo(session) {
 
     if (session.started_at) {
         const started = new Date(session.started_at);
-        setElementText('session-started', `${started.getHours().toString().padStart(2,'0')}:${started.getMinutes().toString().padStart(2,'0')}`);
+        setElementText('session-started', `${started.getHours().toString().padStart(2,'0')}:${started.getMinutes().toString().padStart(2,'0')}:${started.getSeconds().toString().padStart(2,'0')}`);
         sessionStartTime = started;
     } else {
         setElementText('session-started', '--');

--- a/core/ui/static/modules/ui-updates.js
+++ b/core/ui/static/modules/ui-updates.js
@@ -64,7 +64,8 @@ function updateUI(state) {
  * Update timestamp display
  */
 function updateTimestamp(instanceId) {
-    setElementText('last-update', new Date().toLocaleTimeString());
+    const _now = new Date();
+    setElementText('last-update', `${_now.getHours().toString().padStart(2,'0')}:${_now.getMinutes().toString().padStart(2,'0')}`);
     setElementText('instance-id', instanceId || '--');
     // Update footer mission on each poll to ensure it's current
     updateFooterMission();
@@ -143,7 +144,7 @@ function updateSessionInfo(session) {
 
     if (session.started_at) {
         const started = new Date(session.started_at);
-        setElementText('session-started', started.toLocaleTimeString());
+        setElementText('session-started', `${started.getHours().toString().padStart(2,'0')}:${started.getMinutes().toString().padStart(2,'0')}`);
         sessionStartTime = started;
     } else {
         setElementText('session-started', '--');

--- a/core/ui/static/modules/utils.js
+++ b/core/ui/static/modules/utils.js
@@ -96,6 +96,7 @@ function formatFriendlyDate(isoString) {
     if (!isoString) return '';
     try {
         const date = new Date(isoString);
+        if (isNaN(date.getTime())) return '';
         const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
         const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
         const dayOfWeek = days[date.getDay()];

--- a/core/ui/static/modules/utils.js
+++ b/core/ui/static/modules/utils.js
@@ -90,7 +90,7 @@ function formatCompactDate(isoString) {
 /**
  * Format ISO date string to human-friendly format with day of week
  * @param {string} isoString - ISO date string
- * @returns {string} Formatted date like "Fri Dec 15 14:30"
+ * @returns {string} Formatted date like "Fri, Dec 15 2026 14:30"
  */
 function formatFriendlyDate(isoString) {
     if (!isoString) return '';
@@ -101,9 +101,10 @@ function formatFriendlyDate(isoString) {
         const dayOfWeek = days[date.getDay()];
         const month = months[date.getMonth()];
         const dayNum = date.getDate();
+        const year = date.getFullYear();
         const hours = date.getHours().toString().padStart(2, '0');
         const mins = date.getMinutes().toString().padStart(2, '0');
-        return `${dayOfWeek} ${month} ${dayNum} ${hours}:${mins}`;
+        return `${dayOfWeek}, ${month} ${dayNum} ${year} ${hours}:${mins}`;
     } catch (e) {
         return '';
     }

--- a/server/src/Dotbot.Server/wwwroot/css/dashboard.css
+++ b/server/src/Dotbot.Server/wwwroot/css/dashboard.css
@@ -914,7 +914,7 @@ select.filter-input option {
     background: var(--bg-panel);
     border: 1px solid var(--bezel-edge);
     border-radius: 6px;
-    max-width: 900px;
+    max-width: 920px;
     width: 95%;
     max-height: 80vh;
     overflow: hidden;

--- a/server/src/Dotbot.Server/wwwroot/js/dashboard.js
+++ b/server/src/Dotbot.Server/wwwroot/js/dashboard.js
@@ -5,6 +5,15 @@
 (function () {
     'use strict';
 
+    // --- Formatters ---
+    const _dtFormatter = new Intl.DateTimeFormat('en-US', {
+        weekday: 'short', month: 'short', day: 'numeric',
+        year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false
+    });
+    const _timeFormatter = new Intl.DateTimeFormat('en-US', {
+        hour: '2-digit', minute: '2-digit', hour12: false
+    });
+
     // --- State ---
     let allInstances = [];
     let byPerson = {};     // email -> [{ instance, recipient, response }]
@@ -19,10 +28,8 @@
     function formatDashboardDateTime(date) {
         try {
             const d = date instanceof Date ? date : new Date(date);
-            const parts = new Intl.DateTimeFormat('en-US', {
-                weekday: 'short', month: 'short', day: 'numeric',
-                year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false
-            }).formatToParts(d);
+            if (isNaN(d.getTime())) return String(date);
+            const parts = _dtFormatter.formatToParts(d);
             const get = (t) => (parts.find(p => p.type === t) || {}).value || '';
             return `${get('weekday')}, ${get('month')} ${get('day')} ${get('year')} ${get('hour')}:${get('minute')}`;
         } catch (e) { return String(date); }
@@ -31,9 +38,8 @@
     function formatDashboardTime(date) {
         try {
             const d = date instanceof Date ? date : new Date(date);
-            const parts = new Intl.DateTimeFormat('en-US', {
-                hour: '2-digit', minute: '2-digit', hour12: false
-            }).formatToParts(d);
+            if (isNaN(d.getTime())) return '';
+            const parts = _timeFormatter.formatToParts(d);
             const get = (t) => (parts.find(p => p.type === t) || {}).value || '';
             return `${get('hour')}:${get('minute')}`;
         } catch (e) { return ''; }

--- a/server/src/Dotbot.Server/wwwroot/js/dashboard.js
+++ b/server/src/Dotbot.Server/wwwroot/js/dashboard.js
@@ -16,6 +16,29 @@
     let nudgeCooldowns = {}; // key -> timestamp
 
     // --- Helpers ---
+    function formatDashboardDateTime(date) {
+        try {
+            const d = date instanceof Date ? date : new Date(date);
+            const parts = new Intl.DateTimeFormat('en-US', {
+                weekday: 'short', month: 'short', day: 'numeric',
+                year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false
+            }).formatToParts(d);
+            const get = (t) => (parts.find(p => p.type === t) || {}).value || '';
+            return `${get('weekday')}, ${get('month')} ${get('day')} ${get('year')} ${get('hour')}:${get('minute')}`;
+        } catch (e) { return String(date); }
+    }
+
+    function formatDashboardTime(date) {
+        try {
+            const d = date instanceof Date ? date : new Date(date);
+            const parts = new Intl.DateTimeFormat('en-US', {
+                hour: '2-digit', minute: '2-digit', hour12: false
+            }).formatToParts(d);
+            const get = (t) => (parts.find(p => p.type === t) || {}).value || '';
+            return `${get('hour')}:${get('minute')}`;
+        } catch (e) { return ''; }
+    }
+
     function buildRecipientPills(recipients, max) {
         if (!recipients || recipients.length === 0) return '';
         // Sort: non-responders first, then responders
@@ -286,7 +309,7 @@
             </div>
             <div class="instance-meta-item">
                 <span class="instance-meta-label">Created</span>
-                <span class="instance-meta-value">${inst.createdAt ? new Date(inst.createdAt).toLocaleString() : '-'}</span>
+                <span class="instance-meta-value">${inst.createdAt ? formatDashboardDateTime(inst.createdAt) : '-'}</span>
             </div>
             <div class="instance-meta-item">
                 <span class="instance-meta-label">Created By</span>
@@ -814,6 +837,6 @@
 
     function updateRefreshTime() {
         const el = document.getElementById('last-refresh');
-        el.textContent = `Last refresh: ${new Date().toLocaleTimeString()}`;
+        el.textContent = `Last refresh: ${formatDashboardTime(new Date())}`;
     }
 })();


### PR DESCRIPTION
## Linked issue

Closes #438

## Summary of changes

All user-facing date/time calls in the dashboard and control panel UI used `toLocaleString` / `toLocaleTimeString` / `toLocaleDateString` with no locale argument, producing inconsistent output depending on OS locale (e.g. "5/19/2026, 1:26 PM" on en-US, Arabic numerals on ar-SA).

Replaced with locale-independent formatters:
- `dashboard.js`: added `formatDashboardDateTime()` and `formatDashboardTime()` using `Intl.DateTimeFormat('en-US').formatToParts()` — immune to locale punctuation variations even with explicit options
- `core/ui` modules: swapped remaining `toLocale*` calls to inline `getHours/getMinutes` (time-only sites) or existing `formatFriendlyDate()` helper (full datetime sites)
- `formatFriendlyDate()` in `utils.js`: added missing year to output
- `decisions.js`: replaced `toLocaleDateString` in `_friendlyDate()` with manual month array

## Screenshots / recordings
Before:
<img width="1126" height="278" alt="image" src="https://github.com/user-attachments/assets/e0f4f7e6-e004-45fe-875c-c8f8c4d845d2" />

<img width="780" height="378" alt="image" src="https://github.com/user-attachments/assets/fe8bd7e4-7f96-4013-8b4d-6305944b4c9b" />


After:
<img width="1140" height="253" alt="image" src="https://github.com/user-attachments/assets/82e57bf9-6ada-4d50-9ad8-a374dbfb19e1" />

<img width="769" height="351" alt="image" src="https://github.com/user-attachments/assets/8618b1f9-abd2-4111-bb34-484a1e08d1fb" />


## Testing notes

1. Set OS locale to a non-English locale (e.g. German, Arabic)
2. Open Mothership dashboard — all timestamps must render as `"Tue, May 19 2026 13:26"` regardless of locale
3. Auto-refresh footer must show 24h time with no AM/PM
4. Open control panel UI — session-started and last-update fields must show `HH:MM:SS` format, not locale-dependent time string

## Checklist

- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
