### PR TITLE
Merge approval and documentReview into one approval type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ server/publish.zip
 server/teams-app/manifest.json
 server/teams-app/*.zip
 
+# Visual Studio user-local project settings
+*.csproj.user
+
 # Enterprise proposal analysis (proprietary)
 docs/proposal-v4/
 

--- a/core/mcp/modules/NotificationClient.psm1
+++ b/core/mcp/modules/NotificationClient.psm1
@@ -805,6 +805,8 @@ function ConvertTo-TypedResponse {
                            for freeText, "approved"/"rejected" for approval)
       comment            - free-text comment (approval only)
       ranked_items       - array for priorityRanking
+      reviewed_attachment_ids - GUIDs of attachments the reviewer ticked
+                                (approval with attachments only)
       attachment_refs    - array of @{ name; size_bytes; storage_ref; description }
     Returns $null when no meaningful payload found.
     #>
@@ -862,6 +864,14 @@ function ConvertTo-TypedResponse {
             # never need a separate decision field to extract the response.
             if ($decision) { $out['answer']  = $decision }
             if ($comment)  { $out['comment'] = $comment  }
+            # For approval-with-attachments, the server-side respond form
+            # records which attachments the reviewer confirmed reading. Pull
+            # that list through so the local task's questions_resolved entry
+            # carries the same fidelity as the server-side ResponseRecordV2.
+            $reviewedIds = if ($Response.PSObject.Properties['reviewedAttachmentIds']) { @($Response.reviewedAttachmentIds) }
+                           elseif ($Response.PSObject.Properties['reviewed_attachment_ids']) { @($Response.reviewed_attachment_ids) }
+                           else { @() }
+            if ($reviewedIds.Count -gt 0) { $out['reviewed_attachment_ids'] = $reviewedIds }
         }
         'priorityRanking' {
             if ($rankedItems) {

--- a/core/mcp/modules/NotificationClient.psm1
+++ b/core/mcp/modules/NotificationClient.psm1
@@ -265,8 +265,8 @@ function Send-TaskNotification {
     Optional notification settings. If not provided, reads from config.
 
     .PARAMETER Type
-    PRD §4.6 question type — singleChoice (default) | approval | documentReview |
-    freeText | priorityRanking. Drives card rendering and response parsing.
+    PRD sec. 4.6 question type — singleChoice (default) | approval | freeText |
+    priorityRanking. Drives card rendering and response parsing.
 
     .PARAMETER DeliverableSummary
     Optional 1-3 line summary shown in channel notifications (PRD §5.2).
@@ -802,7 +802,7 @@ function ConvertTo-TypedResponse {
     Hashtable. Keys (only set when applicable):
       answer_type        - the type string echoed back
       answer             - resolved string for singleChoice (key) / freeText (string)
-      approval_decision  - approval / documentReview decision value
+      approval_decision  - approval decision value
       comment            - free-text comment
       ranked_items       - array for priorityRanking
       attachment_refs    - array of @{ name; size_bytes; storage_ref; description }
@@ -857,10 +857,6 @@ function ConvertTo-TypedResponse {
 
     switch ($Type) {
         'approval' {
-            if ($decision) { $out['approval_decision'] = $decision }
-            if ($comment)  { $out['comment']           = $comment  }
-        }
-        'documentReview' {
             if ($decision) { $out['approval_decision'] = $decision }
             if ($comment)  { $out['comment']           = $comment  }
         }

--- a/core/mcp/modules/NotificationClient.psm1
+++ b/core/mcp/modules/NotificationClient.psm1
@@ -801,9 +801,9 @@ function ConvertTo-TypedResponse {
     .OUTPUTS
     Hashtable. Keys (only set when applicable):
       answer_type        - the type string echoed back
-      answer             - resolved string for singleChoice (key) / freeText (string)
-      approval_decision  - approval decision value
-      comment            - free-text comment
+      answer             - response value (option key for singleChoice, free text
+                           for freeText, "approved"/"rejected" for approval)
+      comment            - free-text comment (approval only)
       ranked_items       - array for priorityRanking
       attachment_refs    - array of @{ name; size_bytes; storage_ref; description }
     Returns $null when no meaningful payload found.
@@ -857,8 +857,11 @@ function ConvertTo-TypedResponse {
 
     switch ($Type) {
         'approval' {
-            if ($decision) { $out['approval_decision'] = $decision }
-            if ($comment)  { $out['comment']           = $comment  }
+            # For approval, `answer` carries the decision value ("approved" /
+            # "rejected") — same wire shape as singleChoice/freeText so callers
+            # never need a separate decision field to extract the response.
+            if ($decision) { $out['answer']  = $decision }
+            if ($comment)  { $out['comment'] = $comment  }
         }
         'priorityRanking' {
             if ($rankedItems) {

--- a/core/mcp/tools/task-answer-question/metadata.yaml
+++ b/core/mcp/tools/task-answer-question/metadata.yaml
@@ -11,11 +11,12 @@ inputSchema:
       description: "The answer - either an option key (A, B, C, D, E) or a custom freeform answer. Required for singleChoice/freeText types."
     type:
       type: string
-      enum: [singleChoice, approval, documentReview, freeText, priorityRanking]
+      enum: [singleChoice, approval, freeText, priorityRanking]
       description: "Question type. Determines which fields are required/validated."
     decision:
       type: string
-      description: "Required for approval/documentReview. Allowed values vary per type (PRD Section 4.1)."
+      enum: [approved, rejected]
+      description: "Required for approval. Allowed values: approved, rejected."
     comment:
       type: string
       description: "Required when decision=rejected on an approval question."

--- a/core/mcp/tools/task-answer-question/metadata.yaml
+++ b/core/mcp/tools/task-answer-question/metadata.yaml
@@ -8,18 +8,14 @@ inputSchema:
       description: "The unique identifier of the task"
     answer:
       type: string
-      description: "The answer - either an option key (A, B, C, D, E) or a custom freeform answer. Required for singleChoice/freeText types."
+      description: "The user's response. Interpretation depends on `type`: option key (A-E) or custom text for singleChoice; reviewer text for freeText; 'approved' or 'rejected' for approval. Required for all non-priorityRanking types."
     type:
       type: string
       enum: [singleChoice, approval, freeText, priorityRanking]
-      description: "Question type. Determines which fields are required/validated."
-    decision:
-      type: string
-      enum: [approved, rejected]
-      description: "Required for approval. Allowed values: approved, rejected."
+      description: "Question type. Determines which fields are required/validated. Should match the type stamped on the pending question by task_mark_needs_input."
     comment:
       type: string
-      description: "Required when decision=rejected on an approval question."
+      description: "Required when answer='rejected' on an approval question."
     ranked_items:
       type: array
       description: "Required for priorityRanking. Ordered list of item identifiers."

--- a/core/mcp/tools/task-answer-question/script.ps1
+++ b/core/mcp/tools/task-answer-question/script.ps1
@@ -78,6 +78,13 @@ function Invoke-TaskAnswerQuestion {
     if ($rankedItems -and $effectiveType -ne 'priorityRanking') {
         throw "'ranked_items' is only valid for type 'priorityRanking', got type='$effectiveType'"
     }
+    # priorityRanking carries its answer in `ranked_items` (structured shape).
+    # Reject a free-form `answer` here so callers can't smuggle in a string
+    # that would override the synthesis from ranked_items and leave the
+    # persisted entry inconsistent with the ranking.
+    if ($answer -and $effectiveType -eq 'priorityRanking') {
+        throw "'answer' is not valid for type 'priorityRanking'; use 'ranked_items' instead"
+    }
 
     # Synthesize an answer string for typed payloads that don't carry a free-form
     # answer so downstream status-transition logic (skip detection, summary text)

--- a/core/mcp/tools/task-answer-question/script.ps1
+++ b/core/mcp/tools/task-answer-question/script.ps1
@@ -43,10 +43,9 @@ function Invoke-TaskAnswerQuestion {
 
     # Type-specific validation (PRD §4.1, §4.6)
     $validDecisions = @{
-        approval       = @('approved', 'rejected', 'abstained')
-        documentReview = @('approved', 'changes_requested', 'comment_only')
+        approval = @('approved', 'rejected')
     }
-    $validTypes = @('singleChoice', 'approval', 'documentReview', 'freeText', 'priorityRanking')
+    $validTypes = @('singleChoice', 'approval', 'freeText', 'priorityRanking')
     if ($questionType -and $questionType -notin $validTypes) {
         throw "Invalid 'type' value '$questionType'. Allowed: $($validTypes -join ', ')"
     }
@@ -58,8 +57,8 @@ function Invoke-TaskAnswerQuestion {
         if ($decision -notin $validDecisions[$questionType]) {
             throw "Invalid 'decision' value '$decision' for type '$questionType'. Allowed: $($validDecisions[$questionType] -join ', ')"
         }
-        if ($decision -in @('rejected', 'changes_requested') -and -not $comment) {
-            throw "'comment' is required when decision='$decision'"
+        if ($decision -eq 'rejected' -and -not $comment) {
+            throw "'comment' is required when decision='rejected'"
         }
     } elseif ($questionType -eq 'priorityRanking') {
         if (-not $rankedItems -or @($rankedItems).Count -eq 0) {
@@ -78,11 +77,11 @@ function Invoke-TaskAnswerQuestion {
     # 'type' is omitted — legacy callers default to singleChoice for this check
     # so decision/comment/ranked_items can't sneak in alongside a plain answer.
     $effectiveType = if ($questionType) { $questionType } else { 'singleChoice' }
-    if ($decision -and $effectiveType -notin @('approval', 'documentReview')) {
-        throw "'decision' is only valid for type 'approval' or 'documentReview', got type='$effectiveType'"
+    if ($decision -and $effectiveType -ne 'approval') {
+        throw "'decision' is only valid for type 'approval', got type='$effectiveType'"
     }
-    if ($comment -and $effectiveType -notin @('approval', 'documentReview')) {
-        throw "'comment' is only valid for type 'approval' or 'documentReview', got type='$effectiveType'"
+    if ($comment -and $effectiveType -ne 'approval') {
+        throw "'comment' is only valid for type 'approval', got type='$effectiveType'"
     }
     if ($rankedItems -and $effectiveType -ne 'priorityRanking') {
         throw "'ranked_items' is only valid for type 'priorityRanking', got type='$effectiveType'"
@@ -90,7 +89,7 @@ function Invoke-TaskAnswerQuestion {
     # Reject 'answer' when caller passes it alongside a typed payload — would
     # produce inconsistent resolvedEntry (e.g., answer='A' + approval_decision='approved').
     if ($answer -and $effectiveType -notin @('singleChoice', 'freeText')) {
-        throw "'answer' is only valid for type 'singleChoice' or 'freeText', got type='$effectiveType'. Use 'decision' (approval/documentReview) or 'ranked_items' (priorityRanking)."
+        throw "'answer' is only valid for type 'singleChoice' or 'freeText', got type='$effectiveType'. Use 'decision' (approval) or 'ranked_items' (priorityRanking)."
     }
 
     # Synthesize an answer string for non-question types so downstream

--- a/core/mcp/tools/task-answer-question/script.ps1
+++ b/core/mcp/tools/task-answer-question/script.ps1
@@ -27,21 +27,18 @@ function Invoke-TaskAnswerQuestion {
     )
 
     # Extract arguments
-    $taskId = $Arguments['task_id']
-    $answer = $Arguments['answer']
-    $attachments = $Arguments['attachments']
-    $questionId = $Arguments['question_id']  # Optional: which question to answer (for pending_questions batch)
+    $taskId       = $Arguments['task_id']
+    $answer       = $Arguments['answer']
+    $attachments  = $Arguments['attachments']
+    $questionId   = $Arguments['question_id']  # Optional: which question to answer (for pending_questions batch)
     $questionType = if ($Arguments['type']) { "$($Arguments['type'])" } else { $null }
-    $decision = if ($Arguments['decision']) { "$($Arguments['decision'])" } else { $null }
-    $comment = if ($Arguments['comment']) { "$($Arguments['comment'])" } else { $null }
-    $rankedItems = $Arguments['ranked_items']
+    $comment      = if ($Arguments['comment']) { "$($Arguments['comment'])" } else { $null }
+    $rankedItems  = $Arguments['ranked_items']
 
-    # Validate required fields
     if (-not $taskId) {
         throw "Task ID is required"
     }
 
-    # Type-specific validation (PRD §4.1, §4.6)
     $validDecisions = @{
         approval = @('approved', 'rejected')
     }
@@ -51,14 +48,14 @@ function Invoke-TaskAnswerQuestion {
     }
 
     if ($questionType -and $validDecisions.ContainsKey($questionType)) {
-        if (-not $decision) {
-            throw "'decision' is required for type '$questionType'"
+        if (-not $answer) {
+            throw "'answer' is required for type '$questionType' (one of: $($validDecisions[$questionType] -join ', '))"
         }
-        if ($decision -notin $validDecisions[$questionType]) {
-            throw "Invalid 'decision' value '$decision' for type '$questionType'. Allowed: $($validDecisions[$questionType] -join ', ')"
+        if ($answer -notin $validDecisions[$questionType]) {
+            throw "Invalid 'answer' value '$answer' for type '$questionType'. Allowed: $($validDecisions[$questionType] -join ', ')"
         }
-        if ($decision -eq 'rejected' -and -not $comment) {
-            throw "'comment' is required when decision='rejected'"
+        if ($answer -eq 'rejected' -and -not $comment) {
+            throw "'comment' is required when answer='rejected'"
         }
     } elseif ($questionType -eq 'priorityRanking') {
         if (-not $rankedItems -or @($rankedItems).Count -eq 0) {
@@ -73,43 +70,32 @@ function Invoke-TaskAnswerQuestion {
 
     # Cross-field validation: reject mutually-incompatible fields so callers
     # can't smuggle approval semantics into a freeText/singleChoice answer
-    # (would produce inconsistent questions_resolved entries). Runs even when
-    # 'type' is omitted — legacy callers default to singleChoice for this check
-    # so decision/comment/ranked_items can't sneak in alongside a plain answer.
+    # (would produce inconsistent questions_resolved entries).
     $effectiveType = if ($questionType) { $questionType } else { 'singleChoice' }
-    if ($decision -and $effectiveType -ne 'approval') {
-        throw "'decision' is only valid for type 'approval', got type='$effectiveType'"
-    }
     if ($comment -and $effectiveType -ne 'approval') {
         throw "'comment' is only valid for type 'approval', got type='$effectiveType'"
     }
     if ($rankedItems -and $effectiveType -ne 'priorityRanking') {
         throw "'ranked_items' is only valid for type 'priorityRanking', got type='$effectiveType'"
     }
-    # Reject 'answer' when caller passes it alongside a typed payload — would
-    # produce inconsistent resolvedEntry (e.g., answer='A' + approval_decision='approved').
-    if ($answer -and $effectiveType -notin @('singleChoice', 'freeText')) {
-        throw "'answer' is only valid for type 'singleChoice' or 'freeText', got type='$effectiveType'. Use 'decision' (approval) or 'ranked_items' (priorityRanking)."
-    }
 
-    # Synthesize an answer string for non-question types so downstream
-    # status-transition logic (skip detection, summary text) keeps working.
-    if (-not $answer) {
-        $answer = if ($decision) { $decision }
-                  elseif ($rankedItems) {
-                      # Normalize each item: extract optionId string if Claude passed
-                      # PSCustomObject/hashtable items (e.g. from a prior response object)
-                      # so -join doesn't stringify to "System.Management.Automation.PSCustomObject".
-                      $normalized = @($rankedItems | ForEach-Object {
-                          if ($_ -is [string]) { $_ }
-                          elseif ($_ -is [hashtable] -and $_.ContainsKey('optionId')) { "$($_['optionId'])" }
-                          elseif ($_.PSObject.Properties['optionId']) { "$($_.optionId)" }
-                          else { "$_" }
-                      })
-                      $normalized -join ', '
-                  }
-                  else { '' }
+    # Synthesize an answer string for typed payloads that don't carry a free-form
+    # answer so downstream status-transition logic (skip detection, summary text)
+    # keeps working. priorityRanking is the only remaining shape — approval now
+    # routes its decision through $answer directly.
+    if (-not $answer -and $rankedItems) {
+        # Normalize each item: extract optionId string if Claude passed
+        # PSCustomObject/hashtable items (e.g. from a prior response object)
+        # so -join doesn't stringify to "System.Management.Automation.PSCustomObject".
+        $normalized = @($rankedItems | ForEach-Object {
+            if ($_ -is [string]) { $_ }
+            elseif ($_ -is [hashtable] -and $_.ContainsKey('optionId')) { "$($_['optionId'])" }
+            elseif ($_.PSObject.Properties['optionId']) { "$($_.optionId)" }
+            else { "$_" }
+        })
+        $answer = $normalized -join ', '
     }
+    if (-not $answer) { $answer = '' }
 
     # Define tasks directories
     $tasksBaseDir = Join-Path $global:DotbotProjectRoot ".bot\workspace\tasks"
@@ -196,7 +182,6 @@ function Invoke-TaskAnswerQuestion {
         if ($attachments -and $attachments.Count -gt 0) {
             $resolvedEntry['attachments'] = $attachments
         }
-        if ($decision) { $resolvedEntry['approval_decision'] = $decision }
         if ($comment)  { $resolvedEntry['comment']           = $comment  }
         if ($rankedItems) { $resolvedEntry['ranked_items']  = @($rankedItems) }
 
@@ -211,7 +196,6 @@ function Invoke-TaskAnswerQuestion {
             answer_type  = if ($questionType) { $questionType } else { $answerType }
             answered_at  = $answeredAt
         }
-        if ($decision)    { $interviewEntry['approval_decision'] = $decision }
         if ($comment)     { $interviewEntry['comment']           = $comment  }
         if ($rankedItems) { $interviewEntry['ranked_items']      = @($rankedItems) }
         Write-InterviewAnswer -BotRoot (Join-Path $global:DotbotProjectRoot '.bot') -Entry $interviewEntry
@@ -361,7 +345,6 @@ function Invoke-TaskAnswerQuestion {
     if ($attachments -and $attachments.Count -gt 0) {
         $resolvedEntry['attachments'] = $attachments
     }
-    if ($decision) { $resolvedEntry['approval_decision'] = $decision }
     if ($comment)  { $resolvedEntry['comment']           = $comment  }
     if ($rankedItems) { $resolvedEntry['ranked_items']  = @($rankedItems) }
 
@@ -379,7 +362,6 @@ function Invoke-TaskAnswerQuestion {
         answer_type  = if ($questionType) { $questionType } else { $answerType }
         answered_at  = $answeredAt
     }
-    if ($decision)    { $singularInterviewEntry['approval_decision'] = $decision }
     if ($comment)     { $singularInterviewEntry['comment']           = $comment  }
     if ($rankedItems) { $singularInterviewEntry['ranked_items']      = @($rankedItems) }
     Write-InterviewAnswer -BotRoot (Join-Path $global:DotbotProjectRoot '.bot') -Entry $singularInterviewEntry

--- a/core/mcp/tools/task-mark-needs-input/metadata.yaml
+++ b/core/mcp/tools/task-mark-needs-input/metadata.yaml
@@ -114,7 +114,7 @@ inputSchema:
         - sub_tasks
     type:
       type: string
-      enum: [singleChoice, approval, documentReview, freeText, priorityRanking]
+      enum: [singleChoice, approval, freeText, priorityRanking]
       default: singleChoice
       description: "Question type (PRD Section 4.6). Drives card rendering and response parsing."
     deliverable_summary:

--- a/core/mcp/tools/task-mark-needs-input/script.ps1
+++ b/core/mcp/tools/task-mark-needs-input/script.ps1
@@ -20,7 +20,7 @@ function Invoke-TaskMarkNeedsInput {
     if (-not $question -and -not $questionsArg -and -not $splitProposal) { throw "Either 'questions' array, 'question' object, or 'split_proposal' is required" }
     if (($question -or $questionsArg) -and $splitProposal) { throw "Cannot provide both questions and split_proposal - use one at a time" }
 
-    $validTypes = @('singleChoice', 'approval', 'documentReview', 'freeText', 'priorityRanking')
+    $validTypes = @('singleChoice', 'approval', 'freeText', 'priorityRanking')
     if ($questionType -notin $validTypes) {
         throw "Invalid 'type' value '$questionType'. Allowed: $($validTypes -join ', ')"
     }

--- a/core/ui/modules/NotificationPoller.psm1
+++ b/core/ui/modules/NotificationPoller.psm1
@@ -289,6 +289,9 @@ function Invoke-TaskTransitionFromNotification {
         if ($TypedFields.ContainsKey('answer_type'))       { $resolvedEntry['answer_type']       = $TypedFields.answer_type }
         if ($TypedFields.ContainsKey('comment'))           { $resolvedEntry['comment']           = $TypedFields.comment }
         if ($TypedFields.ContainsKey('ranked_items'))      { $resolvedEntry['ranked_items']      = $TypedFields.ranked_items }
+        if ($TypedFields.ContainsKey('reviewed_attachment_ids')) {
+            $resolvedEntry['reviewed_attachment_ids'] = $TypedFields.reviewed_attachment_ids
+        }
         if ($TypedFields.ContainsKey('has_disagreement'))  { $resolvedEntry['has_disagreement']  = $TypedFields.has_disagreement }
         if ($TypedFields.ContainsKey('all_responses'))     { $resolvedEntry['all_responses']     = $TypedFields.all_responses }
         if ($TypedFields.ContainsKey('attachment_refs')) {
@@ -501,6 +504,9 @@ function Invoke-BatchQuestionTransitionFromNotification {
         if ($TypedFields.ContainsKey('answer_type'))       { $resolvedEntry['answer_type']       = $TypedFields.answer_type }
         if ($TypedFields.ContainsKey('comment'))           { $resolvedEntry['comment']           = $TypedFields.comment }
         if ($TypedFields.ContainsKey('ranked_items'))      { $resolvedEntry['ranked_items']      = $TypedFields.ranked_items }
+        if ($TypedFields.ContainsKey('reviewed_attachment_ids')) {
+            $resolvedEntry['reviewed_attachment_ids'] = $TypedFields.reviewed_attachment_ids
+        }
         if ($TypedFields.ContainsKey('has_disagreement'))  { $resolvedEntry['has_disagreement']  = $TypedFields.has_disagreement }
         if ($TypedFields.ContainsKey('all_responses'))     { $resolvedEntry['all_responses']     = $TypedFields.all_responses }
         if ($TypedFields.ContainsKey('attachment_refs')) {

--- a/core/ui/modules/NotificationPoller.psm1
+++ b/core/ui/modules/NotificationPoller.psm1
@@ -163,7 +163,6 @@ function Invoke-NotificationPollTick {
                             $typed['all_responses'] = $allResponses
                         }
                         $answerStr = if ($typed.ContainsKey('answer')) { $typed.answer }
-                                     elseif ($typed.ContainsKey('approval_decision')) { $typed.approval_decision }
                                      elseif ($typed.ContainsKey('ranked_items')) { (@($typed.ranked_items) -join ', ') }
                                      else { '' }
                         Invoke-TaskTransitionFromNotification -TaskFile $taskFile -TaskContent $taskContent `
@@ -209,7 +208,6 @@ function Invoke-NotificationPollTick {
                 $taskContent = Get-Content -Path $taskFile.FullName -Raw | ConvertFrom-Json
 
                 $answerStr = if ($typed.ContainsKey('answer')) { $typed.answer }
-                             elseif ($typed.ContainsKey('approval_decision')) { $typed.approval_decision }
                              elseif ($typed.ContainsKey('ranked_items')) { (@($typed.ranked_items) -join ', ') }
                              else { '' }
                 Invoke-BatchQuestionTransitionFromNotification -TaskFile $taskFile -TaskContent $taskContent `
@@ -289,7 +287,6 @@ function Invoke-TaskTransitionFromNotification {
     }
     if ($TypedFields) {
         if ($TypedFields.ContainsKey('answer_type'))       { $resolvedEntry['answer_type']       = $TypedFields.answer_type }
-        if ($TypedFields.ContainsKey('approval_decision')) { $resolvedEntry['approval_decision'] = $TypedFields.approval_decision }
         if ($TypedFields.ContainsKey('comment'))           { $resolvedEntry['comment']           = $TypedFields.comment }
         if ($TypedFields.ContainsKey('ranked_items'))      { $resolvedEntry['ranked_items']      = $TypedFields.ranked_items }
         if ($TypedFields.ContainsKey('has_disagreement'))  { $resolvedEntry['has_disagreement']  = $TypedFields.has_disagreement }
@@ -502,7 +499,6 @@ function Invoke-BatchQuestionTransitionFromNotification {
     }
     if ($TypedFields) {
         if ($TypedFields.ContainsKey('answer_type'))       { $resolvedEntry['answer_type']       = $TypedFields.answer_type }
-        if ($TypedFields.ContainsKey('approval_decision')) { $resolvedEntry['approval_decision'] = $TypedFields.approval_decision }
         if ($TypedFields.ContainsKey('comment'))           { $resolvedEntry['comment']           = $TypedFields.comment }
         if ($TypedFields.ContainsKey('ranked_items'))      { $resolvedEntry['ranked_items']      = $TypedFields.ranked_items }
         if ($TypedFields.ContainsKey('has_disagreement'))  { $resolvedEntry['has_disagreement']  = $TypedFields.has_disagreement }

--- a/core/ui/modules/TaskAPI.psm1
+++ b/core/ui/modules/TaskAPI.psm1
@@ -382,12 +382,17 @@ function Get-ActionRequired {
 function Submit-TaskAnswer {
     param(
         [Parameter(Mandatory)] [string]$TaskId,
-        $Answer,
+        [string]$Type,           # Question type — "approval" / "singleChoice" / "freeText" /
+                                 # "priorityRanking". The UI knows which card it rendered and
+                                 # passes the type so the MCP tool can validate the typed payload
+                                 # without re-inferring.
+        $Answer,                 # For approval, this is the decision string ("approved" / "rejected").
+                                 # For singleChoice, the option key or custom text.
+                                 # For freeText, the response text.
         [string]$CustomText,
-        $Attachments,  # array of { name, size, content (base64) } from frontend
-        [string]$QuestionId,  # Optional: specific question ID for pending_questions batch
-        [string]$Decision,    # approval decision: "approved" | "rejected" | "abstained"
-        [string]$Comment      # required when Decision = "rejected"
+        $Attachments,            # array of { name, size, content (base64) } from frontend
+        [string]$QuestionId,     # Optional: specific question ID for pending_questions batch
+        [string]$Comment         # required when Type='approval' and Answer='rejected'
     )
 
     # Use custom text as answer when no option selected
@@ -395,11 +400,13 @@ function Submit-TaskAnswer {
         $Answer = $CustomText
     }
 
+    $isApproval = ($Type -eq 'approval')
+
     # Always resolve the question ID so it is used consistently for both attachment
     # placement and the answer submission — not only when attachments are present.
     $resolvedQuestionId = $QuestionId
-    $notificationMeta   = $null   # captured for Send-LocalApprovalResponse if Decision present
-    if (-not $resolvedQuestionId -or $Decision) {
+    $notificationMeta   = $null   # captured for Send-LocalApprovalResponse on approval answers
+    if (-not $resolvedQuestionId -or $isApproval) {
         $needsInputDir = Join-Path $script:Config.BotRoot "workspace\tasks\needs-input"
         $taskFilePath  = Get-ChildItem -Path $needsInputDir -Filter "*.json" -ErrorAction SilentlyContinue |
             Where-Object { (Get-Content $_.FullName -Raw | ConvertFrom-Json).id -eq $TaskId } |
@@ -414,7 +421,7 @@ function Submit-TaskAnswer {
                 }
             }
             # Capture notification metadata for dual-surface push-back
-            if ($Decision) {
+            if ($isApproval) {
                 $notifSource = $null
                 if ($resolvedQuestionId -and $taskData.PSObject.Properties['notifications'] -and $taskData.notifications.PSObject.Properties[$resolvedQuestionId]) {
                     $notifSource = $taskData.notifications.($resolvedQuestionId)
@@ -467,8 +474,11 @@ function Submit-TaskAnswer {
         }
     }
 
-    # If attachments were saved, embed their paths in the answer so the AI can locate them
-    if ($attachmentMeta.Count -gt 0) {
+    # If attachments were saved AND this is a free-form answer (not an approval
+    # or other typed payload), embed their paths in the answer text so the AI
+    # can locate them. For typed payloads (approval / priorityRanking), the
+    # answer field carries the typed value verbatim and must not be polluted.
+    if ($attachmentMeta.Count -gt 0 -and -not $isApproval) {
         $pathList = ($attachmentMeta | ForEach-Object { $_.path }) -join ', '
         $pathNote = "Attached: $pathList"
         $Answer = if ($Answer) { "$Answer`n$pathNote" } else { $pathNote }
@@ -483,15 +493,17 @@ function Submit-TaskAnswer {
         task_id = $TaskId
         answer  = $Answer
     }
-    if ($resolvedQuestionId) { $toolArgs['question_id'] = $resolvedQuestionId }
+    if ($Type)                       { $toolArgs['type']        = $Type        }
+    if ($resolvedQuestionId)         { $toolArgs['question_id'] = $resolvedQuestionId }
     if ($attachmentMeta.Count -gt 0) { $toolArgs['attachments'] = $attachmentMeta }
-    if ($Decision) { $toolArgs['decision'] = $Decision }
-    if ($Comment)  { $toolArgs['comment']  = $Comment  }
+    if ($Comment)                    { $toolArgs['comment']     = $Comment     }
 
     $result = Invoke-TaskAnswerQuestion -Arguments $toolArgs
 
-    # Push approval decision to Mothership so both surfaces stay in sync
-    if ($Decision -and $notificationMeta) {
+    # Push approval decision to Mothership so both surfaces stay in sync.
+    # The approval answer carries the decision string verbatim, so pass it through
+    # as ApprovalDecision unchanged.
+    if ($isApproval -and $notificationMeta) {
         $notifClientModule = Join-Path $script:Config.BotRoot "core/mcp/modules/NotificationClient.psm1"
         if (Test-Path $notifClientModule) {
             Import-Module $notifClientModule -DisableNameChecking -Global -Force:$false
@@ -502,7 +514,7 @@ function Submit-TaskAnswer {
                 -ProjectId        "$($notificationMeta.project_id)" `
                 -QuestionId       "$($notificationMeta.question_id)" `
                 -InstanceId       "$($notificationMeta.instance_id)" `
-                -ApprovalDecision $Decision `
+                -ApprovalDecision $Answer `
                 -Comment          $Comment `
                 -QuestionVersion  $qv
             if (-not $pushResult.success) {

--- a/core/ui/server.ps1
+++ b/core/ui/server.ps1
@@ -1372,7 +1372,7 @@ $docContext
                             $reader = New-Object System.IO.StreamReader($request.InputStream)
                             $body = $reader.ReadToEnd() | ConvertFrom-Json
                             $reader.Close()
-                            $content = Submit-TaskAnswer -TaskId $body.task_id -Answer $body.answer -CustomText $body.custom_text -Attachments $body.attachments -QuestionId $body.question_id -Decision $body.decision -Comment $body.comment | ConvertTo-Json -Depth 10 -Compress
+                            $content = Submit-TaskAnswer -TaskId $body.task_id -Type $body.type -Answer $body.answer -CustomText $body.custom_text -Attachments $body.attachments -QuestionId $body.question_id -Comment $body.comment | ConvertTo-Json -Depth 10 -Compress
                         } catch {
                             $statusCode = 500
                             $content = @{ success = $false; error = "Failed to submit answer: $($_.Exception.Message)" } | ConvertTo-Json -Compress

--- a/core/ui/static/modules/actions.js
+++ b/core/ui/static/modules/actions.js
@@ -306,8 +306,30 @@ function renderQuestionItem(item) {
     }
 
     if (questionType === 'approval') {
+        const attachments = Array.isArray(question.attachments) ? question.attachments
+            : Array.isArray(question.attachmentList) ? question.attachmentList
+            : [];
+        const hasAttachments = attachments.length > 0;
+        const attachmentListHtml = hasAttachments ? `
+                <div class="approval-attachments">
+                    <div class="approval-attachments-label">Confirm the attachments you reviewed:</div>
+                    <ul class="approval-attachment-list">
+                        ${attachments.map(att => {
+                            const id = att.attachmentId || att.id || att.attachment_id || '';
+                            const name = att.name || 'attachment';
+                            return `
+                                <li class="approval-attachment-item">
+                                    <label>
+                                        <input type="checkbox" class="approval-reviewed-attachment" data-attachment-id="${escapeAttr(id)}" />
+                                        <span class="approval-attachment-name">${escapeHtml(name)}</span>
+                                    </label>
+                                </li>
+                            `;
+                        }).join('')}
+                    </ul>
+                </div>` : '';
         return `
-        <div class="action-item" data-task-id="${escapeHtml(item.task_id)}" data-type="question" data-question-type="approval">
+        <div class="action-item" data-task-id="${escapeHtml(item.task_id)}" data-type="question" data-question-type="approval" data-has-attachments="${hasAttachments ? 'true' : 'false'}">
             <div class="action-item-header">
                 <span class="action-item-type question">Approval</span>
                 <span class="action-item-task">${escapeHtml(item.task_name)}</span>
@@ -315,9 +337,9 @@ function renderQuestionItem(item) {
             <div class="action-item-body">
                 <div class="action-question-text">${escapeHtml(question.question || 'No question text')}</div>
                 ${question.context ? `<div class="action-question-context">${escapeHtml(question.context)}</div>` : ''}
+                ${attachmentListHtml}
                 <div class="approval-buttons">
                     <button class="ctrl-btn approval-decision" data-decision="approved">Approve</button>
-                    <button class="ctrl-btn approval-decision" data-decision="abstained">Abstain</button>
                     <button class="ctrl-btn approval-decision danger" data-decision="rejected">Reject</button>
                 </div>
                 <div class="approval-comment-section" style="display:none;">
@@ -868,19 +890,32 @@ function attachActionHandlers(container) {
                 return;
             }
 
+            let reviewedAttachmentIds = null;
+            if (actionItem.dataset.hasAttachments === 'true') {
+                reviewedAttachmentIds = Array.from(
+                    actionItem.querySelectorAll('.approval-reviewed-attachment:checked')
+                ).map(cb => cb.dataset.attachmentId).filter(Boolean);
+                if (reviewedAttachmentIds.length === 0) {
+                    showToast('Please confirm you reviewed at least one attachment', 'warning');
+                    return;
+                }
+            }
+
             btn.disabled = true;
             btn.textContent = 'Submitting...';
 
             try {
+                const body = {
+                    task_id: taskId,
+                    answer: decision,
+                    decision: decision,
+                    comment: comment || null
+                };
+                if (reviewedAttachmentIds) body.reviewed_attachment_ids = reviewedAttachmentIds;
                 const response = await fetch(`${API_BASE}/api/task/answer`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        task_id: taskId,
-                        answer: decision,
-                        decision: decision,
-                        comment: comment || null
-                    })
+                    body: JSON.stringify(body)
                 });
 
                 if (!response.ok) {

--- a/core/ui/static/modules/actions.js
+++ b/core/ui/static/modules/actions.js
@@ -306,30 +306,8 @@ function renderQuestionItem(item) {
     }
 
     if (questionType === 'approval') {
-        const attachments = Array.isArray(question.attachments) ? question.attachments
-            : Array.isArray(question.attachmentList) ? question.attachmentList
-            : [];
-        const hasAttachments = attachments.length > 0;
-        const attachmentListHtml = hasAttachments ? `
-                <div class="approval-attachments">
-                    <div class="approval-attachments-label">Confirm the attachments you reviewed:</div>
-                    <ul class="approval-attachment-list">
-                        ${attachments.map(att => {
-                            const id = att.attachmentId || att.id || att.attachment_id || '';
-                            const name = att.name || 'attachment';
-                            return `
-                                <li class="approval-attachment-item">
-                                    <label>
-                                        <input type="checkbox" class="approval-reviewed-attachment" data-attachment-id="${escapeAttr(id)}" />
-                                        <span class="approval-attachment-name">${escapeHtml(name)}</span>
-                                    </label>
-                                </li>
-                            `;
-                        }).join('')}
-                    </ul>
-                </div>` : '';
         return `
-        <div class="action-item" data-task-id="${escapeHtml(item.task_id)}" data-type="question" data-question-type="approval" data-has-attachments="${hasAttachments ? 'true' : 'false'}">
+        <div class="action-item" data-task-id="${escapeHtml(item.task_id)}" data-type="question" data-question-type="approval">
             <div class="action-item-header">
                 <span class="action-item-type question">Approval</span>
                 <span class="action-item-task">${escapeHtml(item.task_name)}</span>
@@ -337,7 +315,6 @@ function renderQuestionItem(item) {
             <div class="action-item-body">
                 <div class="action-question-text">${escapeHtml(question.question || 'No question text')}</div>
                 ${question.context ? `<div class="action-question-context">${escapeHtml(question.context)}</div>` : ''}
-                ${attachmentListHtml}
                 <div class="approval-buttons">
                     <button class="ctrl-btn approval-decision" data-decision="approved">Approve</button>
                     <button class="ctrl-btn approval-decision danger" data-decision="rejected">Reject</button>
@@ -355,9 +332,12 @@ function renderQuestionItem(item) {
 
     const options = question.options || [];
     const isMultiSelect = question.multi_select || false;
+    // multi_select is a render flag on a singleChoice question — there is no
+    // separate "multiChoice" type in dotbot's local MCP layer.
+    const renderedType = question.type || 'singleChoice';
 
     return `
-        <div class="action-item" data-task-id="${escapeHtml(item.task_id)}" data-type="question">
+        <div class="action-item" data-task-id="${escapeHtml(item.task_id)}" data-type="question" data-question-type="${escapeAttr(renderedType)}">
             <div class="action-item-header">
                 <span class="action-item-type question">Question</span>
                 <span class="action-item-task">${escapeHtml(item.task_name)}</span>
@@ -426,7 +406,7 @@ function renderTaskQuestionsItem(item) {
             <div class="action-item-body">
                 ${questions.map((q, idx) => `
                     ${idx > 0 ? '<div class="question-divider"></div>' : ''}
-                    <div class="task-question-block" data-question-id="${escapeAttr(q.id)}" data-task-id="${escapeAttr(taskId)}">
+                    <div class="task-question-block" data-question-id="${escapeAttr(q.id)}" data-task-id="${escapeAttr(taskId)}" data-question-type="${escapeAttr(q.type || 'singleChoice')}">
                         <div class="action-question-text"><span class="question-number">Q${idx + 1}.</span> ${escapeHtml(q.question)}</div>
                         ${q.context ? `<div class="action-question-context">${escapeHtml(q.context)}</div>` : ''}
                         <div class="answer-options" data-multi-select="false">
@@ -494,6 +474,7 @@ async function submitTaskQuestion(taskId, questionId) {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 task_id: taskId,
+                type: questionBlock.dataset.questionType || 'singleChoice',
                 question_id: questionId,
                 answer: answer,
                 custom_text: customText
@@ -769,6 +750,7 @@ function attachActionHandlers(container) {
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
                         task_id: taskId,
+                        type: actionItem.dataset.questionType || 'singleChoice',
                         answer: selected.length === 1 ? selected[0]
                               : selected.length > 1 ? selected
                               : customText || '',
@@ -890,28 +872,16 @@ function attachActionHandlers(container) {
                 return;
             }
 
-            let reviewedAttachmentIds = null;
-            if (actionItem.dataset.hasAttachments === 'true') {
-                reviewedAttachmentIds = Array.from(
-                    actionItem.querySelectorAll('.approval-reviewed-attachment:checked')
-                ).map(cb => cb.dataset.attachmentId).filter(Boolean);
-                if (reviewedAttachmentIds.length === 0) {
-                    showToast('Please confirm you reviewed at least one attachment', 'warning');
-                    return;
-                }
-            }
-
             btn.disabled = true;
             btn.textContent = 'Submitting...';
 
             try {
                 const body = {
                     task_id: taskId,
+                    type: 'approval',
                     answer: decision,
-                    decision: decision,
                     comment: comment || null
                 };
-                if (reviewedAttachmentIds) body.reviewed_attachment_ids = reviewedAttachmentIds;
                 const response = await fetch(`${API_BASE}/api/task/answer`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },

--- a/server/docs/MOTHERSHIP-E2E-SETUP.md
+++ b/server/docs/MOTHERSHIP-E2E-SETUP.md
@@ -1,6 +1,6 @@
 # Mothership E2E Test Setup (Playwright + Azurite)
 
-How to run the Mothership web UI end-to-end tests locally. Tests cover the magic-link respond flow for all six question types: `singleChoice`, `multiChoice`, `approval`, `documentReview`, `freeText`, `priorityRanking`.
+How to run the Mothership web UI end-to-end tests locally. Tests cover the magic-link respond flow for all question types: `singleChoice`, `multiChoice`, `approval`, `freeText`, `priorityRanking`.
 
 ---
 

--- a/server/src/Dotbot.Server/Models/ApprovalDecisions.cs
+++ b/server/src/Dotbot.Server/Models/ApprovalDecisions.cs
@@ -2,23 +2,15 @@ namespace Dotbot.Server.Models;
 
 public static class ApprovalDecisions
 {
-    public const string Approve = "approve";
-    public const string Reject = "reject";
-    public const string Abstain = "abstain";
+    public const string Approved = "approved";
+    public const string Rejected = "rejected";
 
-    public const string RequestChanges = "request-changes";
-    public const string CommentOnly = "comment-only";
-
-    public static readonly string[] ApprovalAllowed = [Approve, Reject, Abstain];
-    public static readonly string[] DocumentReviewAllowed = [Approve, RequestChanges, CommentOnly];
+    public static readonly string[] ApprovalAllowed = [Approved, Rejected];
 
     public static string Label(string decision) => decision switch
     {
-        Approve => "Approve",
-        Reject => "Reject",
-        Abstain => "Abstain",
-        RequestChanges => "Request Changes",
-        CommentOnly => "Comment Only",
+        Approved => "Approve",
+        Rejected => "Reject",
         _ => decision,
     };
 }

--- a/server/src/Dotbot.Server/Models/QuestionTypes.cs
+++ b/server/src/Dotbot.Server/Models/QuestionTypes.cs
@@ -5,7 +5,6 @@ public static class QuestionTypes
     public const string SingleChoice = "singleChoice";
     public const string MultiChoice = "multiChoice";
     public const string Approval = "approval";
-    public const string DocumentReview = "documentReview";
     public const string FreeText = "freeText";
     public const string PriorityRanking = "priorityRanking";
 
@@ -14,7 +13,6 @@ public static class QuestionTypes
         SingleChoice,
         MultiChoice,
         Approval,
-        DocumentReview,
         FreeText,
         PriorityRanking,
     ];

--- a/server/src/Dotbot.Server/Pages/Respond.cshtml
+++ b/server/src/Dotbot.Server/Pages/Respond.cshtml
@@ -52,23 +52,6 @@
             @switch (Model.Template.Type)
             {
                 case QuestionTypes.Approval:
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Approve, "Approve", "A"))
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Reject, "Reject", "R", requireComment: true))
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Abstain, "Abstain", "X"))
-                    <div class="mt-1">
-                        <label for="comment" class="label-text">Comment (required when rejecting):</label>
-                        <textarea name="comment" id="comment" class="free-text"></textarea>
-                    </div>
-                    break;
-
-                case QuestionTypes.FreeText:
-                    <div class="mt-1">
-                        <label for="freeText" class="label-text">Your response:</label>
-                        <textarea name="freeText" id="freeText" class="free-text" required></textarea>
-                    </div>
-                    break;
-
-                case QuestionTypes.DocumentReview:
                     @if (Model.Template.Attachments is { Count: > 0 } docs)
                     {
                         <div class="mt-1">
@@ -104,12 +87,18 @@
                             </ul>
                         </div>
                     }
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Approve, "Approve", "AP"))
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.RequestChanges, "Request Changes", "RC", requireComment: true))
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.CommentOnly, "Comment Only", "CO"))
+                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Approved, "Approve", "A"))
+                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Rejected, "Reject", "R", requireComment: true))
                     <div class="mt-1">
-                        <label for="comment" class="label-text">Feedback (required for "Request Changes"):</label>
+                        <label for="comment" class="label-text">Comment (required when rejecting):</label>
                         <textarea name="comment" id="comment" class="free-text"></textarea>
+                    </div>
+                    break;
+
+                case QuestionTypes.FreeText:
+                    <div class="mt-1">
+                        <label for="freeText" class="label-text">Your response:</label>
+                        <textarea name="freeText" id="freeText" class="free-text" required></textarea>
                     </div>
                     break;
 
@@ -182,7 +171,7 @@
             if (!form) return;
             const type = form.dataset.questionType;
 
-            // ── Approval / DocumentReview: comment required when destructive option selected ──
+            // ── Approval: comment required when destructive option selected ──
             (function wireApproval() {
                 const radios = form.querySelectorAll('input[type="radio"][name="approvalDecision"]');
                 if (radios.length === 0) return;
@@ -202,9 +191,9 @@
                 });
             })();
 
-            // ── DocumentReview: at least one attachment confirmation ──
+            // ── Approval with attachments: at least one attachment confirmation ──
             (function wireDocReview() {
-                if (type !== 'documentReview') return;
+                if (type !== 'approval') return;
                 const checkboxes = form.querySelectorAll('input[type="checkbox"][name="reviewedAttachmentIds"]');
                 if (checkboxes.length === 0) return;
                 form.addEventListener('submit', function (e) {

--- a/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
@@ -29,8 +29,11 @@ public class NotificationSummaryBuilder
                 ? template.Project.ProjectId
                 : template.Project.Name,
             // Legacy singleChoice templates carry no DeliverableSummary; providers render
-            // Title + Context as before. Validator enforces non-empty for approval with
-            // attachments, so this stays null only when intentional.
+            // Title + Context as before. The CheckDeliverableSummary validator rule that
+            // would require a non-empty value for approval-with-attachments is currently
+            // parked (commented out of QuestionTemplateValidator._rules) pending outpost
+            // support for emitting an attachment summary, so DeliverableSummary may be
+            // null/blank in practice even for that case.
             DeliverableSummary = template.DeliverableSummary,
             Context = template.Context,
             Attachments = template.Attachments?

--- a/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
+++ b/server/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
@@ -29,8 +29,8 @@ public class NotificationSummaryBuilder
                 ? template.Project.ProjectId
                 : template.Project.Name,
             // Legacy singleChoice templates carry no DeliverableSummary; providers render
-            // Title + Context as before. Validator enforces non-empty for approval /
-            // documentReview, so this stays null only when intentional (PRD §8 line 651).
+            // Title + Context as before. Validator enforces non-empty for approval with
+            // attachments, so this stays null only when intentional.
             DeliverableSummary = template.DeliverableSummary,
             Context = template.Context,
             Attachments = template.Attachments?

--- a/server/src/Dotbot.Server/Validation/QuestionTemplateValidator.cs
+++ b/server/src/Dotbot.Server/Validation/QuestionTemplateValidator.cs
@@ -19,7 +19,7 @@ public class QuestionTemplateValidator
             CheckQuestionId,
             CheckProjectId,
             CheckType,
-            CheckDeliverableSummary,
+            // CheckDeliverableSummary,
             CheckOptionUniqueness,
             CheckAttachments,
             CheckReferenceLinks,
@@ -48,11 +48,16 @@ public class QuestionTemplateValidator
             yield return $"Unknown type '{t.Type}'. Allowed types: {string.Join(", ", QuestionTypes.AllowedTypes)}";
     }
 
+    // TODO: unskip when outpost supports preparing summary of attachments
     private IEnumerable<string> CheckDeliverableSummary(QuestionTemplate t)
     {
-        if ((t.Type == QuestionTypes.Approval || t.Type == QuestionTypes.DocumentReview)
+        // Required only when an approval question carries attachments — that is the
+        // doc-review case where a reviewer needs a 1-3 line summary of what they're
+        // approving. Plain approvals (no doc) don't need it.
+        if (t.Type == QuestionTypes.Approval
+            && t.Attachments is { Count: > 0 }
             && string.IsNullOrWhiteSpace(t.DeliverableSummary))
-            yield return $"deliverableSummary is required when type is '{t.Type}'";
+            yield return "deliverableSummary is required when type is 'approval' and attachments are present";
     }
 
     private IEnumerable<string> CheckOptionUniqueness(QuestionTemplate t)

--- a/server/src/Dotbot.Server/Validation/RespondFormHandler.cs
+++ b/server/src/Dotbot.Server/Validation/RespondFormHandler.cs
@@ -39,9 +39,8 @@ public static class RespondFormHandler
 
         return template.Type switch
         {
-            QuestionTypes.Approval => ValidateApproval(input),
+            QuestionTypes.Approval => ValidateApproval(template, input),
             QuestionTypes.FreeText => ValidateFreeText(input),
-            QuestionTypes.DocumentReview => ValidateDocumentReview(template, input),
             QuestionTypes.PriorityRanking => ValidatePriorityRanking(template, input),
             QuestionTypes.SingleChoice or QuestionTypes.MultiChoice
                 => ValidateSingleOrMultiChoice(template, input),
@@ -49,43 +48,14 @@ public static class RespondFormHandler
         };
     }
 
-    private static RespondFormResult ValidateApproval(RespondFormInput input)
+    private static RespondFormResult ValidateApproval(QuestionTemplate template, RespondFormInput input)
     {
         var decision = input.ApprovalDecision?.Trim().ToLowerInvariant();
         if (string.IsNullOrEmpty(decision) || !ApprovalDecisions.ApprovalAllowed.Contains(decision))
-            return RespondFormResult.Fail("Please choose Approve, Reject, or Abstain.");
+            return RespondFormResult.Fail("Please choose Approve or Reject.");
 
-        if (decision == ApprovalDecisions.Reject && string.IsNullOrWhiteSpace(input.Comment))
+        if (decision == ApprovalDecisions.Rejected && string.IsNullOrWhiteSpace(input.Comment))
             return RespondFormResult.Fail("A comment is required when rejecting.");
-
-        return new RespondFormResult
-        {
-            ApprovalDecision = decision,
-            Comment = NullIfBlank(input.Comment),
-            SelectionLabel = ApprovalDecisions.Label(decision),
-        };
-    }
-
-    private static RespondFormResult ValidateFreeText(RespondFormInput input)
-    {
-        if (string.IsNullOrWhiteSpace(input.FreeText))
-            return RespondFormResult.Fail("Please type a response.");
-
-        return new RespondFormResult
-        {
-            FreeText = input.FreeText.Trim(),
-            SelectionLabel = "Free-text response",
-        };
-    }
-
-    private static RespondFormResult ValidateDocumentReview(QuestionTemplate template, RespondFormInput input)
-    {
-        var decision = input.ApprovalDecision?.Trim().ToLowerInvariant();
-        if (string.IsNullOrEmpty(decision) || !ApprovalDecisions.DocumentReviewAllowed.Contains(decision))
-            return RespondFormResult.Fail("Please choose Approve, Request Changes, or Comment Only.");
-
-        if (decision == ApprovalDecisions.RequestChanges && string.IsNullOrWhiteSpace(input.Comment))
-            return RespondFormResult.Fail("A comment is required when requesting changes.");
 
         var templateAttachments = template.Attachments ?? new List<QuestionAttachment>();
         if (templateAttachments.Count > 0)
@@ -117,6 +87,18 @@ public static class RespondFormHandler
             ApprovalDecision = decision,
             Comment = NullIfBlank(input.Comment),
             SelectionLabel = ApprovalDecisions.Label(decision),
+        };
+    }
+
+    private static RespondFormResult ValidateFreeText(RespondFormInput input)
+    {
+        if (string.IsNullOrWhiteSpace(input.FreeText))
+            return RespondFormResult.Fail("Please type a response.");
+
+        return new RespondFormResult
+        {
+            FreeText = input.FreeText.Trim(),
+            SelectionLabel = "Free-text response",
         };
     }
 

--- a/server/tests/Dotbot.Server.Tests/Integration/MagicLinkMiddlewareTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Integration/MagicLinkMiddlewareTests.cs
@@ -41,7 +41,7 @@ public sealed class MagicLinkMiddlewareTests(DotbotApiFactory factory)
             QuestionId = questionId,
             Version = 1,
             Title = $"Review {suffix}",
-            Type = QuestionTypes.DocumentReview,
+            Type = QuestionTypes.Approval,
             DeliverableSummary = "review",
             Options = new(),
             Project = new ProjectRef { ProjectId = ProjectId, Name = "MW" },

--- a/server/tests/Dotbot.Server.Tests/Unit/QuestionTemplateValidatorTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/QuestionTemplateValidatorTests.cs
@@ -73,30 +73,39 @@ public class QuestionTemplateValidatorTests
     [InlineData(QuestionTypes.MultiChoice)]
     [InlineData(QuestionTypes.FreeText)]
     [InlineData(QuestionTypes.PriorityRanking)]
+    [InlineData(QuestionTypes.Approval)]
     public void TypeWithoutDeliverableSummaryRequirement_NoErrorWhenSummaryMissing(string type)
         => Assert.Empty(Validate(Template(type: type)));
 
-    [Theory]
-    [InlineData(QuestionTypes.Approval, null)]
-    [InlineData(QuestionTypes.Approval, "")]
-    [InlineData(QuestionTypes.Approval, "   ")]
-    [InlineData(QuestionTypes.DocumentReview, null)]
-    [InlineData(QuestionTypes.DocumentReview, "")]
-    [InlineData(QuestionTypes.DocumentReview, "   ")]
-    public void ApprovalOrDocumentReviewWithoutDeliverableSummary_OneError(string type, string? summary)
+    // CheckDeliverableSummary is currently parked out of the validator
+    // rules array pending outpost support for preparing the summary of
+    // attachments. The skipped tests below document the intended behaviour
+    // and should be re-enabled once the rule is restored.
+    [Theory(Skip = "CheckDeliverableSummary parked; restore when outpost emits the summary")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ApprovalWithAttachmentsAndNoDeliverableSummary_OneError(string? summary)
     {
-        var errors = Validate(Template(type: type, deliverableSummary: summary));
+        var errors = Validate(Template(
+            type: QuestionTypes.Approval,
+            deliverableSummary: summary,
+            attachments: [new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "n", Url = "https://x" }]));
         Assert.Single(errors);
         Assert.Contains("deliverableSummary", errors[0]);
-        Assert.Contains(type, errors[0]);
+        Assert.Contains("approval", errors[0]);
     }
 
-    [Theory]
-    [InlineData(QuestionTypes.Approval)]
-    [InlineData(QuestionTypes.DocumentReview)]
-    public void ApprovalOrDocumentReviewWithDeliverableSummary_NoErrors(string type)
-        => Assert.Empty(Validate(
-            Template(type: type, deliverableSummary: "ship plan v1")));
+    [Fact]
+    public void ApprovalWithAttachmentsAndDeliverableSummary_NoErrors()
+        => Assert.Empty(Validate(Template(
+            type: QuestionTypes.Approval,
+            deliverableSummary: "ship plan v1",
+            attachments: [new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "n", Url = "https://x" }])));
+
+    [Fact]
+    public void ApprovalWithoutAttachments_NoDeliverableSummaryRequired()
+        => Assert.Empty(Validate(Template(type: QuestionTypes.Approval)));
 
     [Fact]
     public void NullAttachments_NoErrors()
@@ -172,12 +181,13 @@ public class QuestionTemplateValidatorTests
         Assert.Contains("bogus", errors[1]);
     }
 
-    [Fact]
-    public void ProjectIdEmptyAndApprovalWithoutSummary_TwoErrors()
+    [Fact(Skip = "CheckDeliverableSummary parked; restore when outpost emits the summary")]
+    public void ProjectIdEmptyAndApprovalWithAttachmentsWithoutSummary_TwoErrors()
     {
         var errors = Validate(Template(
             projectId: "",
-            type: QuestionTypes.Approval));
+            type: QuestionTypes.Approval,
+            attachments: [new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "n", Url = "https://x" }]));
         Assert.Equal(2, errors.Count);
         Assert.Contains("project.projectId", errors[0]);
         Assert.Contains("deliverableSummary", errors[1]);

--- a/server/tests/Dotbot.Server.Tests/Unit/RespondFormHandlerTests.cs
+++ b/server/tests/Dotbot.Server.Tests/Unit/RespondFormHandlerTests.cs
@@ -13,20 +13,20 @@ public class RespondFormHandlerTests
         Type = type,
         Options = options.ToList(),
         Project = new ProjectRef { ProjectId = "p1" },
-        DeliverableSummary = type is QuestionTypes.Approval or QuestionTypes.DocumentReview ? "deliverable" : null,
+        DeliverableSummary = type == QuestionTypes.Approval ? "deliverable" : null,
     };
 
     private static TemplateOption Option(string key = "A", string title = "Alpha")
         => new() { OptionId = Guid.NewGuid(), Key = key, Title = title };
 
-    // ── Approval ───────────────────────────────────────────────────────────
+    // ── Approval (no attachments) ──────────────────────────────────────────
 
     [Fact]
     public void Approval_NoDecision_Fails()
     {
         var result = RespondFormHandler.Validate(Template(QuestionTypes.Approval), new RespondFormInput());
         Assert.False(result.IsValid);
-        Assert.Contains("Approve, Reject, or Abstain", result.Error);
+        Assert.Contains("Approve or Reject", result.Error);
     }
 
     [Fact]
@@ -39,43 +39,33 @@ public class RespondFormHandlerTests
     }
 
     [Fact]
-    public void Approval_Reject_RequiresComment()
+    public void Approval_Rejected_RequiresComment()
     {
         var result = RespondFormHandler.Validate(
             Template(QuestionTypes.Approval),
-            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Reject, Comment: "   "));
+            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Rejected, Comment: "   "));
         Assert.False(result.IsValid);
         Assert.Contains("comment is required", result.Error, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void Approval_Reject_WithComment_Succeeds()
+    public void Approval_Rejected_WithComment_Succeeds()
     {
         var result = RespondFormHandler.Validate(
             Template(QuestionTypes.Approval),
-            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Reject, Comment: "needs work"));
+            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Rejected, Comment: "needs work"));
         Assert.True(result.IsValid);
-        Assert.Equal(ApprovalDecisions.Reject, result.ApprovalDecision);
+        Assert.Equal(ApprovalDecisions.Rejected, result.ApprovalDecision);
         Assert.Equal("needs work", result.Comment);
         Assert.Equal("Reject", result.SelectionLabel);
     }
 
     [Fact]
-    public void Approval_Approve_NoCommentNeeded()
+    public void Approval_Approved_NoCommentNeeded()
     {
         var result = RespondFormHandler.Validate(
             Template(QuestionTypes.Approval),
-            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Approve));
-        Assert.True(result.IsValid);
-        Assert.Null(result.Comment);
-    }
-
-    [Fact]
-    public void Approval_Abstain_TrimsCommentNullIfBlank()
-    {
-        var result = RespondFormHandler.Validate(
-            Template(QuestionTypes.Approval),
-            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Abstain, Comment: "   "));
+            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Approved));
         Assert.True(result.IsValid);
         Assert.Null(result.Comment);
     }
@@ -85,9 +75,9 @@ public class RespondFormHandlerTests
     {
         var result = RespondFormHandler.Validate(
             Template(QuestionTypes.Approval),
-            new RespondFormInput(ApprovalDecision: "APPROVE"));
+            new RespondFormInput(ApprovalDecision: "APPROVED"));
         Assert.True(result.IsValid);
-        Assert.Equal(ApprovalDecisions.Approve, result.ApprovalDecision);
+        Assert.Equal(ApprovalDecisions.Approved, result.ApprovalDecision);
     }
 
     // ── FreeText ───────────────────────────────────────────────────────────
@@ -112,56 +102,48 @@ public class RespondFormHandlerTests
         Assert.Equal("hello", result.FreeText);
     }
 
-    // ── DocumentReview ─────────────────────────────────────────────────────
+    // ── Approval with attachments (formerly DocumentReview) ────────────────
 
     [Fact]
-    public void DocumentReview_NoDecision_Fails()
+    public void ApprovalWithAttachments_NoDecision_Fails()
     {
-        var template = Template(QuestionTypes.DocumentReview);
+        var template = Template(QuestionTypes.Approval);
+        template.Attachments = [new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "spec", BlobPath = "x" }];
         var result = RespondFormHandler.Validate(template, new RespondFormInput());
         Assert.False(result.IsValid);
     }
 
     [Fact]
-    public void DocumentReview_RequestChanges_RequiresComment()
+    public void ApprovalWithAttachments_Rejected_RequiresComment()
     {
-        var template = Template(QuestionTypes.DocumentReview);
+        var template = Template(QuestionTypes.Approval);
+        template.Attachments = [new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "spec", BlobPath = "x" }];
         var result = RespondFormHandler.Validate(template, new RespondFormInput(
-            ApprovalDecision: ApprovalDecisions.RequestChanges));
+            ApprovalDecision: ApprovalDecisions.Rejected));
         Assert.False(result.IsValid);
         Assert.Contains("comment is required", result.Error, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void DocumentReview_NoTemplateAttachments_AcceptsApproveWithoutReviewedIds()
+    public void ApprovalWithAttachments_RequiresAtLeastOneReviewed()
     {
-        var template = Template(QuestionTypes.DocumentReview);
-        var result = RespondFormHandler.Validate(template, new RespondFormInput(
-            ApprovalDecision: ApprovalDecisions.Approve));
-        Assert.True(result.IsValid);
-        Assert.Null(result.ReviewedAttachmentIds);
-    }
-
-    [Fact]
-    public void DocumentReview_WithAttachments_RequiresAtLeastOneReviewed()
-    {
-        var template = Template(QuestionTypes.DocumentReview);
+        var template = Template(QuestionTypes.Approval);
         template.Attachments = [new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "spec", BlobPath = "x" }];
         var result = RespondFormHandler.Validate(template, new RespondFormInput(
-            ApprovalDecision: ApprovalDecisions.Approve,
+            ApprovalDecision: ApprovalDecisions.Approved,
             ReviewedAttachmentIds: Array.Empty<Guid>()));
         Assert.False(result.IsValid);
         Assert.Contains("reviewed at least one", result.Error, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void DocumentReview_WithAttachments_FiltersUnknownIds()
+    public void ApprovalWithAttachments_FiltersUnknownIds()
     {
         var aid = Guid.NewGuid();
-        var template = Template(QuestionTypes.DocumentReview);
+        var template = Template(QuestionTypes.Approval);
         template.Attachments = [new QuestionAttachment { AttachmentId = aid, Name = "spec", BlobPath = "x" }];
         var result = RespondFormHandler.Validate(template, new RespondFormInput(
-            ApprovalDecision: ApprovalDecisions.Approve,
+            ApprovalDecision: ApprovalDecisions.Approved,
             ReviewedAttachmentIds: new[] { aid, Guid.NewGuid() }));
         Assert.True(result.IsValid);
         Assert.Single(result.ReviewedAttachmentIds!);
@@ -169,25 +151,24 @@ public class RespondFormHandlerTests
     }
 
     [Fact]
-    public void DocumentReview_OnlyUnknownIds_Fails()
+    public void ApprovalWithAttachments_OnlyUnknownIds_Fails()
     {
-        var template = Template(QuestionTypes.DocumentReview);
+        var template = Template(QuestionTypes.Approval);
         template.Attachments = [new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "spec", BlobPath = "x" }];
         var result = RespondFormHandler.Validate(template, new RespondFormInput(
-            ApprovalDecision: ApprovalDecisions.CommentOnly,
-            Comment: "ok",
+            ApprovalDecision: ApprovalDecisions.Approved,
             ReviewedAttachmentIds: new[] { Guid.NewGuid() }));
         Assert.False(result.IsValid);
     }
 
     [Fact]
-    public void DocumentReview_DuplicatesDeduped()
+    public void ApprovalWithAttachments_DuplicatesDeduped()
     {
         var aid = Guid.NewGuid();
-        var template = Template(QuestionTypes.DocumentReview);
+        var template = Template(QuestionTypes.Approval);
         template.Attachments = [new QuestionAttachment { AttachmentId = aid, Name = "spec", BlobPath = "x" }];
         var result = RespondFormHandler.Validate(template, new RespondFormInput(
-            ApprovalDecision: ApprovalDecisions.Approve,
+            ApprovalDecision: ApprovalDecisions.Approved,
             ReviewedAttachmentIds: new[] { aid, aid, aid }));
         Assert.True(result.IsValid);
         Assert.Single(result.ReviewedAttachmentIds!);

--- a/specs/PRD-029-expand-question-service.md
+++ b/specs/PRD-029-expand-question-service.md
@@ -486,12 +486,15 @@ NotificationPoller.psm1                 ResponseStorageService
  Task JSON updated:
    questions_resolved: [{
      id, question, answer, answer_type,
-     approval_decision,          <- NEW for approval types
-     comment,                    <- NEW
+     comment,                    <- NEW (approval only)
      attachment_refs,            <- NEW (refs only, not bytes)
      asked_at, answered_at,
      answered_via: "notification"
    }]
+
+ For approval-typed answers, the decision ("approved" / "rejected") is
+ carried in the `answer` field — there is no separate
+ approval_decision field on persisted entries.
 ```
 
 ### 5.5 Dual-Surface Approval Sync
@@ -505,8 +508,8 @@ Approvals can be submitted from two surfaces: the **Mothership web form** (via c
        |  User approves locally                |  User approves via magic link
        v                                       v
  Save to local task JSON               Save ResponseRecordV2 blob
- approval_decision: "approved"         approvalDecision: "approved"
- answered_via: "outpost"               -> available on next poll
+ answer: "approved"                     approvalDecision: "approved"
+ answered_via: "outpost"                -> available on next poll
        |                                       |
        v                                       v
  POST /api/responses ----------->  Store as ResponseRecordV2

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -3312,6 +3312,19 @@ if (Test-Path $notifModule) {
         -Condition ($typedApproval.answer_type -eq 'approval') `
         -Message "Expected answer_type=approval"
 
+    # ConvertTo-TypedResponse: approval with reviewedAttachmentIds — server-side
+    # respond form stores which attachments the reviewer ticked, the typed
+    # output must surface them so the poller can persist them locally.
+    $approvalResponseReviewed = [PSCustomObject]@{
+        approvalDecision      = 'approved'
+        reviewedAttachmentIds = @('11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222')
+    }
+    $typedApprovalReviewed = ConvertTo-TypedResponse -Response $approvalResponseReviewed -Type 'approval'
+    Assert-True -Name "ConvertTo-TypedResponse propagates reviewed_attachment_ids on approval" `
+        -Condition ($typedApprovalReviewed -and @($typedApprovalReviewed.reviewed_attachment_ids).Count -eq 2 -and `
+                    $typedApprovalReviewed.reviewed_attachment_ids[0] -eq '11111111-1111-1111-1111-111111111111') `
+        -Message "Expected reviewed_attachment_ids array of 2, got: $($typedApprovalReviewed | ConvertTo-Json -Compress)"
+
     # ConvertTo-TypedResponse: approval with attachments (metadata only)
     $docReviewResp = [PSCustomObject]@{
         approvalDecision = 'rejected'
@@ -4151,6 +4164,15 @@ if ((Test-Path $mniMeta) -and (Test-Path $aqMeta)) {
             Assert-True -Name "task-answer-question rejects 'ranked_items' when type is omitted (legacy)" `
                 -Condition ($threw -and $msg -match "'ranked_items' is only valid") `
                 -Message "Expected throw on legacy caller smuggling ranked_items, got: $msg"
+
+            # priorityRanking carries its answer in ranked_items; a free-form answer
+            # alongside must throw — otherwise the persisted entry's answer field
+            # and ranked_items disagree (synthesis takes the free-form value).
+            $threw = $false; $msg = ""
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='priorityRanking'; answer='A'; ranked_items=@('a','b') } } catch { $threw = $true; $msg = $_.Exception.Message }
+            Assert-True -Name "task-answer-question rejects free-form 'answer' on priorityRanking" `
+                -Condition ($threw -and $msg -match "'answer' is not valid for type 'priorityRanking'") `
+                -Message "Expected throw on answer alongside ranked_items, got: $msg"
 
             # changes_requested was a documentReview value — now invalid on the merged approval type
             $threw = $false; $msg = ""

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -3312,16 +3312,16 @@ if (Test-Path $notifModule) {
         -Condition ($typedApproval.answer_type -eq 'approval') `
         -Message "Expected answer_type=approval"
 
-    # ConvertTo-TypedResponse: documentReview with attachments (metadata only)
+    # ConvertTo-TypedResponse: approval with attachments (metadata only)
     $docReviewResp = [PSCustomObject]@{
-        approvalDecision = 'changes_requested'
+        approvalDecision = 'rejected'
         comment          = 'see notes'
         attachments      = @(
             [PSCustomObject]@{ name = 'notes.pdf'; sizeBytes = 1024; storageRef = 'sref-1'; description = 'reviewer notes' }
         )
     }
-    $typedDoc = ConvertTo-TypedResponse -Response $docReviewResp -Type 'documentReview'
-    Assert-True -Name "ConvertTo-TypedResponse documentReview includes attachment_refs metadata" `
+    $typedDoc = ConvertTo-TypedResponse -Response $docReviewResp -Type 'approval'
+    Assert-True -Name "ConvertTo-TypedResponse approval with attachments includes attachment_refs metadata" `
         -Condition ($typedDoc.attachment_refs -and @($typedDoc.attachment_refs).Count -eq 1 -and $typedDoc.attachment_refs[0].storage_ref -eq 'sref-1') `
         -Message "Expected attachment_refs[0].storage_ref=sref-1"
     Assert-True -Name "ConvertTo-TypedResponse does NOT eager-download (no path field)" `
@@ -4115,13 +4115,12 @@ if ((Test-Path $mniMeta) -and (Test-Path $aqMeta)) {
                 -Condition ($threw -and $msg -match "ranked_items.*required") `
                 -Message "Expected throw on missing ranked_items, got: $msg"
 
-            # documentReview with allowed decision should NOT throw on validation —
-            # it will fail later at the task-not-found check, but only AFTER passing validation.
+            # approval with attachments (formerly documentReview) — rejected as a type
             $threw = $false; $msg = ""
             try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='documentReview'; decision='approved' } } catch { $threw = $true; $msg = $_.Exception.Message }
-            Assert-True -Name "task-answer-question accepts documentReview decision=approved (passes validation)" `
-                -Condition ($threw -and $msg -match "not found in needs-input") `
-                -Message "Expected validation to pass and fail on task lookup, got: $msg"
+            Assert-True -Name "task-answer-question rejects deprecated documentReview type" `
+                -Condition ($threw -and $msg -match "Invalid 'type'") `
+                -Message "Expected throw on deprecated documentReview type, got: $msg"
 
             # Invalid type
             $threw = $false; $msg = ""
@@ -4175,12 +4174,12 @@ if ((Test-Path $mniMeta) -and (Test-Path $aqMeta)) {
                 -Condition ($threw -and $msg -match "'answer' is only valid") `
                 -Message "Expected throw, got: $msg"
 
-            # changes_requested requires a comment — same requirement as rejected
+            # changes_requested was a documentReview value — now invalid on the merged approval type
             $threw = $false; $msg = ""
-            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='documentReview'; decision='changes_requested' } } catch { $threw = $true; $msg = $_.Exception.Message }
-            Assert-True -Name "task-answer-question rejects changes_requested without comment" `
-                -Condition ($threw -and $msg -match "comment.*required") `
-                -Message "Expected throw on missing comment for changes_requested, got: $msg"
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='approval'; decision='changes_requested'; comment='ok' } } catch { $threw = $true; $msg = $_.Exception.Message }
+            Assert-True -Name "task-answer-question rejects legacy changes_requested decision on approval" `
+                -Condition ($threw -and $msg -match "Invalid 'decision'") `
+                -Message "Expected throw on legacy changes_requested decision, got: $msg"
 
             # priorityRanking synthesis must normalize PSCustomObject ranked_items to strings —
             # (verify the synthesis-time -join stays safe even for PSCustomObject input)

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -3302,9 +3302,9 @@ if (Test-Path $notifModule) {
         comment          = 'needs more context'
     }
     $typedApproval = ConvertTo-TypedResponse -Response $approvalResponse -Type 'approval'
-    Assert-True -Name "ConvertTo-TypedResponse extracts approval decision" `
-        -Condition ($typedApproval -and $typedApproval.approval_decision -eq 'rejected') `
-        -Message "Expected approval_decision=rejected, got: $($typedApproval | ConvertTo-Json -Compress)"
+    Assert-True -Name "ConvertTo-TypedResponse routes approval decision into answer field" `
+        -Condition ($typedApproval -and $typedApproval.answer -eq 'rejected') `
+        -Message "Expected answer=rejected, got: $($typedApproval | ConvertTo-Json -Compress)"
     Assert-True -Name "ConvertTo-TypedResponse extracts approval comment" `
         -Condition ($typedApproval.comment -eq 'needs more context') `
         -Message "Expected comment, got: $($typedApproval.comment)"
@@ -3712,9 +3712,9 @@ if (Test-Path $notifModule) {
 
         Assert-True -Name "Poller transitions needs-input → analysing on typed approval response" `
             -Condition $movedExists -Message "Expected task moved to analysing/, missing: $movedFile"
-        Assert-True -Name "Poller persists approval_decision (PRD §5.4)" `
-            -Condition ($resolvedQA -and $resolvedQA.approval_decision -eq 'rejected') `
-            -Message "Expected approval_decision=rejected, got: $($resolvedQA | ConvertTo-Json -Compress)"
+        Assert-True -Name "Poller persists approval decision in answer field" `
+            -Condition ($resolvedQA -and $resolvedQA.answer -eq 'rejected') `
+            -Message "Expected answer=rejected, got: $($resolvedQA | ConvertTo-Json -Compress)"
         Assert-True -Name "Poller persists comment from typed response" `
             -Condition ($resolvedQA -and $resolvedQA.comment -eq 'not yet') `
             -Message "Expected comment='not yet'"
@@ -4075,8 +4075,10 @@ if ((Test-Path $mniMeta) -and (Test-Path $aqMeta)) {
     Assert-True -Name "task-answer-question schema declares 'type' enum (full PRD)" `
         -Condition ($aqText -match '(?ms)\btype:\s*\r?\n\s+type:\s*string\s*\r?\n\s+enum:\s*\[singleChoice') `
         -Message "Expected type field with full PRD enum"
-    Assert-True -Name "task-answer-question schema declares 'decision'" `
-        -Condition ($aqText -match 'decision:') -Message "Expected decision key"
+    Assert-True -Name "task-answer-question schema declares 'answer' as canonical response field" `
+        -Condition ($aqText -match '(?ms)\banswer:\s*\r?\n\s+type:\s*string') -Message "Expected answer key with string type"
+    Assert-True -Name "task-answer-question schema does NOT declare deprecated 'decision'" `
+        -Condition (-not ($aqText -match '(?ms)^\s+decision:\s*\r?\n')) -Message "Decision field collapsed into answer; schema must not re-declare it"
     Assert-True -Name "task-answer-question schema declares 'comment'" `
         -Condition ($aqText -match 'comment:') -Message "Expected comment key"
     Assert-True -Name "task-answer-question schema declares 'ranked_items'" `
@@ -4094,16 +4096,16 @@ if ((Test-Path $mniMeta) -and (Test-Path $aqMeta)) {
         try {
             . $aqScript
 
-            # Invalid decision for approval
+            # Invalid answer for approval
             $threw = $false; $msg = ""
-            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='approval'; decision='bogus' } } catch { $threw = $true; $msg = $_.Exception.Message }
-            Assert-True -Name "task-answer-question rejects invalid approval decision" `
-                -Condition ($threw -and $msg -match "Invalid 'decision'") `
-                -Message "Expected throw on bogus decision, got: $msg"
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='approval'; answer='bogus' } } catch { $threw = $true; $msg = $_.Exception.Message }
+            Assert-True -Name "task-answer-question rejects invalid approval answer" `
+                -Condition ($threw -and $msg -match "Invalid 'answer'") `
+                -Message "Expected throw on bogus approval answer, got: $msg"
 
-            # decision=rejected without comment
+            # answer=rejected without comment
             $threw = $false; $msg = ""
-            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='approval'; decision='rejected' } } catch { $threw = $true; $msg = $_.Exception.Message }
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='approval'; answer='rejected' } } catch { $threw = $true; $msg = $_.Exception.Message }
             Assert-True -Name "task-answer-question rejects rejected without comment" `
                 -Condition ($threw -and $msg -match "comment.*rejected") `
                 -Message "Expected throw on missing comment, got: $msg"
@@ -4129,57 +4131,33 @@ if ((Test-Path $mniMeta) -and (Test-Path $aqMeta)) {
                 -Condition ($threw -and $msg -match "Invalid 'type'") `
                 -Message "Expected throw on bogus type, got: $msg"
 
-            # Cross-field validation: incompatible-field combinations
-            $threw = $false; $msg = ""
-            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='freeText'; answer='ok'; decision='approved' } } catch { $threw = $true; $msg = $_.Exception.Message }
-            Assert-True -Name "task-answer-question rejects 'decision' on freeText type" `
-                -Condition ($threw -and $msg -match "'decision' is only valid") `
-                -Message "Expected throw, got: $msg"
-
+            # Cross-field validation: comment only valid on approval
             $threw = $false; $msg = ""
             try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='singleChoice'; answer='A'; comment='nope' } } catch { $threw = $true; $msg = $_.Exception.Message }
             Assert-True -Name "task-answer-question rejects 'comment' on singleChoice type" `
                 -Condition ($threw -and $msg -match "'comment' is only valid") `
                 -Message "Expected throw, got: $msg"
 
+            # Cross-field validation: ranked_items only valid on priorityRanking
             $threw = $false; $msg = ""
-            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='approval'; decision='approved'; ranked_items=@('a','b') } } catch { $threw = $true; $msg = $_.Exception.Message }
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='approval'; answer='approved'; ranked_items=@('a','b') } } catch { $threw = $true; $msg = $_.Exception.Message }
             Assert-True -Name "task-answer-question rejects 'ranked_items' on approval type" `
                 -Condition ($threw -and $msg -match "'ranked_items' is only valid") `
                 -Message "Expected throw, got: $msg"
 
-            # Cross-field validation must also fire when 'type' is omitted (legacy callers)
-            $threw = $false; $msg = ""
-            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; answer='A'; decision='approved' } } catch { $threw = $true; $msg = $_.Exception.Message }
-            Assert-True -Name "task-answer-question rejects 'decision' when type is omitted (legacy)" `
-                -Condition ($threw -and $msg -match "'decision' is only valid") `
-                -Message "Expected throw on legacy caller smuggling decision, got: $msg"
-
+            # ranked_items smuggling when type omitted (defaults to singleChoice)
             $threw = $false; $msg = ""
             try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; answer='B'; ranked_items=@('a','b') } } catch { $threw = $true; $msg = $_.Exception.Message }
             Assert-True -Name "task-answer-question rejects 'ranked_items' when type is omitted (legacy)" `
                 -Condition ($threw -and $msg -match "'ranked_items' is only valid") `
                 -Message "Expected throw on legacy caller smuggling ranked_items, got: $msg"
 
-            # 'answer' rejected for typed payloads — would produce inconsistent resolvedEntry with both answer and approval_decision set
-            $threw = $false; $msg = ""
-            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='approval'; decision='approved'; answer='A' } } catch { $threw = $true; $msg = $_.Exception.Message }
-            Assert-True -Name "task-answer-question rejects 'answer' alongside approval decision" `
-                -Condition ($threw -and $msg -match "'answer' is only valid") `
-                -Message "Expected throw, got: $msg"
-
-            $threw = $false; $msg = ""
-            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='priorityRanking'; ranked_items=@('a','b'); answer='A' } } catch { $threw = $true; $msg = $_.Exception.Message }
-            Assert-True -Name "task-answer-question rejects 'answer' alongside priorityRanking" `
-                -Condition ($threw -and $msg -match "'answer' is only valid") `
-                -Message "Expected throw, got: $msg"
-
             # changes_requested was a documentReview value — now invalid on the merged approval type
             $threw = $false; $msg = ""
-            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='approval'; decision='changes_requested'; comment='ok' } } catch { $threw = $true; $msg = $_.Exception.Message }
-            Assert-True -Name "task-answer-question rejects legacy changes_requested decision on approval" `
-                -Condition ($threw -and $msg -match "Invalid 'decision'") `
-                -Message "Expected throw on legacy changes_requested decision, got: $msg"
+            try { Invoke-TaskAnswerQuestion -Arguments @{ task_id='x'; type='approval'; answer='changes_requested'; comment='ok' } } catch { $threw = $true; $msg = $_.Exception.Message }
+            Assert-True -Name "task-answer-question rejects legacy changes_requested answer on approval" `
+                -Condition ($threw -and $msg -match "Invalid 'answer'") `
+                -Message "Expected throw on legacy changes_requested answer, got: $msg"
 
             # priorityRanking synthesis must normalize PSCustomObject ranked_items to strings —
             # (verify the synthesis-time -join stays safe even for PSCustomObject input)

--- a/tests/Test-E2E-Mothership-QA.ps1
+++ b/tests/Test-E2E-Mothership-QA.ps1
@@ -3,9 +3,9 @@
 .SYNOPSIS
     Layer 5: Mothership web UI E2E — Playwright against live server + Azurite.
 .DESCRIPTION
-    Runs Playwright specs that navigate the magic-link respond flow for all six
-    question types: singleChoice, multiChoice, freeText, approval,
-    documentReview, priorityRanking.
+    Runs Playwright specs that navigate the magic-link respond flow for all
+    question types: singleChoice, multiChoice, freeText, approval (with and
+    without attachments), priorityRanking.
 
     For each question type the script:
       1. POST /api/templates  — creates a template
@@ -173,25 +173,13 @@ $questionTypes = @(
         Submit  = @{ selectedKey = "opt_a" }
     }
     @{
-        Type               = "approval"
-        Title              = "Playwright E2E: approval"
-        DeliverableSummary = "Playwright E2E test deliverable for approval"
-        Options = @(
-            @{ key = "approve"; label = "Approve" }
-            @{ key = "reject";  label = "Reject"  }
-            @{ key = "abstain"; label = "Abstain" }
-        )
-        Submit  = @{ approvalDecision = "approve" }
-    }
-    @{
-        Type               = "documentReview"
-        Title              = "Playwright E2E: documentReview"
-        DeliverableSummary = "Playwright E2E test deliverable for documentReview"
+        Type    = "approval"
+        Title   = "Playwright E2E: approval"
         Options = @(
             @{ key = "approve"; label = "Approve" }
             @{ key = "reject";  label = "Reject"  }
         )
-        Submit  = @{ approvalDecision = "approve" }
+        Submit  = @{ approvalDecision = "approved" }
     }
     @{
         Type   = "freeText"

--- a/tests/e2e-server/specs/mothership-question-flow.spec.ts
+++ b/tests/e2e-server/specs/mothership-question-flow.spec.ts
@@ -58,16 +58,10 @@ for (const scenario of scenarios) {
 
       if (scenario.type === "approval") {
         await expect(
-          page.locator('[value="approve"], [data-key="approve"]').first(),
+          page.locator('[value="approved"], [data-key="approve"]').first(),
         ).toBeVisible();
         await expect(
-          page.locator('[value="reject"], [data-key="reject"]').first(),
-        ).toBeVisible();
-      }
-
-      if (scenario.type === "documentReview") {
-        await expect(
-          page.locator('[value="approve"], [data-key="approve"]').first(),
+          page.locator('[value="rejected"], [data-key="reject"]').first(),
         ).toBeVisible();
       }
 
@@ -98,8 +92,8 @@ for (const scenario of scenarios) {
         }
       }
 
-      if (scenario.type === "approval" || scenario.type === "documentReview") {
-        const decision = scenario.submit.approvalDecision ?? "approve";
+      if (scenario.type === "approval") {
+        const decision = scenario.submit.approvalDecision ?? "approved";
         const radio = page
           .locator(`input[type="radio"][value="${decision}"]`)
           .first();
@@ -151,8 +145,8 @@ for (const scenario of scenarios) {
         injectBody.freeText = scenario.submit.freeText ?? "test answer";
       } else if (scenario.type === "priorityRanking") {
         injectBody.rankedItems = scenario.submit.rankedItems;
-      } else if (scenario.type === "approval" || scenario.type === "documentReview") {
-        injectBody.approvalDecision = scenario.submit.approvalDecision ?? "approve";
+      } else if (scenario.type === "approval") {
+        injectBody.approvalDecision = scenario.submit.approvalDecision ?? "approved";
       } else {
         injectBody.selectedKey = scenario.submit.selectedKey;
       }
@@ -173,8 +167,8 @@ for (const scenario of scenarios) {
       } else if (scenario.type === "priorityRanking") {
         expect(Array.isArray(last.rankedItems)).toBeTruthy();
         expect(last.rankedItems.length).toBeGreaterThan(0);
-      } else if (scenario.type === "approval" || scenario.type === "documentReview") {
-        expect(last.approvalDecision).toBe(scenario.submit.approvalDecision ?? "approve");
+      } else if (scenario.type === "approval") {
+        expect(last.approvalDecision).toBe(scenario.submit.approvalDecision ?? "approved");
       } else if (scenario.submit.selectedKey) {
         expect(last.selectedKey).toBe(scenario.submit.selectedKey);
       }


### PR DESCRIPTION
## Linked issue

Closes #445

## Summary of changes

Merge the `documentReview` question type into `approval`. Attachments become optional on `approval`; reviewer decision narrows to `approved` / `rejected`. Outpost Decisions tab and Mothership respond form both render the merged shape.

Two commits, one per surface:

- `feat(server)` — type enum, validator, RespondFormHandler, Respond.cshtml, unit + integration + Playwright + Mothership QA fixture
- `feat(mcp,outpost)` — `task_mark_needs_input` + `task_answer_question` schema; outpost actions.js drops Abstain + renders attachment checklist when present

Behaviour:

- `documentReview` removed from the allowed type set
- `approval` decisions narrowed to `approved` / `rejected`; drops `abstained` / `changes_requested` / `comment_only`
- Approval question can carry attachments; respond surfaces render the per-attachment "I reviewed this" checklist and block submission until at least one is acknowledged
- `reviewedAttachmentIds` flows through `/api/responses` and `/api/task/answer`
- `comment` required only when decision = `rejected`
- `CheckDeliverableSummary` validator rule parked pending outpost support for emitting attachment summary; tests covering the rule marked `Skip` so intent stays documented

## Screenshots / recordings

n/a — no new UI surface; existing approval card simplified (Abstain dropped, attachment checklist enabled when applicable).

## Testing notes

- `dotnet test server/tests/Dotbot.Server.Tests/` — 326/326 pass, 2 skip (the parked deliverableSummary tests)
- `pwsh tests/Run-Tests.ps1` — Layer 1-3 pass on local
- Playwright `mothership-question-flow.spec.ts` updated to drive the merged shape; locator + decision values reflect `approved`/`rejected`
- `Test-E2E-Mothership-QA.ps1` updated; documentReview scenario dropped
- Manual e2e through a workflow + Mothership round-trip: approval question fired from analysis, reviewer responded via magic link, response persisted on the server

## Out of scope / follow-ups

- Framework bugfixes surfaced during the manual e2e (resumed-task field propagation in `ProcessRegistry`, `model` not propagated by `workflow-manifest`, hashtable-vs-PSObject probe in `Invoke-WorkflowProcess`) — separate PR
- Teaching `98-analyse-task.md` when to use `approval` vs `singleChoice` vs other question types — separate PR
- Wiring `needs_review` to publish an approval question to Mothership instead of parking locally — separate issue

Refs #29 (parent), #417 (dual-surface).

## Checklist

- [x] Tests added or updated
- [x] Docs updated (if behaviour changed)
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)