### PR TITLE
fix(harness): park task to needs-input on mid-run auth expiry

### DIFF
--- a/src/runtime/Modules/Dotbot.Harness/Adapters/ClaudeCodeAdapter.ps1
+++ b/src/runtime/Modules/Dotbot.Harness/Adapters/ClaudeCodeAdapter.ps1
@@ -85,6 +85,7 @@ function Invoke-ClaudeCodeAdapterStream {
         lastUsageLogAt = 0
         lastToolResultTime = $null
         pendingToolNames = @{}
+        lastError = ''
     }
 
     $cliArgs = @(
@@ -359,6 +360,7 @@ function Invoke-ClaudeCodeAdapterStream {
                     [Console]::Error.WriteLine("$($t.Amber)Error: $errorMsg$($t.Reset)")
                     [Console]::Error.Flush()
                     Write-ActivityLog -Type "error" -Message $errorMsg
+                    $state.lastError = $errorMsg
                     return
                 }
 
@@ -691,6 +693,7 @@ function Invoke-ClaudeCodeAdapterStream {
         $pendingReadTask = $null
         $stopDeadline = $null
         $stopLogged = $false
+        $stopRequested = $false
 
         while ($true) {
             if (-not $mainExited -and $claudeProc.HasExited) {
@@ -797,6 +800,15 @@ function Invoke-ClaudeCodeAdapterStream {
                 [Console]::Error.WriteLine("$($t.Bezel)[DEBUG] Process tree cleanup error: $($_.Exception.Message)$($t.Reset)")
                 [Console]::Error.Flush()
             }
+        }
+
+        # Surface the stream outcome so the consumer can classify failures
+        # (e.g. mid-run auth expiry). ErrorText carries the last stream-json
+        # error event, which the Claude CLI reports without a non-zero exit.
+        return [pscustomobject]@{
+            ExitCode      = $claudeProc.ExitCode
+            StopRequested = $stopRequested
+            ErrorText     = $state.lastError
         }
 
     } finally {

--- a/src/runtime/Modules/Dotbot.Harness/Adapters/CodexAdapter.ps1
+++ b/src/runtime/Modules/Dotbot.Harness/Adapters/CodexAdapter.ps1
@@ -166,6 +166,7 @@ function Invoke-CodexLineHandler {
             [Console]::Error.WriteLine("$($t.Amber)Error: $errorMsg$($t.Reset)")
             [Console]::Error.Flush()
             Write-ActivityLog -Type "error" -Message $errorMsg
+            $State.lastError = $errorMsg
             return 'error'
         }
 
@@ -176,6 +177,7 @@ function Invoke-CodexLineHandler {
             [Console]::Error.WriteLine("$($t.Amber)Error: $errorMsg$($t.Reset)")
             [Console]::Error.Flush()
             Write-ActivityLog -Type "error" -Message $errorMsg
+            $State.lastError = $errorMsg
             return 'error'
         }
 
@@ -271,6 +273,7 @@ function Invoke-CodexAdapterStream {
         lastUnknown      = Get-Date
         theme            = $t
         basePath         = $WorkingDirectory
+        lastError        = ''
     }
 
     if ($ShowDebugJson) {
@@ -308,7 +311,14 @@ function Invoke-CodexAdapterStream {
             -Theme $t
         if ($streamResult.ExitCode -ne 0 -and -not $streamResult.StopRequested) {
             $nativeExitCode = $streamResult.ExitCode
-            throw "Codex CLI exited with code $nativeExitCode."
+            throw "Codex CLI exited with code $nativeExitCode. $($state.lastError)"
+        }
+        # Surface the stream outcome so the consumer can classify failures
+        # (e.g. mid-run auth expiry) the same way the Claude adapter does.
+        return [pscustomobject]@{
+            ExitCode      = $streamResult.ExitCode
+            StopRequested = $streamResult.StopRequested
+            ErrorText     = $state.lastError
         }
     } finally {
         [Console]::OutputEncoding = $prevOutputEncoding

--- a/src/runtime/Modules/Dotbot.Harness/Private/Failure.ps1
+++ b/src/runtime/Modules/Dotbot.Harness/Private/Failure.ps1
@@ -20,7 +20,12 @@ $script:HarnessFailureRules = @(
         Description      = 'Authentication error detected'
         Recoverable      = $true
         SuggestedAction  = 'Switch auth method or refresh credentials'
-        Substrings       = @('authentication failed', 'invalid api key', 'not authenticated', 'unauthorized')
+        Substrings       = @(
+            'authentication failed', 'invalid api key', 'not authenticated', 'unauthorized',
+            'oauth token', 'token expired', 'authentication_error', 'please run /login',
+            're-authenticate', 'session expired', 'credentials'
+        )
+        Regex            = '\b401\b'
     },
     @{
         Type             = 'VerificationFailed'
@@ -81,7 +86,8 @@ function Get-FailureReason {
                     $matched = $true; break
                 }
             }
-        } elseif ($rule.Regex) {
+        }
+        if (-not $matched -and $rule.Regex) {
             $matched = $combined -match $rule.Regex
         }
         if ($matched) {

--- a/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
+++ b/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
@@ -1372,7 +1372,7 @@ Review all context above. Decide whether to write clarification-questions.json (
         if ($ShowVerboseOutput) { $streamArgs['ShowVerbose'] = $true }
         if ($PermissionMode) { $streamArgs['PermissionMode'] = $PermissionMode }
 
-        Invoke-HarnessStream @streamArgs
+        Invoke-HarnessStream @streamArgs | Out-Null
 
         # Check what the interview pass wrote
         if (Test-Path $summaryPath) {

--- a/src/runtime/Scripts/Expand-TaskGroups.ps1
+++ b/src/runtime/Scripts/Expand-TaskGroups.ps1
@@ -240,7 +240,7 @@ foreach ($group in $sortedGroups) {
     # Invoke harness to expand this group
     $sessionId = New-HarnessSession
     try {
-        Invoke-HarnessStream -Prompt $prompt -Model $Model -SessionId $sessionId -PersistSession:$false -WorkingDirectory $projectRoot
+        Invoke-HarnessStream -Prompt $prompt -Model $Model -SessionId $sessionId -PersistSession:$false -WorkingDirectory $projectRoot | Out-Null
     } catch {
         Write-GroupActivity "Error expanding group $($group.name): $($_.Exception.Message)"
         Write-Status "Failed to expand group: $($group.name)" -Type Error

--- a/src/runtime/Scripts/Invoke-PromptProcess.ps1
+++ b/src/runtime/Scripts/Invoke-PromptProcess.ps1
@@ -80,7 +80,7 @@ try {
     if ($ShowVerbose) { $streamArgs['ShowVerbose'] = $true }
     if ($permissionMode) { $streamArgs['PermissionMode'] = $permissionMode }
 
-    Invoke-HarnessStream @streamArgs
+    Invoke-HarnessStream @streamArgs | Out-Null
 
     $processData.status = 'completed'
     $processData.completed_at = (Get-Date).ToUniversalTime().ToString("o")

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -939,7 +939,7 @@ Instructions:
             if ($ShowVerbose) { $adjustArgs['ShowVerbose'] = $true }
             if ($PermissionMode) { $adjustArgs['PermissionMode'] = $PermissionMode }
             if ($ProjectRoot) { $adjustArgs['WorkingDirectory'] = $ProjectRoot }
-            Invoke-HarnessStream @adjustArgs
+            Invoke-HarnessStream @adjustArgs | Out-Null
             Write-Status "Post-answer adjustment complete for $($Task.name)" -Type Complete
         } catch {
             $adjustErr = $_.Exception.Message
@@ -1788,6 +1788,8 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
             }
 
             Write-Header "Execution Phase"
+            $streamResult = $null
+            $execErrorText = ''
             try {
                 $streamArgs = @{
                     Prompt = $fullExecutionPrompt
@@ -1810,10 +1812,11 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
                 $streamArgs['StopReason'] = "task '$($task.id)' reached a terminal state"
                 $streamArgs['StopGraceSeconds'] = $providerCompletionGraceSeconds
                 $streamArgs['StopCheckIntervalSeconds'] = $providerStopCheckIntervalSeconds
-                Invoke-HarnessStream @streamArgs
+                $streamResult = Invoke-HarnessStream @streamArgs
                 $exitCode = 0
             } catch {
-                Write-Status "Execution error: $($_.Exception.Message)" -Type Error
+                $execErrorText = $_.Exception.Message
+                Write-Status "Execution error: $execErrorText" -Type Error
                 $exitCode = 1
             }
 
@@ -1883,8 +1886,28 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
                 Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Completion check failed (attempt $attemptNumber): '$($task.name)' is not in-progress or done (unexpected state)."
             }
 
-            # Task not completed - handle failure
-            $failureReason = Get-FailureReason -ExitCode $exitCode -Stdout "" -Stderr "" -TimedOut $false
+            # Task not completed - handle failure. Feed the classifier the real
+            # harness error text (stream-json error event and/or caught exception)
+            # so type-aware rules like AuthError can match instead of always
+            # falling through to the generic Crash default.
+            $harnessErrText = @($streamResult.ErrorText, $execErrorText | Where-Object { $_ }) -join "`n"
+            $failureReason = Get-FailureReason -ExitCode $exitCode -Stdout $harnessErrText -Stderr $harnessErrText -TimedOut $false
+
+            # Auth expiry mid-run: park to needs-input (worktree retained, no
+            # merge, retry budget not consumed) and prompt the operator to
+            # re-authenticate, instead of burning retries against the same wall.
+            if ($failureReason.type -eq 'AuthError') {
+                $authContext = "$($failureReason.description). $($failureReason.suggested_action). Detail: $harnessErrText"
+                Write-Status "Auth expiry detected — parking for re-authentication: $($task.name)" -Type Warn
+                Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task '$($task.name)' parked (needs-input): re-authentication required"
+                Set-WorkflowTaskNeedsInput -Task $task -RunDir $runDir `
+                    -QuestionId "auth-expiry-$($task.id)" `
+                    -Question "Re-authentication required for task '$($task.name)'" `
+                    -Context $authContext | Out-Null
+                $taskParked = $true
+                break
+            }
+
             if (-not $failureReason.recoverable) {
                 Write-Status "Non-recoverable failure - skipping" -Type Error
                 try {

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -1813,8 +1813,7 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
                 $streamArgs['StopGraceSeconds'] = $providerCompletionGraceSeconds
                 $streamArgs['StopCheckIntervalSeconds'] = $providerStopCheckIntervalSeconds
                 $streamResult = Invoke-HarnessStream @streamArgs
-                $exitCode = 0
-            } catch {
+                $exitCode = if ($streamResult -and $streamResult.PSObject.Properties['ExitCode']) { [int]$streamResult.ExitCode } else { 0 }
                 $execErrorText = $_.Exception.Message
                 Write-Status "Execution error: $execErrorText" -Type Error
                 $exitCode = 1

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -1814,6 +1814,7 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
                 $streamArgs['StopCheckIntervalSeconds'] = $providerStopCheckIntervalSeconds
                 $streamResult = Invoke-HarnessStream @streamArgs
                 $exitCode = if ($streamResult -and $streamResult.PSObject.Properties['ExitCode']) { [int]$streamResult.ExitCode } else { 0 }
+            } catch {
                 $execErrorText = $_.Exception.Message
                 Write-Status "Execution error: $execErrorText" -Type Error
                 $exitCode = 1
@@ -1896,7 +1897,8 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
             # merge, retry budget not consumed) and prompt the operator to
             # re-authenticate, instead of burning retries against the same wall.
             if ($failureReason.type -eq 'AuthError') {
-                $authContext = "$($failureReason.description). $($failureReason.suggested_action). Detail: $harnessErrText"
+                $authDetail = if ($harnessErrText.Length -gt 1000) { $harnessErrText.Substring(0, 1000) + " … [truncated, showing 1000 of $($harnessErrText.Length) chars]" } else { $harnessErrText }
+                $authContext = "$($failureReason.description). $($failureReason.suggested_action). Detail: $authDetail"
                 Write-Status "Auth expiry detected — parking for re-authentication: $($task.name)" -Type Warn
                 Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task '$($task.name)' parked (needs-input): re-authentication required"
                 Set-WorkflowTaskNeedsInput -Task $task -RunDir $runDir `

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -1485,6 +1485,33 @@ if ($harnessLoaded) {
         -Condition ($registered -contains 'Copilot') `
         -Message "Adapters registered: $($registered -join ', ')"
 
+    # Failure classifier (#467): auth-expiry text must classify as AuthError so
+    # the consumer can park to needs-input instead of burning retries.
+    $authReason = Get-FailureReason -ExitCode 1 -Stdout 'OAuth token expired. Please run /login.' -Stderr '' -TimedOut $false
+    Assert-True -Name "Get-FailureReason classifies oauth expiry as AuthError" `
+        -Condition ($authReason.type -eq 'AuthError') `
+        -Message "Expected AuthError, got '$($authReason.type)'"
+
+    $http401Reason = Get-FailureReason -ExitCode 1 -Stdout 'Request failed: HTTP 401 Unauthorized' -Stderr '' -TimedOut $false
+    Assert-True -Name "Get-FailureReason classifies 401 as AuthError (word-bounded)" `
+        -Condition ($http401Reason.type -eq 'AuthError') `
+        -Message "Expected AuthError, got '$($http401Reason.type)'"
+
+    $not401Reason = Get-FailureReason -ExitCode 1 -Stdout 'request returned 4012 items' -Stderr '' -TimedOut $false
+    Assert-True -Name "Get-FailureReason does not treat 4012 as a 401 auth error" `
+        -Condition ($not401Reason.type -ne 'AuthError') `
+        -Message "Expected non-AuthError, got '$($not401Reason.type)'"
+
+    $emptyReason = Get-FailureReason -ExitCode 1 -Stdout '' -Stderr '' -TimedOut $false
+    Assert-True -Name "Get-FailureReason falls through to Crash on empty text" `
+        -Condition ($emptyReason.type -eq 'Crash') `
+        -Message "Expected Crash, got '$($emptyReason.type)'"
+
+    $timeoutReason = Get-FailureReason -ExitCode 1 -Stdout 'unauthorized' -Stderr '' -TimedOut $true
+    Assert-True -Name "Get-FailureReason gives Timeout precedence over auth text" `
+        -Condition ($timeoutReason.type -eq 'Timeout') `
+        -Message "Expected Timeout, got '$($timeoutReason.type)'"
+
     # Test Get-HarnessConfig for Claude (default)
     $claudeConfig = $null
     try { $claudeConfig = Get-HarnessConfig -Name "claude" } catch { Write-Verbose "Settings operation failed: $_" }

--- a/tests/Test-MockClaude.ps1
+++ b/tests/Test-MockClaude.ps1
@@ -164,6 +164,22 @@ try {
                 if (Test-Path $modeFile) { Remove-Item $modeFile -Force }
             }
 
+            # #467: a stream-json error event (e.g. mid-run auth expiry) is
+            # surfaced to the caller as ErrorText so the failure classifier can
+            # detect it instead of receiving empty text.
+            try {
+                $modeFile = Join-Path $mockLogDir "mock-claude-mode.txt"
+                "auth-error" | Set-Content -Path $modeFile
+                $authResult = Invoke-HarnessStream -Prompt "Auth expiry test" -Model "best" -HarnessName "claude" 2>$null
+                Assert-True -Name "Invoke-HarnessStream surfaces stream error as ErrorText (#467)" `
+                    -Condition ($null -ne $authResult -and $authResult.ErrorText -match 'OAuth token expired') `
+                    -Message "Expected ErrorText to carry the auth-expiry message, got: '$($authResult.ErrorText)'"
+            } catch {
+                Write-TestResult -Name "Invoke-HarnessStream surfaces stream error as ErrorText (#467)" -Status Fail -Message $_.Exception.Message
+            } finally {
+                if (Test-Path $modeFile) { Remove-Item $modeFile -Force }
+            }
+
         } catch {
             Write-TestResult -Name "Dotbot.Harness module import" -Status Fail -Message $_.Exception.Message
         }

--- a/tests/mock-claude.ps1
+++ b/tests/mock-claude.ps1
@@ -86,6 +86,17 @@ switch ($mode) {
         exit 1
     }
 
+    "auth-error" {
+        # Emit a stream-json error event carrying an auth-expiry message, then
+        # exit 0 — mirrors the Claude CLI reporting a mid-run token expiry
+        # without a non-zero exit code (#467).
+        $errorEvent = @{
+            type    = "error"
+            message = "OAuth token expired. Please run /login to re-authenticate."
+        } | ConvertTo-Json -Compress
+        Write-Output $errorEvent
+    }
+
     "hang-after-result" {
         # Emit a valid stream, then stay alive silently. This reproduces a
         # provider CLI held open by a background tool call after task completion.


### PR DESCRIPTION
## Linked issue

Closes #467

## Summary of changes

When a background access token / session expired mid-run (e.g. an MCP server like Jira, or the provider session), dotbot did **not** treat it as a distinct situation. The `AuthError` classifier type existed but was **never consumed** — dead code. The failure collapsed into the generic retry path: the task silently retried against the same auth wall, got skipped with `max-retries`, and no signal reached the operator.

This PR wires up the detection that already existed, across three layers:

- **Adapters surface the signal.** `ClaudeCodeAdapter` and `CodexAdapter` now record the stream error text (`lastError`) and return a standard result object `{ ExitCode; StopRequested; ErrorText }`. The Codex throw message also carries the error text. The Claude CLI reports a mid-run auth expiry via a stream-json `error` event **without** a non-zero exit, so `ErrorText` is the only way to surface it.

- **No return leak.** Because adapters now return an object, the four `Invoke-HarnessStream` call sites that do not consume the return (`Invoke-PromptProcess`, `Expand-TaskGroups`, the interview loop in `Dotbot.Task`, and the post-answer adjust in `Invoke-WorkflowProcess`) suppress it with `| Out-Null` so it cannot leak into the output stream and corrupt a function's return value.

- **Classifier fed real text + type-aware park.** The execution consumer captures the stream result and the caught exception text and passes them to `Get-FailureReason`. When the result is `AuthError`, the task is parked to `needs-input` via the existing `Set-WorkflowTaskNeedsInput` path — worktree retained, no merge, `consecutive_failures` not bumped, retry budget **not** consumed — with an actionable re-authentication prompt. On answer, the existing needs-input machinery requeues the task and reuses the worktree (no work lost).

- **Broader auth rule.** `Failure.ps1` expands the `AuthError` substrings (`oauth token`, `token expired`, `authentication_error`, `please run /login`, `re-authenticate`, `session expired`, `credentials`, …) and adds a word-bounded `\b401\b` regex. The rule engine now allows a rule to carry both `Substrings` and `Regex`. `TimedOut` is still checked first, so timeout-vs-auth precedence is preserved.

## Acceptance criteria

- [x] **Auth-expiry errors are detected and classified distinctly from generic failures.** Adapters surface `ErrorText`; `Get-FailureReason` now receives real text and matches `AuthError` (broadened substrings + word-bounded `\b401\b`). Covered by new `Test-Components` unit tests and isolated mock validation.

- [x] **The run parks to `needs-input` with an actionable re-authentication prompt.** On `AuthError` the consumer calls `Set-WorkflowTaskNeedsInput` (`QuestionId "auth-expiry-<task>"`, "Re-authentication required…", context with detail) before the recoverable / max-retries checks.

- [x] **The task resumes from the park after re-auth, not from the beginning (worktree reused, no work lost).** Reuses the existing parked path: worktree retained, no merge, `consecutive_failures` not bumped, retry budget not consumed; the existing needs-input machinery requeues the task and reuses the worktree on answer. _Inherited behavior — no new automated end-to-end resume test in this PR; a fresh provider session is opened on resume (true provider-session resume is out of scope per the issue)._

- [x] **`AuthError` is wired to a handler; the dead-code path is removed.** `AuthError` is now consumed in `Invoke-WorkflowProcess`. _(The type was already named `AuthError` in the codebase, so the issue's "formerly `AuthLimit`" rename was a no-op.)_

## Screenshots / recordings

N/A — no UI changes.

## Testing notes

- `pwsh tests/Run-Tests.ps1 -Layer 1` — ALL PASSED.
- `pwsh tests/Run-Tests.ps1 -Layer 2` — ALL PASSED.
- `pwsh tests/Run-Tests.ps1 -Layer 3` — ALL PASSED.

## Checklist

- [x] Tests added or updated
- [x] Docs updated (if behaviour changed) — N/A, no user-facing docs affected
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
