### PR TITLE
feat(review): add Revise decision that preserves the worktree and injects reviewer feedback

### DIFF
--- a/content/prompts/99-autonomous-task.md
+++ b/content/prompts/99-autonomous-task.md
@@ -64,6 +64,9 @@ task is complete.
 ### User Decisions
 {{QUESTIONS_RESOLVED}}
 
+### Reviewer Feedback
+{{REVIEWER_FEEDBACK}}
+
 ---
 
 ## Implementation Protocol

--- a/content/workflows/start-from-jira/prompts/99-autonomous-task.md
+++ b/content/workflows/start-from-jira/prompts/99-autonomous-task.md
@@ -69,6 +69,9 @@ task is complete.
 ### User Decisions
 {{QUESTIONS_RESOLVED}}
 
+### Reviewer Feedback
+{{REVIEWER_FEEDBACK}}
+
 ---
 
 ## Execution Mode Dispatch

--- a/src/mcp/tools/task-submit-review/metadata.json
+++ b/src/mcp/tools/task-submit-review/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "task_submit_review",
-  "description": "Submit a human review decision for a task in needs-review status. Approve\nmerges the task worktree and transitions to done (after verification gates).\nReject discards the worktree, appends reviewer feedback to\nextensions.review.feedback, and returns the task to todo for rework.\n",
+  "description": "Submit a human review decision for a task in needs-review status. Approve\nmerges the task worktree and transitions to done (after verification gates).\nReject discards the worktree, appends reviewer feedback to\nextensions.review.feedback, and returns the task to todo for a fresh\nregeneration. Revise keeps the worktree (branch + uncommitted edits),\nappends feedback, and returns the task to todo for a targeted in-place\ncorrection.\n",
   "inputSchema": {
     "type": "object",
     "properties": {
@@ -8,22 +8,26 @@
         "type": "string",
         "description": "Canonical task ID (t_XXXXXXXX). Must be in needs-review status."
       },
+      "decision": {
+        "type": "string",
+        "enum": ["approve", "reject", "revise"],
+        "description": "Review decision. 'approve' merges and completes. 'reject' discards the worktree and restarts from scratch. 'revise' preserves the worktree and applies a targeted correction. Takes precedence over 'approved' when both are sent."
+      },
       "approved": {
         "type": "boolean",
-        "description": "True to approve and complete the task, false to reject and restart it."
+        "description": "Deprecated; use 'decision'. True maps to 'approve', false to 'reject'. Ignored when 'decision' is provided."
       },
       "comment": {
         "type": "string",
-        "description": "Reviewer comment — required when rejecting, optional when approving."
+        "description": "Reviewer comment — required when rejecting or revising, optional when approving."
       },
       "what_was_wrong": {
         "type": "string",
-        "description": "Specific description of what the implementation got wrong (used when rejecting to guide the next attempt)."
+        "description": "Specific description of what the implementation got wrong (used when rejecting or revising to guide the next attempt)."
       }
     },
     "required": [
-      "task_id",
-      "approved"
+      "task_id"
     ]
   }
 }

--- a/src/mcp/tools/task-submit-review/script.ps1
+++ b/src/mcp/tools/task-submit-review/script.ps1
@@ -2,14 +2,26 @@ function Invoke-TaskSubmitReview {
     param([hashtable]$Arguments)
 
     $taskId   = $Arguments['task_id']
+    $decision = $Arguments['decision']
     $approved = $Arguments['approved']
     $comment      = $Arguments['comment']
     $whatWasWrong = $Arguments['what_was_wrong']
 
-    if (-not $taskId)        { throw "Task ID is required" }
-    if ($null -eq $approved) { throw "approved flag is required (true or false)" }
-    if ($approved -isnot [bool]) {
-        return @{ success = $false; error = "'approved' must be a JSON boolean (true or false), not a string or other type" }
+    if (-not $taskId) { throw "Task ID is required" }
+
+    # Resolve the canonical decision. 'decision' takes precedence; 'approved'
+    # is the deprecated boolean fallback (true -> approve, false -> reject).
+    if ($decision) {
+        if ($decision -notin @('approve', 'reject', 'revise')) {
+            return @{ success = $false; error = "'decision' must be one of: approve, reject, revise" }
+        }
+    } elseif ($null -ne $approved) {
+        if ($approved -isnot [bool]) {
+            return @{ success = $false; error = "'approved' must be a JSON boolean (true or false), not a string or other type" }
+        }
+        $decision = if ($approved) { 'approve' } else { 'reject' }
+    } else {
+        throw "A 'decision' (approve, reject, or revise) is required"
     }
 
     # Verify current state
@@ -23,90 +35,79 @@ function Invoke-TaskSubmitReview {
     $projectRoot = $global:DotbotProjectRoot
     $botRoot     = $global:DotbotBotRoot
 
-    # Ensure Dotbot.Worktree is loaded so we can call Reset-TaskWorktree /
-    # Complete-TaskWorktree directly. Both .bot/-installed and DOTBOT_HOME
-    # locations are tried; the MCP server has Dotbot.Core/Logging in scope
-    # but Dotbot.Worktree is on-demand.
-    if (-not (Get-Module Dotbot.Worktree)) {
-        $candidates = @(
-            (Join-Path $projectRoot ".bot/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psd1"),
-            (Join-Path $env:DOTBOT_HOME "src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psd1")
-        )
-        foreach ($c in $candidates) {
-            if ($c -and (Test-Path $c)) {
-                Import-Module $c -DisableNameChecking -Global -ErrorAction SilentlyContinue
-                break
+    # Ensure Dotbot.Worktree (Reset-/Complete-TaskWorktree) and Dotbot.Task
+    # (Resolve-TaskReviewDecision) are loaded so we can call them directly. Both
+    # .bot/-installed and DOTBOT_HOME locations are tried; the MCP server has
+    # Dotbot.Core/Logging in scope but these are on-demand.
+    foreach ($mod in @('Dotbot.Worktree', 'Dotbot.Task')) {
+        if (-not (Get-Module $mod)) {
+            $candidates = @(
+                (Join-Path $projectRoot ".bot/src/runtime/Modules/$mod/$mod.psd1"),
+                (Join-Path $env:DOTBOT_HOME "src/runtime/Modules/$mod/$mod.psd1")
+            )
+            foreach ($c in $candidates) {
+                if ($c -and (Test-Path $c)) {
+                    Import-Module $c -DisableNameChecking -Global -ErrorAction SilentlyContinue
+                    break
+                }
             }
         }
     }
 
-    # ── REJECT PATH ──────────────────────────────────────────────────────────
-    if (-not $approved) {
-        if ([string]::IsNullOrWhiteSpace($comment)) {
-            return @{ success = $false; error = "'comment' is required when rejecting — describe what needs to change so the implementor can act on the feedback" }
+    # ── REJECT / REVISE PATH ─────────────────────────────────────────────────
+    if ($decision -ne 'approve') {
+        $resolved = Resolve-TaskReviewDecision -Task $task -Decision $decision -Comment $comment -WhatWasWrong $whatWasWrong -Now $now
+        if (-not $resolved.success) {
+            return $resolved
         }
 
-        # Build feedback entry and append to existing extensions.review.feedback array
-        $feedbackEntry = [ordered]@{
-            comment        = "$comment"
-            what_was_wrong = if ($whatWasWrong) { "$whatWasWrong" } else { "" }
-            timestamp      = $now
-        }
-        $existingFeedback = @()
-        if ($task.extensions -and $task.extensions.PSObject.Properties['review'] -and
-            $task.extensions.review.PSObject.Properties['feedback'] -and $task.extensions.review.feedback) {
-            $existingFeedback = @($task.extensions.review.feedback)
-        }
-        $newFeedback = @($existingFeedback) + @($feedbackEntry)
-
-        # State move first (atomic), worktree cleanup after (best-effort).
-        # The PATCH below replaces the review extension with the new shape:
-        # status=rejected, rejected_at=now, feedback=[…], and clears the
-        # execution-phase fields so the next attempt starts fresh.
-        $reviewReplacement = @{
-            required       = $true
-            status         = 'rejected'
-            rejected_at    = $now
-            feedback       = $newFeedback
-            pending_commit = $null
-            requested_at   = $null
-            request_reason = $null
-        }
+        # State move first (atomic), worktree cleanup after (best-effort). The
+        # PATCH replaces extensions.review with the new shape (status,
+        # feedback, cleared execution fields); the POST returns the task to todo.
         $null = Invoke-McpRuntimeRequest -Method PATCH -Path "/tasks/$taskId" -Body @{
             actor      = Get-McpActor
-            extensions = @{ review = $reviewReplacement }
+            extensions = @{ review = $resolved.reviewReplacement }
         }
         $null = Invoke-McpRuntimeRequest -Method POST -Path "/tasks/$taskId/status" -Body @{
-            to     = 'todo'
+            to     = $resolved.targetStatus
             actor  = Get-McpActor
-            reason = "Review rejected: $comment"
+            reason = $resolved.statusReason
         }
 
-        # Discard the worktree + branch so the next cycle starts clean
+        # Reject discards the worktree + branch so the next cycle starts clean;
+        # revise preserves them so the next pickup reuses the prior attempt.
         $resetMsg = $null
-        try {
-            if (Get-Command Reset-TaskWorktree -ErrorAction SilentlyContinue) {
-                $resetResult = Reset-TaskWorktree -TaskId $taskId -ProjectRoot $projectRoot -BotRoot $botRoot
-                $resetMsg = $resetResult.message
+        if ($resolved.resetWorktree) {
+            try {
+                if (Get-Command Reset-TaskWorktree -ErrorAction SilentlyContinue) {
+                    $resetResult = Reset-TaskWorktree -TaskId $taskId -ProjectRoot $projectRoot -BotRoot $botRoot
+                    $resetMsg = $resetResult.message
+                    if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
+                        Write-BotLog -Level Info -Message "Reset-TaskWorktree for '$taskId': $($resetResult.message)"
+                    }
+                }
+            } catch {
                 if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
-                    Write-BotLog -Level Info -Message "Reset-TaskWorktree for '$taskId': $($resetResult.message)"
+                    Write-BotLog -Level Warn -Message "Could not reset worktree for task $taskId" -Exception $_
                 }
             }
-        } catch {
-            if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
-                Write-BotLog -Level Warn -Message "Could not reset worktree for task $taskId" -Exception $_
-            }
         }
 
+        $resultMessage = if ($decision -eq 'revise') {
+            "Revision requested — task returned to todo; worktree preserved for a targeted correction"
+        } else {
+            "Review rejected — task returned to todo for rework"
+        }
         return @{
             success        = $true
-            message        = "Review rejected — task returned to todo for rework"
+            message        = $resultMessage
             task_id        = $taskId
             task_name      = [string]$task.name
             old_status     = 'needs-review'
-            new_status     = 'todo'
+            new_status     = $resolved.targetStatus
+            decision       = $decision
             approved       = $false
-            feedback_count = $newFeedback.Count
+            feedback_count = $resolved.feedbackCount
             worktree_reset = $resetMsg
         }
     }
@@ -182,6 +183,7 @@ function Invoke-TaskSubmitReview {
         task_name   = [string]$task.name
         old_status  = 'needs-review'
         new_status  = 'done'
+        decision    = 'approve'
         approved    = $true
         merge_message = $mergeMsg
     }

--- a/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
+++ b/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
@@ -348,10 +348,12 @@ function _FlattenTask {
     $exec = $null
     $wfx  = $null
     $runner = $null
+    $review = $null
     if ($Content.PSObject.Properties['extensions'] -and $Content.extensions) {
         if ($Content.extensions.PSObject.Properties['executor']) { $exec = $Content.extensions.executor }
         if ($Content.extensions.PSObject.Properties['workflow']) { $wfx  = $Content.extensions.workflow }
         if ($Content.extensions.PSObject.Properties['runner'])   { $runner = $Content.extensions.runner }
+        if ($Content.extensions.PSObject.Properties['review'])   { $review = $Content.extensions.review }
     }
     function _ext { param($Bag, [string]$Key)
         if ($null -eq $Bag) { return $null }
@@ -405,6 +407,7 @@ function _FlattenTask {
         applicable_standards  = _ext $wfx 'applicable_standards'
         needs_interview       = _ext $wfx 'needs_interview'
         questions_resolved    = _ext $runner 'questions_resolved'
+        review_feedback       = _ext $review 'feedback'
         pending_question      = _ext $runner 'pending_question'
         current_handoff       = _ext $runner 'current_handoff'
         resume_context        = _ext $runner 'resume_context'

--- a/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psd1
+++ b/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psd1
@@ -23,6 +23,7 @@
     FunctionsToExport = @(
         # Task lifecycle helpers
         'Build-TaskPrompt'
+        'Resolve-TaskReviewDecision'
         'Test-TaskCompletion'
         'Reset-InProgressTasks'
         'Reset-SkippedTasks'

--- a/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
+++ b/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
@@ -167,6 +167,20 @@ function Build-TaskPrompt {
     }
     $prompt = $prompt -replace '\{\{QUESTIONS_RESOLVED\}\}', $questionsResolved
 
+    # Format and replace reviewer feedback accumulated across review cycles
+    $reviewerFeedback = ""
+    if ($Task.review_feedback -and $Task.review_feedback.Count -gt 0) {
+        $reviewerFeedback = "A reviewer rejected your previous attempt. You **MUST** address each item below. The worktree already contains your prior attempt — make targeted corrections per this feedback; do not rewrite sections the feedback does not touch.`n`n"
+        foreach ($item in $Task.review_feedback) {
+            $reviewerFeedback += "- **What to change:** $($item.comment)`n"
+            if ($item.what_was_wrong) {
+                $reviewerFeedback += "  **What was wrong:** $($item.what_was_wrong)`n"
+            }
+        }
+        $reviewerFeedback += "`n"
+    }
+    $prompt = $prompt -replace '\{\{REVIEWER_FEEDBACK\}\}', $reviewerFeedback
+
     $resumeContext = ""
     if ($Task.resume_context) {
         try {
@@ -186,6 +200,94 @@ function Build-TaskPrompt {
     $prompt = $prompt -replace '\{\{STEERING_PROTOCOL\}\}', $steeringProtocol
 
     return $prompt
+}
+
+function Resolve-TaskReviewDecision {
+    <#
+    .SYNOPSIS
+    Compute the state mutation for a non-approve review decision (reject or revise).
+
+    .DESCRIPTION
+    Pure decision logic shared by the MCP submit-review tool and the UI's
+    Submit-TaskReview. It does NOT perform any I/O: callers apply the returned
+    descriptor with their own runtime client and conditionally call
+    Reset-TaskWorktree. This keeps the feedback-assembly and decision->state
+    mapping in one place while leaving each caller's request/error semantics
+    intact.
+
+    Both 'reject' and 'revise' append the reviewer comment to
+    extensions.review.feedback[] and return the task to todo, so the feedback is
+    injected into the next execution prompt. They differ only in whether the
+    worktree is discarded: reject resets it (fresh regeneration), revise
+    preserves it (targeted in-place correction).
+
+    .PARAMETER Task
+    The task object as returned by GET /tasks/<id> (already fetched by the caller).
+
+    .PARAMETER Decision
+    'reject' or 'revise'.
+
+    .PARAMETER Now
+    UTC timestamp string to stamp on the feedback entry and review status.
+
+    .OUTPUTS
+    On a validation failure: @{ success = $false; error = <message> }.
+    On success: @{
+        success           = $true
+        reviewReplacement = <extensions.review shape to PATCH>
+        targetStatus      = 'todo'
+        statusReason      = <transition reason string>
+        resetWorktree     = <bool: $true for reject, $false for revise>
+        feedbackCount     = <int>
+    }
+    #>
+    param(
+        [Parameter(Mandatory)] $Task,
+        [Parameter(Mandatory)] [ValidateSet('reject', 'revise')] [string]$Decision,
+        [string]$Comment,
+        [string]$WhatWasWrong,
+        [Parameter(Mandatory)] [string]$Now
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Comment)) {
+        return @{ success = $false; error = "'comment' is required when ${Decision}ing — describe what needs to change so the implementor can act on the feedback" }
+    }
+
+    $feedbackEntry = [ordered]@{
+        comment        = "$Comment"
+        what_was_wrong = if ($WhatWasWrong) { "$WhatWasWrong" } else { "" }
+        timestamp      = $Now
+    }
+    $existingFeedback = @()
+    if ($Task.extensions -and $Task.extensions.PSObject.Properties['review'] -and
+        $Task.extensions.review.PSObject.Properties['feedback'] -and $Task.extensions.review.feedback) {
+        $existingFeedback = @($Task.extensions.review.feedback)
+    }
+    $newFeedback = @($existingFeedback) + @($feedbackEntry)
+
+    $isReject = $Decision -eq 'reject'
+    $reviewReplacement = @{
+        required       = $true
+        status         = if ($isReject) { 'rejected' } else { 'revision_requested' }
+        feedback       = $newFeedback
+        pending_commit = $null
+        requested_at   = $null
+        request_reason = $null
+    }
+    if ($isReject) {
+        $reviewReplacement.rejected_at = $Now
+    } else {
+        $reviewReplacement.revision_requested_at = $Now
+    }
+
+    return @{
+        success           = $true
+        reviewReplacement = $reviewReplacement
+        targetStatus      = 'todo'
+        statusReason      = "Review ${Decision}ed: $Comment"
+        resetWorktree     = $isReject
+        feedbackCount     = $newFeedback.Count
+    }
 }
 
 #endregion
@@ -1577,6 +1679,8 @@ Review all context above. Decide whether to write clarification-questions.json (
 Export-ModuleMember -Function @(
     # Prompt building
     'Build-TaskPrompt'
+    # Review decisions
+    'Resolve-TaskReviewDecision'
     # Completion detection
     'Test-TaskCompletion'
     # State recovery

--- a/src/ui/modules/TaskAPI.psm1
+++ b/src/ui/modules/TaskAPI.psm1
@@ -711,17 +711,29 @@ function Submit-TaskReview {
     #>
     param(
         [Parameter(Mandatory)] [string]$TaskId,
-        [Parameter(Mandatory)] [bool]$Approved,
+        [string]$Decision,
+        [bool]$Approved,
         [string]$Comment,
         [string]$WhatWasWrong,
         [string]$Actor
     )
+
+    # 'decision' takes precedence; 'approved' is the deprecated boolean fallback.
+    if (-not $Decision) {
+        $Decision = if ($Approved) { 'approve' } else { 'reject' }
+    }
+    if ($Decision -notin @('approve', 'reject', 'revise')) {
+        return @{ success = $false; error = "'decision' must be one of: approve, reject, revise" }
+    }
 
     if (-not (Get-Module Dotbot.Runtime)) {
         Import-Module (Join-Path $PSScriptRoot ".." ".." "runtime" "Modules" "Dotbot.Runtime" "Dotbot.Runtime.psd1") -DisableNameChecking -Global -ErrorAction SilentlyContinue
     }
     if (-not (Get-Module Dotbot.Worktree)) {
         Import-Module (Join-Path $PSScriptRoot ".." ".." "runtime" "Modules" "Dotbot.Worktree" "Dotbot.Worktree.psd1") -DisableNameChecking -Global -ErrorAction SilentlyContinue
+    }
+    if (-not (Get-Module Dotbot.Task)) {
+        Import-Module (Join-Path $PSScriptRoot ".." ".." "runtime" "Modules" "Dotbot.Task" "Dotbot.Task.psd1") -DisableNameChecking -Global -ErrorAction SilentlyContinue
     }
 
     $botRoot     = $script:Config.BotRoot
@@ -730,71 +742,63 @@ function Submit-TaskReview {
     $global:DotbotBotRoot = $botRoot
     $now = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
 
-    # Verify current state
-    $task = Invoke-RuntimeRequest -BotRoot $botRoot -Method GET -Path "/tasks/$TaskId"
+    # Verify current state. GET /tasks/{id} returns the envelope
+    # { status_code; body = { task; path }; ... }, so the task object lives at
+    # .body.task — not at the top level.
+    $taskResp = Invoke-RuntimeRequest -BotRoot $botRoot -Method GET -Path "/tasks/$TaskId"
+    $task = if ($taskResp -and $taskResp.body -and $taskResp.body.PSObject.Properties['task']) { $taskResp.body.task } else { $null }
     if (-not $task) { throw "Task '$TaskId' not found" }
     if ([string]$task.status -ne 'needs-review') {
         return @{ success = $false; error = "Task '$TaskId' is in status '$($task.status)', not needs-review" }
     }
 
-    # ── REJECT PATH ──────────────────────────────────────────────────────────
-    if (-not $Approved) {
-        if ([string]::IsNullOrWhiteSpace($Comment)) {
-            return @{ success = $false; error = "'comment' is required when rejecting — describe what needs to change so the implementor can act on the feedback" }
+    # ── REJECT / REVISE PATH ─────────────────────────────────────────────────
+    if ($Decision -ne 'approve') {
+        $resolved = Resolve-TaskReviewDecision -Task $task -Decision $Decision -Comment $Comment -WhatWasWrong $WhatWasWrong -Now $now
+        if (-not $resolved.success) {
+            return $resolved
         }
 
-        $feedbackEntry = [ordered]@{
-            comment        = "$Comment"
-            what_was_wrong = if ($WhatWasWrong) { "$WhatWasWrong" } else { "" }
-            timestamp      = $now
-        }
-        $existing = @()
-        if ($task.extensions -and $task.extensions.PSObject.Properties['review'] -and
-            $task.extensions.review.PSObject.Properties['feedback'] -and $task.extensions.review.feedback) {
-            $existing = @($task.extensions.review.feedback)
-        }
-        $newFeedback = @($existing) + @($feedbackEntry)
-
-        $reviewReplacement = @{
-            required       = $true
-            status         = 'rejected'
-            rejected_at    = $now
-            feedback       = $newFeedback
-            pending_commit = $null
-            requested_at   = $null
-            request_reason = $null
-        }
         $null = Invoke-RuntimeRequest -BotRoot $botRoot -Method PATCH -Path "/tasks/$TaskId" -Body @{
             actor      = $actorName
-            extensions = @{ review = $reviewReplacement }
+            extensions = @{ review = $resolved.reviewReplacement }
         }
         $null = Invoke-RuntimeRequest -BotRoot $botRoot -Method POST -Path "/tasks/$TaskId/status" -Body @{
-            to     = 'todo'
+            to     = $resolved.targetStatus
             actor  = $actorName
-            reason = "Review rejected: $Comment"
+            reason = $resolved.statusReason
         }
 
+        # Reject discards the worktree; revise preserves it for a targeted fix.
         $resetMsg = $null
-        try {
-            if (Get-Command Reset-TaskWorktree -ErrorAction SilentlyContinue) {
-                $resetResult = Reset-TaskWorktree -TaskId $TaskId -ProjectRoot $projectRoot -BotRoot $botRoot
-                $resetMsg = $resetResult.message
-            }
-        } catch {
-            if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
-                Write-BotLog -Level Warn -Message "Could not reset worktree for task $TaskId" -Exception $_
+        if ($resolved.resetWorktree) {
+            try {
+                if (Get-Command Reset-TaskWorktree -ErrorAction SilentlyContinue) {
+                    $resetResult = Reset-TaskWorktree -TaskId $TaskId -ProjectRoot $projectRoot -BotRoot $botRoot
+                    $resetMsg = $resetResult.message
+                }
+            } catch {
+                if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
+                    Write-BotLog -Level Warn -Message "Could not reset worktree for task $TaskId" -Exception $_
+                }
             }
         }
 
+        $resultMessage = if ($Decision -eq 'revise') {
+            "Revision requested — task returned to todo; worktree preserved for a targeted correction"
+        } else {
+            "Review rejected — task returned to todo for rework"
+        }
         return @{
             success        = $true
-            message        = "Review rejected — task returned to todo for rework"
+            message        = $resultMessage
             task_id        = $TaskId
             task_name      = [string]$task.name
             old_status     = 'needs-review'
-            new_status     = 'todo'
+            new_status     = $resolved.targetStatus
+            decision       = $Decision
             approved       = $false
-            feedback_count = $newFeedback.Count
+            feedback_count = $resolved.feedbackCount
             worktree_reset = $resetMsg
         }
     }
@@ -837,6 +841,7 @@ function Submit-TaskReview {
         task_name     = [string]$task.name
         old_status    = 'needs-review'
         new_status    = 'done'
+        decision      = 'approve'
         approved      = $true
         merge_message = $mergeMsg
     }

--- a/src/ui/server.ps1
+++ b/src/ui/server.ps1
@@ -1702,7 +1702,7 @@ $docContext
                             $reader = New-Object System.IO.StreamReader($request.InputStream)
                             $body = $reader.ReadToEnd() | ConvertFrom-Json
                             $reader.Close()
-                            $content = Submit-TaskReview -TaskId $body.task_id -Approved ([bool]$body.approved) -Comment $body.comment -WhatWasWrong $body.what_was_wrong -Actor 'ui:user' | ConvertTo-Json -Depth 10 -Compress
+                            $content = Submit-TaskReview -TaskId $body.task_id -Decision ([string]$body.decision) -Approved ([bool]$body.approved) -Comment $body.comment -WhatWasWrong $body.what_was_wrong -Actor 'ui:user' | ConvertTo-Json -Depth 10 -Compress
                         } catch {
                             $statusCode = 500
                             $content = @{ success = $false; error = "Failed to submit review: $($_.Exception.Message)" } | ConvertTo-Json -Compress

--- a/src/ui/static/modules/actions.js
+++ b/src/ui/static/modules/actions.js
@@ -853,12 +853,17 @@ function attachActionHandlers(container) {
 
     // Approve review buttons
     container.querySelectorAll('.approve-review').forEach(btn => {
-        btn.addEventListener('click', () => handleReviewAction(btn, true));
+        btn.addEventListener('click', () => handleReviewAction(btn, 'approve'));
+    });
+
+    // Revise review buttons
+    container.querySelectorAll('.revise-review').forEach(btn => {
+        btn.addEventListener('click', () => handleReviewAction(btn, 'revise'));
     });
 
     // Reject review buttons
     container.querySelectorAll('.reject-review').forEach(btn => {
-        btn.addEventListener('click', () => handleReviewAction(btn, false));
+        btn.addEventListener('click', () => handleReviewAction(btn, 'reject'));
     });
 
     // Task batch questions: per-question option selection
@@ -1378,12 +1383,13 @@ function renderReviewItem(item) {
                 ` : ''}
 
                 <div class="review-reject-fields" style="display:none;">
-                    <textarea class="review-comment" placeholder="Reviewer comment (required for reject) — what should the implementor change?"></textarea>
+                    <textarea class="review-comment" placeholder="Reviewer comment (required for reject or revise) — what should the implementor change?"></textarea>
                     <textarea class="review-what-wrong" placeholder="(Optional) What was wrong with this attempt?"></textarea>
                 </div>
 
                 <div class="action-submit">
                     <button class="ctrl-btn reject-review">Reject &amp; restart</button>
+                    <button class="ctrl-btn revise-review">Revise</button>
                     <button class="ctrl-btn primary approve-review">Approve &amp; merge</button>
                 </div>
             </div>
@@ -1391,17 +1397,19 @@ function renderReviewItem(item) {
     `;
 }
 
-async function handleReviewAction(btn, approved) {
+async function handleReviewAction(btn, decision) {
     const actionItem = btn.closest('.action-item');
     const taskId = actionItem?.dataset.taskId;
     if (!taskId) return;
 
-    // First-click on Reject reveals the comment fields; second click submits.
-    if (!approved) {
-        const rejectFields = actionItem.querySelector('.review-reject-fields');
-        if (rejectFields && rejectFields.style.display === 'none') {
-            rejectFields.style.display = 'block';
-            btn.textContent = 'Confirm reject';
+    const needsComment = decision === 'reject' || decision === 'revise';
+
+    // First click on Reject/Revise reveals the comment fields; second click submits.
+    if (needsComment) {
+        const feedbackFields = actionItem.querySelector('.review-reject-fields');
+        if (feedbackFields && feedbackFields.style.display === 'none') {
+            feedbackFields.style.display = 'block';
+            btn.textContent = decision === 'revise' ? 'Confirm revise' : 'Confirm reject';
             return;
         }
     }
@@ -1409,13 +1417,17 @@ async function handleReviewAction(btn, approved) {
     const comment = actionItem.querySelector('.review-comment')?.value?.trim() || '';
     const whatWasWrong = actionItem.querySelector('.review-what-wrong')?.value?.trim() || '';
 
-    if (!approved && !comment) {
-        showToast('A comment is required when rejecting — describe what needs to change', 'warning');
+    if (needsComment && !comment) {
+        const verb = decision === 'revise' ? 'revising' : 'rejecting';
+        showToast(`A comment is required when ${verb} — describe what needs to change`, 'warning');
         return;
     }
 
+    const pendingText = { approve: 'Approving...', revise: 'Revising...', reject: 'Rejecting...' };
+    const restoreText = { approve: 'Approve & merge', revise: 'Confirm revise', reject: 'Confirm reject' };
+
     btn.disabled = true;
-    btn.textContent = approved ? 'Approving...' : 'Rejecting...';
+    btn.textContent = pendingText[decision];
 
     try {
         const response = await fetch(`${API_BASE}/api/task/submit-review`, {
@@ -1423,7 +1435,7 @@ async function handleReviewAction(btn, approved) {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 task_id: taskId,
-                approved: approved,
+                decision: decision,
                 comment: comment || null,
                 what_was_wrong: whatWasWrong || null
             })
@@ -1441,17 +1453,17 @@ async function handleReviewAction(btn, approved) {
                     '<div class="empty-state">No pending actions</div>';
             }
             if (typeof pollState === 'function') { pollState(); }
-            showToast(result.message || (approved ? 'Approved' : 'Rejected'), 'success');
+            showToast(result.message || 'Review submitted', 'success');
         } else {
             showToast('Failed to submit review: ' + (result.error || 'Unknown error'), 'error');
             btn.disabled = false;
-            btn.textContent = approved ? 'Approve & merge' : 'Confirm reject';
+            btn.textContent = restoreText[decision];
         }
     } catch (error) {
         console.error('Error submitting review:', error);
         showToast('Error submitting review', 'error');
         btn.disabled = false;
-        btn.textContent = approved ? 'Approve & merge' : 'Confirm reject';
+        btn.textContent = restoreText[decision];
     }
 }
 

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -683,6 +683,86 @@ if (Test-Path $promptBuilderScript) {
     Assert-True -Name "Build-TaskPrompt keeps full INSTANCE_ID available" `
         -Condition ($promptResult -match '\[bot-full:A1B2C3D4-1111-2222-3333-444455556666\]') `
         -Message "Expected full INSTANCE_ID replacement"
+
+    # Reviewer feedback injection: when review_feedback is present, the
+    # {{REVIEWER_FEEDBACK}} block must carry the mandate + each comment; when
+    # absent the placeholder collapses to empty (no leftover token).
+    $feedbackTemplate = "BEGIN`n{{REVIEWER_FEEDBACK}}`nEND"
+
+    $feedbackTask = [PSCustomObject]@{
+        id = "7b012fb8-d6fa-45e8-b89e-062b4bcb16ae"
+        name = "Feedback Task"
+        category = "feature"
+        priority = 10
+        description = "x"
+        applicable_standards = @(); applicable_agents = @(); acceptance_criteria = @(); steps = @()
+        questions_resolved = @()
+        review_feedback = @(
+            [PSCustomObject]@{ comment = "Fix the header copy"; what_was_wrong = "Used wrong product name"; timestamp = "2026-06-15T00:00:00Z" }
+            [PSCustomObject]@{ comment = "Tighten the spacing"; what_was_wrong = ""; timestamp = "2026-06-15T01:00:00Z" }
+        )
+    }
+    $feedbackResult = Build-TaskPrompt -PromptTemplate $feedbackTemplate -Task $feedbackTask -SessionId "sess-1" -InstanceId "A1B2C3D4-1111-2222-3333-444455556666"
+
+    Assert-True -Name "Build-TaskPrompt injects reviewer feedback mandate" `
+        -Condition ($feedbackResult -match 'MUST\*\* address each item') `
+        -Message "Expected the feedback mandate text in the prompt"
+    Assert-True -Name "Build-TaskPrompt injects each feedback comment" `
+        -Condition (($feedbackResult -match 'Fix the header copy') -and ($feedbackResult -match 'Tighten the spacing')) `
+        -Message "Expected every feedback comment in the prompt"
+    Assert-True -Name "Build-TaskPrompt injects what_was_wrong when present" `
+        -Condition ($feedbackResult -match 'Used wrong product name') `
+        -Message "Expected what_was_wrong detail in the prompt"
+    Assert-True -Name "Build-TaskPrompt leaves no REVIEWER_FEEDBACK placeholder" `
+        -Condition ($feedbackResult -notmatch '\{\{REVIEWER_FEEDBACK\}\}') `
+        -Message "Expected the placeholder to be replaced"
+
+    $noFeedbackTask = [PSCustomObject]@{
+        id = "7b012fb8-d6fa-45e8-b89e-062b4bcb16ae"
+        name = "No Feedback Task"
+        category = "feature"; priority = 10; description = "x"
+        applicable_standards = @(); applicable_agents = @(); acceptance_criteria = @(); steps = @()
+        questions_resolved = @(); review_feedback = @()
+    }
+    $noFeedbackResult = Build-TaskPrompt -PromptTemplate $feedbackTemplate -Task $noFeedbackTask -SessionId "sess-1" -InstanceId "A1B2C3D4-1111-2222-3333-444455556666"
+    Assert-True -Name "Build-TaskPrompt yields empty feedback block when none" `
+        -Condition ($noFeedbackResult -match "BEGIN`n`nEND") `
+        -Message "Expected an empty feedback block (placeholder replaced with empty string)"
+
+    # Resolve-TaskReviewDecision: shared decision logic for reject vs revise.
+    $reviewTask = [PSCustomObject]@{
+        name = "Review Decision Task"
+        extensions = [PSCustomObject]@{
+            review = [PSCustomObject]@{ feedback = @([PSCustomObject]@{ comment = "old"; what_was_wrong = ""; timestamp = "2026-06-14T00:00:00Z" }) }
+        }
+    }
+
+    $rejectDecision = Resolve-TaskReviewDecision -Task $reviewTask -Decision 'reject' -Comment 'Please redo' -WhatWasWrong 'broken' -Now '2026-06-15T00:00:00Z'
+    Assert-True -Name "Resolve-TaskReviewDecision reject sets rejected status" `
+        -Condition ($rejectDecision.success -and $rejectDecision.reviewReplacement.status -eq 'rejected') `
+        -Message "Reject must set review status to rejected"
+    Assert-True -Name "Resolve-TaskReviewDecision reject discards worktree" `
+        -Condition ($rejectDecision.resetWorktree -eq $true) `
+        -Message "Reject must request worktree reset"
+    Assert-True -Name "Resolve-TaskReviewDecision reject accumulates feedback" `
+        -Condition ($rejectDecision.feedbackCount -eq 2) `
+        -Message "Reject must append to existing feedback (1 existing + 1 new = 2)"
+
+    $reviseDecision = Resolve-TaskReviewDecision -Task $reviewTask -Decision 'revise' -Comment 'Tweak it' -WhatWasWrong '' -Now '2026-06-15T00:00:00Z'
+    Assert-True -Name "Resolve-TaskReviewDecision revise sets revision_requested status" `
+        -Condition ($reviseDecision.success -and $reviseDecision.reviewReplacement.status -eq 'revision_requested') `
+        -Message "Revise must set review status to revision_requested"
+    Assert-True -Name "Resolve-TaskReviewDecision revise preserves worktree" `
+        -Condition ($reviseDecision.resetWorktree -eq $false) `
+        -Message "Revise must NOT request worktree reset"
+    Assert-True -Name "Resolve-TaskReviewDecision revise returns task to todo" `
+        -Condition ($reviseDecision.targetStatus -eq 'todo') `
+        -Message "Revise must return the task to todo"
+
+    $missingComment = Resolve-TaskReviewDecision -Task $reviewTask -Decision 'revise' -Comment '   ' -Now '2026-06-15T00:00:00Z'
+    Assert-True -Name "Resolve-TaskReviewDecision requires a comment" `
+        -Condition (-not $missingComment.success -and $missingComment.error -match 'required') `
+        -Message "A blank comment must be rejected with an error"
 } else {
     Write-TestResult -Name "Dotbot.Task module exists" -Status Fail -Message "Module not found at $promptBuilderScript"
 }


### PR DESCRIPTION
## Linked issue

Closes #465

## Summary of changes

Adds a third review verb, **Revise**, alongside the existing **Approve** and **Reject**, and wires accumulated reviewer feedback into the execution prompt so re-runs are no longer blind.

Previously, rejecting a task in `needs-review` discarded its worktree and branch and regenerated from an empty base. Reviewer feedback was persisted to `extensions.review.feedback[]` but never injected into the next execution prompt, making targeted, iterative corrections impossible.

The three verbs now behave as follows:

| Verb                 | Behaviour                                                         | Worktree                     | Status |
| -------------------- | ----------------------------------------------------------------- | ---------------------------- | ------ |
| **Approve & merge**  | merge then complete                                               | removed after merge          | `done` |
| **Reject & restart** | discard + fresh regeneration                                      | reset (`Reset-TaskWorktree`) | `todo` |
| **Revise** _(new)_   | preserve branch + uncommitted edits, targeted in-place correction | preserved                    | `todo` |

Both Reject and Revise append the reviewer comment to `extensions.review.feedback[]` and return the task to `todo`; they differ only in whether the worktree is discarded. The accumulated feedback is injected into the next run via a new `{{REVIEWER_FEEDBACK}}` prompt block.

Key changes:

- **Centralized decision logic** — new `Resolve-TaskReviewDecision` in `Dotbot.Task.psm1` is a pure (no-I/O) function shared by the MCP `task_submit_review` tool and the UI's `Submit-TaskReview`, eliminating the duplicated reject logic. It returns a descriptor (`reviewReplacement`, `targetStatus`, `resetWorktree`, `feedbackCount`); callers apply it and conditionally reset the worktree.
- **Feedback injection** — `Build-TaskPrompt` now formats `review_feedback` into the `{{REVIEWER_FEEDBACK}}` placeholder added to `99-autonomous-task.md` (and the `start-from-jira` variant), with an explicit mandate to address each item via targeted corrections. `_FlattenTask` surfaces `extensions.review.feedback` onto the task object.
- **MCP tool** — `metadata.json` gains a `decision` field (`approve` | `reject` | `revise`); the legacy `approved` boolean is kept as a deprecated fallback (`true` → approve, `false` → reject) and `task_id` is now the only required field.
- **UI** — `actions.js` adds a **Revise** button and reworks `handleReviewAction` to take a `decision` string instead of an `approved` boolean, with two-click confirm and a comment requirement for both reject and revise.

### Acceptance criteria coverage

- [x] A task can be re-run with its previous output as an editable base — **Revise** preserves the worktree + branch (never calls `Reset-TaskWorktree`)
- [x] Only sections targeted by feedback are regenerated — the `{{REVIEWER_FEEDBACK}}` block mandates targeted corrections over rewrite
- [x] Feedback accumulated across cycles is injected and honoured — appended to `extensions.review.feedback[]` and rendered with "you **MUST** address each item"
- [x] The full-regeneration path remains available — **Reject & restart** is unchanged
- [x] Manual edits between runs are preserved — Revise never resets the worktree, so uncommitted edits survive

## Screenshots / recordings

The review action card now shows three verbs — **Reject & restart**, **Revise**, and **Approve & merge** — with the shared comment / "what was wrong" fields revealed on Reject or Revise:

<img width="1480" height="920" alt="09-reject-fields-filled" src="https://github.com/user-attachments/assets/f0a1db76-1ac5-4e4b-bff4-42d5aa9e9d96" />


Submitting a Revise returns the task to `todo` while preserving the worktree:

<img width="1480" height="920" alt="07-revise-result-overview" src="https://github.com/user-attachments/assets/bd0634ea-bfa5-4643-8211-183c82ba8de4" />

## Testing notes

`tests/Test-Components.ps1` adds coverage for:

- `Build-TaskPrompt` injects the feedback mandate and every feedback comment, leaves no leftover `{{REVIEWER_FEEDBACK}}` placeholder, and yields an empty block when there is no feedback.
- `Resolve-TaskReviewDecision` sets `rejected` status and requests a worktree reset for reject, sets `revision_requested` status and preserves the worktree for revise, and accumulates feedback across cycles.

## Checklist

- [x] Tests added or updated
- [x] Docs updated (if behaviour changed)
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
