### PR TITLE
Merge documentReview into approval question type [#445]

### DIFF
--- a/docs/specs/PRD-029-expand-question-service.md
+++ b/docs/specs/PRD-029-expand-question-service.md
@@ -15,7 +15,7 @@
 The QuestionService currently supports only **single-choice questions** (with optional free text) delivered to a **flat recipient list** via a **single channel per request**. This limits dotbot's ability to:
 
 - Request **stakeholder sign-off** on generated artifacts (architecture docs, PRDs, diagrams)
-- Gather **structured input** beyond option selection (free-text answers, priority rankings, document reviews)
+- Gather **structured input** beyond option selection (free-text answers, priority rankings, approvals with attached documents)
 - **Attach generated artifacts** (rendered markdown, diagrams) to question notifications for review on the server
 - Give recipients enough **context in-channel** to triage without opening the web form
 
@@ -26,7 +26,7 @@ These gaps block the vision of dotbot as an autonomous agent that collaborates w
 Channel messages and the web form split responsibility deliberately:
 
 - **Channels (Teams, Email, Slack, Jira) are the *context surface*.** Every notification carries a rich human-in-the-loop summary: question title + type, a 1-3 line deliverable summary, the list of attachments to review, and any external review links. A reviewer can judge urgency and scope from their inbox/chat, without clicking through.
-- **The Mothership web form is the *interaction surface*.** All actual submission - button clicks, comments, drag-and-drop ranking, document-review confirmation - happens here via a magic link. Keeping submission in one place means new question types don't multiply per-channel rendering work.
+- **The Mothership web form is the *interaction surface*.** All actual submission - button clicks, comments, drag-and-drop ranking, per-attachment review confirmation - happens here via a magic link. Keeping submission in one place means new question types don't multiply per-channel rendering work.
 
 Channels stay read-only. Interaction lives on the web form.
 
@@ -34,8 +34,8 @@ Channels stay read-only. Interaction lives on the web form.
 
 ## 2. Goals
 
-1. **Artifact approval workflow** - stakeholders can approve/reject generated documents with comments, via any delivery channel (notification -> Mothership web form). Outpost Decisions tab push-back is P2 scope (see sec.7).
-2. **New question types** - approval (yes/no/abstain + comments), document review, free-text input, priority ranking
+1. **Artifact approval workflow** - stakeholders can approve/reject generated documents with comments, via any delivery channel (notification -> Mothership web form). Outpost Decisions tab push-back (dual-surface approval, whitepaper section 6.2.1) is out of scope here and tracked in [#416](https://github.com/andresharpe/dotbot/issues/416).
+2. **New question types** - approval (approve/reject + comments, with optional attached documents for the reviewer to confirm), free-text input, priority ranking
 3. **Attachment support** - generated artifacts (markdown->PDF, diagrams, code diffs) referenced inline with questions across all channels
 4. **Rich in-channel summaries** - every notification contains deliverable summary, attachment list, and review links, so a reviewer can triage in place
 
@@ -65,14 +65,13 @@ Channels stay read-only. Interaction lives on the web form.
 | `CreateInstanceRequest` | Single channel | One `Channel` field, flat `Recipients` |
 | Delivery providers | 4 channels | Teams (Adaptive Cards), Email (HTML), Jira (wiki tables), Slack (Block Kit) |
 | `DeliveryOrchestrator` | Basic routing | Channel validation, business hours, magic links, reminders/escalation |
-| Outpost MCP | Task-level question groups | `task-mark-needs-input` accepts `pending_questions[]` on the task; each question is published as its own template + instance. `task-answer-question` answers per question id. `NotificationPoller.psm1` reconciles each instance independently. |
+| Outpost MCP | Task-level question groups | `task_set_status` moves the task to `needs-input` and `task_update` writes `pending_question` / `pending_questions[]` onto the task. The runtime `Send-TaskNotification` publishes each question as its own template + instance. `NotificationPoller.psm1` polls Mothership for responses and dispatches each via `Resolve-NotificationAnswer` + `Resolve-TaskInputAnswer` to update the task. |
 
 ### 3.2 What's Missing
 
 - No `Type` enum - the `"singleChoice"` string is the only known value
 - No attachment support on `QuestionTemplate` (only on `ResponseRecordV2`)
-- No approval-specific response model (approve/reject/abstain + comments)
-- No dual-surface approval sync between Outpost and Mothership
+- No approval-specific response model (approve/reject + comments, with optional per-attachment confirmations)
 - No review link model to reference external artifacts for in-context review
 - **No shared notification-summary model** - each provider hand-rolls its own message, so adding a field (e.g. attachment list) today means editing four files with drift between them
 
@@ -87,8 +86,7 @@ Introduce a string-constant taxonomy for `Type` on `QuestionTemplate` (validated
 | Type | Behavior | Options | Response Model |
 |------|----------|---------|----------------|
 | `singleChoice` | Select one option from a list (current behavior) | Required, 2+ options | `SelectedOptionId` + optional `FreeText` |
-| `approval` | Approve/reject/abstain with mandatory comment on reject | Fixed: Approve, Reject, Abstain | `ApprovalDecision` (`approved` \| `rejected` \| `abstained`) + `Comment` (required on reject) |
-| `documentReview` | Review attached artifact(s) and provide feedback | Fixed: Approve, Request Changes, Comment Only | `ApprovalDecision` (`approved` \| `changes_requested` \| `comment_only`) + `Comment` + `ReviewedAttachmentIds` |
+| `approval` | Approve/reject with mandatory comment on reject. Optional `attachments` make the reviewer confirm each attached document before submitting. | None (Approve/Reject buttons are rendered by the form) | `Answer` (`"approved"` \| `"rejected"`) + `Comment` (required on reject) + `ReviewedAttachmentIds` (when attachments present) |
 | `freeText` | Open-ended text response | None (no options) | `FreeText` (required) |
 | `priorityRanking` | Rank items by ordinal priority (no weights) | Required, 2+ items to rank | `RankedItems[]` (ordered list of option IDs) |
 
@@ -106,11 +104,11 @@ public class QuestionTemplate
 }
 ```
 
-The `Options` field remains required for `singleChoice` and `priorityRanking`, is auto-generated (Approve/Reject/Abstain) for `approval` and `documentReview`, and empty for `freeText`.
+The `Options` field remains required for `singleChoice` and `priorityRanking`, is empty for `approval` and `freeText` (the form renders Approve/Reject buttons directly for `approval`).
 
 A static `QuestionTypes` class (`Models/QuestionTypes.cs`) holds the five string constants (`QuestionTypes.SingleChoice`, `QuestionTypes.Approval`, etc.) plus `AllowedTypes` for validation. The server validates `QuestionTemplate.Type` against `AllowedTypes` at `POST /api/templates` and rejects typos with `400 Bad Request`.
 
-`DeliverableSummary` is the author-supplied 1-3 sentence explanation of *what needs review*. It is rendered prominently in every channel notification. **Required** for `approval` and `documentReview` templates (validated at `POST /api/templates`; rejected with `400 Bad Request` if missing or blank); **optional** for `singleChoice`, `freeText`, and `priorityRanking` where the title + options carry enough context on their own.
+`DeliverableSummary` is the author-supplied 1-3 sentence explanation of *what needs review*. It is rendered prominently in every channel notification. **Required** for `approval` templates that carry attachments (validated at `POST /api/templates`; rejected with `400 Bad Request` if missing or blank); **optional** for plain `approval`, `singleChoice`, `freeText`, and `priorityRanking` where the title + options carry enough context on their own. (Note: the rule is currently parked in the validator pending outpost support for emitting the summary; see the TODO on `CheckDeliverableSummary`.)
 
 `priorityRanking` uses **ordinal ranks only** (1 = highest priority, 2 = next, ...). No weighted scores in this release - a future enhancement could add an optional `Weight: double?` on `RankedItem` non-breakingly.
 
@@ -178,13 +176,14 @@ public class ResponseRecordV2
 {
     // ... existing fields (SelectedOptionId, FreeText, etc.) ...
 
-    // NEW - approval/review responses
-    // Values scoped by QuestionTemplate.Type:
-    //   approval:       "approved" | "rejected" | "abstained"
-    //   documentReview: "approved" | "changes_requested" | "comment_only"
+    // NEW - approval responses (merged with the former documentReview type)
+    // Decision values for QuestionTemplate.Type == "approval":
+    //   "approved" | "rejected"
     public string? ApprovalDecision { get; set; }
     public string? Comment { get; set; }                // required on reject
-    public List<Guid>? ReviewedAttachmentIds { get; set; }
+    public List<Guid>? ReviewedAttachmentIds { get; set; }  // populated when the
+                                                            // approval template
+                                                            // carries attachments
     public List<RankedItem>? RankedItems { get; set; }  // for priorityRanking
 }
 
@@ -197,20 +196,17 @@ public class RankedItem
 
 Backwards-compatible: existing `singleChoice` responses continue using `SelectedOptionId` + `FreeText`.
 
-### 4.4 Dual-Surface Approval Flow
+### 4.4 Approval Flow
 
-Per the whitepaper (section 6.2.1), approvals work on both the Outpost Decisions tab and via Mothership channels. For `approval` and `documentReview` question types:
+For `approval` question instances (with or without attachments):
 
 1. Outpost publishes template with `Type = "approval"` + attachments
-2. Mothership creates instance -> delivers notifications to channels AND marks as pending in Decisions API
-3. Respondent approves via **either** surface:
-   - **Channel notification -> Mothership web form:** reads full context from the rich notification, clicks magic link -> opens question page -> submits response
-   - **Outpost:** approves in the Decisions tab locally
-4. **First response (by timestamp) is authoritative.** No quorum, no override - this is the governance posture for v1. Applies in the P0 single-surface flow (only the web form exists) and in the P2 dual-surface flow.
-5. Mothership syncs the decision back to the originating outpost
-6. **(P2 only)** With dual-surface enabled, a second response may arrive after the task has transitioned. The task state does not change. The second response is stored on the instance blob with its own timestamp and **flagged in the dashboard as agreement (same decision) or disagreement (different decision) for human review** - the flag is derived at read time by comparing to the first response's `ApprovalDecision`. Without dual-surface (P0 scope), only one response is possible per question.
+2. Mothership creates instance and delivers notifications to channels
+3. Respondent reads context from the rich notification, clicks the magic link, opens the question page, submits the response on the Mothership web form
+4. **First response (by timestamp) is authoritative.** No quorum, no override - this is the governance posture for v1. (One response per question in P0 scope. See P2 forward-pointer below for dual-surface conflict handling.)
+5. Outpost reconciles the response on the next poll tick
 
-**No new API endpoints needed** - the existing `POST /api/responses` and `ResponseRecordV2` accommodate this with the new `ApprovalDecision` field. The Outpost's Decisions tab needs a UI update to render approval-type questions (out of scope for this PRD - tracked separately).
+**Outpost Decisions tab push-back (dual-surface approval, whitepaper section 6.2.1) is out of scope for this PRD.** Today the Outpost Decisions tab approves an `approval`-typed question via the same path as any other pending question - no special-case handling, no push-back to Mothership. The proper dual-surface flow (local approval pushed to Mothership via `POST /api/responses`, first-by-timestamp resolution, agreement/disagreement flagging) is tracked separately in [#416](https://github.com/andresharpe/dotbot/issues/416).
 
 ### 4.5 Channel Delivery Model: Rich Notification + Link
 
@@ -275,8 +271,7 @@ public class ReviewLinkRef
 | Type | Web Form Rendering |
 |------|--------------------|
 | `singleChoice` | Radio buttons + optional free text (current behavior) |
-| `approval` | Approve/Reject/Abstain buttons + comment textarea (required on reject) |
-| `documentReview` | Attachment list with a confirmation checkbox per item (recorded in `ReviewedAttachmentIds`) + decision buttons (Approve / Request Changes / Comment Only) + feedback textarea |
+| `approval` | Approve/Reject buttons + comment textarea (required on reject). When the template carries `attachments`, the form also renders a confirmation checkbox per item (recorded in `ReviewedAttachmentIds`) above the decision buttons. |
 | `freeText` | Multiline textarea (required) |
 | `priorityRanking` | Drag-and-drop sortable list |
 
@@ -288,58 +283,41 @@ public class ReviewLinkRef
 
 ### 4.6 Outpost-Side Changes
 
-**MCP tool: `task-mark-needs-input`** - extend metadata/script:
+v4 has no dedicated MCP tool for question publishing or answering. Questions move through the generic `task_set_status` transition (with `status: needs-input`) plus a `task_update` that writes `pending_question` (single) or `pending_questions[]` (batch) onto the task. Notification dispatch and response parsing live in runtime modules.
+
+**Pending question carrier (on the task JSON, under `extensions.runner.pending_question` or `pending_questions[]`):**
 
 ```json
-[
-  {
-    "name": "type",
-    "type": "string",
-    "enum": ["singleChoice", "approval", "documentReview", "freeText", "priorityRanking"],
-    "description": "Question type (default: singleChoice)"
-  },
-  {
-    "name": "deliverable_summary",
-    "type": "string",
-    "description": "1-3 line summary of what needs review (shown in channel notifications)"
-  },
-  {
-    "name": "attachments",
-    "type": "array",
-    "description": "File paths to attach (uploaded to Mothership)",
-    "items": {
-      "type": "object",
-      "properties": {
-        "path": { "type": "string" },
-        "description": { "type": "string" }
-      }
-    }
-  },
-  {
-    "name": "review_links",
-    "type": "array",
-    "description": "External URLs for reviewer context",
-    "items": {
-      "type": "object",
-      "properties": {
-        "title": { "type": "string" },
-        "url": { "type": "string" },
-        "type": { "type": "string", "enum": ["pull-request", "document", "design", "other"] }
-      }
-    }
-  }
-]
+{
+  "id": "q_xxxxxxxx",
+  "question": "...",
+  "context": "...",
+  "options": [ { "key": "A", "label": "...", "rationale": "..." } ],
+  "recommendation": "A",
+  "type": "singleChoice | approval | freeText | priorityRanking",
+  "deliverable_summary": "1-3 line summary of what needs review",
+  "attachments": [
+    { "path": "workspace/attachments/.../file.pdf", "description": "..." }
+  ],
+  "review_links": [
+    { "title": "PR #42", "url": "https://...", "type": "pull-request" }
+  ]
+}
 ```
 
-**`NotificationClient.psm1`** - extend to:
-1. Upload attachments via `POST /api/attachments` before creating template
-2. Include `type`, `deliverable_summary`, `attachments`, `reviewLinks` on template
-3. Handle type-specific response parsing on poll (metadata only - no file download)
+The `type`, `deliverable_summary`, `attachments`, `review_links` fields are the new additions; existing tasks without them continue to behave as `singleChoice`.
 
-**`task-answer-question`** - extend to handle approval/review responses:
-- Accept `decision` parameter - valid values vary by question type (see sec.4.1 table): `approval` accepts `approved` / `rejected` / `abstained`; `documentReview` accepts `approved` / `changes_requested` / `comment_only`
-- Accept `comment` parameter (required when `decision = rejected` on an `approval` question)
-- Accept `ranked_items` for priority ranking
+**Runtime: `src/runtime/Modules/Dotbot.Notification/Dotbot.Notification.psm1`** - extend `Send-TaskNotification` and `Invoke-AttachmentBatchUpload` to:
+1. Upload attachments via `POST /api/attachments` before creating the template
+2. Include `type`, `deliverableSummary`, `attachments`, `referenceLinks` on the template payload
+3. Map outpost-side keys (`title`, `url`, `type`) to server-side wire shape (`label`, `url`) for `referenceLinks`
+
+**Runtime: `src/runtime/Modules/Dotbot.TaskInput/Dotbot.TaskInput.psm1`** - extend `Resolve-TaskInputAnswer`:
+- For `approval` questions, accept the response payload's `answer` value (`approved` / `rejected`)
+- Carry `comment` from the response into the resolved entry (required when `answer = rejected` on `approval`)
+- For `priorityRanking`, carry `ranked_items` through to the resolved entry
+
+**UI: `src/ui/modules/NotificationPoller.psm1`** - extend `Resolve-NotificationAnswer` to read `approvalDecision`, `comment`, `rankedItems`, and `reviewedAttachmentIds` from the Mothership response and map them to the runtime answer-resolver inputs above.
 
 ---
 
@@ -364,7 +342,7 @@ NotificationPoller.psm1                 ResponseStorageService
   POST /api/templates                   Store QuestionTemplate blob
   POST /api/instances                   Create QuestionInstance + deliver
   POST /api/attachments                 Upload file to blob store (NEW)
-  POST /api/responses                   Push local approval (NEW, P2)
+  POST /api/responses                   Push local approval (out of scope - see #416)
 
   ---- Pull (Outpost <- Mothership) ----
   GET  /api/instances/{p}/{q}/{i}/responses   Return ResponseRecordV2[]
@@ -379,13 +357,14 @@ NotificationPoller.psm1                 ResponseStorageService
  ------                                            ----------
  Claude (analysis phase)
    |
-   | calls task-mark-needs-input
-   |   type: "approval"
-   |   deliverable_summary: "Architecture v2 introduces ..."
-   |   attachments: [architecture-v2.pdf]
+   | calls task_update to attach pending_question
+   |   { type: "approval",
+   |     deliverable_summary: "Architecture v2 introduces ...",
+   |     attachments: [architecture-v2.pdf] }
+   | then task_set_status -> needs-input
    |
    v
- Invoke-TaskMarkNeedsInput
+ Dotbot.Task runtime (Send-TaskNotification)
    |
    +-1- Upload attachments -----------------------> POST /api/attachments
    |    (multipart/form-data)                      -> IAttachmentStorage.UploadAsync()
@@ -447,8 +426,9 @@ NotificationPoller.psm1                 ResponseStorageService
                                                     | load QuestionTemplate + Instance
                                                     | render type-specific form:
                                                     |   singleChoice -> radio buttons
-                                                    |   approval -> approve/reject/abstain + comment
-                                                    |   documentReview -> per-attachment checklist + decision + feedback
+                                                    |   approval -> approve/reject + comment
+                                                    |               (attachments present? add the
+                                                    |               per-attachment confirmation checklist)
                                                     |   freeText -> textarea
                                                     |   priorityRanking -> drag-and-drop list
                                                     v
@@ -496,45 +476,20 @@ NotificationPoller.psm1                 ResponseStorageService
  Task JSON updated:
    questions_resolved: [{
      id, question, answer, answer_type,
-     approval_decision,          <- NEW for approval types
-     comment,                    <- NEW
+     comment,                    <- NEW (approval only)
      attachment_refs,            <- NEW (refs only, not bytes)
      asked_at, answered_at,
      answered_via: "notification"
    }]
+
+ For approval-typed answers, the decision ("approved" / "rejected") is
+ carried in the `answer` field — there is no separate
+ approval_decision field on persisted entries.
 ```
 
-### 5.5 Dual-Surface Approval Sync
+### 5.5 Dual-Surface Approval Sync (out of scope)
 
-Approvals can be submitted from two surfaces: the **Mothership web form** (via channel notification) and the **Outpost Decisions tab** (locally). The sync uses the existing pull-based architecture - no new push mechanism needed.
-
-```
- OUTPOST Decisions Tab                  MOTHERSHIP Web Form
- ---------------------                  --------------------
-       |                                       |
-       |  User approves locally                |  User approves via magic link
-       v                                       v
- Save to local task JSON               Save ResponseRecordV2 blob
- approval_decision: "approved"         approvalDecision: "approved"
- answered_via: "outpost"               -> available on next poll
-       |                                       |
-       v                                       v
- POST /api/responses ----------->  Store as ResponseRecordV2
- (push local decision to server)
-
-                                   +------------------------------------+
-                                   | RESOLUTION                         |
-                                   |  -> First by timestamp wins         |
-                                   |  -> Later responses recorded with   |
-                                   |    agreement/disagreement flag     |
-                                   |    (derived at read time)          |
-                                   |  -> Never overrides the first       |
-                                   +------------------------------------+
-```
-
-**New Outpost-side requirement:** The Decisions tab needs a "push-back" path - when a user approves locally, `NotificationClient.psm1` must call `POST /api/responses` to write the decision to the Mothership so it's visible fleet-wide. This is a new capability (today the Outpost only pushes questions, never responses).
-
-**Idempotency.** The outpost generates a `ResponseId` (Guid) once per local approval. It includes this ID in the `POST /api/responses` body. The server treats the endpoint as an upsert: if a blob already exists for that `ResponseId`, it returns `200 OK` with the existing record; otherwise it stores a new one. This means transient-network retries never create duplicates. Different surfaces (web form vs outpost) generate different `ResponseId`s, so both are stored and first-wins applies on decision timestamp.
+Out of scope for this PRD. Tracked in [#416](https://github.com/andresharpe/dotbot/issues/416): Outpost Decisions tab push-back via `POST /api/responses`, first-by-timestamp resolution, agreement/disagreement flagging, and the `ResponseId` upsert/idempotency contract all live there.
 
 ### 5.6 Reminder & Escalation (Server-Side Background)
 
@@ -569,20 +524,20 @@ Mostly unchanged from current behavior. `ReminderEscalationService` scans active
 | Modify | `Services/Delivery/EmailDeliveryProvider.cs` | HTML email renders full `NotificationSummary` |
 | Modify | `Services/Delivery/SlackDeliveryProvider.cs` | Block Kit renders full `NotificationSummary` |
 | Modify | `Services/Delivery/JiraDeliveryProvider.cs` | Wiki comment renders full `NotificationSummary` |
-| Modify | `Pages/Respond.cshtml` | Full question-type handling: approval form, ranking drag-and-drop, document review, free text |
+| Modify | `Pages/Respond.cshtml` | Full question-type handling: approval form (with optional attachment-review checklist), ranking drag-and-drop, free text |
 | Create | API endpoint: `POST /api/attachments` | Multipart upload -> `IAttachmentStorage` |
 | Create | API endpoint: `GET /api/attachments/{storageRef}` | Stream blob content; middleware validates `?token={jwt}` and verifies JWT's `instanceId` owns the `storageRef` |
 
 ### Outpost-side (Client)
 
+v4 routes question publishing and answering through runtime modules + generic MCP tools (`task_set_status`, `task_update`); the v3-era `task-mark-needs-input` and `task-answer-question` tools are gone.
+
 | Action | Path | Change |
 |--------|------|--------|
-| Modify | `systems/mcp/tools/task-mark-needs-input/metadata.json` | Add `type`, `deliverable_summary`, `attachments`, `review_links` params |
-| Modify | `systems/mcp/tools/task-mark-needs-input/script.ps1` | Upload attachments, include new fields on template |
-| Modify | `systems/mcp/tools/task-answer-question/metadata.json` | Add `decision`, `comment`, `ranked_items` params |
-| Modify | `systems/mcp/tools/task-answer-question/script.ps1` | Handle type-specific response fields |
-| Modify | `systems/mcp/modules/NotificationClient.psm1` or `MothershipClient.psm1` | Attachment upload, type-specific response parsing (refs only), push-back local approvals |
-| Modify | `systems/ui/modules/NotificationPoller.psm1` | Handle approval/review response types, update Decisions tab state on poll |
+| Modify | `src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1` | Propagate the new pending-question fields (`type`, `deliverable_summary`, `attachments`, `review_links`) into the `Send-TaskNotification` call |
+| Modify | `src/runtime/Modules/Dotbot.Notification/Dotbot.Notification.psm1` | `Send-TaskNotification` accepts `Type`, `DeliverableSummary`, `Attachments`, `ReviewLinks` and emits them on the template payload (already present in v4 - any drift fixed here); `Invoke-AttachmentBatchUpload` uploads attachments before publish |
+| Modify | `src/runtime/Modules/Dotbot.TaskInput/Dotbot.TaskInput.psm1` | `Resolve-TaskInputAnswer` accepts approval `answer` (`approved`/`rejected`) + `comment`; `priorityRanking` accepts `ranked_items` |
+| Modify | `src/ui/modules/NotificationPoller.psm1` | `Resolve-NotificationAnswer` reads `approvalDecision`, `comment`, `rankedItems`, `reviewedAttachmentIds` from the Mothership response (refs only, no file download) and maps them to the runtime answer-resolver |
 
 ---
 
@@ -590,16 +545,16 @@ Mostly unchanged from current behavior. `ReminderEscalationService` scans active
 
 ### P0 - Must Have
 
-- [ ] `QuestionTemplate.Type` supports values: `singleChoice`, `approval`, `documentReview`, `freeText`, `priorityRanking`
-- [ ] `QuestionTemplate` accepts optional `Attachments` and `ReviewLinks`; `DeliverableSummary` is **required** for `approval` + `documentReview` (validated at `POST /api/templates`), optional for other types (see sec.4.1)
+- [ ] `QuestionTemplate.Type` supports values: `singleChoice`, `approval`, `freeText`, `priorityRanking`
+- [ ] `QuestionTemplate` accepts optional `Attachments` and `ReviewLinks`; `DeliverableSummary` is **required** for `approval` templates that carry attachments (validated at `POST /api/templates`), optional for other types (see sec.4.1)
 - [ ] `NotificationSummary` DTO + `NotificationSummaryBuilder` exist and are used by all four providers
 - [ ] All 4 channels (Teams, Email, Slack, Jira) render notifications containing: question title + type badge, deliverable summary, attachment list, review-link list, magic link to web form
 - [ ] Mothership web form (`Respond.cshtml`) supports all question types with full interactivity
 - [ ] `IAttachmentStorage` abstraction with **both** `AzureBlobAttachmentStorage` and `LocalFileAttachmentStorage` implementations; backend selectable via config
 - [ ] `POST /api/attachments` + `GET /api/attachments/{storageRef}` functional; per-file limit 15 MB, per-question total limit 50 MB (both configurable)
 - [ ] `ResponseRecordV2` captures `ApprovalDecision`, `Comment` for approval/review responses
-- [ ] `task-mark-needs-input` MCP tool accepts `type`, `deliverable_summary`, `attachments`, `review_links`
-- [ ] `task-answer-question` MCP tool accepts `decision`, `comment` for approval responses
+- [ ] Pending-question carrier on the task JSON accepts `type`, `deliverable_summary`, `attachments`, `review_links`; `Send-TaskNotification` in `src/runtime/Modules/Dotbot.Notification` emits them on the template payload to Mothership
+- [ ] `Resolve-NotificationAnswer` (UI poller) + `Resolve-TaskInputAnswer` (runtime) accept `approvalDecision` / `answer` (`approved` / `rejected`) + `comment` for approval responses, and persist them into the task's `questions_resolved` entry
 - [ ] Outpost poller records attachment references only (no eager download)
 - [ ] Approval uses first-response-wins semantics (no quorum)
 - [ ] Reject on `approval` type requires a non-empty `Comment` - validated on server + web form
@@ -610,14 +565,12 @@ Mostly unchanged from current behavior. `ReminderEscalationService` scans active
 
 ### P1 - Should Have
 
-- [ ] `documentReview` type with per-attachment confirmation checklist and decision buttons (Approve / Request Changes / Comment Only) in web form
+- [ ] `approval` questions with attachments render the per-attachment confirmation checklist above the Approve / Reject decision buttons in the web form
 - [ ] `priorityRanking` type with drag-and-drop ranking in web form (ordinal only)
 
 ### P2 - Nice to Have
 
-- [ ] Dual-surface approval sync: Outpost Decisions tab push-back via `POST /api/responses` (see sec.5.5)
-- [ ] Poller reads approval responses and updates Decisions tab state
-- [ ] Dual-surface conflict handling: first-by-timestamp wins, later responses recorded on instance blob with agreement/disagreement flag derived at read time
+- [ ] Dual-surface approval sync (Outpost Decisions tab push-back, first-by-timestamp resolution, agreement/disagreement flagging) - tracked in [#416](https://github.com/andresharpe/dotbot/issues/416)
 - [ ] `ReviewLink.RequiresReview` enforcement (must confirm reviewed before submitting response)
 - [ ] Attachment inline preview in web form (PDF viewer, image preview, markdown render)
 

--- a/docs/specs/PRD-029-expand-question-service.md
+++ b/docs/specs/PRD-029-expand-question-service.md
@@ -50,6 +50,11 @@ Channels stay read-only. Interaction lives on the web form.
 - **In-channel interactive submission** - no Adaptive Card form posts, no Slack modals. Submission stays on the web form.
 - **Eager attachment download on the outpost** - the poller records attachment references only. If a tool needs the bytes, it fetches via `GET /api/attachments/{storageRef}` on demand.
 - **Attachment cleanup / orphan sweep** - not implemented in v1. Orphans from failed uploads, superseded templates, or deleted questions remain in storage; manual cleanup if ever needed. On known client-side upload failures the outpost calls `DELETE /api/attachments/{storageRef}` for already-uploaded files in the same publish, so successful-partial-then-failed publishes don't leak. Crash-mid-publish is accepted debt.
+- **Interview clarification pipelines** - out of scope for producing or consuming the new question types. Two parallel question/answer flows live outside the task-level `needs-input` machinery this PRD covers and are not touched here:
+  1. `Invoke-InterviewLoop` in `src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1` runs inside the interview executor plugin. It publishes `clarification-questions.json` and reads answers from `clarification-answers.{ProcessId}.json` in `product_dir`, producing `interview-summary.md` as its deliverable. Clarification questions are open-ended by design (singleChoice / freeText only); approval and priorityRanking semantics do not apply.
+  2. `Invoke-TaskClarificationLoopIfPresent` in `src/runtime/Scripts/Invoke-WorkflowProcess.ps1` runs as a post-task hook on every workflow task. It picks up a `clarification-questions.json` the task agent may have written during its work, collects answers via file-watch only, appends them to `interview-summary.md` under a `## Clarification Log` table, and runs `recipes/includes/adjust-after-answers.md` as a separate Claude session to rewrite affected artifacts. The Teams notification path for this hook is documented in its source as "tracked as follow-up work" and is not implemented in v4.
+
+  The shared `Resolve-NotificationAnswer` parser is type-agnostic so threading new typed fields through it does not break the interview loop, but both interview pipelines read only `answer` + `attachments` from the resolved hashtable and drop the other typed fields on purpose. Bringing either pipeline into the typed-question model is a future change tracked separately.
 
 ---
 
@@ -318,6 +323,8 @@ The `type`, `deliverable_summary`, `attachments`, `review_links` fields are the 
 - For `priorityRanking`, carry `ranked_items` through to the resolved entry
 
 **UI: `src/ui/modules/NotificationPoller.psm1`** - extend `Resolve-NotificationAnswer` to read `approvalDecision`, `comment`, `rankedItems`, and `reviewedAttachmentIds` from the Mothership response and map them to the runtime answer-resolver inputs above.
+
+> **Not touched here:** `Invoke-InterviewLoop` in `src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1` runs its own parallel question/answer pipeline for interview clarification questions (file-based, ephemeral, not persisted to `questions_resolved`). It calls the same `Resolve-NotificationAnswer` parser but uses only `answer` + `attachments` from the result and drops the rest on purpose. Clarification questions are open-ended by design; approval / priorityRanking semantics do not apply. Threading these question types into the interview pipeline is a future change - see the Non-Goals list in Section 2.
 
 ---
 

--- a/src/runtime/Modules/Dotbot.Notification/Dotbot.Notification.psm1
+++ b/src/runtime/Modules/Dotbot.Notification/Dotbot.Notification.psm1
@@ -263,9 +263,8 @@ function Send-TaskNotification {
     Optional notification settings. If not provided, reads from config.
 
     .PARAMETER Type
-    PRD Section 4.6 question type — singleChoice (default) | approval |
-    documentReview | freeText | priorityRanking. Drives card rendering and
-    response parsing.
+    PRD Section 4.6 question type — singleChoice (default) | approval | freeText
+    | priorityRanking. Drives card rendering and response parsing.
 
     .PARAMETER DeliverableSummary
     Optional 1-3 line summary shown in channel notifications (PRD Section 5.2).
@@ -518,10 +517,14 @@ function Get-TaskNotificationResponse {
 function Resolve-NotificationAnswer {
     <#
     .SYNOPSIS
-    Extracts the answer text from a Teams response and downloads any attached files.
+    Extracts the answer text from a server response, downloads any attached files,
+    and surfaces type-specific fields (comment, ranked_items, reviewed_attachment_ids)
+    so the runtime can persist them on the resolved questions_resolved entry.
 
     .PARAMETER Response
-    The response object returned by Get-TaskNotificationResponse.
+    The response object returned by Get-TaskNotificationResponse. Mirrors the
+    server-side ResponseRecordV2 shape (selectedKey, freeText, approvalDecision,
+    comment, rankedItems, reviewedAttachmentIds, attachments).
 
     .PARAMETER Settings
     Notification settings (needs server_url, api_key).
@@ -530,9 +533,14 @@ function Resolve-NotificationAnswer {
     Local directory to save attachment files into (created if needed).
 
     .OUTPUTS
-    Hashtable with keys:
-      answer      - resolved answer string (with paths appended if attachments present)
-      attachments - array of @{ name, size, path } metadata (empty array if none)
+    Hashtable with keys (only the type-specific keys are present when relevant):
+      answer                  - resolved answer string (with paths appended if attachments present).
+                                For approval, this is the decision value ("approved" / "rejected").
+      attachments             - array of @{ name, size, path } metadata (empty array if none)
+      comment                 - optional reviewer comment (approval responses)
+      ranked_items            - optional array of ranked items (priorityRanking responses)
+      reviewed_attachment_ids - optional array of attachment ids the reviewer ticked
+                                (approval with attached documents)
     Returns $null if no valid answer found in the response.
     #>
     param(
@@ -541,9 +549,19 @@ function Resolve-NotificationAnswer {
         [Parameter(Mandatory)] [string]$AttachDir
     )
 
-    $answer = if ($Response.selectedKey) { $Response.selectedKey }
-              elseif ($Response.freeText)  { $Response.freeText }
-              else                         { $null }
+    # For approval-typed responses the server populates approvalDecision and leaves
+    # selectedKey/freeText null; for singleChoice it populates selectedKey; for
+    # freeText it populates freeText; for priorityRanking it populates rankedItems.
+    # The wire response object does not carry the question type, so the order below
+    # picks whichever field the server actually filled in.
+    $hasApprovalDecision = $Response.PSObject.Properties['approvalDecision'] -and $Response.approvalDecision
+    $hasRankedItems      = $Response.PSObject.Properties['rankedItems']      -and $Response.rankedItems
+
+    $answer = if ($hasApprovalDecision)         { "$($Response.approvalDecision)" }
+              elseif ($Response.selectedKey)    { $Response.selectedKey }
+              elseif ($Response.freeText)       { $Response.freeText }
+              elseif ($hasRankedItems)          { (@($Response.rankedItems) | Sort-Object rank | ForEach-Object { "$($_.optionId)" }) -join ', ' }
+              else                              { $null }
 
     $hasAttachments = $Response.attachments -and @($Response.attachments).Count -gt 0
     if (-not $answer -and -not $hasAttachments) { return $null }
@@ -582,10 +600,26 @@ function Resolve-NotificationAnswer {
         }
     }
 
-    return @{
+    $result = @{
         answer      = $answer
         attachments = $attachmentMeta
     }
+
+    # Surface type-specific fields from the server-side ResponseRecordV2 so the
+    # runtime can write them onto the resolved questions_resolved entry. Each is
+    # passed through only when the server actually populated it; the local resolver
+    # at the runtime layer decides which fields make sense for the question type.
+    if ($Response.PSObject.Properties['comment'] -and $Response.comment) {
+        $result['comment'] = "$($Response.comment)"
+    }
+    if ($hasRankedItems) {
+        $result['ranked_items'] = @($Response.rankedItems)
+    }
+    if ($Response.PSObject.Properties['reviewedAttachmentIds'] -and $Response.reviewedAttachmentIds) {
+        $result['reviewed_attachment_ids'] = @($Response.reviewedAttachmentIds)
+    }
+
+    return $result
 }
 
 function Send-AttachmentUpload {
@@ -873,7 +907,8 @@ function Send-LocalApprovalResponse {
     The GUID string identifying the task/workflow instance.
 
     .PARAMETER ApprovalDecision
-    The decision value: "approved", "rejected", or "abstained".
+    The decision value: "approved" or "rejected" (the server-side ApprovalDecisions
+    taxonomy was narrowed under [#445]; sending other values fails validation).
 
     .PARAMETER Comment
     Optional free-text comment. Required by convention when Decision = "rejected".

--- a/src/runtime/Modules/Dotbot.TaskInput/Dotbot.TaskInput.psm1
+++ b/src/runtime/Modules/Dotbot.TaskInput/Dotbot.TaskInput.psm1
@@ -447,7 +447,14 @@ function Add-TaskInputResolvedQuestion {
         [Parameter(Mandatory)] [hashtable]$Resolved,
         [Parameter(Mandatory)] [string]$AnsweredAt,
         [Parameter(Mandatory)] [string]$AnsweredVia,
-        [array]$Attachments = @()
+        [array]$Attachments = @(),
+        # Type-specific fields surfaced by Resolve-NotificationAnswer when polling
+        # answers from the Mothership. Comment is approval-only, RankedItems is
+        # priorityRanking-only, ReviewedAttachmentIds is approval-with-attachments.
+        # Each is written onto the resolved entry only when populated.
+        [string]$Comment,
+        [array]$RankedItems,
+        [array]$ReviewedAttachmentIds
     )
 
     $entry = @{
@@ -461,6 +468,15 @@ function Add-TaskInputResolvedQuestion {
     }
     if ($Attachments -and @($Attachments).Count -gt 0) {
         $entry['attachments'] = $Attachments
+    }
+    if ($Comment) {
+        $entry['comment'] = $Comment
+    }
+    if ($RankedItems -and @($RankedItems).Count -gt 0) {
+        $entry['ranked_items'] = @($RankedItems)
+    }
+    if ($ReviewedAttachmentIds -and @($ReviewedAttachmentIds).Count -gt 0) {
+        $entry['reviewed_attachment_ids'] = @($ReviewedAttachmentIds)
     }
 
     $existing = ConvertTo-TaskInputArray (Get-TaskInputProp -Object $RunnerBag -Name 'questions_resolved')
@@ -478,7 +494,13 @@ function Invoke-TaskQuestionAnswerTransition {
         [string]$QuestionId,
         [array]$Attachments = @(),
         [string]$AnsweredVia = 'ui',
-        [string]$Actor
+        [string]$Actor,
+        # Type-specific fields supplied by the notification poller (server -> outpost
+        # direction only). Local UI submissions leave these unset; only the answer
+        # string is captured for the local approve/reject path.
+        [string]$Comment,
+        [array]$RankedItems,
+        [array]$ReviewedAttachmentIds
     )
 
     $taskId = [string](Get-TaskInputProp -Object $TaskContent -Name 'id')
@@ -503,7 +525,7 @@ function Invoke-TaskQuestionAnswerTransition {
 
         $resolved = Resolve-TaskInputAnswer -Question $targetQuestion -Answer $Answer
         $now = Get-TaskInputTimestamp
-        Add-TaskInputResolvedQuestion -RunnerBag $runner -Question $targetQuestion -Resolved $resolved -AnsweredAt $now -AnsweredVia $AnsweredVia -Attachments $Attachments | Out-Null
+        Add-TaskInputResolvedQuestion -RunnerBag $runner -Question $targetQuestion -Resolved $resolved -AnsweredAt $now -AnsweredVia $AnsweredVia -Attachments $Attachments -Comment $Comment -RankedItems $RankedItems -ReviewedAttachmentIds $ReviewedAttachmentIds | Out-Null
         Write-TaskInputInterviewAnswer -BotRoot $BotRoot -TaskId $taskId -Entry @{
             task_id = $taskId
             question_id = Get-TaskInputProp -Object $targetQuestion -Name 'id'
@@ -586,7 +608,7 @@ function Invoke-TaskQuestionAnswerTransition {
 
     $resolvedSingle = Resolve-TaskInputAnswer -Question $pendingQuestion -Answer $Answer
     $nowSingle = Get-TaskInputTimestamp
-        Add-TaskInputResolvedQuestion -RunnerBag $runner -Question $pendingQuestion -Resolved $resolvedSingle -AnsweredAt $nowSingle -AnsweredVia $AnsweredVia -Attachments $Attachments | Out-Null
+        Add-TaskInputResolvedQuestion -RunnerBag $runner -Question $pendingQuestion -Resolved $resolvedSingle -AnsweredAt $nowSingle -AnsweredVia $AnsweredVia -Attachments $Attachments -Comment $Comment -RankedItems $RankedItems -ReviewedAttachmentIds $ReviewedAttachmentIds | Out-Null
     Write-TaskInputInterviewAnswer -BotRoot $BotRoot -TaskId $taskId -Entry @{
             task_id = $taskId
             question_id = Get-TaskInputProp -Object $pendingQuestion -Name 'id'

--- a/src/server-dotnet/docs/MOTHERSHIP-E2E-SETUP.md
+++ b/src/server-dotnet/docs/MOTHERSHIP-E2E-SETUP.md
@@ -1,6 +1,6 @@
 # Mothership E2E Test Setup (Playwright + Azurite)
 
-How to run the Mothership web UI end-to-end tests locally. Tests cover the magic-link respond flow for all six question types: `singleChoice`, `multiChoice`, `approval`, `documentReview`, `freeText`, `priorityRanking`.
+How to run the Mothership web UI end-to-end tests locally. Tests cover the magic-link respond flow for all question types: `singleChoice`, `multiChoice`, `approval` (with and without attachments), `freeText`, `priorityRanking`.
 
 ---
 

--- a/src/server-dotnet/src/Dotbot.Server/Models/ApprovalDecisions.cs
+++ b/src/server-dotnet/src/Dotbot.Server/Models/ApprovalDecisions.cs
@@ -2,23 +2,15 @@ namespace Dotbot.Server.Models;
 
 public static class ApprovalDecisions
 {
-    public const string Approve = "approve";
-    public const string Reject = "reject";
-    public const string Abstain = "abstain";
+    public const string Approved = "approved";
+    public const string Rejected = "rejected";
 
-    public const string RequestChanges = "request-changes";
-    public const string CommentOnly = "comment-only";
-
-    public static readonly string[] ApprovalAllowed = [Approve, Reject, Abstain];
-    public static readonly string[] DocumentReviewAllowed = [Approve, RequestChanges, CommentOnly];
+    public static readonly string[] ApprovalAllowed = [Approved, Rejected];
 
     public static string Label(string decision) => decision switch
     {
-        Approve => "Approve",
-        Reject => "Reject",
-        Abstain => "Abstain",
-        RequestChanges => "Request Changes",
-        CommentOnly => "Comment Only",
+        Approved => "Approve",
+        Rejected => "Reject",
         _ => decision,
     };
 }

--- a/src/server-dotnet/src/Dotbot.Server/Models/QuestionTypes.cs
+++ b/src/server-dotnet/src/Dotbot.Server/Models/QuestionTypes.cs
@@ -5,7 +5,6 @@ public static class QuestionTypes
     public const string SingleChoice = "singleChoice";
     public const string MultiChoice = "multiChoice";
     public const string Approval = "approval";
-    public const string DocumentReview = "documentReview";
     public const string FreeText = "freeText";
     public const string PriorityRanking = "priorityRanking";
 
@@ -14,7 +13,6 @@ public static class QuestionTypes
         SingleChoice,
         MultiChoice,
         Approval,
-        DocumentReview,
         FreeText,
         PriorityRanking,
     ];

--- a/src/server-dotnet/src/Dotbot.Server/Pages/Respond.cshtml
+++ b/src/server-dotnet/src/Dotbot.Server/Pages/Respond.cshtml
@@ -52,23 +52,6 @@
             @switch (Model.Template.Type)
             {
                 case QuestionTypes.Approval:
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Approve, "Approve", "A"))
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Reject, "Reject", "R", requireComment: true))
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Abstain, "Abstain", "X"))
-                    <div class="mt-1">
-                        <label for="comment" class="label-text">Comment (required when rejecting):</label>
-                        <textarea name="comment" id="comment" class="free-text"></textarea>
-                    </div>
-                    break;
-
-                case QuestionTypes.FreeText:
-                    <div class="mt-1">
-                        <label for="freeText" class="label-text">Your response:</label>
-                        <textarea name="freeText" id="freeText" class="free-text" required></textarea>
-                    </div>
-                    break;
-
-                case QuestionTypes.DocumentReview:
                     @if (Model.Template.Attachments is { Count: > 0 } docs)
                     {
                         <div class="mt-1">
@@ -104,12 +87,18 @@
                             </ul>
                         </div>
                     }
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Approve, "Approve", "AP"))
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.RequestChanges, "Request Changes", "RC", requireComment: true))
-                    @Html.Raw(ApprovalRadio(ApprovalDecisions.CommentOnly, "Comment Only", "CO"))
+                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Approved, "Approve", "A"))
+                    @Html.Raw(ApprovalRadio(ApprovalDecisions.Rejected, "Reject", "R", requireComment: true))
                     <div class="mt-1">
-                        <label for="comment" class="label-text">Feedback (required for "Request Changes"):</label>
+                        <label for="comment" class="label-text">Comment (required when rejecting):</label>
                         <textarea name="comment" id="comment" class="free-text"></textarea>
+                    </div>
+                    break;
+
+                case QuestionTypes.FreeText:
+                    <div class="mt-1">
+                        <label for="freeText" class="label-text">Your response:</label>
+                        <textarea name="freeText" id="freeText" class="free-text" required></textarea>
                     </div>
                     break;
 
@@ -182,7 +171,7 @@
             if (!form) return;
             const type = form.dataset.questionType;
 
-            // ── Approval / DocumentReview: comment required when destructive option selected ──
+            // ── Approval: comment required when destructive option selected ──
             (function wireApproval() {
                 const radios = form.querySelectorAll('input[type="radio"][name="approvalDecision"]');
                 if (radios.length === 0) return;
@@ -202,9 +191,9 @@
                 });
             })();
 
-            // ── DocumentReview: at least one attachment confirmation ──
+            // ── Approval with attachments: at least one attachment confirmation ──
             (function wireDocReview() {
-                if (type !== 'documentReview') return;
+                if (type !== 'approval') return;
                 const checkboxes = form.querySelectorAll('input[type="checkbox"][name="reviewedAttachmentIds"]');
                 if (checkboxes.length === 0) return;
                 form.addEventListener('submit', function (e) {

--- a/src/server-dotnet/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
+++ b/src/server-dotnet/src/Dotbot.Server/Services/Delivery/NotificationSummaryBuilder.cs
@@ -29,8 +29,11 @@ public class NotificationSummaryBuilder
                 ? template.Project.ProjectId
                 : template.Project.Name,
             // Legacy singleChoice templates carry no DeliverableSummary; providers render
-            // Title + Context as before. Validator enforces non-empty for approval /
-            // documentReview, so this stays null only when intentional (PRD §8 line 651).
+            // Title + Context as before. The CheckDeliverableSummary validator rule that
+            // would require a non-empty value for approval-with-attachments is currently
+            // parked (commented out of QuestionTemplateValidator._rules) pending outpost
+            // support for emitting an attachment summary, so DeliverableSummary may be
+            // null/blank in practice even for that case.
             DeliverableSummary = template.DeliverableSummary,
             Context = template.Context,
             Attachments = template.Attachments?

--- a/src/server-dotnet/src/Dotbot.Server/TestModeEndpoints.cs
+++ b/src/server-dotnet/src/Dotbot.Server/TestModeEndpoints.cs
@@ -111,9 +111,11 @@ public static class TestModeEndpoints
                 ProjectId = body.ProjectId,
                 SelectedKey = string.IsNullOrWhiteSpace(body.SelectedKey) ? null : body.SelectedKey,
                 ApprovalDecision = string.IsNullOrWhiteSpace(body.ApprovalDecision) ? null : body.ApprovalDecision,
+                Comment = string.IsNullOrWhiteSpace(body.Comment) ? null : body.Comment,
                 FreeText = string.IsNullOrWhiteSpace(body.FreeText) ? null : body.FreeText,
                 Attachments = attachmentRecords.Count > 0 ? attachmentRecords : null,
                 RankedItems = body.RankedItems?.Count > 0 ? body.RankedItems : null,
+                ReviewedAttachmentIds = body.ReviewedAttachmentIds?.Count > 0 ? body.ReviewedAttachmentIds : null,
                 ResponderEmail = body.ResponderEmail,
                 ResponderAadObjectId = body.ResponderAadObjectId
             };
@@ -183,11 +185,13 @@ internal record TestResponseRequest(
     int? QuestionVersion,
     string? SelectedKey,
     string? ApprovalDecision,
+    string? Comment,
     string? FreeText,
     string? ResponderEmail,
     string? ResponderAadObjectId,
     List<TestResponseAttachment>? Attachments,
-    List<RankedItem>? RankedItems);
+    List<RankedItem>? RankedItems,
+    List<Guid>? ReviewedAttachmentIds);
 
 internal record TestResponseAttachment(string Name, string ContentBase64);
 

--- a/src/server-dotnet/src/Dotbot.Server/Validation/QuestionTemplateValidator.cs
+++ b/src/server-dotnet/src/Dotbot.Server/Validation/QuestionTemplateValidator.cs
@@ -19,7 +19,7 @@ public class QuestionTemplateValidator
             CheckQuestionId,
             CheckProjectId,
             CheckType,
-            CheckDeliverableSummary,
+            // CheckDeliverableSummary,
             CheckOptionUniqueness,
             CheckAttachments,
             CheckReferenceLinks,
@@ -48,11 +48,16 @@ public class QuestionTemplateValidator
             yield return $"Unknown type '{t.Type}'. Allowed types: {string.Join(", ", QuestionTypes.AllowedTypes)}";
     }
 
+    // TODO: unskip when outpost supports preparing summary of attachments
     private IEnumerable<string> CheckDeliverableSummary(QuestionTemplate t)
     {
-        if ((t.Type == QuestionTypes.Approval || t.Type == QuestionTypes.DocumentReview)
+        // Required only when an approval question carries attachments — that is the
+        // doc-review case where a reviewer needs a 1-3 line summary of what they're
+        // approving. Plain approvals (no doc) don't need it.
+        if (t.Type == QuestionTypes.Approval
+            && t.Attachments is { Count: > 0 }
             && string.IsNullOrWhiteSpace(t.DeliverableSummary))
-            yield return $"deliverableSummary is required when type is '{t.Type}'";
+            yield return "deliverableSummary is required when type is 'approval' and attachments are present";
     }
 
     private IEnumerable<string> CheckOptionUniqueness(QuestionTemplate t)

--- a/src/server-dotnet/src/Dotbot.Server/Validation/RespondFormHandler.cs
+++ b/src/server-dotnet/src/Dotbot.Server/Validation/RespondFormHandler.cs
@@ -39,9 +39,8 @@ public static class RespondFormHandler
 
         return template.Type switch
         {
-            QuestionTypes.Approval => ValidateApproval(input),
+            QuestionTypes.Approval => ValidateApproval(template, input),
             QuestionTypes.FreeText => ValidateFreeText(input),
-            QuestionTypes.DocumentReview => ValidateDocumentReview(template, input),
             QuestionTypes.PriorityRanking => ValidatePriorityRanking(template, input),
             QuestionTypes.SingleChoice or QuestionTypes.MultiChoice
                 => ValidateSingleOrMultiChoice(template, input),
@@ -49,43 +48,14 @@ public static class RespondFormHandler
         };
     }
 
-    private static RespondFormResult ValidateApproval(RespondFormInput input)
+    private static RespondFormResult ValidateApproval(QuestionTemplate template, RespondFormInput input)
     {
         var decision = input.ApprovalDecision?.Trim().ToLowerInvariant();
         if (string.IsNullOrEmpty(decision) || !ApprovalDecisions.ApprovalAllowed.Contains(decision))
-            return RespondFormResult.Fail("Please choose Approve, Reject, or Abstain.");
+            return RespondFormResult.Fail("Please choose Approve or Reject.");
 
-        if (decision == ApprovalDecisions.Reject && string.IsNullOrWhiteSpace(input.Comment))
+        if (decision == ApprovalDecisions.Rejected && string.IsNullOrWhiteSpace(input.Comment))
             return RespondFormResult.Fail("A comment is required when rejecting.");
-
-        return new RespondFormResult
-        {
-            ApprovalDecision = decision,
-            Comment = NullIfBlank(input.Comment),
-            SelectionLabel = ApprovalDecisions.Label(decision),
-        };
-    }
-
-    private static RespondFormResult ValidateFreeText(RespondFormInput input)
-    {
-        if (string.IsNullOrWhiteSpace(input.FreeText))
-            return RespondFormResult.Fail("Please type a response.");
-
-        return new RespondFormResult
-        {
-            FreeText = input.FreeText.Trim(),
-            SelectionLabel = "Free-text response",
-        };
-    }
-
-    private static RespondFormResult ValidateDocumentReview(QuestionTemplate template, RespondFormInput input)
-    {
-        var decision = input.ApprovalDecision?.Trim().ToLowerInvariant();
-        if (string.IsNullOrEmpty(decision) || !ApprovalDecisions.DocumentReviewAllowed.Contains(decision))
-            return RespondFormResult.Fail("Please choose Approve, Request Changes, or Comment Only.");
-
-        if (decision == ApprovalDecisions.RequestChanges && string.IsNullOrWhiteSpace(input.Comment))
-            return RespondFormResult.Fail("A comment is required when requesting changes.");
 
         var templateAttachments = template.Attachments ?? new List<QuestionAttachment>();
         if (templateAttachments.Count > 0)
@@ -117,6 +87,18 @@ public static class RespondFormHandler
             ApprovalDecision = decision,
             Comment = NullIfBlank(input.Comment),
             SelectionLabel = ApprovalDecisions.Label(decision),
+        };
+    }
+
+    private static RespondFormResult ValidateFreeText(RespondFormInput input)
+    {
+        if (string.IsNullOrWhiteSpace(input.FreeText))
+            return RespondFormResult.Fail("Please type a response.");
+
+        return new RespondFormResult
+        {
+            FreeText = input.FreeText.Trim(),
+            SelectionLabel = "Free-text response",
         };
     }
 

--- a/src/server-dotnet/tests/Dotbot.Server.Tests/Integration/MagicLinkMiddlewareTests.cs
+++ b/src/server-dotnet/tests/Dotbot.Server.Tests/Integration/MagicLinkMiddlewareTests.cs
@@ -41,7 +41,7 @@ public sealed class MagicLinkMiddlewareTests(DotbotApiFactory factory)
             QuestionId = questionId,
             Version = 1,
             Title = $"Review {suffix}",
-            Type = QuestionTypes.DocumentReview,
+            Type = QuestionTypes.Approval,
             DeliverableSummary = "review",
             Options = new(),
             Project = new ProjectRef { ProjectId = ProjectId, Name = "MW" },

--- a/src/server-dotnet/tests/Dotbot.Server.Tests/Unit/QuestionTemplateValidatorTests.cs
+++ b/src/server-dotnet/tests/Dotbot.Server.Tests/Unit/QuestionTemplateValidatorTests.cs
@@ -73,30 +73,39 @@ public class QuestionTemplateValidatorTests
     [InlineData(QuestionTypes.MultiChoice)]
     [InlineData(QuestionTypes.FreeText)]
     [InlineData(QuestionTypes.PriorityRanking)]
+    [InlineData(QuestionTypes.Approval)]
     public void TypeWithoutDeliverableSummaryRequirement_NoErrorWhenSummaryMissing(string type)
         => Assert.Empty(Validate(Template(type: type)));
 
-    [Theory]
-    [InlineData(QuestionTypes.Approval, null)]
-    [InlineData(QuestionTypes.Approval, "")]
-    [InlineData(QuestionTypes.Approval, "   ")]
-    [InlineData(QuestionTypes.DocumentReview, null)]
-    [InlineData(QuestionTypes.DocumentReview, "")]
-    [InlineData(QuestionTypes.DocumentReview, "   ")]
-    public void ApprovalOrDocumentReviewWithoutDeliverableSummary_OneError(string type, string? summary)
+    // CheckDeliverableSummary is currently parked out of the validator
+    // rules array pending outpost support for preparing the summary of
+    // attachments. The skipped tests below document the intended behaviour
+    // and should be re-enabled once the rule is restored.
+    [Theory(Skip = "CheckDeliverableSummary parked; restore when outpost emits the summary")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ApprovalWithAttachmentsAndNoDeliverableSummary_OneError(string? summary)
     {
-        var errors = Validate(Template(type: type, deliverableSummary: summary));
+        var errors = Validate(Template(
+            type: QuestionTypes.Approval,
+            deliverableSummary: summary,
+            attachments: [new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "n", Url = "https://x" }]));
         Assert.Single(errors);
         Assert.Contains("deliverableSummary", errors[0]);
-        Assert.Contains(type, errors[0]);
+        Assert.Contains("approval", errors[0]);
     }
 
-    [Theory]
-    [InlineData(QuestionTypes.Approval)]
-    [InlineData(QuestionTypes.DocumentReview)]
-    public void ApprovalOrDocumentReviewWithDeliverableSummary_NoErrors(string type)
-        => Assert.Empty(Validate(
-            Template(type: type, deliverableSummary: "ship plan v1")));
+    [Fact]
+    public void ApprovalWithAttachmentsAndDeliverableSummary_NoErrors()
+        => Assert.Empty(Validate(Template(
+            type: QuestionTypes.Approval,
+            deliverableSummary: "ship plan v1",
+            attachments: [new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "n", Url = "https://x" }])));
+
+    [Fact]
+    public void ApprovalWithoutAttachments_NoDeliverableSummaryRequired()
+        => Assert.Empty(Validate(Template(type: QuestionTypes.Approval)));
 
     [Fact]
     public void NullAttachments_NoErrors()
@@ -172,12 +181,13 @@ public class QuestionTemplateValidatorTests
         Assert.Contains("bogus", errors[1]);
     }
 
-    [Fact]
-    public void ProjectIdEmptyAndApprovalWithoutSummary_TwoErrors()
+    [Fact(Skip = "CheckDeliverableSummary parked; restore when outpost emits the summary")]
+    public void ProjectIdEmptyAndApprovalWithAttachmentsWithoutSummary_TwoErrors()
     {
         var errors = Validate(Template(
             projectId: "",
-            type: QuestionTypes.Approval));
+            type: QuestionTypes.Approval,
+            attachments: [new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "n", Url = "https://x" }]));
         Assert.Equal(2, errors.Count);
         Assert.Contains("project.projectId", errors[0]);
         Assert.Contains("deliverableSummary", errors[1]);

--- a/src/server-dotnet/tests/Dotbot.Server.Tests/Unit/RespondFormHandlerTests.cs
+++ b/src/server-dotnet/tests/Dotbot.Server.Tests/Unit/RespondFormHandlerTests.cs
@@ -13,20 +13,20 @@ public class RespondFormHandlerTests
         Type = type,
         Options = options.ToList(),
         Project = new ProjectRef { ProjectId = "p1" },
-        DeliverableSummary = type is QuestionTypes.Approval or QuestionTypes.DocumentReview ? "deliverable" : null,
+        DeliverableSummary = type == QuestionTypes.Approval ? "deliverable" : null,
     };
 
     private static TemplateOption Option(string key = "A", string title = "Alpha")
         => new() { OptionId = Guid.NewGuid(), Key = key, Title = title };
 
-    // ── Approval ───────────────────────────────────────────────────────────
+    // ── Approval (no attachments) ──────────────────────────────────────────
 
     [Fact]
     public void Approval_NoDecision_Fails()
     {
         var result = RespondFormHandler.Validate(Template(QuestionTypes.Approval), new RespondFormInput());
         Assert.False(result.IsValid);
-        Assert.Contains("Approve, Reject, or Abstain", result.Error);
+        Assert.Contains("Approve or Reject", result.Error);
     }
 
     [Fact]
@@ -39,43 +39,33 @@ public class RespondFormHandlerTests
     }
 
     [Fact]
-    public void Approval_Reject_RequiresComment()
+    public void Approval_Rejected_RequiresComment()
     {
         var result = RespondFormHandler.Validate(
             Template(QuestionTypes.Approval),
-            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Reject, Comment: "   "));
+            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Rejected, Comment: "   "));
         Assert.False(result.IsValid);
         Assert.Contains("comment is required", result.Error, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void Approval_Reject_WithComment_Succeeds()
+    public void Approval_Rejected_WithComment_Succeeds()
     {
         var result = RespondFormHandler.Validate(
             Template(QuestionTypes.Approval),
-            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Reject, Comment: "needs work"));
+            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Rejected, Comment: "needs work"));
         Assert.True(result.IsValid);
-        Assert.Equal(ApprovalDecisions.Reject, result.ApprovalDecision);
+        Assert.Equal(ApprovalDecisions.Rejected, result.ApprovalDecision);
         Assert.Equal("needs work", result.Comment);
         Assert.Equal("Reject", result.SelectionLabel);
     }
 
     [Fact]
-    public void Approval_Approve_NoCommentNeeded()
+    public void Approval_Approved_NoCommentNeeded()
     {
         var result = RespondFormHandler.Validate(
             Template(QuestionTypes.Approval),
-            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Approve));
-        Assert.True(result.IsValid);
-        Assert.Null(result.Comment);
-    }
-
-    [Fact]
-    public void Approval_Abstain_TrimsCommentNullIfBlank()
-    {
-        var result = RespondFormHandler.Validate(
-            Template(QuestionTypes.Approval),
-            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Abstain, Comment: "   "));
+            new RespondFormInput(ApprovalDecision: ApprovalDecisions.Approved));
         Assert.True(result.IsValid);
         Assert.Null(result.Comment);
     }
@@ -85,9 +75,9 @@ public class RespondFormHandlerTests
     {
         var result = RespondFormHandler.Validate(
             Template(QuestionTypes.Approval),
-            new RespondFormInput(ApprovalDecision: "APPROVE"));
+            new RespondFormInput(ApprovalDecision: "APPROVED"));
         Assert.True(result.IsValid);
-        Assert.Equal(ApprovalDecisions.Approve, result.ApprovalDecision);
+        Assert.Equal(ApprovalDecisions.Approved, result.ApprovalDecision);
     }
 
     // ── FreeText ───────────────────────────────────────────────────────────
@@ -112,56 +102,48 @@ public class RespondFormHandlerTests
         Assert.Equal("hello", result.FreeText);
     }
 
-    // ── DocumentReview ─────────────────────────────────────────────────────
+    // ── Approval with attachments (formerly DocumentReview) ────────────────
 
     [Fact]
-    public void DocumentReview_NoDecision_Fails()
+    public void ApprovalWithAttachments_NoDecision_Fails()
     {
-        var template = Template(QuestionTypes.DocumentReview);
+        var template = Template(QuestionTypes.Approval);
+        template.Attachments = [new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "spec", BlobPath = "x" }];
         var result = RespondFormHandler.Validate(template, new RespondFormInput());
         Assert.False(result.IsValid);
     }
 
     [Fact]
-    public void DocumentReview_RequestChanges_RequiresComment()
+    public void ApprovalWithAttachments_Rejected_RequiresComment()
     {
-        var template = Template(QuestionTypes.DocumentReview);
+        var template = Template(QuestionTypes.Approval);
+        template.Attachments = [new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "spec", BlobPath = "x" }];
         var result = RespondFormHandler.Validate(template, new RespondFormInput(
-            ApprovalDecision: ApprovalDecisions.RequestChanges));
+            ApprovalDecision: ApprovalDecisions.Rejected));
         Assert.False(result.IsValid);
         Assert.Contains("comment is required", result.Error, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void DocumentReview_NoTemplateAttachments_AcceptsApproveWithoutReviewedIds()
+    public void ApprovalWithAttachments_RequiresAtLeastOneReviewed()
     {
-        var template = Template(QuestionTypes.DocumentReview);
-        var result = RespondFormHandler.Validate(template, new RespondFormInput(
-            ApprovalDecision: ApprovalDecisions.Approve));
-        Assert.True(result.IsValid);
-        Assert.Null(result.ReviewedAttachmentIds);
-    }
-
-    [Fact]
-    public void DocumentReview_WithAttachments_RequiresAtLeastOneReviewed()
-    {
-        var template = Template(QuestionTypes.DocumentReview);
+        var template = Template(QuestionTypes.Approval);
         template.Attachments = [new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "spec", BlobPath = "x" }];
         var result = RespondFormHandler.Validate(template, new RespondFormInput(
-            ApprovalDecision: ApprovalDecisions.Approve,
+            ApprovalDecision: ApprovalDecisions.Approved,
             ReviewedAttachmentIds: Array.Empty<Guid>()));
         Assert.False(result.IsValid);
         Assert.Contains("reviewed at least one", result.Error, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void DocumentReview_WithAttachments_FiltersUnknownIds()
+    public void ApprovalWithAttachments_FiltersUnknownIds()
     {
         var aid = Guid.NewGuid();
-        var template = Template(QuestionTypes.DocumentReview);
+        var template = Template(QuestionTypes.Approval);
         template.Attachments = [new QuestionAttachment { AttachmentId = aid, Name = "spec", BlobPath = "x" }];
         var result = RespondFormHandler.Validate(template, new RespondFormInput(
-            ApprovalDecision: ApprovalDecisions.Approve,
+            ApprovalDecision: ApprovalDecisions.Approved,
             ReviewedAttachmentIds: new[] { aid, Guid.NewGuid() }));
         Assert.True(result.IsValid);
         Assert.Single(result.ReviewedAttachmentIds!);
@@ -169,25 +151,24 @@ public class RespondFormHandlerTests
     }
 
     [Fact]
-    public void DocumentReview_OnlyUnknownIds_Fails()
+    public void ApprovalWithAttachments_OnlyUnknownIds_Fails()
     {
-        var template = Template(QuestionTypes.DocumentReview);
+        var template = Template(QuestionTypes.Approval);
         template.Attachments = [new QuestionAttachment { AttachmentId = Guid.NewGuid(), Name = "spec", BlobPath = "x" }];
         var result = RespondFormHandler.Validate(template, new RespondFormInput(
-            ApprovalDecision: ApprovalDecisions.CommentOnly,
-            Comment: "ok",
+            ApprovalDecision: ApprovalDecisions.Approved,
             ReviewedAttachmentIds: new[] { Guid.NewGuid() }));
         Assert.False(result.IsValid);
     }
 
     [Fact]
-    public void DocumentReview_DuplicatesDeduped()
+    public void ApprovalWithAttachments_DuplicatesDeduped()
     {
         var aid = Guid.NewGuid();
-        var template = Template(QuestionTypes.DocumentReview);
+        var template = Template(QuestionTypes.Approval);
         template.Attachments = [new QuestionAttachment { AttachmentId = aid, Name = "spec", BlobPath = "x" }];
         var result = RespondFormHandler.Validate(template, new RespondFormInput(
-            ApprovalDecision: ApprovalDecisions.Approve,
+            ApprovalDecision: ApprovalDecisions.Approved,
             ReviewedAttachmentIds: new[] { aid, aid, aid }));
         Assert.True(result.IsValid);
         Assert.Single(result.ReviewedAttachmentIds!);

--- a/src/ui/modules/NotificationPoller.psm1
+++ b/src/ui/modules/NotificationPoller.psm1
@@ -213,8 +213,12 @@ function Invoke-NotificationPollTick {
                     $resolved  = Resolve-NotificationAnswer -Response $response -Settings $settings -AttachDir $attachDir
 
                     if ($resolved) {
+                        $comment      = if ($resolved.ContainsKey('comment'))                 { $resolved.comment }                 else { $null }
+                        $rankedItems  = if ($resolved.ContainsKey('ranked_items'))            { @($resolved.ranked_items) }        else { @() }
+                        $reviewedIds  = if ($resolved.ContainsKey('reviewed_attachment_ids')) { @($resolved.reviewed_attachment_ids) } else { @() }
                         Invoke-TaskTransitionFromNotification -TaskFile $taskFile -TaskContent $taskContent `
-                            -Answer $resolved.answer -Attachments $resolved.attachments -BotRoot $botRoot
+                            -Answer $resolved.answer -Attachments $resolved.attachments -BotRoot $botRoot `
+                            -Comment $comment -RankedItems $rankedItems -ReviewedAttachmentIds $reviewedIds
                     }
                 }
                 continue
@@ -247,8 +251,12 @@ function Invoke-NotificationPollTick {
                 if (-not (Test-Path $taskFile.FullName)) { break }
                 $taskContent = Get-Content -Path $taskFile.FullName -Raw | ConvertFrom-Json
 
+                $comment      = if ($resolved.ContainsKey('comment'))                 { $resolved.comment }                 else { $null }
+                $rankedItems  = if ($resolved.ContainsKey('ranked_items'))            { @($resolved.ranked_items) }        else { @() }
+                $reviewedIds  = if ($resolved.ContainsKey('reviewed_attachment_ids')) { @($resolved.reviewed_attachment_ids) } else { @() }
                 Invoke-BatchQuestionTransitionFromNotification -TaskFile $taskFile -TaskContent $taskContent `
-                    -Question $pq -Answer $resolved.answer -Attachments $resolved.attachments -BotRoot $botRoot
+                    -Question $pq -Answer $resolved.answer -Attachments $resolved.attachments -BotRoot $botRoot `
+                    -Comment $comment -RankedItems $rankedItems -ReviewedAttachmentIds $reviewedIds
 
                 # Re-read after mutation to pick up updated pending_questions for next iteration
                 if (Test-Path $taskFile.FullName) {
@@ -273,7 +281,15 @@ function Invoke-TaskTransitionFromNotification {
         [Parameter(Mandatory)] [object]$TaskContent,
         [Parameter(Mandatory)] [AllowEmptyString()] [string]$Answer,
         [Parameter(Mandatory)] [string]$BotRoot,
-        [array]$Attachments = @()
+        [array]$Attachments = @(),
+        # Type-specific fields surfaced by Resolve-NotificationAnswer from the server
+        # response (approval comment, priorityRanking ranked_items, approval-with-
+        # attachments reviewed_attachment_ids). Threaded into the resolved entry by
+        # Add-TaskInputResolvedQuestion. Each is unset when the server response did
+        # not populate it.
+        [string]$Comment,
+        [array]$RankedItems,
+        [array]$ReviewedAttachmentIds
     )
 
     Invoke-TaskQuestionAnswerTransition -TaskFile $TaskFile `
@@ -281,7 +297,10 @@ function Invoke-TaskTransitionFromNotification {
         -Answer $Answer `
         -BotRoot $BotRoot `
         -Attachments $Attachments `
-        -AnsweredVia 'notification'
+        -AnsweredVia 'notification' `
+        -Comment $Comment `
+        -RankedItems $RankedItems `
+        -ReviewedAttachmentIds $ReviewedAttachmentIds
 }
 
 function Invoke-SplitTransitionFromNotification {
@@ -333,7 +352,10 @@ function Invoke-BatchQuestionTransitionFromNotification {
         [Parameter(Mandatory)] [object]$Question,
         [Parameter(Mandatory)] [AllowEmptyString()] [string]$Answer,
         [Parameter(Mandatory)] [string]$BotRoot,
-        [array]$Attachments = @()
+        [array]$Attachments = @(),
+        [string]$Comment,
+        [array]$RankedItems,
+        [array]$ReviewedAttachmentIds
     )
 
     Invoke-TaskQuestionAnswerTransition -TaskFile $TaskFile `
@@ -342,7 +364,10 @@ function Invoke-BatchQuestionTransitionFromNotification {
         -BotRoot $BotRoot `
         -QuestionId $Question.id `
         -Attachments $Attachments `
-        -AnsweredVia 'notification'
+        -AnsweredVia 'notification' `
+        -Comment $Comment `
+        -RankedItems $RankedItems `
+        -ReviewedAttachmentIds $ReviewedAttachmentIds
 }
 
 Export-ModuleMember -Function @(

--- a/src/ui/modules/TaskAPI.psm1
+++ b/src/ui/modules/TaskAPI.psm1
@@ -427,15 +427,64 @@ function Get-ActionRequired {
     }
 }
 
+function Assert-TaskAnswerSubmissionShape {
+    <#
+    .SYNOPSIS
+    Type-specific contract validation for a local Submit-TaskAnswer payload.
+
+    .DESCRIPTION
+    Each question type has its own wire-shape contract from the local UI.
+    Centralised here so Submit-TaskAnswer stays focused on attachment handling
+    and the runtime transition call. Throws a descriptive error on contract
+    violation; returns silently on success.
+
+    Approval contract (mirrors the local Decisions card in actions.js and the
+    server-side ApprovalDecisions enum):
+      - $Answer must be exactly "approved" or "rejected" (empty is allowed
+        and falls through; callers that require a non-empty answer enforce
+        that separately).
+      - "rejected" requires a non-empty $Comment.
+      - $Attachments cannot be present — the approval card has no dropzone,
+        so a non-empty $Attachments here means a misbehaving caller.
+
+    Other types (singleChoice / freeText / priorityRanking) have no extra
+    shape constraints here; the server validates the response payload on
+    its side.
+    #>
+    param(
+        [string]$Type,
+        $Answer,
+        $Attachments,
+        [string]$Comment
+    )
+
+    switch ($Type) {
+        'approval' {
+            $answerValue = if ($Answer -is [array]) { @($Answer)[0] } else { [string]$Answer }
+            if ($answerValue -and $answerValue -notin @('approved', 'rejected')) {
+                throw "Submit-TaskAnswer: approval answer must be 'approved' or 'rejected' (got: '$answerValue')"
+            }
+            if ($answerValue -eq 'rejected' -and [string]::IsNullOrWhiteSpace($Comment)) {
+                throw "Submit-TaskAnswer: approval 'rejected' requires a non-empty Comment"
+            }
+            if ($Attachments -and @($Attachments).Count -gt 0) {
+                throw "Submit-TaskAnswer: approval submissions cannot carry attachments"
+            }
+        }
+        default {
+            # No additional shape constraints for singleChoice / freeText /
+            # priorityRanking today.
+        }
+    }
+}
+
 function Submit-TaskAnswer {
     param(
         [Parameter(Mandatory)] [string]$TaskId,
         [string]$Type,       # Question type — "approval" / "singleChoice" / "freeText" /
-                             # "priorityRanking". The UI knows which card it rendered and
-                             # passes the type so this function can branch on typed payloads
-                             # (approval answer carries the decision verbatim; freeText is
-                             # never wrapped with the "Attached: ..." suffix used by raw text
-                             # singleChoice answers).
+                             # "priorityRanking". Drives approval-specific validation
+                             # (canonical decision values, no attachments) and the
+                             # dual-surface push-back call to Send-LocalApprovalResponse.
         $Answer,             # For approval, this is the decision string ("approved" / "rejected").
                              # For singleChoice, the option key or custom text.
                              # For freeText, the response text.
@@ -451,6 +500,10 @@ function Submit-TaskAnswer {
     if ((-not $Answer -or ($Answer -is [array] -and $Answer.Count -eq 0)) -and $CustomText) {
         $Answer = $CustomText
     }
+
+    # Type-specific contract checks (approval decision value, no-attachments
+    # on approval, reject-needs-comment). See Assert-TaskAnswerSubmissionShape.
+    Assert-TaskAnswerSubmissionShape -Type $Type -Answer $Answer -Attachments $Attachments -Comment $Comment
 
     # Always resolve the question ID so it is used consistently for both attachment
     # placement and the answer submission — not only when attachments are present.
@@ -518,11 +571,11 @@ function Submit-TaskAnswer {
         }
     }
 
-    # If attachments were saved AND this is a free-form answer (not an approval
-    # or other typed payload), embed their paths in the answer text so the AI
-    # can locate them. For approval the answer field carries the decision value
-    # verbatim ("approved" / "rejected") and must not be polluted.
-    if ($attachmentMeta.Count -gt 0 -and -not $isApproval) {
+    # Embed attachment disk paths in the answer text so the AI agent reading
+    # questions_resolved later can find them. Approval submissions cannot
+    # reach this block — the validation above throws on attachments-with-
+    # approval, so $isApproval implies $attachmentMeta is empty.
+    if ($attachmentMeta.Count -gt 0) {
         $pathList = ($attachmentMeta | ForEach-Object { $_.path }) -join ', '
         $pathNote = "Attached: $pathList"
         $Answer = if ($Answer) { "$Answer`n$pathNote" } else { $pathNote }
@@ -931,6 +984,7 @@ Export-ModuleMember -Function @(
     'Initialize-TaskAPI',
     'Get-TaskPlan',
     'Get-ActionRequired',
+    'Assert-TaskAnswerSubmissionShape',
     'Submit-TaskAnswer',
     'Submit-SplitApproval',
     'Submit-TaskReview',

--- a/src/ui/modules/TaskAPI.psm1
+++ b/src/ui/modules/TaskAPI.psm1
@@ -430,13 +430,22 @@ function Get-ActionRequired {
 function Submit-TaskAnswer {
     param(
         [Parameter(Mandatory)] [string]$TaskId,
-        $Answer,
+        [string]$Type,       # Question type — "approval" / "singleChoice" / "freeText" /
+                             # "priorityRanking". The UI knows which card it rendered and
+                             # passes the type so this function can branch on typed payloads
+                             # (approval answer carries the decision verbatim; freeText is
+                             # never wrapped with the "Attached: ..." suffix used by raw text
+                             # singleChoice answers).
+        $Answer,             # For approval, this is the decision string ("approved" / "rejected").
+                             # For singleChoice, the option key or custom text.
+                             # For freeText, the response text.
         [string]$CustomText,
-        $Attachments,  # array of { name, size, content (base64) } from frontend
-        [string]$QuestionId,  # Optional: specific question ID for pending_questions batch
-        [string]$Decision,    # approval decision: "approved" | "rejected" | "abstained"
-        [string]$Comment      # required when Decision = "rejected"
+        $Attachments,        # array of { name, size, content (base64) } from frontend
+        [string]$QuestionId, # Optional: specific question ID for pending_questions batch
+        [string]$Comment     # Required when Type='approval' and Answer='rejected'
     )
+
+    $isApproval = ($Type -eq 'approval')
 
     # Use custom text as answer when no option selected
     if ((-not $Answer -or ($Answer -is [array] -and $Answer.Count -eq 0)) -and $CustomText) {
@@ -509,8 +518,11 @@ function Submit-TaskAnswer {
         }
     }
 
-    # If attachments were saved, embed their paths in the answer so the AI can locate them
-    if ($attachmentMeta.Count -gt 0) {
+    # If attachments were saved AND this is a free-form answer (not an approval
+    # or other typed payload), embed their paths in the answer text so the AI
+    # can locate them. For approval the answer field carries the decision value
+    # verbatim ("approved" / "rejected") and must not be polluted.
+    if ($attachmentMeta.Count -gt 0 -and -not $isApproval) {
         $pathList = ($attachmentMeta | ForEach-Object { $_.path }) -join ', '
         $pathNote = "Attached: $pathList"
         $Answer = if ($Answer) { "$Answer`n$pathNote" } else { $pathNote }
@@ -537,12 +549,17 @@ function Submit-TaskAnswer {
         -AnsweredVia 'ui' `
         -Actor $actorName
 
-    # Dual-surface approval push-back: if the UI submitted an approval Decision
-    # (approved/rejected/abstained), mirror it to the Mothership so the server-side
+    # Dual-surface approval push-back: if the UI submitted an approval answer
+    # (approved / rejected), mirror it to the Mothership so the server-side
     # /respond surface and the local UI converge on the same answer. Best-effort;
     # a failure here is logged but doesn't fail the user-visible submission since
     # the local task has already transitioned.
-    if ($Decision) {
+    # NOTE: the full dual-surface contract (first-by-timestamp resolution,
+    # agreement / disagreement flag derivation, dashboard rendering) is tracked
+    # separately in #416. The wiring here is a stop-gap that pushes the
+    # decision string to the server using a deterministic ResponseId so retries
+    # are idempotent.
+    if ($isApproval) {
         $taskContent = $foundTask.Content
         $runner = $null
         if ($taskContent.PSObject.Properties['extensions'] -and $taskContent.extensions -and
@@ -571,11 +588,13 @@ function Submit-TaskAnswer {
             $qvRaw = if ($notifSource.PSObject.Properties['question_version']) { "$($notifSource.question_version)" } else { '' }
             $qvTest = 0
             $qv = if ([int]::TryParse($qvRaw, [ref]$qvTest) -and $qvTest -gt 0) { $qvTest } else { 1 }
+            # The approval answer carries the decision string verbatim, so pass it
+            # through as ApprovalDecision unchanged.
             $pushResult = Send-LocalApprovalResponse `
                 -ProjectId        "$($notifSource.project_id)" `
                 -QuestionId       "$($notifSource.question_id)" `
                 -InstanceId       "$($notifSource.instance_id)" `
-                -ApprovalDecision $Decision `
+                -ApprovalDecision "$Answer" `
                 -Comment          $Comment `
                 -QuestionVersion  $qv
             if (-not $pushResult.success -and (Get-Command Write-BotLog -ErrorAction SilentlyContinue)) {

--- a/src/ui/server.ps1
+++ b/src/ui/server.ps1
@@ -1683,7 +1683,7 @@ $docContext
                             $reader = New-Object System.IO.StreamReader($request.InputStream)
                             $body = $reader.ReadToEnd() | ConvertFrom-Json
                             $reader.Close()
-                            $content = Submit-TaskAnswer -TaskId $body.task_id -Answer $body.answer -CustomText $body.custom_text -Attachments $body.attachments -QuestionId $body.question_id -Decision $body.decision -Comment $body.comment | ConvertTo-Json -Depth 10 -Compress
+                            $content = Submit-TaskAnswer -TaskId $body.task_id -Type $body.type -Answer $body.answer -CustomText $body.custom_text -Attachments $body.attachments -QuestionId $body.question_id -Comment $body.comment | ConvertTo-Json -Depth 10 -Compress
                         } catch {
                             $statusCode = 500
                             $content = @{ success = $false; error = "Failed to submit answer: $($_.Exception.Message)" } | ConvertTo-Json -Compress

--- a/src/ui/static/app.js
+++ b/src/ui/static/app.js
@@ -63,6 +63,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Start data flows
     startPolling();
     startRuntimeTimer();
+
+    // Mark the page as fully initialised so external observers (notably the
+    // Layer 5 Playwright E2E suite) can wait for a real "init complete"
+    // signal rather than racing against asynchronous module bootstrapping.
+    // Some elements (e.g. `.tab[data-tab="overview"]`) ship with `class="active"`
+    // hardcoded in index.html, so toggling on that class is not a safe
+    // indicator that initTabs() has wired its click handlers yet.
+    document.body.dataset.appReady = '1';
 });
 
 // ========== CLEANUP ==========

--- a/src/ui/static/modules/actions.js
+++ b/src/ui/static/modules/actions.js
@@ -333,7 +333,7 @@ function renderQuestionItem(item) {
     const renderedType = question.type || 'singleChoice';
 
     return `
-        <div class="action-item" data-task-id="${escapeHtml(item.task_id)}" data-type="question" data-question-type="${escapeAttr(renderedType)}">
+        <div class="action-item" data-task-id="${escapeAttr(item.task_id)}" data-type="question" data-question-type="${escapeAttr(renderedType)}">
             <div class="action-item-header">
                 <span class="action-item-type question">Question</span>
                 <span class="action-item-task">${escapeHtml(item.task_name)}</span>

--- a/src/ui/static/modules/actions.js
+++ b/src/ui/static/modules/actions.js
@@ -313,7 +313,6 @@ function renderQuestionItem(item) {
                 ${question.context ? `<div class="action-question-context">${escapeHtml(question.context)}</div>` : ''}
                 <div class="approval-buttons">
                     <button class="ctrl-btn approval-decision" data-decision="approved">Approve</button>
-                    <button class="ctrl-btn approval-decision" data-decision="abstained">Abstain</button>
                     <button class="ctrl-btn approval-decision danger" data-decision="rejected">Reject</button>
                 </div>
                 <div class="approval-comment-section" style="display:none;">
@@ -329,9 +328,12 @@ function renderQuestionItem(item) {
 
     const options = question.options || [];
     const isMultiSelect = question.multi_select || false;
+    // multi_select is a render flag on a singleChoice question — there is no
+    // separate "multiChoice" type in dotbot's local MCP layer.
+    const renderedType = question.type || 'singleChoice';
 
     return `
-        <div class="action-item" data-task-id="${escapeHtml(item.task_id)}" data-type="question">
+        <div class="action-item" data-task-id="${escapeHtml(item.task_id)}" data-type="question" data-question-type="${escapeAttr(renderedType)}">
             <div class="action-item-header">
                 <span class="action-item-type question">Question</span>
                 <span class="action-item-task">${escapeHtml(item.task_name)}</span>
@@ -400,7 +402,7 @@ function renderTaskQuestionsItem(item) {
             <div class="action-item-body">
                 ${questions.map((q, idx) => `
                     ${idx > 0 ? '<div class="question-divider"></div>' : ''}
-                    <div class="task-question-block" data-question-id="${escapeAttr(q.id)}" data-task-id="${escapeAttr(taskId)}">
+                    <div class="task-question-block" data-question-id="${escapeAttr(q.id)}" data-task-id="${escapeAttr(taskId)}" data-question-type="${escapeAttr(q.type || 'singleChoice')}">
                         <div class="action-question-text"><span class="question-number">Q${idx + 1}.</span> ${escapeHtml(q.question)}</div>
                         ${q.context ? `<div class="action-question-context">${escapeHtml(q.context)}</div>` : ''}
                         <div class="answer-options" data-multi-select="false">
@@ -468,6 +470,7 @@ async function submitTaskQuestion(taskId, questionId) {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 task_id: taskId,
+                type: questionBlock.dataset.questionType || 'singleChoice',
                 question_id: questionId,
                 answer: answer,
                 custom_text: customText
@@ -671,6 +674,7 @@ function attachActionHandlers(container) {
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
                         task_id: taskId,
+                        type: actionItem.dataset.questionType || 'singleChoice',
                         answer: selected.length === 1 ? selected[0]
                               : selected.length > 1 ? selected
                               : customText || '',
@@ -801,8 +805,8 @@ function attachActionHandlers(container) {
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
                         task_id: taskId,
+                        type: 'approval',
                         answer: decision,
-                        decision: decision,
                         comment: comment || null
                     })
                 });

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -6221,6 +6221,83 @@ finally {
 }
 
 # ═══════════════════════════════════════════════════════════════════
+# ASSERT-TASKANSWERSUBMISSIONSHAPE (PR #445)
+# ═══════════════════════════════════════════════════════════════════
+# Type-specific contract validation for Submit-TaskAnswer payloads. The
+# approval branch enforces canonical decision values, the reject-needs-
+# comment rule, and the no-attachments-on-approval rule. Other types pass
+# through unchanged. See `Assert-TaskAnswerSubmissionShape` in
+# src/ui/modules/TaskAPI.psm1.
+
+Write-Host ""
+Write-Host "  ASSERT-TASKANSWERSUBMISSIONSHAPE" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+# Load TaskAPI so the exported Assert function is in scope.
+$taskApiPath = Join-Path $botDir 'src/ui/modules/TaskAPI.psm1'
+if (Test-Path $taskApiPath) {
+    Import-Module $taskApiPath -DisableNameChecking -Global -Force -ErrorAction SilentlyContinue
+}
+
+# Each case shape:
+#   label        - assertion name suffix
+#   type         - $Type
+#   answer       - $Answer
+#   attachments  - $Attachments (optional)
+#   comment      - $Comment (optional)
+#   expectThrow  - $true when the call must throw, $false when it must pass
+#   throwMatch   - optional regex the thrown message must match
+$validatorCases = @(
+    # ── approval / valid ────────────────────────────────────────────
+    @{ label = 'approval/approved'                       ; type = 'approval' ; answer = 'approved' ; expectThrow = $false }
+    @{ label = 'approval/rejected with comment'          ; type = 'approval' ; answer = 'rejected' ; comment = 'needs work' ; expectThrow = $false }
+    @{ label = 'approval/empty answer (no decision yet)' ; type = 'approval' ; answer = ''         ; expectThrow = $false }
+
+    # ── approval / invalid ──────────────────────────────────────────
+    @{ label = 'approval/abstained rejected by enum'                 ; type = 'approval' ; answer = 'abstained' ; expectThrow = $true ; throwMatch = "'abstained'" }
+    @{ label = 'approval/approve (wrong tense) rejected by enum'     ; type = 'approval' ; answer = 'approve'   ; expectThrow = $true ; throwMatch = "'approve'"   }
+    @{ label = 'approval/rejected without comment throws'            ; type = 'approval' ; answer = 'rejected'  ; expectThrow = $true ; throwMatch = 'non-empty Comment' }
+    @{ label = 'approval/rejected with whitespace-only comment throws' ; type = 'approval' ; answer = 'rejected' ; comment = "   `t" ; expectThrow = $true ; throwMatch = 'non-empty Comment' }
+    @{ label = 'approval/attachments throws'                         ; type = 'approval' ; answer = 'approved'  ; attachments = @(@{ name = 'x.txt'; size = 1; content = 'eA==' }) ; expectThrow = $true ; throwMatch = 'cannot carry attachments' }
+
+    # ── other types / no extra constraints ──────────────────────────
+    @{ label = 'singleChoice/anything passes'                        ; type = 'singleChoice'   ; answer = 'A'                 ; expectThrow = $false }
+    @{ label = 'freeText/anything passes'                            ; type = 'freeText'       ; answer = 'some text'         ; expectThrow = $false }
+    @{ label = 'priorityRanking/anything passes'                     ; type = 'priorityRanking'; answer = 'opt1, opt2, opt3'  ; expectThrow = $false }
+)
+
+foreach ($case in $validatorCases) {
+    $label       = $case.label
+    $attachments = if ($case.ContainsKey('attachments')) { $case.attachments } else { $null }
+    $commentArg  = if ($case.ContainsKey('comment'))     { $case.comment }     else { '' }
+    $threw       = $false
+    $message     = $null
+    try {
+        Assert-TaskAnswerSubmissionShape `
+            -Type $case.type `
+            -Answer $case.answer `
+            -Attachments $attachments `
+            -Comment $commentArg
+    } catch {
+        $threw   = $true
+        $message = $_.Exception.Message
+    }
+
+    if ($case.expectThrow) {
+        Assert-True -Name "submit-shape/$label : throws" -Condition $threw `
+            -Message "Expected throw but call returned silently"
+        if ($threw -and $case.ContainsKey('throwMatch')) {
+            Assert-True -Name "submit-shape/$label : message matches '$($case.throwMatch)'" `
+                -Condition ($message -match [regex]::Escape($case.throwMatch)) `
+                -Message "Actual: $message"
+        }
+    } else {
+        Assert-True -Name "submit-shape/$label : passes" -Condition (-not $threw) `
+            -Message "Unexpected throw: $message"
+    }
+}
+
+# ═══════════════════════════════════════════════════════════════════
 # CLEANUP
 # ═══════════════════════════════════════════════════════════════════
 

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -6050,6 +6050,177 @@ try {
 }
 
 # ═══════════════════════════════════════════════════════════════════
+# RESOLVE-NOTIFICATIONANSWER PARSER (PR #445)
+# ═══════════════════════════════════════════════════════════════════
+# Behavioural unit tests for Dotbot.Notification's Resolve-NotificationAnswer.
+# Exercises each question-type wire shape with synthetic Mothership response
+# objects. Asserts the type-specific keys (comment, ranked_items,
+# reviewed_attachment_ids) appear ONLY when the server populated the
+# corresponding field — the interview pipeline (Invoke-InterviewLoop) reads
+# only .answer + .attachments from the resolved hashtable, so extensions to
+# the parser must stay optional or InterviewLoop silently breaks.
+
+Write-Host ""
+Write-Host "  RESOLVE-NOTIFICATIONANSWER PARSER" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+# Dotbot.Notification was re-imported by the merge-failure escalation block's
+# finally above, so it's already in scope. Re-import here defensively so this
+# section is self-contained if the file is reordered.
+$notifModulePath = Join-Path $botDir 'src/runtime/Modules/Dotbot.Notification/Dotbot.Notification.psd1'
+if (Test-Path $notifModulePath) {
+    Import-Module $notifModulePath -DisableNameChecking -Global -Force -ErrorAction SilentlyContinue
+}
+
+# Placeholder settings — Resolve-NotificationAnswer only reads them when the
+# response carries attachments. Every test below passes attachments=$null on
+# the response object so the function never reaches the /api/attachments
+# download path.
+$resolveStubSettings = [pscustomobject]@{
+    enabled    = $true
+    server_url = 'http://localhost:0'
+    api_key    = 'test'
+}
+
+$resolveAttachRoot = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-test-resolve-$(([guid]::NewGuid()).ToString().Substring(0,8))"
+New-Item -Path $resolveAttachRoot -ItemType Directory -Force | Out-Null
+
+# ─── Test data ─────────────────────────────────────────────────────────
+# GUIDs captured up front so 'expected' fields can reference them.
+$resolveG1   = [guid]::NewGuid().ToString()
+$resolveG2   = [guid]::NewGuid().ToString()
+$resolveOptA = [guid]::NewGuid().ToString()
+$resolveOptB = [guid]::NewGuid().ToString()
+$resolveOptC = [guid]::NewGuid().ToString()
+
+# Each case shape:
+#   label                 - human-readable name used in assertion messages
+#   response              - PSCustomObject fed to Resolve-NotificationAnswer
+#   expectNull            - $true when the resolver should return $null and
+#                           skip all other assertions
+#   expectedAnswer        - expected value of .answer
+#   expectedKeys          - exact set of keys that must be present on the result
+#                           hashtable (omitted -> no exact-keyset assertion)
+#   expectedComment       - expected value of .comment when present
+#   expectedRankedCount   - expected count of .ranked_items entries
+#   expectedReviewedIds   - expected array of reviewed_attachment_ids
+$resolveCases = @(
+    @{
+        label          = 'singleChoice'
+        response       = [pscustomobject]@{ selectedKey = 'A' }
+        expectedAnswer = 'A'
+        expectedKeys   = @('answer', 'attachments')
+    },
+    @{
+        label          = 'freeText'
+        response       = [pscustomobject]@{ freeText = 'free response body' }
+        expectedAnswer = 'free response body'
+        expectedKeys   = @('answer', 'attachments')
+    },
+    @{
+        label          = 'approval-approved (no extras)'
+        response       = [pscustomobject]@{ approvalDecision = 'approved' }
+        expectedAnswer = 'approved'
+        expectedKeys   = @('answer', 'attachments')
+    },
+    @{
+        label           = 'approval-rejected with comment'
+        response        = [pscustomobject]@{
+            approvalDecision = 'rejected'
+            comment          = 'needs more context'
+        }
+        expectedAnswer  = 'rejected'
+        expectedKeys    = @('answer', 'attachments', 'comment')
+        expectedComment = 'needs more context'
+    },
+    @{
+        label               = 'approval-approved with reviewedAttachmentIds'
+        response            = [pscustomobject]@{
+            approvalDecision      = 'approved'
+            reviewedAttachmentIds = @($resolveG1, $resolveG2)
+        }
+        expectedAnswer      = 'approved'
+        expectedKeys        = @('answer', 'attachments', 'reviewed_attachment_ids')
+        expectedReviewedIds = @($resolveG1, $resolveG2)
+    },
+    @{
+        label               = 'priorityRanking (out-of-order input)'
+        response            = [pscustomobject]@{
+            # Intentionally feed items in non-rank order; resolver must sort
+            # by rank when projecting the answer string.
+            rankedItems = @(
+                [pscustomobject]@{ optionId = $resolveOptC; rank = 3 }
+                [pscustomobject]@{ optionId = $resolveOptA; rank = 1 }
+                [pscustomobject]@{ optionId = $resolveOptB; rank = 2 }
+            )
+        }
+        expectedAnswer      = "$resolveOptA, $resolveOptB, $resolveOptC"
+        expectedKeys        = @('answer', 'attachments', 'ranked_items')
+        expectedRankedCount = 3
+    },
+    @{
+        label      = 'empty response (no answer fields)'
+        response   = [pscustomobject]@{}
+        expectNull = $true
+    }
+)
+
+try {
+    foreach ($case in $resolveCases) {
+        $label = $case.label
+        $r = Resolve-NotificationAnswer -Response $case.response -Settings $resolveStubSettings -AttachDir $resolveAttachRoot
+
+        if ($case.expectNull) {
+            Assert-True -Name "resolver/$label : returns null" -Condition ($null -eq $r)
+            continue
+        }
+
+        Assert-True -Name "resolver/$label : returns a hashtable" -Condition ($null -ne $r)
+        if ($null -eq $r) { continue }  # guard so subsequent asserts don't NPE on a failure
+
+        Assert-Equal -Name "resolver/$label : answer matches expected" `
+            -Expected $case.expectedAnswer -Actual $r.answer
+
+        Assert-True -Name "resolver/$label : attachments is empty array (no wire attachments)" `
+            -Condition (@($r.attachments).Count -eq 0)
+
+        if ($case.ContainsKey('expectedKeys')) {
+            $actualKeys = @($r.Keys | Sort-Object)
+            $expected = @($case.expectedKeys | Sort-Object)
+            $extra   = @($actualKeys | Where-Object { $expected -notcontains $_ })
+            $missing = @($expected | Where-Object { $actualKeys -notcontains $_ })
+            Assert-True -Name "resolver/$label : exact key set matches" `
+                -Condition (($extra.Count -eq 0) -and ($missing.Count -eq 0)) `
+                -Message "Extra: $($extra -join ', '); Missing: $($missing -join ', ')"
+        }
+
+        if ($case.ContainsKey('expectedComment')) {
+            Assert-Equal -Name "resolver/$label : comment carries server value" `
+                -Expected $case.expectedComment -Actual $r.comment
+        }
+
+        if ($case.ContainsKey('expectedRankedCount')) {
+            Assert-Equal -Name "resolver/$label : ranked_items count" `
+                -Expected $case.expectedRankedCount -Actual (@($r.ranked_items).Count)
+        }
+
+        if ($case.ContainsKey('expectedReviewedIds')) {
+            $expectedIds = @($case.expectedReviewedIds)
+            $actualIds   = @($r.reviewed_attachment_ids)
+            Assert-Equal -Name "resolver/$label : reviewed_attachment_ids count" `
+                -Expected $expectedIds.Count -Actual $actualIds.Count
+            for ($i = 0; $i -lt $expectedIds.Count; $i++) {
+                Assert-Equal -Name "resolver/$label : reviewed_attachment_ids[$i] preserved verbatim" `
+                    -Expected $expectedIds[$i] -Actual $actualIds[$i]
+            }
+        }
+    }
+}
+finally {
+    Remove-Item -Path $resolveAttachRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# ═══════════════════════════════════════════════════════════════════
 # CLEANUP
 # ═══════════════════════════════════════════════════════════════════
 

--- a/tests/Test-E2E-Mothership-QA.ps1
+++ b/tests/Test-E2E-Mothership-QA.ps1
@@ -3,9 +3,9 @@
 .SYNOPSIS
     Layer 5: Mothership web UI E2E — Playwright against live server + Azurite.
 .DESCRIPTION
-    Runs Playwright specs that navigate the magic-link respond flow for all six
-    question types: singleChoice, multiChoice, freeText, approval,
-    documentReview, priorityRanking.
+    Runs Playwright specs that navigate the magic-link respond flow for all
+    question types: singleChoice, multiChoice, freeText, approval (with and
+    without attachments), priorityRanking.
 
     For each question type the script:
       1. POST /api/templates  — creates a template
@@ -173,25 +173,13 @@ $questionTypes = @(
         Submit  = @{ selectedKey = "opt_a" }
     }
     @{
-        Type               = "approval"
-        Title              = "Playwright E2E: approval"
-        DeliverableSummary = "Playwright E2E test deliverable for approval"
-        Options = @(
-            @{ key = "approve"; label = "Approve" }
-            @{ key = "reject";  label = "Reject"  }
-            @{ key = "abstain"; label = "Abstain" }
-        )
-        Submit  = @{ approvalDecision = "approve" }
-    }
-    @{
-        Type               = "documentReview"
-        Title              = "Playwright E2E: documentReview"
-        DeliverableSummary = "Playwright E2E test deliverable for documentReview"
+        Type    = "approval"
+        Title   = "Playwright E2E: approval"
         Options = @(
             @{ key = "approve"; label = "Approve" }
             @{ key = "reject";  label = "Reject"  }
         )
-        Submit  = @{ approvalDecision = "approve" }
+        Submit  = @{ approvalDecision = "approved" }
     }
     @{
         Type   = "freeText"

--- a/tests/Test-E2E-Mothership-QA.ps1
+++ b/tests/Test-E2E-Mothership-QA.ps1
@@ -5,7 +5,10 @@
 .DESCRIPTION
     Runs Playwright specs that navigate the magic-link respond flow for all
     question types: singleChoice, multiChoice, freeText, approval (with and
-    without attachments), priorityRanking.
+    without attachments), priorityRanking. The approval-with-attachments
+    scenario uploads a template attachment via POST /api/attachments, embeds
+    it on the template payload, and asserts the per-attachment confirmation
+    checklist + reviewedAttachmentIds round-trip on submit.
 
     For each question type the script:
       1. POST /api/templates  — creates a template
@@ -174,12 +177,32 @@ $questionTypes = @(
     }
     @{
         Type    = "approval"
+        Variant = "no-attachments"
         Title   = "Playwright E2E: approval"
         Options = @(
             @{ key = "approve"; label = "Approve" }
             @{ key = "reject";  label = "Reject"  }
         )
         Submit  = @{ approvalDecision = "approved" }
+    }
+    @{
+        Type        = "approval"
+        Variant     = "with-attachments"
+        Title       = "Playwright E2E: approval with attachments"
+        Options     = @(
+            @{ key = "approve"; label = "Approve" }
+            @{ key = "reject";  label = "Reject"  }
+        )
+        # Each entry becomes a single template attachment via POST /api/attachments.
+        # Content is inline so the test does not depend on any on-disk file under
+        # the project root (Send-AttachmentUpload guards against that, but this
+        # test uploads directly with X-Api-Key so it just needs a tmp file).
+        Attachments = @(
+            @{ name = 'playwright-design.txt'; content = 'Sample design document body for E2E approval review.' }
+        )
+        # reviewedAttachmentIds is filled in after uploads complete so the
+        # injected response matches the per-attachment confirmation checklist.
+        Submit      = @{ approvalDecision = "approved" }
     }
     @{
         Type   = "freeText"
@@ -202,8 +225,36 @@ $questionTypes = @(
 # HELPERS
 # ═══════════════════════════════════════════════════════════════════
 
+function New-Attachment {
+    <#
+    .SYNOPSIS
+    Uploads a single in-memory blob to POST /api/attachments and returns the
+    server-issued metadata in the QuestionAttachment wire shape.
+
+    .OUTPUTS
+    Hashtable: @{ attachmentId; name; blobPath; sizeBytes }.
+    #>
+    param([string]$Name, [string]$Content, [string]$Url, [string]$Key)
+
+    $tmpFile = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-mothership-e2e-$([guid]::NewGuid().ToString('N').Substring(0,8))-$Name"
+    Set-Content -LiteralPath $tmpFile -Value $Content -Encoding UTF8 -NoNewline
+    try {
+        $form = @{ file = Get-Item -LiteralPath $tmpFile }
+        $resp = Invoke-RestMethod -Uri "$($Url.TrimEnd('/'))/api/attachments" -Method Post `
+            -Form $form -Headers @{ "X-Api-Key" = $Key } -TimeoutSec 30
+        return @{
+            attachmentId = "$($resp.attachmentId)"
+            name         = "$($resp.name)"
+            blobPath     = "$($resp.storageRef)"
+            sizeBytes    = [int64]$resp.sizeBytes
+        }
+    } finally {
+        Remove-Item -LiteralPath $tmpFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
 function New-Template {
-    param([hashtable]$Qt, [string]$Url, [string]$Key)
+    param([hashtable]$Qt, [string]$Url, [string]$Key, [array]$Attachments = @())
 
     $options = @()
     if ($Qt.ContainsKey('Options')) {
@@ -229,6 +280,17 @@ function New-Template {
             name      = "Playwright E2E Project"
         }
         status             = "published"
+    }
+
+    if ($Attachments -and @($Attachments).Count -gt 0) {
+        $body['attachments'] = @(foreach ($att in @($Attachments)) {
+            @{
+                attachmentId = "$($att.attachmentId)"
+                name         = "$($att.name)"
+                blobPath     = "$($att.blobPath)"
+                sizeBytes    = [int64]$att.sizeBytes
+            }
+        })
     }
 
     $response = Invoke-RestMethod -Uri "$($Url.TrimEnd('/'))/api/templates" -Method Post `
@@ -297,11 +359,30 @@ try {
     $scenarios = @()
 
     foreach ($qt in $questionTypes) {
-        $label = $qt.Type
+        $label = if ($qt.ContainsKey('Variant')) { "$($qt.Type)-$($qt.Variant)" } else { $qt.Type }
         Write-Host "  SEEDING: $label" -ForegroundColor Cyan
 
+        # Upload any template-level attachments before template creation so the
+        # template payload can reference the server-issued attachmentId + blobPath.
+        $uploadedAttachments = @()
+        if ($qt.ContainsKey('Attachments') -and @($qt.Attachments).Count -gt 0) {
+            $attUploadFailed = $false
+            foreach ($att in @($qt.Attachments)) {
+                try {
+                    $uploaded = New-Attachment -Name $att.name -Content $att.content -Url $serverUrl -Key $apiKey
+                    $uploadedAttachments += $uploaded
+                } catch {
+                    Write-TestResult -Name "Mothership[$label]: attachment uploaded ($($att.name))" -Status Fail -Message $_.Exception.Message
+                    $attUploadFailed = $true
+                    break
+                }
+            }
+            if ($attUploadFailed) { continue }
+            Write-TestResult -Name "Mothership[$label]: $($uploadedAttachments.Count) attachment(s) uploaded" -Status Pass
+        }
+
         try {
-            $tmpl = New-Template -Qt $qt -Url $serverUrl -Key $apiKey
+            $tmpl = New-Template -Qt $qt -Url $serverUrl -Key $apiKey -Attachments $uploadedAttachments
             Write-TestResult -Name "Mothership[$label]: template created" -Status Pass
         } catch {
             Write-TestResult -Name "Mothership[$label]: template created" -Status Fail -Message $_.Exception.Message
@@ -338,8 +419,17 @@ try {
             }
         }
 
+        # Approval-with-attachments: thread the server-issued attachmentIds onto
+        # the injected response so the Playwright assertion can verify the
+        # round-trip and the form's per-attachment confirmation requirement is
+        # satisfied when the spec ticks all checkboxes.
+        if ($qt.Type -eq 'approval' -and $uploadedAttachments.Count -gt 0) {
+            $submit.reviewedAttachmentIds = @($uploadedAttachments | ForEach-Object { $_.attachmentId })
+        }
+
         $scenarios += @{
             type         = $qt.Type
+            variant      = if ($qt.ContainsKey('Variant')) { $qt.Variant } else { $null }
             title        = $qt.Title
             questionId   = $tmpl.QuestionId
             instanceId   = $instanceId

--- a/tests/e2e-server/specs/mothership-question-flow.spec.ts
+++ b/tests/e2e-server/specs/mothership-question-flow.spec.ts
@@ -8,6 +8,12 @@ interface RankedItem {
 
 interface Scenario {
   type: string;
+  /**
+   * Optional disambiguator used when more than one scenario shares a `type`
+   * (currently: approval `no-attachments` vs `with-attachments`). Drives the
+   * test-describe label so Playwright does not collapse them.
+   */
+  variant?: string | null;
   title: string;
   questionId: string;
   instanceId: string;
@@ -17,6 +23,13 @@ interface Scenario {
     approvalDecision?: string;
     freeText?: string;
     rankedItems?: RankedItem[];
+    /**
+     * For approval-with-attachments: the server-issued attachment IDs the
+     * fixture confirmed. Both used to tick the per-attachment checklist on
+     * the form and injected into the test response so the persisted record
+     * round-trips the same set.
+     */
+    reviewedAttachmentIds?: string[];
   };
   responsesUrl: string;
   injectUrl: string;
@@ -41,7 +54,13 @@ if (scenarios.length === 0) {
 }
 
 for (const scenario of scenarios) {
-  test.describe(`Mothership respond flow — ${scenario.type}`, () => {
+  const label = scenario.variant ? `${scenario.type}-${scenario.variant}` : scenario.type;
+  const hasAttachmentChecklist =
+    scenario.type === "approval" &&
+    Array.isArray(scenario.submit.reviewedAttachmentIds) &&
+    scenario.submit.reviewedAttachmentIds.length > 0;
+
+  test.describe(`Mothership respond flow — ${label}`, () => {
     test("renders question title and correct UI elements", async ({ page }) => {
       await page.goto(scenario.respondUrl);
 
@@ -63,6 +82,20 @@ for (const scenario of scenarios) {
         await expect(
           page.locator('[value="rejected"], [data-key="reject"]').first(),
         ).toBeVisible();
+
+        if (hasAttachmentChecklist) {
+          // The approval-with-attachments form renders one
+          // <input type="checkbox" name="reviewedAttachmentIds" value="<id>" />
+          // per template attachment, above the decision buttons (Respond.cshtml
+          // line 78). Verify each expected id is present.
+          for (const id of scenario.submit.reviewedAttachmentIds!) {
+            await expect(
+              page.locator(
+                `input[type="checkbox"][name="reviewedAttachmentIds"][value="${id}"]`,
+              ),
+            ).toBeVisible();
+          }
+        }
       }
 
       if (scenario.type === "freeText") {
@@ -70,7 +103,7 @@ for (const scenario of scenarios) {
       }
 
       if (scenario.type === "priorityRanking") {
-        await expect(page.locator('.rank-item').first()).toBeVisible();
+        await expect(page.locator(".rank-item").first()).toBeVisible();
       }
     });
 
@@ -93,6 +126,19 @@ for (const scenario of scenarios) {
       }
 
       if (scenario.type === "approval") {
+        // For approval-with-attachments the form's submit guard blocks the
+        // decision until at least one reviewedAttachmentIds checkbox is
+        // ticked (Respond.cshtml line 194-205). Tick every expected id.
+        if (hasAttachmentChecklist) {
+          for (const id of scenario.submit.reviewedAttachmentIds!) {
+            await page
+              .locator(
+                `input[type="checkbox"][name="reviewedAttachmentIds"][value="${id}"]`,
+              )
+              .check();
+          }
+        }
+
         const decision = scenario.submit.approvalDecision ?? "approved";
         const radio = page
           .locator(`input[type="radio"][value="${decision}"]`)
@@ -147,6 +193,9 @@ for (const scenario of scenarios) {
         injectBody.rankedItems = scenario.submit.rankedItems;
       } else if (scenario.type === "approval") {
         injectBody.approvalDecision = scenario.submit.approvalDecision ?? "approved";
+        if (hasAttachmentChecklist) {
+          injectBody.reviewedAttachmentIds = scenario.submit.reviewedAttachmentIds;
+        }
       } else {
         injectBody.selectedKey = scenario.submit.selectedKey;
       }
@@ -169,6 +218,14 @@ for (const scenario of scenarios) {
         expect(last.rankedItems.length).toBeGreaterThan(0);
       } else if (scenario.type === "approval") {
         expect(last.approvalDecision).toBe(scenario.submit.approvalDecision ?? "approved");
+        if (hasAttachmentChecklist) {
+          const persisted: string[] = Array.isArray(last.reviewedAttachmentIds)
+            ? last.reviewedAttachmentIds.map((g: string) => String(g))
+            : [];
+          const expected = scenario.submit.reviewedAttachmentIds!.map((g) => String(g));
+          // Order-independent equality: server may normalise or sort.
+          expect(persisted.sort()).toEqual(expected.sort());
+        }
       } else if (scenario.submit.selectedKey) {
         expect(last.selectedKey).toBe(scenario.submit.selectedKey);
       }

--- a/tests/e2e-server/specs/mothership-question-flow.spec.ts
+++ b/tests/e2e-server/specs/mothership-question-flow.spec.ts
@@ -58,16 +58,10 @@ for (const scenario of scenarios) {
 
       if (scenario.type === "approval") {
         await expect(
-          page.locator('[value="approve"], [data-key="approve"]').first(),
+          page.locator('[value="approved"], [data-key="approve"]').first(),
         ).toBeVisible();
         await expect(
-          page.locator('[value="reject"], [data-key="reject"]').first(),
-        ).toBeVisible();
-      }
-
-      if (scenario.type === "documentReview") {
-        await expect(
-          page.locator('[value="approve"], [data-key="approve"]').first(),
+          page.locator('[value="rejected"], [data-key="reject"]').first(),
         ).toBeVisible();
       }
 
@@ -98,8 +92,8 @@ for (const scenario of scenarios) {
         }
       }
 
-      if (scenario.type === "approval" || scenario.type === "documentReview") {
-        const decision = scenario.submit.approvalDecision ?? "approve";
+      if (scenario.type === "approval") {
+        const decision = scenario.submit.approvalDecision ?? "approved";
         const radio = page
           .locator(`input[type="radio"][value="${decision}"]`)
           .first();
@@ -151,8 +145,8 @@ for (const scenario of scenarios) {
         injectBody.freeText = scenario.submit.freeText ?? "test answer";
       } else if (scenario.type === "priorityRanking") {
         injectBody.rankedItems = scenario.submit.rankedItems;
-      } else if (scenario.type === "approval" || scenario.type === "documentReview") {
-        injectBody.approvalDecision = scenario.submit.approvalDecision ?? "approve";
+      } else if (scenario.type === "approval") {
+        injectBody.approvalDecision = scenario.submit.approvalDecision ?? "approved";
       } else {
         injectBody.selectedKey = scenario.submit.selectedKey;
       }
@@ -173,8 +167,8 @@ for (const scenario of scenarios) {
       } else if (scenario.type === "priorityRanking") {
         expect(Array.isArray(last.rankedItems)).toBeTruthy();
         expect(last.rankedItems.length).toBeGreaterThan(0);
-      } else if (scenario.type === "approval" || scenario.type === "documentReview") {
-        expect(last.approvalDecision).toBe(scenario.submit.approvalDecision ?? "approve");
+      } else if (scenario.type === "approval") {
+        expect(last.approvalDecision).toBe(scenario.submit.approvalDecision ?? "approved");
       } else if (scenario.submit.selectedKey) {
         expect(last.selectedKey).toBe(scenario.submit.selectedKey);
       }

--- a/tests/e2e/specs/lists.spec.ts
+++ b/tests/e2e/specs/lists.spec.ts
@@ -82,12 +82,13 @@ test.describe("Process list rendering (Processes tab)", () => {
     seededProcs.push(proc);
 
     await page.goto("/");
-    // Wait for initTabs() to have wired the click handlers (the default tab
-    // marks itself active as part of that init). Without this, clicking the
-    // tab too early no-ops because the listener has not attached yet.
-    await expect(page.locator('.tab[data-tab="overview"]')).toHaveClass(
-      /active/,
-    );
+    // Wait for app.js's DOMContentLoaded handler to finish (sets
+    // body[data-app-ready="1"] at the end). The page's `load` event fires
+    // before initTabs() finishes its async chain, so clicking a tab
+    // immediately after goto() can land before the listener is attached.
+    // Cannot use overview-active as a guard because index.html hardcodes
+    // `class="tab active"` on the overview button.
+    await expect(page.locator("body")).toHaveAttribute("data-app-ready", "1");
     await page.locator('.tab[data-tab="processes"]').click();
     await expect(page.locator("#tab-processes")).toHaveClass(/active/);
 
@@ -100,11 +101,7 @@ test.describe("Process list rendering (Processes tab)", () => {
 
   test("renders empty state when no process JSONs exist", async ({ page }) => {
     await page.goto("/");
-    // Same init-race guard as the previous test — wait for initTabs() to mark
-    // the default tab active before clicking another tab.
-    await expect(page.locator('.tab[data-tab="overview"]')).toHaveClass(
-      /active/,
-    );
+    await expect(page.locator("body")).toHaveAttribute("data-app-ready", "1");
     await page.locator('.tab[data-tab="processes"]').click();
     await expect(page.locator("#tab-processes")).toHaveClass(/active/);
 


### PR DESCRIPTION
## Linked issue

Closes #445.

Supersedes the reverted PR #449 by porting its work onto post-v4 main.
Worktree-isolated authoring on `feature/pr-13-v4-merge-approval-documentreview`.

## Summary of changes

Collapses `documentReview` into the `approval` question type end-to-end. Server side narrows the approval decision values to `approved` / `rejected` (drops `abstained` / `request-changes` / `comment-only` from the v3 taxonomy). Outpost side picks up the server's typed-response fields (comment, ranked_items, reviewed_attachment_ids) and persists them on the local task's `questions_resolved` entry when populated.

Three Q&A pipelines exist in v4. Only the task-level needs-input pipeline participates in the type change:

| Pipeline | Where | In scope here? |
|---|---|---|
| Task needs-input (NotificationPoller -> Submit-TaskAnswer -> Resolve-TaskInputAnswer) | `src/ui/modules/`, `src/runtime/Modules/Dotbot.TaskInput/` | YES |
| Interview clarification (`Invoke-InterviewLoop`) | `src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1` | NO - reads only `.answer` + `.attachments` from the resolved hashtable, ignores typed extras |
| Post-task clarification (`Invoke-TaskClarificationLoopIfPresent`) | `src/runtime/Scripts/Invoke-WorkflowProcess.ps1` | NO - file-driven only in v4, does not call `Resolve-NotificationAnswer` |

Both interview pipelines are formally scoped out in PRD-029 Section 2 Non-Goals.

The full dual-surface approval contract (first-by-timestamp resolution, agreement/disagreement flag derivation, dashboard markers) stays out of scope here and is tracked in [#416](https://github.com/andresharpe/dotbot/issues/416). The existing `Send-LocalApprovalResponse` push-back wiring is preserved unchanged; only the value source is updated (`$Answer` instead of `$Decision`) because the decision now rides on the answer string verbatim.

### Server side
- `QuestionTypes.cs` + `ApprovalDecisions.cs`: drop `DocumentReview`, narrow allowed decision values to `approved` / `rejected`.
- `QuestionTemplateValidator.cs`, `RespondFormHandler.cs`, `Pages/Respond.cshtml`, `NotificationSummaryBuilder.cs`: merge `documentReview` validation + rendering into the `approval` branch (with-or-without attachments). `CheckDeliverableSummary` rule scoped to approval-with-attachments and parked per the in-tree TODO.
- Server test suites updated to the merged shape.

### Outpost runtime + UI
- `Resolve-NotificationAnswer` (Dotbot.Notification): extracts `approvalDecision` / `comment` / `rankedItems` / `reviewedAttachmentIds` from the server-side `ResponseRecordV2` and returns each as an optional key on the resolved hashtable.
- `Add-TaskInputResolvedQuestion` + `Invoke-TaskQuestionAnswerTransition` (Dotbot.TaskInput): accept optional `Comment` / `RankedItems` / `ReviewedAttachmentIds` parameters; persist to `questions_resolved` only when populated.
- `Invoke-TaskTransitionFromNotification` + batch variant (NotificationPoller): thread the typed fields through to the runtime answer resolver.
- `Submit-TaskAnswer` (TaskAPI): rename `$Decision` -> `$Type`; push `$Answer` as `ApprovalDecision` in the dual-surface push-back call; skip the `Attached: ...` text injection on approval so the answer field carries the decision value verbatim.
- `actions.js`: drop the Abstain button; add `data-question-type` attributes; rewrite the three `/api/task/answer` fetch bodies to send `type` instead of `decision`.
- Documentation docstrings: `Send-TaskNotification` Type enum no longer mentions `documentReview`; `Send-LocalApprovalResponse` ApprovalDecision values narrowed.

### Spec
- `PRD-029-expand-question-service.md`: collapse `approval` + `documentReview` rows in the taxonomy + web-form tables; rewrite Sec.4.6 Outpost-Side Changes for v4 surfaces (`task_set_status` + `task_update` instead of the deleted v3 MCP tools `task-mark-needs-input` / `task-answer-question`); defer dual-surface approval to #416 with explicit Sec.4.4 / Sec.5.5 forward-pointers; mark both interview pipelines as Non-Goals.

### Tests
- Server: existing Dotbot.Server.Tests suite passes with the merged taxonomy.
- E2E fixtures (`Test-E2E-Mothership-QA.ps1`, `mothership-question-flow.spec.ts`): updated to the merged approval shape.
- New behavioural unit test in `Test-Components.ps1` (Layer 2): data-driven `Resolve-NotificationAnswer` test with 7 cases (singleChoice, freeText, three approval variants, priorityRanking, empty) and 30 assertions including a Pipeline-1-safety key-set guard.

## Screenshots / recordings

UI change is the Abstain button removal on the Decisions tab approval card. No layout change. No screenshot included.

## Testing notes

Local verification done:

- `dotnet test src/server-dotnet/Dotbot.Server.sln` -> 326 passed, 2 skipped, 0 failed.
- `pwsh tests/Run-Tests.ps1 -Layer 1` -> all 16 Layer 1 suites passed (Test-Structure / Compilation / WorkflowManifest / DataModel / Runtime / Worktree / Executor / Hooks / MdRefs / NoLegacyVocabulary / NoBackslashPaths / StartFromPromptClarification / ActivityLogHygiene / PrivacyScan / PathSanitizer / McpSurface).
- New resolver behavioural tests in `Test-Components.ps1`: 30 assertions, all passing in isolation (Layer 2 not run in full because the inbox-watcher integration test in the same file spawns a real Claude session — that's a separate Test-Components hygiene concern, unrelated to this change).

For manual E2E against a real Mothership round-trip see `src/server-dotnet/docs/MOTHERSHIP-E2E-SETUP.md`.

## Checklist

- [x] Tests added or updated
- [x] Docs updated (PRD-029 reflects the merged taxonomy + v4 MCP surfaces + interview-pipeline scope-out)
- [x] Linked issue exists (#445)
- [x] Follows the contribution guide


## CI workflow restoration (pre-existing v4 regression, fixed in this PR)

PR #455 (Merge v4 into main, bc587c5) renamed all `.github/workflows/*.yml` files to `.json`. GitHub Actions only recognises `.yml` / `.yaml`, so since that merge no checks have run on any PR — the "Expected — Waiting for status to be reported" placeholder on this PR was the visible symptom.

Restored the 12 workflow files to `.yml` and adjusted paths the v4 layout broke:

- `test.yml`: dropped the `pwsh install.ps1` step (no install.ps1 at root in v4 — Layer 1-3 tests import modules directly from `src/`). Markdown-refs hook path `core/hooks/verify/` -> `src/hooks/verify/`.
- `server.yml`: path filters and dotnet commands `server/` -> `src/server-dotnet/`. Server run command `server/src/Dotbot.Server` -> `src/server-dotnet/src/Dotbot.Server`.
- `studio-ui.yml`: path filters and working-directory `studio-ui` -> `src/studio-ui`.

Other workflows (release.yml, bump-release.yml, stale.yml, etc.) trigger on schedules / tags only and do not fire on PRs — restored as-is. They still reference v3 paths (top-level `install.ps1`, `scripts/`, `workflows/`, `stacks/`, `dotbot.psd1`, etc.) and need rework before the next tagged release. Worth filing as a separate follow-up.
