### PR TITLE
feat(ui): resizable panel splitter and pipeline column widths (#469)

### DIFF
--- a/src/ui/static/css/layout.css
+++ b/src/ui/static/css/layout.css
@@ -318,13 +318,38 @@
 }
 
 /* ========== MAIN LAYOUT ========== */
+:root {
+    --sidebar-width: 280px;
+}
+
 .main-layout {
     display: grid;
-    grid-template-columns: 280px 1fr;
+    grid-template-columns: var(--sidebar-width) 4px 1fr;
     flex: 1;
     overflow: hidden;
-    gap: 1px;
     background: var(--bezel-edge);
+}
+
+.panel-splitter {
+    background: var(--bezel-edge);
+    cursor: col-resize;
+    transition: background 0.15s ease;
+    position: relative;
+    z-index: 10;
+}
+
+.panel-splitter:hover,
+.panel-splitter.dragging {
+    background: var(--color-primary-dim);
+}
+
+.panel-splitter::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -4px;
+    right: -4px;
+    bottom: 0;
 }
 
 /* ========== MAIN CONTENT ========== */

--- a/src/ui/static/css/layout.css
+++ b/src/ui/static/css/layout.css
@@ -1,7 +1,6 @@
 /* DOTBOT Control Panel - Layout
  * Page structure: control panel, header, footer, main content area
  */
-
 /* ========== LAYOUT ========== */
 .control-panel {
     display: flex;

--- a/src/ui/static/css/responsive.css
+++ b/src/ui/static/css/responsive.css
@@ -5,7 +5,7 @@
 /* ========== RESPONSIVE ========== */
 @media (max-width: 1200px) {
     .main-layout {
-        grid-template-columns: 260px 1fr;
+        grid-template-columns: var(--sidebar-width, 260px) 4px 1fr;
     }
 
     .stats-row {
@@ -54,6 +54,10 @@
 
     .main-layout {
         grid-template-columns: 1fr;
+    }
+
+    .panel-splitter {
+        display: none;
     }
 
     .hamburger-menu {

--- a/src/ui/static/css/views.css
+++ b/src/ui/static/css/views.css
@@ -99,6 +99,34 @@
     padding: 12px 14px;
     background: var(--primary-05);
     border-bottom: 1px solid var(--primary-10);
+    position: relative;
+}
+
+.column-resize-handle {
+    position: absolute;
+    right: -4px;
+    top: 0;
+    bottom: 0;
+    width: 8px;
+    cursor: col-resize;
+    z-index: 5;
+}
+
+.column-resize-handle::after {
+    content: '';
+    position: absolute;
+    left: 3px;
+    top: 20%;
+    bottom: 20%;
+    width: 2px;
+    background: transparent;
+    transition: background 0.15s ease;
+    border-radius: 1px;
+}
+
+.column-resize-handle:hover::after,
+.column-resize-handle.dragging::after {
+    background: var(--color-primary-dim);
 }
 
 .column-label {

--- a/src/ui/static/index.html
+++ b/src/ui/static/index.html
@@ -81,7 +81,7 @@
         </div>
 
         <!-- Main Layout -->
-        <div class="main-layout">
+        <div class="main-layout" id="main-layout">
             <!-- Left Sidebar (Context-Aware) -->
             <aside class="sidebar-left">
                 <!-- Overview Context: Control, Session, Verification (mirrors right sidebar) -->
@@ -386,6 +386,9 @@
                     </div>
                 </div>
             </aside>
+
+            <!-- Panel Splitter -->
+            <div class="panel-splitter" id="panel-splitter" title="Drag to resize · Double-click to reset"></div>
 
             <!-- Main Content -->
             <main class="main-content">
@@ -1582,6 +1585,7 @@
 
     <!-- Modules (dependency order) -->
     <script src="modules/config.js"></script>
+    <script src="modules/layout.js"></script>
     <script src="modules/fleet.js"></script>
     <script src="modules/utils.js"></script>
     <script src="modules/icons.js"></script>

--- a/src/ui/static/modules/layout.js
+++ b/src/ui/static/modules/layout.js
@@ -1,0 +1,196 @@
+/**
+ * Layout persistence: draggable panel splitter + resizable pipeline columns.
+ * Storage keys: dotbot:layout:sidebarWidth, dotbot:layout:columnWidths
+ */
+
+const SIDEBAR_MIN = 160;
+const SIDEBAR_MAX = 520;
+const SIDEBAR_DEFAULT = 280;
+const COLUMN_MIN = 120;
+const STORAGE_SIDEBAR = 'dotbot:layout:sidebarWidth';
+const STORAGE_COLUMNS = 'dotbot:layout:columnWidths';
+
+// ── Storage helpers ──────────────────────────────────────────────────────────
+
+function layoutGet(key) {
+    try { return window.localStorage.getItem(key); } catch (e) { return null; }
+}
+
+function layoutSet(key, value) {
+    try { window.localStorage.setItem(key, value); } catch (e) { /* ignore */ }
+}
+
+function layoutRemove(key) {
+    try { window.localStorage.removeItem(key); } catch (e) { /* ignore */ }
+}
+
+// ── Sidebar width ────────────────────────────────────────────────────────────
+
+function applySidebarWidth(px) {
+    document.documentElement.style.setProperty('--sidebar-width', `${px}px`);
+}
+
+function restoreSidebarWidth() {
+    const stored = layoutGet(STORAGE_SIDEBAR);
+    if (stored) {
+        const px = parseInt(stored, 10);
+        if (px >= SIDEBAR_MIN && px <= SIDEBAR_MAX) applySidebarWidth(px);
+    }
+}
+
+function initPanelSplitter() {
+    const splitter = document.getElementById('panel-splitter');
+    const layout = document.getElementById('main-layout');
+    if (!splitter || !layout) return;
+
+    let dragging = false;
+    let startX = 0;
+    let startWidth = 0;
+
+    splitter.addEventListener('mousedown', (e) => {
+        dragging = true;
+        startX = e.clientX;
+        startWidth = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--sidebar-width'), 10) || SIDEBAR_DEFAULT;
+        splitter.classList.add('dragging');
+        document.body.style.cursor = 'col-resize';
+        document.body.style.userSelect = 'none';
+        e.preventDefault();
+    });
+
+    document.addEventListener('mousemove', (e) => {
+        if (!dragging) return;
+        const delta = e.clientX - startX;
+        const newWidth = Math.max(SIDEBAR_MIN, Math.min(SIDEBAR_MAX, startWidth + delta));
+        applySidebarWidth(newWidth);
+    });
+
+    document.addEventListener('mouseup', () => {
+        if (!dragging) return;
+        dragging = false;
+        splitter.classList.remove('dragging');
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+        const current = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--sidebar-width'), 10);
+        if (current !== SIDEBAR_DEFAULT) {
+            layoutSet(STORAGE_SIDEBAR, current);
+        } else {
+            layoutRemove(STORAGE_SIDEBAR);
+        }
+    });
+
+    splitter.addEventListener('dblclick', () => {
+        applySidebarWidth(SIDEBAR_DEFAULT);
+        layoutRemove(STORAGE_SIDEBAR);
+    });
+}
+
+// ── Pipeline column resize ───────────────────────────────────────────────────
+
+function loadColumnWidths() {
+    try {
+        const raw = layoutGet(STORAGE_COLUMNS);
+        return raw ? JSON.parse(raw) : {};
+    } catch (e) { return {}; }
+}
+
+function saveColumnWidths(map) {
+    try { layoutSet(STORAGE_COLUMNS, JSON.stringify(map)); } catch (e) { /* ignore */ }
+}
+
+function getColumnKey(col) {
+    const label = col.querySelector('.column-label');
+    return label ? label.textContent.trim().replace(/\s+/g, '_') : null;
+}
+
+function applyColumnWidth(col, px) {
+    col.style.flex = 'none';
+    col.style.width = `${px}px`;
+}
+
+function resetColumnWidth(col) {
+    col.style.flex = '';
+    col.style.width = '';
+}
+
+function initColumnResizeHandles() {
+    const container = document.querySelector('.pipeline-container');
+    if (!container) return;
+
+    const columns = Array.from(container.querySelectorAll('.pipeline-column'));
+    const widths = loadColumnWidths();
+
+    columns.forEach((col) => {
+        const key = getColumnKey(col);
+        if (key && widths[key]) {
+            applyColumnWidth(col, widths[key]);
+        }
+
+        const header = col.querySelector('.column-header');
+        if (!header) return;
+
+        const handle = document.createElement('div');
+        handle.className = 'column-resize-handle';
+        handle.title = 'Drag to resize · Double-click to reset';
+        header.appendChild(handle);
+
+        let dragging = false;
+        let startX = 0;
+        let startWidth = 0;
+
+        handle.addEventListener('mousedown', (e) => {
+            dragging = true;
+            startX = e.clientX;
+            startWidth = col.getBoundingClientRect().width;
+            handle.classList.add('dragging');
+            document.body.style.cursor = 'col-resize';
+            document.body.style.userSelect = 'none';
+            e.preventDefault();
+            e.stopPropagation();
+        });
+
+        document.addEventListener('mousemove', (e) => {
+            if (!dragging) return;
+            const delta = e.clientX - startX;
+            const newWidth = Math.max(COLUMN_MIN, startWidth + delta);
+            applyColumnWidth(col, newWidth);
+        });
+
+        document.addEventListener('mouseup', () => {
+            if (!dragging) return;
+            dragging = false;
+            handle.classList.remove('dragging');
+            document.body.style.cursor = '';
+            document.body.style.userSelect = '';
+
+            if (key) {
+                const map = loadColumnWidths();
+                map[key] = Math.round(col.getBoundingClientRect().width);
+                saveColumnWidths(map);
+            }
+        });
+
+        handle.addEventListener('dblclick', (e) => {
+            e.stopPropagation();
+            resetColumnWidth(col);
+            if (key) {
+                const map = loadColumnWidths();
+                delete map[key];
+                if (Object.keys(map).length) {
+                    saveColumnWidths(map);
+                } else {
+                    layoutRemove(STORAGE_COLUMNS);
+                }
+            }
+        });
+    });
+}
+
+// ── Init ─────────────────────────────────────────────────────────────────────
+
+// Restore sidebar width before first paint to avoid flash.
+restoreSidebarWidth();
+
+document.addEventListener('DOMContentLoaded', () => {
+    initPanelSplitter();
+    initColumnResizeHandles();
+});


### PR DESCRIPTION
## Linked issue

Closes #469

## Summary of changes

The dashboard layout was fully fixed-width with no user control. The sidebar was hardcoded to `280px 1fr` in `.main-layout`, pipeline columns were equal `flex: 1` with no handles, and nothing about panel proportions was persisted across refreshes.

Changes:

- **`css/layout.css`** — replaced the static `280px` sidebar track with a `--sidebar-width` CSS custom property; inserted a 4px `.panel-splitter` strip as the second grid track (`var(--sidebar-width) 4px 1fr`). Added hover/dragging highlight styles with an expanded hit-target pseudo-element.
- **`css/responsive.css`** — updated the 1200px breakpoint to use `var(--sidebar-width, 260px)`; hidden `.panel-splitter` at ≤900px where the sidebar becomes a mobile drawer (existing behaviour unchanged).
- **`css/views.css`** — added `.column-resize-handle` absolutely positioned on the right edge of each `.column-header`; shows a visible highlight bar on hover/drag.
- **`index.html`** — added `id="main-layout"` to the grid root; inserted `<div class="panel-splitter" id="panel-splitter">` between `<aside>` and `<main>`; added `<script src="modules/layout.js">` before `fleet.js`.
- **`modules/layout.js`** (new) — drag logic for the panel splitter (clamped `160px–520px`, writes `--sidebar-width` live); drag logic for per-column handles injected into each `.pipeline-column .column-header`; `dotbot:layout:sidebarWidth` and `dotbot:layout:columnWidths` localStorage persistence mirroring the `dotbot:selectedRuntimeId` pattern from `fleet.js`; sidebar width restored before first paint to avoid layout flash; double-click on any handle/splitter resets that dimension to its CSS default.

## Screenshots / recordings

<!-- UI change — screenshot or recording recommended before merge -->

<img width="1901" height="908" alt="image" src="https://github.com/user-attachments/assets/63cda862-2e50-4d15-8723-dbcde7ecb16c" />

<img width="789" height="932" alt="image" src="https://github.com/user-attachments/assets/ff9e6cf6-3cc1-4781-ac94-e5d6ab602a96" />

<img width="1247" height="923" alt="image" src="https://github.com/user-attachments/assets/4e2f25fd-29c7-4036-9bb2-0568ca55dc1c" />

## Testing notes

1. Load the dashboard — sidebar renders at default 280px (no visible change from before).
2. Grab the thin strip between the sidebar and main content, drag left/right — layout updates live.
3. Refresh — sidebar width is restored to where you left it.
4. Double-click the splitter — resets to 280px; subsequent refresh confirms default is persisted.
5. On the Pipeline tab, hover the right edge of any column header (Todo, Working, Needs Input, Done) — cursor becomes `col-resize`.
6. Drag a column handle — that column widens/narrows; other columns fill the remaining space.
7. Refresh — resized column widths are restored.
8. Double-click a column handle — that column resets to equal flex width.
9. Resize the browser to ≤900px — splitter is hidden, sidebar reverts to mobile drawer behaviour; no regressions.
10. Drag sidebar past min (160px) and max (520px) — clamped, does not overflow.

## Checklist

- [ ] Tests added or updated
- [ ] Docs updated (if behaviour changed)
- [x] Linked issue exists
- [ ] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)