### PR TITLE
fix(controls): clarify STOP button is graceful, not immediate

### DIFF
--- a/src/ui/static/modules/controls.js
+++ b/src/ui/static/modules/controls.js
@@ -707,7 +707,7 @@ function renderWorkflowControls(workflows) {
                 </div>
                 <div class="process-control-actions">
                     <button class="ctrl-btn-xs primary wf-run-btn" title="Run any pending task (workflow-agnostic)" ${isRunning ? 'disabled' : ''}>Run</button>
-                    <button class="ctrl-btn-xs wf-stop-btn" title="Stop the pending-tasks runner" ${!isRunning ? 'disabled' : ''}>Stop</button>
+                    <button class="ctrl-btn-xs wf-stop-btn" title="Graceful stop — waits for current task to finish before stopping" ${!isRunning ? 'disabled' : ''}>Stop</button>
                 </div>
             </div>
         `;
@@ -720,7 +720,7 @@ function renderWorkflowControls(workflows) {
                 </div>
                 <div class="process-control-actions">
                     <button class="ctrl-btn-xs primary wf-run-btn" title="${isRunning ? 'Start another run' : 'Create tasks and start workflow'}">Run</button>
-                    <button class="ctrl-btn-xs wf-stop-btn" title="Stop workflow: ${displayName}" ${!isRunning ? 'disabled' : ''}>Stop</button>
+                    <button class="ctrl-btn-xs wf-stop-btn" title="Graceful stop — waits for current task to finish, then stops '${displayName}'" ${!isRunning ? 'disabled' : ''}>Stop</button>
                 </div>
             </div>
         `;
@@ -805,8 +805,8 @@ async function stopPendingTasks() {
         });
         const data = await response.json();
         if (data.success) {
-            showSignalFeedback(`Stop signal sent (${data.stopped} runner${data.stopped === 1 ? '' : 's'})`);
-            showToast('Pending-tasks stop signal sent', 'success');
+            showSignalFeedback(`Stop signal sent — runner will stop after current task completes (${data.stopped} active)`);
+            showToast('Pending-tasks stop signal sent — will stop after current task', 'success');
         } else {
             showSignalFeedback(`Error: ${data.error || 'Stop failed'}`);
         }
@@ -897,8 +897,8 @@ async function stopWorkflow(name) {
         });
         const data = await response.json();
         if (data.success) {
-            showSignalFeedback(`Stop signal sent to workflow: ${name}`);
-            showToast(`Workflow "${name}" stop signal sent`, 'success');
+            showSignalFeedback(`Stop signal sent — workflow '${name}' will stop after current task completes`);
+            showToast(`Workflow "${name}" will stop after current task`, 'success');
         } else {
             showSignalFeedback(`Error: ${data.error || 'Stop failed'}`);
         }

--- a/src/ui/static/modules/controls.js
+++ b/src/ui/static/modules/controls.js
@@ -805,8 +805,8 @@ async function stopPendingTasks() {
         });
         const data = await response.json();
         if (data.success) {
-            showSignalFeedback(`Stop signal sent — runner will stop after current task completes (${data.stopped} active)`);
-            showToast('Pending-tasks stop signal sent — will stop after current task', 'success');
+            showSignalFeedback(`Stop signal sent — runner will stop after current task completes (${data.stopped} runner${data.stopped === 1 ? '' : 's'})`);
+            showToast('Pending-tasks stop signal sent — will stop after current task completes', 'success');
         } else {
             showSignalFeedback(`Error: ${data.error || 'Stop failed'}`);
         }
@@ -898,7 +898,7 @@ async function stopWorkflow(name) {
         const data = await response.json();
         if (data.success) {
             showSignalFeedback(`Stop signal sent — workflow '${name}' will stop after current task completes`);
-            showToast(`Workflow "${name}" will stop after current task`, 'success');
+            showToast(`Workflow "${name}" will stop after current task completes`, 'success');
         } else {
             showSignalFeedback(`Error: ${data.error || 'Stop failed'}`);
         }


### PR DESCRIPTION
## Linked issue

Closes #471

## Summary of changes

STOP button gave no feedback and looked broken during active Claude execution. Root cause: `.stop` signal is only checked at loop boundaries — Claude runs to completion before the runner exits.

No behavior change. Updated tooltip and notification copy to set correct expectations:
- Tooltip: "Graceful stop — waits for current task to finish, then stops '…'"
- Signal feedback + toast: "will stop after current task completes"

## Screenshots / recordings

**Before**

| Tooltip | Signal feedback | Toast |
|---|---|---|
| <img width="500" height="73" alt="Screenshot 2026-06-10 125027" src="https://github.com/user-attachments/assets/af8d20aa-e24b-4e9f-9dbb-5bb760ebee02" /> | <img width="322" height="80" alt="Screenshot 2026-06-10 125046" src="https://github.com/user-attachments/assets/b0816c49-517d-477e-a9db-356764db3381" /> | <img width="423" height="52" alt="Screenshot 2026-06-10 125115" src="https://github.com/user-attachments/assets/f67666be-8486-4a6b-b2bf-b8ec93404dc9" /> |

**After**

| Tooltip | Signal feedback | Toast |
|---|---|---|
| <img width="787" height="73" alt="Screenshot 2026-06-10 123359" src="https://github.com/user-attachments/assets/0c87e587-797b-4c86-af34-815a1cc0fc17" /> | <img width="320" height="92" alt="Screenshot 2026-06-10 123511" src="https://github.com/user-attachments/assets/6472c54f-5bcc-4c82-a9a2-14139863fad2" /> | <img width="478" height="64" alt="image" src="https://github.com/user-attachments/assets/b13472ab-3405-40e0-9b28-5191a619498a" /> |

## Testing notes

1. Start a workflow with a long-running Claude task
2. Hover STOP — verify tooltip describes graceful stop
3. Click STOP — verify signal feedback and toast both say "will stop after current task completes"
4. Confirm Claude finishes current task, then runner exits

## Checklist

- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
