### PR TITLE
fix(mcp): increase preflight timeout and retry initialize

### DIFF
--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -565,10 +565,15 @@ function Test-DotbotMcpReadiness {
 
             if ($attempt -lt $maxAttempts) {
                 Write-BotLog -Level Debug -Message "MCP preflight initialize attempt $attempt failed ($($init.message)), retrying..."
-                try { $proc.StandardInput.Close() } catch {}
+                try { $proc.StandardInput.Close() } catch { Write-BotLog -Level Debug -Message "MCP preflight stdin cleanup failed" -Exception $_ }
                 if (-not $proc.HasExited) {
-                    try { $proc.Kill($true) } catch { try { $proc.Kill() } catch {} }
-                    try { $proc.WaitForExit(1000) | Out-Null } catch {}
+                    try {
+                        $proc.Kill($true)
+                    } catch {
+                        Write-BotLog -Level Debug -Message "MCP preflight process-tree kill failed; retrying process kill" -Exception $_
+                        try { $proc.Kill() } catch { Write-BotLog -Level Debug -Message "MCP preflight process kill failed" -Exception $_ }
+                    }
+                    try { $proc.WaitForExit(1000) | Out-Null } catch { Write-BotLog -Level Debug -Message "MCP preflight process wait failed" -Exception $_ }
                 }
                 $proc.Dispose()
                 $proc = $null

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -537,12 +537,16 @@ function Test-DotbotMcpReadiness {
         $psi.Environment['DOTBOT_PROJECT_ROOT'] = $WorktreePath
         $psi.Environment['__DOTBOT_MANAGED'] = '1'
 
-        $proc = [System.Diagnostics.Process]::new()
-        $proc.StartInfo = $psi
-        $proc.Start() | Out-Null
+        $maxAttempts = 2
+        $init = @{ ok = $false; message = 'Preflight loop did not execute.' }
+        for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            # Fresh process per attempt: StreamReader cannot have two concurrent ReadLineAsync
+            # calls, and MCP initialize is a one-shot handshake — reusing the same process
+            # would send it twice, leaving the server in an undefined state.
+            $proc = [System.Diagnostics.Process]::new()
+            $proc.StartInfo = $psi
+            $proc.Start() | Out-Null
 
-        $init = $null
-        for ($attempt = 1; $attempt -le 2; $attempt++) {
             $initRequest = @{
                 jsonrpc = '2.0'
                 id      = 1
@@ -558,22 +562,31 @@ function Test-DotbotMcpReadiness {
 
             $init = Read-DotbotMcpPreflightLine -Process $proc
             if ($init.ok) { break }
-            if ($attempt -lt 2) {
+
+            if ($attempt -lt $maxAttempts) {
                 Write-BotLog -Level Debug -Message "MCP preflight initialize attempt $attempt failed ($($init.message)), retrying..."
+                try { $proc.StandardInput.Close() } catch {}
+                if (-not $proc.HasExited) {
+                    try { $proc.Kill($true) } catch { try { $proc.Kill() } catch {} }
+                    try { $proc.WaitForExit(1000) | Out-Null } catch {}
+                }
+                $proc.Dispose()
+                $proc = $null
             }
         }
         if (-not $init.ok) { return @{ ok = $false; reason = 'initialize_failed'; message = $init.message } }
-        if ($init.response.ContainsKey('error')) {
+        if ($init.response -is [hashtable] -and $init.response.ContainsKey('error')) {
             return @{ ok = $false; reason = 'initialize_error'; message = "MCP initialize failed: $($init.response.error.message)" }
         }
 
+        # Server is warm after successful initialize; 15s ceiling shared intentionally.
         $listRequest = @{ jsonrpc = '2.0'; id = 2; method = 'tools/list'; params = @{} } | ConvertTo-Json -Depth 5 -Compress
         $proc.StandardInput.WriteLine($listRequest)
         $proc.StandardInput.Flush()
 
         $list = Read-DotbotMcpPreflightLine -Process $proc
         if (-not $list.ok) { return @{ ok = $false; reason = 'tools_list_failed'; message = $list.message } }
-        if ($list.response.ContainsKey('error')) {
+        if ($list.response -is [hashtable] -and $list.response.ContainsKey('error')) {
             return @{ ok = $false; reason = 'tools_list_error'; message = "MCP tools/list failed: $($list.response.error.message)" }
         }
 

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -463,7 +463,7 @@ function New-ExecutorRunContext {
 function Read-DotbotMcpPreflightLine {
     param(
         [Parameter(Mandatory)] [System.Diagnostics.Process]$Process,
-        [int]$TimeoutMs = 5000
+        [int]$TimeoutMs = 15000
     )
 
     $readTask = $Process.StandardOutput.ReadLineAsync()
@@ -541,20 +541,27 @@ function Test-DotbotMcpReadiness {
         $proc.StartInfo = $psi
         $proc.Start() | Out-Null
 
-        $initRequest = @{
-            jsonrpc = '2.0'
-            id      = 1
-            method  = 'initialize'
-            params  = @{
-                protocolVersion = '2024-11-05'
-                capabilities    = @{}
-                clientInfo      = @{ name = 'dotbot-workflow-preflight'; version = '1' }
-            }
-        } | ConvertTo-Json -Depth 10 -Compress
-        $proc.StandardInput.WriteLine($initRequest)
-        $proc.StandardInput.Flush()
+        $init = $null
+        for ($attempt = 1; $attempt -le 2; $attempt++) {
+            $initRequest = @{
+                jsonrpc = '2.0'
+                id      = 1
+                method  = 'initialize'
+                params  = @{
+                    protocolVersion = '2024-11-05'
+                    capabilities    = @{}
+                    clientInfo      = @{ name = 'dotbot-workflow-preflight'; version = '1' }
+                }
+            } | ConvertTo-Json -Depth 10 -Compress
+            $proc.StandardInput.WriteLine($initRequest)
+            $proc.StandardInput.Flush()
 
-        $init = Read-DotbotMcpPreflightLine -Process $proc
+            $init = Read-DotbotMcpPreflightLine -Process $proc
+            if ($init.ok) { break }
+            if ($attempt -lt 2) {
+                Write-BotLog -Level Debug -Message "MCP preflight initialize attempt $attempt failed ($($init.message)), retrying..."
+            }
+        }
         if (-not $init.ok) { return @{ ok = $false; reason = 'initialize_failed'; message = $init.message } }
         if ($init.response.ContainsKey('error')) {
             return @{ ok = $false; reason = 'initialize_error'; message = "MCP initialize failed: $($init.response.error.message)" }


### PR DESCRIPTION
## Linked issue

Closes #473

## Summary of changes

`Read-DotbotMcpPreflightLine` had a hardcoded 5s timeout introduced in `ef80c06`. When worktree file copy runs slow under I/O load (~9s), cold `pwsh` startup for the MCP server exceeds that window — first run fails, retry succeeds because the worktree already exists.

Two fixes in `Invoke-WorkflowProcess.ps1`:
- Default `TimeoutMs` raised from 5 000 → 15 000 ms
- `initialize` RPC retries once before failing; logs first failure at Debug level

## Testing notes

1. Start a fresh session (`dotbot go`) with no existing worktree for the task
2. Confirm first run completes without `initialize_failed` error

## Checklist

- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
