### PR TITLE
fix: recover in-progress tasks on workflow runner restart (#470)

### DIFF
--- a/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
+++ b/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
@@ -534,10 +534,11 @@ function Get-NextWorkflowTask {
     #>
     param(
         [Parameter(Mandatory)] [string]$BotRoot,
-        [string]$RunId
+        [string]$RunId,
+        [string]$WorkflowName
     )
 
-    $scopeLabel = if ($RunId) { "run $RunId" } else { "pending task set" }
+    $scopeLabel = if ($RunId) { "run $RunId" } elseif ($WorkflowName) { "workflow $WorkflowName" } else { "pending task set" }
     if ($RunId) {
         if (-not (Test-DotbotProcessOptionalCommand -CommandName 'Find-WorkflowRunDir' -ModuleName 'Dotbot.Workflow')) {
             return @{ success = $false; task = $null; message = "Dotbot.Workflow not loaded — Find-WorkflowRunDir unavailable." }
@@ -572,6 +573,10 @@ function Get-NextWorkflowTask {
             if ($RunId) {
                 $taskRunId = Get-DotbotTaskNestedProp -Object $content -Path @('provenance', 'run_id')
                 if ($taskRunId -and $taskRunId -ne $RunId) { continue }
+            }
+            if ($WorkflowName -and -not $RunId) {
+                $taskWorkflow = Get-DotbotTaskNestedProp -Object $content -Path @('provenance', 'workflow')
+                if ([string]$taskWorkflow -ne $WorkflowName) { continue }
             }
             $allTasks += @{ Content = $content; FilePath = $f.FullName }
         } catch {

--- a/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
+++ b/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
@@ -399,82 +399,94 @@ function Test-TaskCompletion {
 function Reset-InProgressTasks {
     <#
     .SYNOPSIS
-    Reset all in-progress tasks to todo status
-    
-    .PARAMETER TasksBaseDir
-    Base directory containing task subdirectories (todo, in-progress, done)
-    
+    Reset in-progress tasks to todo status for crash recovery.
+
+    .DESCRIPTION
+    Scans $RunDir for task JSON files whose status field is 'in-progress' and
+    resets them to 'todo' via an atomic in-place write. Designed for the current
+    workflow-runs layout where files never move between directories — status is
+    a JSON field. Called at process startup to recover tasks left in-progress by
+    a previously killed runner.
+
+    .PARAMETER RunDir
+    Directory to scan. For a workflow run: the resolved run dir
+    (workspace/tasks/workflow-runs/<runId>). For the pending-task-scope (no RunId):
+    the tasks base dir scanned recursively.
+
+    .PARAMETER Recurse
+    When set, scans $RunDir recursively. Used for the no-RunId (pending-task-scope)
+    case where tasks may be nested under workflow-runs/ and standalone/.
+
+    .PARAMETER ExcludeRunIds
+    Run IDs whose in-progress tasks must not be reset. Pass the run_id values of
+    all currently active processes so their tasks are left untouched.
+
+    .PARAMETER WorkflowName
+    When set, only reset tasks whose provenance.workflow matches this value.
+    Use when the runner is scoped to a specific workflow (RESUME by workflow name).
+
     .OUTPUTS
-    Array of hashtables with reset task information
+    Array of hashtables @{ id; name; file } for each recovered task.
     #>
     param(
         [Parameter(Mandatory = $true)]
-        [string]$TasksBaseDir
+        [string]$RunDir,
+
+        [switch]$Recurse,
+
+        [string[]]$ExcludeRunIds = @(),
+
+        [string]$WorkflowName = ''
     )
-    
+
     $resetTasks = @()
-    $inProgressDir = Join-Path $TasksBaseDir "in-progress"
-    
-    if (-not (Test-Path $inProgressDir)) {
+
+    if (-not (Test-Path -LiteralPath $RunDir)) {
         return $resetTasks
     }
-    
-    $inProgressTasks = @(Get-ChildItem -Path $inProgressDir -Filter "*.json" -File -ErrorAction SilentlyContinue)
-    
-    if ($inProgressTasks.Count -eq 0) {
-        return $resetTasks
-    }
-    
-    foreach ($taskFile in $inProgressTasks) {
+
+    $taskFiles = @(Get-ChildItem -LiteralPath $RunDir -Filter '*.json' -File -Recurse:$Recurse -ErrorAction SilentlyContinue |
+                    Where-Object { $_.Name -ne 'run.json' })
+
+    foreach ($taskFile in $taskFiles) {
         try {
-            # Re-verify file exists (may have been moved by concurrent process)
-            if (-not (Test-Path $taskFile.FullName)) { continue }
+            if (-not (Test-Path -LiteralPath $taskFile.FullName)) { continue }
 
-            $taskContent = Get-Content -Path $taskFile.FullName -Raw | ConvertFrom-Json
-            $taskId = $taskContent.id
-            $taskName = $taskContent.name
+            $taskContent = Get-Content -LiteralPath $taskFile.FullName -Raw | ConvertFrom-Json
+            if ([string]$taskContent.status -ne 'in-progress') { continue }
 
-            # Check if this task was already completed — if so, just delete the orphan
-            $doneFile = Join-Path $TasksBaseDir "done" $taskFile.Name
-            if (Test-Path $doneFile) {
-                Remove-TaskFileAtomic -Path $taskFile.FullName -TaskId $taskId
-                continue
+            # Skip tasks whose owning run has a live process.
+            if ($ExcludeRunIds.Count -gt 0) {
+                $taskRunId = if ($taskContent.PSObject.Properties['provenance'] -and $taskContent.provenance) {
+                    [string]$taskContent.provenance.run_id
+                } else { $null }
+                if ($taskRunId -and $ExcludeRunIds -contains $taskRunId) { continue }
             }
 
-            $targetDir = Join-Path $TasksBaseDir "todo"
-            $targetStatus = "todo"
-
-            # Ensure target directory exists
-            if (-not (Test-Path $targetDir)) {
-                New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+            # Scope to a specific workflow when the runner was started for one.
+            if ($WorkflowName) {
+                $taskWorkflow = if ($taskContent.PSObject.Properties['provenance'] -and $taskContent.provenance) {
+                    [string]$taskContent.provenance.workflow
+                } else { $null }
+                if ($taskWorkflow -ne $WorkflowName) { continue }
             }
 
-            $targetPath = Join-Path $targetDir $taskFile.Name
+            $taskId   = [string]$taskContent.id
+            $taskName = if ($taskContent.PSObject.Properties['name'] -and $taskContent.name) { [string]$taskContent.name } else { $taskId }
 
-            # Update status
-            $taskContent.status = $targetStatus
-            $taskContent.started_at = $null
-            $taskContent.updated_at = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+            $taskContent.status = 'todo'
+            if ($taskContent.PSObject.Properties['started_at'])  { $taskContent.started_at  = $null }
+            if ($taskContent.PSObject.Properties['updated_at'])  { $taskContent.updated_at   = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ') }
 
-            # Atomic move: write target first, then delete source. A crash between
-            # the two steps leaves a duplicate (recoverable) instead of losing the task.
-            Move-TaskFileAtomic -SourcePath $taskFile.FullName `
-                                -TargetPath $targetPath `
-                                -Content $taskContent `
-                                -Depth 10 `
-                                -TaskId $taskId
+            Write-TaskFileAtomic -Path $taskFile.FullName -Content $taskContent -Depth 20 -TaskId $taskId
 
-            $resetTasks += @{
-                id = $taskId
-                name = $taskName
-                file = $taskFile.Name
-            }
+            $resetTasks += @{ id = $taskId; name = $taskName; file = $taskFile.Name }
         } catch {
-            Write-BotLog -Level Warn -Message "Error processing task: $($taskFile.Name)" -Exception $_
+            Write-BotLog -Level Warn -Message "Reset-InProgressTasks: error processing '$($taskFile.Name)'" -Exception $_
         }
     }
-    
-    return $resetTasks
+
+    return ,$resetTasks
 }
 
 function Reset-SkippedTasks {

--- a/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
+++ b/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
@@ -442,7 +442,7 @@ function Reset-InProgressTasks {
     $resetTasks = @()
 
     if (-not (Test-Path -LiteralPath $RunDir)) {
-        return $resetTasks
+        return ,$resetTasks
     }
 
     $taskFiles = @(Get-ChildItem -LiteralPath $RunDir -Filter '*.json' -File -Recurse:$Recurse -ErrorAction SilentlyContinue |

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -1076,7 +1076,14 @@ if (-not $RunId) {
         ForEach-Object {
             try {
                 $p = Get-Content -LiteralPath $_.FullName -Raw | ConvertFrom-Json
-                if ($p.status -in @('running', 'starting') -and $p.run_id) { [string]$p.run_id }
+                $pStatus = if ($p.PSObject.Properties['status'])  { [string]$p.status  } else { $null }
+                $pRunId  = if ($p.PSObject.Properties['run_id'])  { [string]$p.run_id  } else { $null }
+                $pPid    = if ($p.PSObject.Properties['pid'])     { $p.pid             } else { $null }
+                # Only exclude run_id when the process is running/starting AND its PID is still alive.
+                # Killed processes leave status='running' in their file — PID check distinguishes live vs stale.
+                if ($pStatus -in @('running', 'starting') -and $pRunId -and $pPid) {
+                    if (Get-Process -Id $pPid -ErrorAction SilentlyContinue) { $pRunId }
+                }
             } catch {
                 Write-BotLog -Level Debug -Message "Crash recovery: failed to read process file '$($_.Name)'" -Exception $_
             }

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -42,6 +42,7 @@ if ($settings.execution -and $settings.execution.PSObject.Properties['provider_s
 }
 
 $tasksBaseDir = Join-Path (Join-Path $botRoot "workspace") "tasks"
+$WorkflowName = if ($processData -is [hashtable] -and $processData['workflow_name']) { [string]$processData['workflow_name'] } else { $null }
 
 if (-not (Get-Module Dotbot.TaskInput)) {
     Import-Module (Join-Path $PSScriptRoot ".." "Modules" "Dotbot.TaskInput" "Dotbot.TaskInput.psd1") -DisableNameChecking -Global
@@ -1061,12 +1062,45 @@ if ($RunId) {
 } else {
     $runDir = $tasksBaseDir
 }
-$todoCount = 0
 $taskSnapshotRecurse = -not [bool]$RunId
+
+# Crash recovery: reset in-progress tasks left by a previously killed runner.
+# For RunId runs: scoped to this run's dir — no exclusion needed.
+# For no-RunId (pending-task-scope): collect active run IDs so we don't touch
+# tasks that belong to a workflow run with a live process.
+$crashRecoveryParams = @{ RunDir = $runDir; Recurse = $taskSnapshotRecurse }
+if ($WorkflowName) { $crashRecoveryParams['WorkflowName'] = $WorkflowName }
+if (-not $RunId) {
+    $activeRunIds = @(
+        Get-ChildItem -LiteralPath $processesDir -Filter '*.json' -File -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            try {
+                $p = Get-Content -LiteralPath $_.FullName -Raw | ConvertFrom-Json
+                if ($p.status -in @('running', 'starting') -and $p.run_id) { [string]$p.run_id }
+            } catch {
+                Write-BotLog -Level Debug -Message "Crash recovery: failed to read process file '$($_.Name)'" -Exception $_
+            }
+        } | Where-Object { $_ }
+    )
+    if ($activeRunIds.Count -gt 0) { $crashRecoveryParams['ExcludeRunIds'] = $activeRunIds }
+}
+$recovered = Reset-InProgressTasks @crashRecoveryParams
+if (-not $recovered) { $recovered = @() }
+if ($recovered.Count -gt 0) {
+    $recoveredNames = ($recovered | ForEach-Object { $_['name'] }) -join ', '
+    Write-Status "Crash recovery: reset $($recovered.Count) in-progress task(s) to todo: $recoveredNames" -Type Warn
+    Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Crash recovery: reset $($recovered.Count) in-progress task(s) to todo"
+}
+
+$todoCount = 0
 foreach ($f in @(Get-ChildItem -LiteralPath $runDir -Filter '*.json' -File -Recurse:$taskSnapshotRecurse -ErrorAction SilentlyContinue |
                     Where-Object { $_.Name -ne 'run.json' })) {
     try {
         $t = Get-Content -Path $f.FullName -Raw | ConvertFrom-Json
+        if ($WorkflowName -and -not $RunId) {
+            $tw = if ($t.PSObject.Properties['provenance'] -and $t.provenance) { [string]$t.provenance.workflow } else { $null }
+            if ($tw -ne $WorkflowName) { continue }
+        }
         switch ([string]$t.status) {
             'todo'     { $todoCount++ }
         }
@@ -1153,7 +1187,7 @@ try {
         Write-Status "Fetching next task..." -Type Process
 
         # Walk the run directory fresh on every pickup (no in-memory index).
-        $taskResult = Get-NextWorkflowTask -BotRoot $botRoot -RunId $RunId
+        $taskResult = Get-NextWorkflowTask -BotRoot $botRoot -RunId $RunId -WorkflowName $WorkflowName
 
         Write-Diag "TaskPickup: success=$($taskResult.success) hasTask=$($null -ne $taskResult.task) msg=$($taskResult.message)"
 
@@ -1193,7 +1227,7 @@ try {
                     if (Test-ProcessStopSignal -Id $procId) { break }
                     $processData.last_heartbeat = (Get-Date).ToUniversalTime().ToString("o")
                     Write-ProcessFile -Id $procId -Data $processData
-                    $taskResult = Get-NextWorkflowTask -BotRoot $botRoot -RunId $RunId
+                    $taskResult = Get-NextWorkflowTask -BotRoot $botRoot -RunId $RunId -WorkflowName $WorkflowName
                     if ($taskResult.task) { $foundTask = $true; break }
 
                     if ($RunId -and (Test-WorkflowComplete -BotRoot $botRoot -RunId $RunId)) {
@@ -1276,7 +1310,7 @@ try {
                 } catch {
                     Write-Diag "Slot ${Slot}: task $($task.id) claimed by another slot, retrying..."
                     Start-Sleep -Milliseconds 200
-                    $taskResult = Get-NextWorkflowTask -BotRoot $botRoot -RunId $RunId
+                    $taskResult = Get-NextWorkflowTask -BotRoot $botRoot -RunId $RunId -WorkflowName $WorkflowName
                     if (-not $taskResult.task) { break }
                     $task = $taskResult.task
                 }
@@ -1614,7 +1648,7 @@ try {
         try {
 
         # Re-read task data if a concurrent state update changed the selected task.
-        $freshTask = Get-NextWorkflowTask -BotRoot $botRoot -RunId $RunId
+        $freshTask = Get-NextWorkflowTask -BotRoot $botRoot -RunId $RunId -WorkflowName $WorkflowName
         Write-Diag "Execution TaskGetNext: hasTask=$($null -ne $freshTask.task) matchesId=$($freshTask.task.id -eq $task.id)"
         if ($freshTask.task -and $freshTask.task.id -eq $task.id) {
             $task = $freshTask.task

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -5875,7 +5875,7 @@ try {
 
     $phase4GoPortFile = Join-Path $phase4GoProject ".bot/.control/ui-port"
     $phase4GoRuntimeFile = Join-Path $phase4GoProject ".bot/.control/runtime.json"
-    $deadline = [DateTime]::UtcNow.AddSeconds(12)
+    $deadline = [DateTime]::UtcNow.AddSeconds(30)
     while ([DateTime]::UtcNow -lt $deadline -and
            ((-not (Test-Path $phase4GoPortFile)) -or (-not (Test-Path $phase4GoRuntimeFile))) -and
            -not $phase4GoProcess.HasExited) {

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -1595,6 +1595,75 @@ finally {
     }
 }
 
+# ─── Get-NextWorkflowTask WorkflowName scoping (issue #470) ─────────────────
+# Verifies that -WorkflowName filters tasks by provenance.workflow when RunId
+# is omitted, so a RESUME on one workflow never picks up tasks from another.
+
+$testProject2 = $null
+$savedDotbotProjectRoot2 = $global:DotbotProjectRoot
+try {
+    $testProject2 = New-SourceBackedTestProject -RepoRoot $repoRoot
+    Push-Location $testProject2
+    $botDir2  = Join-Path $testProject2 ".bot"
+    $tasksDir = Join-Path $botDir2 "workspace\tasks\workflow-runs"
+    $runDirA  = Join-Path $tasksDir "run-workflow-a"
+    $runDirB  = Join-Path $tasksDir "run-workflow-b"
+    New-Item -ItemType Directory -Path $runDirA -Force | Out-Null
+    New-Item -ItemType Directory -Path $runDirB -Force | Out-Null
+
+    $global:DotbotProjectRoot = $testProject2
+
+    Import-Module (Join-Path $botDir2 "src/runtime/Modules/Dotbot.Task/Dotbot.Task.psd1")    -Force -DisableNameChecking
+    Import-Module (Join-Path $botDir2 "src/runtime/Modules/Dotbot.Process/Dotbot.Process.psd1") -Force -DisableNameChecking
+
+    function New-ScopedTaskFixture {
+        param(
+            [Parameter(Mandatory)][string]$TaskId,
+            [Parameter(Mandatory)][string]$Status,
+            [Parameter(Mandatory)][string]$Dir,
+            [string]$WorkflowName
+        )
+        $task = [ordered]@{
+            id          = $TaskId
+            name        = "Fixture $TaskId"
+            description = "WorkflowName scoping fixture"
+            status      = $Status
+            priority    = 50
+            provenance  = [ordered]@{ workflow = $WorkflowName; run_id = (Split-Path $Dir -Leaf) }
+            updated_at  = "2026-01-01T00:00:00Z"
+        }
+        $task | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $Dir "$TaskId.json") -Encoding UTF8
+    }
+
+    New-ScopedTaskFixture -TaskId "wf-a-task" -Status "todo" -Dir $runDirA -WorkflowName "start-from-prompt"
+    New-ScopedTaskFixture -TaskId "wf-b-task" -Status "todo" -Dir $runDirB -WorkflowName "fast-prompt"
+
+    # ── Scenario 1: WorkflowName scopes to correct workflow ──
+    $next = Get-NextWorkflowTask -BotRoot $botDir2 -WorkflowName "start-from-prompt"
+    Assert-True -Name "Get-NextWorkflowTask: WorkflowName returns task from target workflow" `
+        -Condition ($next.success -and $next.task -and $next.task['id'] -eq 'wf-a-task') `
+        -Message "Expected task 'wf-a-task', got: $($next | ConvertTo-Json -Compress)"
+
+    # ── Scenario 2: WorkflowName excludes other workflow's tasks ──
+    $nextOther = Get-NextWorkflowTask -BotRoot $botDir2 -WorkflowName "fast-prompt"
+    Assert-True -Name "Get-NextWorkflowTask: WorkflowName excludes tasks from other workflows" `
+        -Condition ($nextOther.success -and $nextOther.task -and $nextOther.task['id'] -eq 'wf-b-task') `
+        -Message "Expected task 'wf-b-task', got: $($nextOther | ConvertTo-Json -Compress)"
+
+    # ── Scenario 3: WorkflowName with no matching tasks returns null task ──
+    $nextNone = Get-NextWorkflowTask -BotRoot $botDir2 -WorkflowName "nonexistent-workflow"
+    Assert-True -Name "Get-NextWorkflowTask: WorkflowName with no match returns success=true, task=null" `
+        -Condition ($nextNone.success -and $null -eq $nextNone.task) `
+        -Message "Expected success=true task=null, got: $($nextNone | ConvertTo-Json -Compress)"
+}
+finally {
+    $global:DotbotProjectRoot = $savedDotbotProjectRoot2
+    Pop-Location -ErrorAction SilentlyContinue
+    if ($testProject2) {
+        Remove-TestProject -Path $testProject2
+    }
+}
+
 # ─── task-get-next runtime condition evaluation ──────────────────────────────
 # task-get-next is a thin HTTP wrapper around GET /tasks/next. Condition
 # evaluation is covered by handler-level runtime tests.

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -1502,6 +1502,97 @@ finally {
     }
 }
 
+# ─── Reset-InProgressTasks crash recovery (issue #470) ──────────────────────
+# Verifies that Reset-InProgressTasks resets in-progress tasks to todo via
+# in-place JSON field update (new workflow-runs layout). Tasks in other statuses
+# must not be touched. The function must handle both flat and recursive scan.
+
+$testProject = $null
+$savedDotbotProjectRoot = $global:DotbotProjectRoot
+try {
+    $testProject = New-SourceBackedTestProject -RepoRoot $repoRoot
+    Push-Location $testProject
+    $botDir   = Join-Path $testProject ".bot"
+    $runDir   = Join-Path $botDir "workspace\tasks\workflow-runs\test-run-001"
+    New-Item -ItemType Directory -Path $runDir -Force | Out-Null
+
+    $global:DotbotProjectRoot = $testProject
+
+    Import-Module (Join-Path $botDir "src/runtime/Modules/Dotbot.Task/Dotbot.Task.psd1") -Force -DisableNameChecking
+
+    function New-TaskFixture {
+        param(
+            [Parameter(Mandatory)][string]$TaskId,
+            [Parameter(Mandatory)][string]$Status,
+            [Parameter(Mandatory)][string]$Dir
+        )
+        $task = [ordered]@{
+            id          = $TaskId
+            name        = "Fixture $TaskId"
+            description = "Reset-InProgressTasks fixture for #470"
+            status      = $Status
+            started_at  = if ($Status -eq 'in-progress') { "2026-01-01T00:00:00Z" } else { $null }
+            updated_at  = "2026-01-01T00:00:00Z"
+            completed_at = $null
+        }
+        $task | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $Dir "$TaskId.json") -Encoding UTF8
+    }
+
+    # ── Scenario 1: in-progress task is reset to todo ──
+    New-TaskFixture -TaskId "rip-stuck"   -Status "in-progress" -Dir $runDir
+    New-TaskFixture -TaskId "rip-todo"    -Status "todo"         -Dir $runDir
+    New-TaskFixture -TaskId "rip-done"    -Status "done"         -Dir $runDir
+
+    $result = @(Reset-InProgressTasks -RunDir $runDir)
+    Assert-True -Name "Reset-InProgressTasks: returns one recovered entry (issue #470)" `
+        -Condition ($result.Count -eq 1) `
+        -Message "Expected 1 recovered task, got $($result.Count)"
+    Assert-True -Name "Reset-InProgressTasks: recovered entry has correct id" `
+        -Condition ($result[0].id -eq 'rip-stuck') `
+        -Message "Expected id 'rip-stuck', got '$($result[0].id)'"
+
+    $stuckContent = Get-Content -Path (Join-Path $runDir "rip-stuck.json") -Raw | ConvertFrom-Json
+    Assert-Equal -Name "Reset-InProgressTasks: stuck task status reset to todo" `
+        -Expected "todo" -Actual ([string]$stuckContent.status) `
+        -Message "Expected status 'todo', got '$($stuckContent.status)'"
+    Assert-True -Name "Reset-InProgressTasks: started_at cleared on reset" `
+        -Condition ($null -eq $stuckContent.started_at) `
+        -Message "Expected started_at to be null after reset"
+
+    $todoContent = Get-Content -Path (Join-Path $runDir "rip-todo.json") -Raw | ConvertFrom-Json
+    Assert-Equal -Name "Reset-InProgressTasks: todo task not touched" `
+        -Expected "todo" -Actual ([string]$todoContent.status) `
+        -Message "Expected todo task status unchanged"
+
+    $doneContent = Get-Content -Path (Join-Path $runDir "rip-done.json") -Raw | ConvertFrom-Json
+    Assert-Equal -Name "Reset-InProgressTasks: done task not touched" `
+        -Expected "done" -Actual ([string]$doneContent.status) `
+        -Message "Expected done task status unchanged"
+
+    # ── Scenario 2: no in-progress tasks — returns empty ──
+    $result2 = Reset-InProgressTasks -RunDir $runDir
+    Assert-True -Name "Reset-InProgressTasks: no-op when no in-progress tasks" `
+        -Condition ($result2.Count -eq 0) `
+        -Message "Expected 0 recovered tasks on second call, got $($result2.Count)"
+
+    # ── Scenario 3: Recurse flag scans nested dirs ──
+    $nestedDir = Join-Path $runDir "sub"
+    New-Item -ItemType Directory -Path $nestedDir -Force | Out-Null
+    New-TaskFixture -TaskId "rip-nested" -Status "in-progress" -Dir $nestedDir
+
+    $result3 = @(Reset-InProgressTasks -RunDir $runDir -Recurse)
+    Assert-True -Name "Reset-InProgressTasks: Recurse finds nested in-progress task" `
+        -Condition ($result3.Count -eq 1 -and $result3[0].id -eq 'rip-nested') `
+        -Message "Expected 1 nested task recovered, got $($result3.Count)"
+}
+finally {
+    $global:DotbotProjectRoot = $savedDotbotProjectRoot
+    Pop-Location -ErrorAction SilentlyContinue
+    if ($testProject) {
+        Remove-TestProject -Path $testProject
+    }
+}
+
 # ─── task-get-next runtime condition evaluation ──────────────────────────────
 # task-get-next is a thin HTTP wrapper around GET /tasks/next. Condition
 # evaluation is covered by handler-level runtime tests.

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -1543,7 +1543,8 @@ try {
     New-TaskFixture -TaskId "rip-todo"    -Status "todo"         -Dir $runDir
     New-TaskFixture -TaskId "rip-done"    -Status "done"         -Dir $runDir
 
-    $result = @(Reset-InProgressTasks -RunDir $runDir)
+    $result = Reset-InProgressTasks -RunDir $runDir
+    if (-not $result) { $result = @() }
     Assert-True -Name "Reset-InProgressTasks: returns one recovered entry (issue #470)" `
         -Condition ($result.Count -eq 1) `
         -Message "Expected 1 recovered task, got $($result.Count)"
@@ -1580,7 +1581,8 @@ try {
     New-Item -ItemType Directory -Path $nestedDir -Force | Out-Null
     New-TaskFixture -TaskId "rip-nested" -Status "in-progress" -Dir $nestedDir
 
-    $result3 = @(Reset-InProgressTasks -RunDir $runDir -Recurse)
+    $result3 = Reset-InProgressTasks -RunDir $runDir -Recurse
+    if (-not $result3) { $result3 = @() }
     Assert-True -Name "Reset-InProgressTasks: Recurse finds nested in-progress task" `
         -Condition ($result3.Count -eq 1 -and $result3[0].id -eq 'rip-nested') `
         -Message "Expected 1 nested task recovered, got $($result3.Count)"


### PR DESCRIPTION
## Linked issue

Closes #470

## Summary of changes

When a task-runner process is killed mid-execution, any task left in `in-progress` status was permanently stuck. On RESUME, `Get-NextWorkflowTask` filters for `status == 'todo'` only — the stuck task was invisible and the runner exited with "0 todo".

**Root cause:** `Reset-InProgressTasks` existed but targeted an old subdir-based layout (`in-progress/` directory) that is dead in production. Real tasks live in `workspace/tasks/workflow-runs/<runId>/*.json` with status as a JSON field.

**Changes:**

- `Dotbot.Task.psm1` — refactored `Reset-InProgressTasks` for the current JSON-field layout. Scans task files in-place, resets `status → todo` and clears `started_at` via atomic write. Adds `WorkflowName` param to scope recovery to the target workflow only, and `ExcludeRunIds` to protect tasks owned by currently-running processes.
- `Dotbot.Process.psm1` — added `WorkflowName` param to `Get-NextWorkflowTask`. When set (and no `RunId`), filters task pickup to `provenance.workflow == WorkflowName`. Prevents a workflow runner from picking up tasks belonging to other workflows.
- `Invoke-WorkflowProcess.ps1` — calls `Reset-InProgressTasks` at startup before the todo count snapshot. Extracts `WorkflowName` from process data and passes it to both recovery and all `Get-NextWorkflowTask` calls. Also scopes the startup `$todoCount` log to the target workflow.

`in-progress → todo` is not a valid HTTP transition, so recovery writes files directly — intentional bypass of the state machine.

## Testing notes

1. Start a workflow run (`dotbot workflow run <name>`), wait until a task reaches `in-progress`
2. Kill the terminal running the task-runner
3. Start runtime again (`dotbot go`), click RESUME on that workflow
4. Logs show `Crash recovery: reset 1 in-progress task(s) to todo: <task-name>`
5. Runner picks up the task and completes normally
6. Verify other workflows' in-progress tasks are **not** reset when resuming an unrelated workflow

## Checklist

- [x] Tests added or updated
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
