### PR TITLE
fix(mcp): bump server metadata version to 4.0.0

### DIFF
--- a/src/mcp/metadata.json
+++ b/src/mcp/metadata.json
@@ -2,7 +2,7 @@
   "protocolVersion": "2024-11-05",
   "serverInfo": {
     "name": "dotbot",
-    "version": "3.5.0",
+    "version": "4.0.0",
     "description": "Dotbot MCP server - supports and provides tools to the dotbot agentic and autonomous software product engineering system"
   },
   "capabilities": {


### PR DESCRIPTION
The MCP server metadata (`src/mcp/metadata.json`) still reported `3.5.0` while `version.json` was bumped to `4.0.0` in the v4 merge. This aligns the reported `serverInfo.version` with the release version.

Noticed while updating the docs site for v4.