### PR TITLE
[426] Render generic form.modes[].fields in the workflow launch modal

### DIFF
--- a/core/runtime/modules/workflow-manifest.ps1
+++ b/core/runtime/modules/workflow-manifest.ps1
@@ -280,6 +280,77 @@ function Format-ManifestEntryForError {
     return '{ ' + ($pairs -join ', ') + ' }'
 }
 
+function Test-WorkflowFormFieldSchema {
+    <#
+    .SYNOPSIS
+    Validate form field declarations in a workflow manifest.
+
+    .DESCRIPTION
+    Returns an array of error strings — one per malformed field. Checks both
+    form.modes[].fields and a legacy top-level form.fields block. Each field
+    must declare a non-empty 'id' (the UI keys submitted values by it) and, when
+    'type' is present, it must be one of: text, textarea, toggle.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [object]$Manifest,
+
+        [string]$WorkflowName = '<unknown>'
+    )
+
+    if (-not $WorkflowName -or $WorkflowName -eq '<unknown>') {
+        $manifestName = Get-ManifestEntryField -Entry $Manifest -Field 'name'
+        if ($manifestName) { $WorkflowName = $manifestName }
+    }
+
+    $validTypes = @('text', 'textarea', 'toggle')
+    $errors = @()
+
+    $form = Get-ManifestEntryField -Entry $Manifest -Field 'form'
+
+    if (-not $form) {
+        return @()
+    }
+
+    $fieldOwners = @()
+    $modes = Get-ManifestEntryField -Entry $form -Field 'modes'
+
+    if ($modes) {
+        $fieldOwners += @($modes)
+    } else {
+        $fieldOwners += $form
+    }
+
+    foreach ($owner in $fieldOwners) {
+        $fields = Get-ManifestEntryField -Entry $owner -Field 'fields'
+
+        if (-not $fields) {
+            continue
+        }
+
+        $i = 0
+
+        foreach ($field in @($fields)) {
+            $id = Get-ManifestEntryField -Entry $field -Field 'id'
+
+            if ([string]::IsNullOrWhiteSpace([string]$id)) {
+                $rendered = Format-ManifestEntryForError -Entry $field
+                $errors += "form fields entry [$i] in workflow '$WorkflowName' is missing the required 'id' field. Entry: $rendered"
+            }
+
+            $type = Get-ManifestEntryField -Entry $field -Field 'type'
+
+            if ($type -and ($type -notin $validTypes)) {
+                $errors += "form field '$id' in workflow '$WorkflowName' has unknown type '$type'. Expected one of: $($validTypes -join ', ')."
+            }
+
+            $i++
+        }
+    }
+
+    return $errors
+}
+
 function Test-WorkflowManifestSchema {
     <#
     .SYNOPSIS
@@ -312,8 +383,10 @@ function Test-WorkflowManifestSchema {
         if (-not $WorkflowName) { $WorkflowName = '<unknown>' }
     }
 
+    $errors += @(Test-WorkflowFormFieldSchema -Manifest $Manifest -WorkflowName $WorkflowName)
+
     $requires = Get-ManifestEntryField -Entry $Manifest -Field 'requires'
-    if (-not $requires) { return @() }
+    if (-not $requires) { return $errors }
 
     # env_vars: each entry must have 'var'
     $envVars = Get-ManifestEntryField -Entry $requires -Field 'env_vars'

--- a/core/ui/server.ps1
+++ b/core/ui/server.ps1
@@ -341,7 +341,7 @@ function Add-StaticAssetVersions {
     })
 }
 
-function Get-WorkflowFormFields {
+function Get-WorkflowFormField {
     param([object]$Owner)
 
     if (-not $Owner) {
@@ -455,7 +455,7 @@ function Get-WorkflowFormConfig {
                 foreach ($key in @('interview_label', 'interview_hint', 'prompt_placeholder')) {
                     if ($activeMode[$key]) { $workflowDialog[$key] = "$($activeMode[$key])" }
                 }
-                $workflowDialog['fields'] = Get-WorkflowFormFields -Owner $mode
+                $workflowDialog['fields'] = Get-WorkflowFormField -Owner $mode
                 break
             }
         }
@@ -479,7 +479,7 @@ function Get-WorkflowFormConfig {
                 $val = if ($form -is [System.Collections.IDictionary]) { $form[$key] } else { $form.$key }
                 if ($val) { $workflowDialog[$key] = "$val" }
             }
-            $workflowDialog['fields'] = Get-WorkflowFormFields -Owner $form
+            $workflowDialog['fields'] = Get-WorkflowFormField -Owner $form
         }
     }
 

--- a/core/ui/server.ps1
+++ b/core/ui/server.ps1
@@ -341,6 +341,67 @@ function Add-StaticAssetVersions {
     })
 }
 
+function Get-WorkflowFormFields {
+    param([object]$Owner)
+
+    if (-not $Owner) {
+        return ,@()
+    }
+
+    $rawFields = Get-ManifestEntryField -Entry $Owner -Field 'fields'
+
+    if (-not $rawFields) {
+        return ,@()
+    }
+
+    $fields = @()
+
+    foreach ($field in @($rawFields)) {
+
+        if (-not $field) {
+            continue
+        }
+
+        $id = Get-ManifestEntryField -Entry $field -Field 'id'
+
+        if ([string]::IsNullOrWhiteSpace([string]$id)) {
+            continue
+        }
+
+        $normalized = @{ id = "$id" }
+
+        foreach ($key in @('type', 'label', 'placeholder', 'hint')) {
+            $val = Get-ManifestEntryField -Entry $field -Field $key
+
+            if ($null -ne $val) {
+                $normalized[$key] = "$val"
+            }
+        }
+
+        $requiredVal = Get-ManifestEntryField -Entry $field -Field 'required'
+
+        if ($null -ne $requiredVal) {
+            $normalized['required'] = [bool]$requiredVal
+        }
+
+        $defaultVal = Get-ManifestEntryField -Entry $field -Field 'default'
+
+        if ($null -ne $defaultVal) {
+            $normalized['default'] = $defaultVal
+        }
+
+        $rowsVal = Get-ManifestEntryField -Entry $field -Field 'rows'
+
+        if ($null -ne $rowsVal) {
+            $normalized['rows'] = [int]$rowsVal
+        }
+
+        $fields += $normalized
+    }
+
+    return ,@($fields)
+}
+
 # ---------------------------------------------------------------------------
 # Workflow form configuration helper
 # ---------------------------------------------------------------------------
@@ -394,6 +455,7 @@ function Get-WorkflowFormConfig {
                 foreach ($key in @('interview_label', 'interview_hint', 'prompt_placeholder')) {
                     if ($activeMode[$key]) { $workflowDialog[$key] = "$($activeMode[$key])" }
                 }
+                $workflowDialog['fields'] = Get-WorkflowFormFields -Owner $mode
                 break
             }
         }
@@ -417,6 +479,7 @@ function Get-WorkflowFormConfig {
                 $val = if ($form -is [System.Collections.IDictionary]) { $form[$key] } else { $form.$key }
                 if ($val) { $workflowDialog[$key] = "$val" }
             }
+            $workflowDialog['fields'] = Get-WorkflowFormFields -Owner $form
         }
     }
 
@@ -2133,6 +2196,17 @@ $docContext
                                         New-Item -Path $launchersDir -ItemType Directory -Force | Out-Null
                                     }
                                     $body.prompt | Set-Content -Path (Join-Path $launchersDir "workflow-launch-prompt.txt") -Encoding UTF8 -NoNewline
+                                }
+
+                                if ($body -and $body.PSObject.Properties['form'] -and $body.form) {
+                                    $launchersDir = Join-Path $botRoot ".control\launchers"
+
+                                    if (-not (Test-Path $launchersDir)) {
+                                        New-Item -Path $launchersDir -ItemType Directory -Force | Out-Null
+                                    }
+
+                                    $formInputPath = Join-Path $launchersDir "$wfName-form-input.json"
+                                    $body.form | ConvertTo-Json -Depth 5 | Set-Content -Path $formInputPath -Encoding UTF8 -NoNewline
                                 }
 
                                 $manifest = Read-WorkflowManifest -WorkflowDir $wfDir

--- a/core/ui/static/css/modal.css
+++ b/core/ui/static/css/modal.css
@@ -609,6 +609,26 @@
     border-left: 3px solid var(--color-primary-dim);
 }
 
+#workflow-launch-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+#workflow-launch-fields:empty {
+    display: none;
+}
+
+.field-required {
+    color: var(--color-error);
+}
+
+.field-error {
+    font-size: 11px;
+    color: var(--color-error);
+    line-height: 1.5;
+}
+
 .form-row {
     display: flex;
     gap: 12px;

--- a/core/ui/static/index.html
+++ b/core/ui/static/index.html
@@ -1480,6 +1480,7 @@
                         <div class="form-hint" id="workflow-launch-description">
                             Claude will create your mission, tech stack, and entity model documents based on your description and any attached files.
                         </div>
+                        <div id="workflow-launch-fields"></div>
                         <div class="form-group">
                             <label class="form-label">Attach context files (optional)</label>
                             <div class="workflow-launch-dropzone" id="workflow-launch-dropzone">

--- a/core/ui/static/modules/workflow-launch.js
+++ b/core/ui/static/modules/workflow-launch.js
@@ -311,6 +311,153 @@ function renderWorkflowCardGrid(container) {
 }
 
 /**
+ * Render generic form fields declared in workflow.yaml form.modes[].fields.
+ * Supported types: text, textarea, toggle. Unknown types are skipped with a warn.
+ * @param {Array} fields - normalized field schemas from the form config
+ */
+function renderWorkflowLaunchFields(fields) {
+    const container = document.getElementById('workflow-launch-fields');
+
+    if (!container) {
+        return;
+    }
+
+    container.replaceChildren();
+
+    if (!Array.isArray(fields) || fields.length === 0) {
+        return;
+    }
+
+    fields.forEach(field => {
+
+        if (!field || !field.id) {
+            return;
+        }
+
+        const type = field.type || 'text';
+        const label = field.label || field.id;
+        const hint = field.hint || '';
+        const required = field.required === true;
+
+        if (type === 'toggle') {
+            const option = document.createElement('div');
+            option.className = 'form-option';
+            option.dataset.fieldId = field.id;
+            option.dataset.fieldType = type;
+            option.innerHTML = `
+                <label class="form-checkbox-label">
+                    <input type="checkbox" data-field-input${field.default === true ? ' checked' : ''}>
+                    <span class="form-checkbox-text">${escapeHtml(label)}</span>
+                </label>
+                ${hint ? `<div class="form-option-hint">${escapeHtml(hint)}</div>` : ''}
+            `;
+            container.appendChild(option);
+            return;
+        }
+
+        if (type !== 'text' && type !== 'textarea') {
+            console.warn(`Unknown workflow form field type "${type}" for field "${field.id}" — skipping`);
+            return;
+        }
+
+        const group = document.createElement('div');
+        group.className = 'form-group';
+        group.dataset.fieldId = field.id;
+        group.dataset.fieldType = type;
+
+        const placeholder = field.placeholder || '';
+        const defaultValue = field.default != null ? String(field.default) : '';
+        const control = type === 'textarea'
+            ? `<textarea class="form-textarea" data-field-input rows="${Number(field.rows) || 3}" placeholder="${escapeAttr(placeholder)}">${escapeHtml(defaultValue)}</textarea>`
+            : `<input type="text" class="form-input" data-field-input placeholder="${escapeAttr(placeholder)}" value="${escapeAttr(defaultValue)}">`;
+
+        group.innerHTML = `
+            <label class="form-label">${escapeHtml(label)}${required ? ' <span class="field-required">*</span>' : ''}</label>
+            ${control}
+            ${hint ? `<div class="form-hint">${escapeHtml(hint)}</div>` : ''}
+            <div class="field-error" data-field-error hidden></div>
+        `;
+        container.appendChild(group);
+    });
+}
+
+/**
+ * Collect declared field values keyed by field id.
+ * Toggle fields yield a boolean; text/textarea yield the trimmed string.
+ * @returns {Object} map of field id to value
+ */
+function collectWorkflowLaunchFields() {
+    const container = document.getElementById('workflow-launch-fields');
+    const values = {};
+
+    if (!container) {
+        return values;
+    }
+
+    container.querySelectorAll('[data-field-id]').forEach(group => {
+        const id = group.dataset.fieldId;
+        const input = group.querySelector('[data-field-input]');
+
+        if (!id || !input) {
+            return;
+        }
+
+        if (group.dataset.fieldType === 'toggle') {
+            values[id] = input.checked;
+        } else {
+            values[id] = input.value.trim();
+        }
+    });
+
+    return values;
+}
+
+/**
+ * Validate required fields, showing inline errors. Returns true when valid.
+ * @returns {boolean}
+ */
+function validateWorkflowLaunchFields() {
+    const container = document.getElementById('workflow-launch-fields');
+
+    if (!container) {
+        return true;
+    }
+
+    const fields = (workflowLaunchDialog?.fields) || [];
+    let valid = true;
+
+    fields.forEach(field => {
+
+        if (!field || field.required !== true || field.type === 'toggle') {
+            return;
+        }
+
+        const group = container.querySelector(`[data-field-id="${CSS.escape(field.id)}"]`);
+
+        if (!group) {
+            return;
+        }
+
+        const input = group.querySelector('[data-field-input]');
+        const errorEl = group.querySelector('[data-field-error]');
+        const empty = !input || input.value.trim() === '';
+
+        if (empty) {
+            valid = false;
+
+            if (errorEl) {
+                errorEl.textContent = `${field.label || field.id} is required`;
+                errorEl.hidden = false;
+            }
+        } else if (errorEl) {
+            errorEl.hidden = true;
+        }
+    });
+
+    return valid;
+}
+
+/**
  * Apply a workflow's dialog config to the modal DOM.
  *
  * Sets description, interview label/hint, prompt placeholder, section
@@ -357,6 +504,14 @@ function applyWorkflowLaunchDialog(dialog, phases, mode) {
     // Remove any auto-detect button injected on a previous apply so repeated
     // calls (per-workflow form re-fetch) don't stack duplicates.
     document.getElementById('workflow-launch-auto-detect-container')?.remove();
+
+    const fieldsContainer = document.getElementById('workflow-launch-fields');
+
+    if (fieldsContainer) {
+        fieldsContainer.replaceChildren();
+    }
+
+    renderWorkflowLaunchFields(dialog?.fields || []);
 
     if (dialog) {
         if (descEl && dialog.description != null) descEl.textContent = dialog.description;
@@ -665,8 +820,14 @@ async function submitWorkflowLaunch() {
         skipPhases.push(cb.dataset.phaseId);
     });
 
-    if (!prompt) {
+    const promptVisible = workflowLaunchDialog?.show_prompt !== false;
+
+    if (promptVisible && !prompt) {
         showToast('Please describe your project', 'warning');
+        return;
+    }
+
+    if (!validateWorkflowLaunchFields()) {
         return;
     }
 
@@ -741,17 +902,24 @@ async function executeWorkflowLaunch(prompt, needsInterview, autoWorkflow, skipP
         return;
     }
 
+    const formValues = collectWorkflowLaunchFields();
+    const payload = {
+        prompt: prompt,
+        files: workflowLaunchFiles.map(f => ({
+            name: f.name,
+            content: f.content
+        }))
+    };
+
+    if (Object.keys(formValues).length > 0) {
+        payload.form = formValues;
+    }
+
     try {
         const response = await fetch(`${API_BASE}/api/workflows/${encodeURIComponent(workflowLaunchName)}/run`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                prompt: prompt,
-                files: workflowLaunchFiles.map(f => ({
-                    name: f.name,
-                    content: f.content
-                }))
-            })
+            body: JSON.stringify(payload)
         });
 
         const result = await response.json();

--- a/tests/Test-ServerStartup.ps1
+++ b/tests/Test-ServerStartup.ps1
@@ -304,6 +304,21 @@ form:
   show_files: false
   show_interview: true
   show_auto_workflow: false
+  fields:
+    - id: jira_keys
+      type: text
+      label: "Jira Tickets"
+      required: true
+      placeholder: "PROJ-123"
+      hint: "Comma-separated"
+    - id: instructions
+      type: textarea
+      label: "Instructions"
+      rows: 3
+    - id: approval_mode
+      type: toggle
+      label: "Require approval"
+      default: true
 tasks:
   - name: "Bravo Phase 1"
     type: prompt
@@ -379,6 +394,23 @@ tasks:
             Assert-Equal -Name "bravo phases count matches bravo manifest" `
                 -Expected 2 `
                 -Actual ([int]$bravoResp.phases.Count)
+
+            # Field-config extraction
+            $bravoFields = @($bravoResp.dialog.fields)
+            Assert-Equal -Name "bravo form exposes 3 fields" -Expected 3 -Actual $bravoFields.Count
+            $jiraField = $bravoFields | Where-Object { $_.id -eq 'jira_keys' }
+            Assert-Equal -Name "bravo jira_keys field type is text" -Expected "text" -Actual $jiraField.type
+            Assert-Equal -Name "bravo jira_keys field is required" -Expected $true -Actual ([bool]$jiraField.required)
+            Assert-Equal -Name "bravo jira_keys field hint preserved" -Expected "Comma-separated" -Actual $jiraField.hint
+            $instructionsField = $bravoFields | Where-Object { $_.id -eq 'instructions' }
+            Assert-Equal -Name "bravo instructions field rows preserved" -Expected 3 -Actual ([int]$instructionsField.rows)
+            $approvalField = $bravoFields | Where-Object { $_.id -eq 'approval_mode' }
+            Assert-Equal -Name "bravo approval_mode field type is toggle" -Expected "toggle" -Actual $approvalField.type
+            Assert-Equal -Name "bravo approval_mode default is true" -Expected $true -Actual ([bool]$approvalField.default)
+
+            # Backward compatibility: alpha declares no fields → empty array
+            $alphaFields = @($alphaResp.dialog.fields)
+            Assert-Equal -Name "alpha form exposes no fields" -Expected 0 -Actual $alphaFields.Count
         }
 
         # --- 404 for unknown workflow ---

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -499,6 +499,90 @@ Assert-True -Name "WorkflowName param appears in error" `
 Write-Host ""
 
 # ═══════════════════════════════════════════════════════════════════
+# TEST-WORKFLOWFORMFIELDSCHEMA
+# ═══════════════════════════════════════════════════════════════════
+
+Write-Host "  TEST-WORKFLOWFORMFIELDSCHEMA" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+# Valid fields under a mode produce no errors
+$validFieldsManifest = @{
+    name = "fields-wf"
+    form = @{
+        modes = @(
+            @{
+                id = "new_project"
+                fields = @(
+                    @{ id = "jira_keys"; type = "text"; label = "Jira Tickets"; required = $true }
+                    @{ id = "instructions"; type = "textarea"; rows = 3 }
+                    @{ id = "approval_mode"; type = "toggle"; default = $false }
+                )
+            }
+        )
+    }
+}
+$validFieldErrors = @(Test-WorkflowFormFieldSchema -Manifest $validFieldsManifest)
+Assert-Equal -Name "Valid fields produce 0 errors" -Expected 0 -Actual $validFieldErrors.Count
+
+# Manifest without a form block produces no errors
+$noFormErrors = @(Test-WorkflowFormFieldSchema -Manifest @{ name = "x" })
+Assert-Equal -Name "Manifest without form produces 0 errors" -Expected 0 -Actual $noFormErrors.Count
+
+# Mode without fields produces no errors (backward compatibility)
+$noFieldsErrors = @(Test-WorkflowFormFieldSchema -Manifest @{
+    name = "no-fields"
+    form = @{ modes = @(@{ id = "m1"; show_prompt = $true }) }
+})
+Assert-Equal -Name "Mode without fields produces 0 errors" -Expected 0 -Actual $noFieldsErrors.Count
+
+# Field missing 'id' produces 1 error naming the workflow
+$missingIdManifest = @{
+    name = "bad-fields"
+    form = @{ modes = @(@{ id = "m1"; fields = @(@{ type = "text"; label = "No id" }) }) }
+}
+$missingIdErrors = @(Test-WorkflowFormFieldSchema -Manifest $missingIdManifest)
+Assert-Equal -Name "Field missing 'id' produces 1 error" -Expected 1 -Actual $missingIdErrors.Count
+Assert-True -Name "Missing-id error names the workflow" `
+    -Condition ($missingIdErrors[0] -match "bad-fields") `
+    -Message "Workflow name not in error: $($missingIdErrors[0])"
+Assert-True -Name "Missing-id error names the 'id' field" `
+    -Condition ($missingIdErrors[0] -match "'id'") `
+    -Message "Field name not in error"
+
+# Unknown field type produces 1 error listing valid types
+$badTypeManifest = @{
+    name = "bad-type"
+    form = @{ modes = @(@{ id = "m1"; fields = @(@{ id = "f1"; type = "dropdown" }) }) }
+}
+$badTypeErrors = @(Test-WorkflowFormFieldSchema -Manifest $badTypeManifest)
+Assert-Equal -Name "Unknown field type produces 1 error" -Expected 1 -Actual $badTypeErrors.Count
+Assert-True -Name "Unknown-type error lists valid types" `
+    -Condition ($badTypeErrors[0] -match "text, textarea, toggle") `
+    -Message "Valid types not listed in error"
+
+# Field without a type is allowed (UI defaults to text)
+$noTypeErrors = @(Test-WorkflowFormFieldSchema -Manifest @{
+    name = "no-type"
+    form = @{ modes = @(@{ id = "m1"; fields = @(@{ id = "f1" }) }) }
+})
+Assert-Equal -Name "Field without type produces 0 errors" -Expected 0 -Actual $noTypeErrors.Count
+
+# Legacy top-level form.fields (no modes) is also validated
+$legacyFieldErrors = @(Test-WorkflowFormFieldSchema -Manifest @{
+    name = "legacy-form"
+    form = @{ fields = @(@{ type = "text" }) }
+})
+Assert-Equal -Name "Legacy form.fields missing id produces 1 error" -Expected 1 -Actual $legacyFieldErrors.Count
+
+# Test-WorkflowManifestSchema surfaces form-field errors alongside requires errors
+$combinedErrors = @(Test-WorkflowManifestSchema -Manifest $missingIdManifest)
+Assert-True -Name "Test-WorkflowManifestSchema includes form-field errors" `
+    -Condition ($combinedErrors.Count -ge 1 -and ($combinedErrors -join ' ') -match "'id'") `
+    -Message "form-field error not surfaced by Test-WorkflowManifestSchema"
+
+Write-Host ""
+
+# ═══════════════════════════════════════════════════════════════════
 # CONVERT-MANIFESTTASKSTOPHASES
 # ═══════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Linked issue

Closes #426

## Summary of changes

The workflow launch modal could previously only render a single free-text
`<textarea>` (`show_prompt: true`); the per-mode `fields:` slot in
`workflow.yaml` was silently ignored. This PR makes the modal render typed,
labeled inputs declared in `form.modes[].fields` — so workflows can collect
structured launch input as a YAML edit instead of a core JS change — and
writes the submitted values as JSON for downstream tasks to consume.

## Changes

- **Server schema extraction** (`core/ui/server.ps1`): new `Get-WorkflowFormFields`
  normalizes a mode's (or legacy form block's) `fields[]` into
  `id, type, label, required, default, placeholder, hint, rows`; wired into
  `Get-WorkflowFormConfig` so `/api/info` and `/api/workflows/{name}/form`
  expose `dialog.fields`.
- **Structured output** (`core/ui/server.ps1`): the `/api/workflows/{name}/run`
  handler writes the posted `form` object to
  `.bot/.control/launchers/{workflow}-form-input.json` (prompt/files handling
  unchanged).
- **Generic UI rendering** (`core/ui/static/modules/workflow-launch.js`,
  `index.html`, `css/modal.css`): a dispatcher renders `text` / `textarea`
  (with `rows`) / `toggle` (honoring `default`), warns and skips unknown
  types, enforces `required` with inline errors, and posts values keyed by
  `field.id`. The free-text prompt is only required when `show_prompt !== false`.
- **Schema validation** (`core/runtime/modules/workflow-manifest.ps1`): new
  `Test-WorkflowFormFieldSchema` (surfaced via `Test-WorkflowManifestSchema`)
  validates each field has an `id` and a known `type`.
- **Tests**: Layer 1 field-schema coverage in `tests/Test-WorkflowManifest.ps1`;
  Layer 2 field-config extraction in `tests/Test-ServerStartup.ps1`.

## Screenshots / recordings

Launch modal rendered entirely from `form.modes[].fields` (text, textarea,
toggle with default-checked, required marker):

<img width="800" height="776" alt="localhost_8687_" src="https://github.com/user-attachments/assets/2ff07e3a-3d39-495c-918e-db3a5264c751" />

## Testing notes

- Layer 1 unit tests: `pwsh tests/Test-WorkflowManifest.ps1` — 442/442 pass
  (includes new `TEST-WORKFLOWFORMFIELDSCHEMA` cases: missing `id`, unknown
  `type`, legacy `form.fields`, backward-compat empty).
- Layer 2 server tests: `pwsh tests/Test-ServerStartup.ps1` — 57/57 pass
  (asserts `/api/workflows/{name}/form` returns `fields[]` with types/`rows`/
  `required`/`default`, and that a fields-less workflow returns an empty array).
- Manual end-to-end in a real `dotbot init` project: opened the launch modal,
  required-field validation blocked an empty submit, and a successful submit
  wrote `demo-launch-fields-form-input.json`
  (`{"project_name":"acme-portal", ..., "dry_run": true}` — boolean preserved);
  a downstream `prompt_template` task read that JSON and echoed the values.
- Backward compatibility: `start-from-prompt` (no `fields:`) still renders only
  the single free-text textarea.

## Checklist

- [x] Tests added or updated
- [x] Docs updated (if behaviour changed)
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
