### PR TITLE
ci: drop stale dotbot.psd1 references

### DIFF
--- a/.github/workflows/bump-release.yml
+++ b/.github/workflows/bump-release.yml
@@ -44,10 +44,6 @@ jobs:
           }
           $new = $parts -join '.'
           @{ version = $new } | ConvertTo-Json | Set-Content $versionFile
-          # Also update module manifest
-          $psd1 = Get-Content dotbot.psd1 -Raw
-          $psd1 = $psd1 -replace "ModuleVersion = '.*?'", "ModuleVersion = '$new'"
-          $psd1 | Set-Content dotbot.psd1 -NoNewline
           Write-Host "Bumped $current -> $new ($bump)"
           "version=$new" >> $env:GITHUB_OUTPUT
 
@@ -56,7 +52,7 @@ jobs:
           VERSION="${{ steps.bump.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add version.json dotbot.psd1
+          git add version.json
           git commit -m "Bump version to v${VERSION}"
           git tag "v${VERSION}"
           git push origin main --tags


### PR DESCRIPTION
## Linked issue

Closes #475

## Summary of changes

`bump-release.yml` referenced `dotbot.psd1` at the repo root — file doesn't exist in v4. Removed the three psd1 read/write lines and dropped `dotbot.psd1` from `git add`. Workflow now bumps `version.json` only.

## Testing notes

Trigger `Bump & Release` via Actions → Run workflow (patch). `Bump version` step should complete without `Cannot find path` error. Verify commit contains only `version.json` change.

## Checklist

- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
