### PR TITLE
test: redirect DOTBOT_HOME to stub for behavioral tests

### DIFF
--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -4960,7 +4960,7 @@ if (Test-Path $inboxWatcherModule) {
             Remove-Item -Force -ErrorAction SilentlyContinue
 
     } finally {
-        if ($prevDotbotHome -ne $null) { $env:DOTBOT_HOME = $prevDotbotHome } else { $env:DOTBOT_HOME = $null }
+        if ($null -ne $prevDotbotHome) { $env:DOTBOT_HOME = $prevDotbotHome } else { $env:DOTBOT_HOME = $null }
         try { Stop-InboxWatcher } catch {}
         Remove-Module InboxWatcher -ErrorAction SilentlyContinue
         if ($inboxTestRoot -and (Test-Path $inboxTestRoot)) {

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -4641,6 +4641,7 @@ if (Test-Path $inboxWatcherModule) {
 
     $inboxTestRoot = Join-Path ([IO.Path]::GetTempPath()) "inbox-watcher-test-$([guid]::NewGuid().ToString('N').Substring(0,8))"
     try {
+        $prevDotbotHome = $env:DOTBOT_HOME
         # ── Scaffolding ──────────────────────────────────────────────────
         $inboxBotRoot  = Join-Path $inboxTestRoot ".bot"
         $settingsDir   = Join-Path $inboxBotRoot "settings"
@@ -4816,7 +4817,6 @@ if (Test-Path $inboxWatcherModule) {
         "# test stub — exits immediately" |
             Set-Content -LiteralPath (Join-Path $stubLauncherDir "Invoke-DotbotProcess.ps1") -Encoding UTF8
 
-        $prevDotbotHome = $env:DOTBOT_HOME
         $env:DOTBOT_HOME = $inboxBotRoot
 
         $launchersDir = Join-Path $controlDir "launchers"

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -4808,11 +4808,16 @@ if (Test-Path $inboxWatcherModule) {
         # ═══════════════════════════════════════════════════════════════
         # Behavioral tests — stub launcher satisfies the Test-Path guard
         # without needing a real dotbot install.
+        # DOTBOT_HOME is redirected to $inboxBotRoot so InboxWatcher resolves
+        # the launcher path to the stub, not the real Invoke-DotbotProcess.ps1.
         # ═══════════════════════════════════════════════════════════════
         $stubLauncherDir = Join-Path $inboxBotRoot "src" "runtime" "Scripts"
         $null = New-Item -ItemType Directory -Force -Path $stubLauncherDir
         "# test stub — exits immediately" |
             Set-Content -LiteralPath (Join-Path $stubLauncherDir "Invoke-DotbotProcess.ps1") -Encoding UTF8
+
+        $prevDotbotHome = $env:DOTBOT_HOME
+        $env:DOTBOT_HOME = $inboxBotRoot
 
         $launchersDir = Join-Path $controlDir "launchers"
 
@@ -4955,6 +4960,7 @@ if (Test-Path $inboxWatcherModule) {
             Remove-Item -Force -ErrorAction SilentlyContinue
 
     } finally {
+        if ($prevDotbotHome -ne $null) { $env:DOTBOT_HOME = $prevDotbotHome } else { $env:DOTBOT_HOME = $null }
         try { Stop-InboxWatcher } catch {}
         Remove-Module InboxWatcher -ErrorAction SilentlyContinue
         if ($inboxTestRoot -and (Test-Path $inboxTestRoot)) {


### PR DESCRIPTION
## Linked issue

Closes #476

## Summary of changes

`InboxWatcher` resolves the launcher path from `$env:DOTBOT_HOME`, not `$BotRoot`. The behavioral tests (8–10) placed a stub `Invoke-DotbotProcess.ps1` under `$inboxBotRoot` but never overrode `DOTBOT_HOME`, so the stub was unreachable and the real launcher spawned an authenticated Claude session on every Layer 2 run (~$0.35/run, 2–3 min hang).

Fix: save and override `$env:DOTBOT_HOME = $inboxBotRoot` before the behavioral test section, restore in `finally`. No production code changed.

## Testing notes

Run `tests/Run-Tests.ps1 -Layer 2` and verify:
- No Claude console window appears during the run
- All inbox-watcher tests pass: Detection, Debounce, Coalescing, Sanitization, Stop boundary

## Checklist

- [x] Tests added or updated
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
