### PR TITLE
feat: per-run integration branch + configurable base branch

### DIFF
--- a/content/settings/settings.default.json
+++ b/content/settings/settings.default.json
@@ -53,6 +53,9 @@
     "provider_completion_grace_seconds": 10,
     "provider_stop_check_interval_seconds": 2
   },
+  "git": {
+    "base_branch": null
+  },
   "editor": {
     "name": "off",
     "custom_command": ""

--- a/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psd1
+++ b/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psd1
@@ -19,6 +19,7 @@
         'Read-WorktreeMap'
         'Write-WorktreeMap'
         'Invoke-WorktreeMapLocked'
+        'Resolve-DotbotBaseBranch'
         'Resolve-MainBranch'
         'Assert-OnBaseBranch'
         'Stop-WorktreeProcesses'

--- a/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1
+++ b/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1
@@ -144,18 +144,51 @@ function Write-WorktreeMap {
     }
 }
 
-function Resolve-MainBranch {
+function Resolve-DotbotBaseBranch {
     <#
     .SYNOPSIS
-    Find the canonical integration branch (main or master) by explicit name lookup.
-    Never reads symbolic HEAD — safe to call when the main repo may be on a task branch.
+    Resolve the base branch (the trunk a run is cut from / merged into).
+    Reads the configured git.base_branch when a BotRoot is supplied; when set it
+    must exist (fail-fast, no silent fallback). When empty, falls back to the
+    canonical main/master lookup. Never reads symbolic HEAD — safe to call when
+    the main repo may be on a task branch.
     #>
-    param([string]$ProjectRoot)
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [string]$BotRoot
+    )
+
+    $configured = $null
+    if ($BotRoot -and (Get-Command Get-MergedSettings -ErrorAction SilentlyContinue)) {
+        $merged = Get-MergedSettings -BotRoot $BotRoot
+        if ($merged -and $merged.PSObject.Properties['git'] -and $merged.git -and $merged.git.PSObject.Properties['base_branch']) {
+            $configured = $merged.git.base_branch
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace([string]$configured)) {
+        git -C $ProjectRoot rev-parse --verify $configured 2>$null | Out-Null
+        if ($LASTEXITCODE -eq 0) { return [string]$configured }
+        throw "git.base_branch is set to '$configured' but no such branch exists in $ProjectRoot. Create it or update the setting — refusing to fall back to main/master."
+    }
+
     foreach ($candidate in @('main', 'master')) {
         git -C $ProjectRoot rev-parse --verify $candidate 2>$null | Out-Null
         if ($LASTEXITCODE -eq 0) { return $candidate }
     }
     return $null
+}
+
+function Resolve-MainBranch {
+    <#
+    .SYNOPSIS
+    Find the canonical integration branch (main or master) by explicit name lookup,
+    honouring git.base_branch when a BotRoot is supplied. Delegates to
+    Resolve-DotbotBaseBranch. Never reads symbolic HEAD — safe to call when the
+    main repo may be on a task branch.
+    #>
+    param([string]$ProjectRoot, [string]$BotRoot)
+    return Resolve-DotbotBaseBranch -ProjectRoot $ProjectRoot -BotRoot $BotRoot
 }
 
 function Test-RepositoryHasCommits {
@@ -1314,7 +1347,8 @@ function New-TaskWorktree {
         [Parameter(Mandatory)][string]$TaskId,
         [Parameter(Mandatory)][string]$TaskName,
         [Parameter(Mandatory)][string]$ProjectRoot,
-        [Parameter(Mandatory)][string]$BotRoot
+        [Parameter(Mandatory)][string]$BotRoot,
+        [string]$BaseBranch
     )
 
     $shortId = $TaskId.Substring(0, [Math]::Min(8, $TaskId.Length))
@@ -1338,7 +1372,7 @@ function New-TaskWorktree {
             Repair-TaskWorktreeProductWorkspace -WorktreePath $worktreePath -BotRoot $BotRoot
             Initialize-DotbotWorktreeExecutionEnvironment -WorktreePath $worktreePath -ProjectRoot $ProjectRoot -BotRoot $BotRoot
             # Valid worktree — ensure map entry exists and return it
-            $existingBaseBranch = Resolve-MainBranch -ProjectRoot $ProjectRoot
+            $existingBaseBranch = if (-not [string]::IsNullOrWhiteSpace($BaseBranch)) { $BaseBranch } else { Resolve-DotbotBaseBranch -ProjectRoot $ProjectRoot -BotRoot $BotRoot }
             Invoke-WorktreeMapLocked -BotRoot $BotRoot -Action {
                 $lockedMap = Read-WorktreeMap -BotRoot $BotRoot
                 if (-not $lockedMap.ContainsKey($TaskId)) {
@@ -1372,7 +1406,7 @@ function New-TaskWorktree {
         # A clean newly-initialized repo has no commits yet, so use git's
         # orphan worktree mode for the first task without creating a synthetic
         # base commit in the main checkout.
-        $baseBranch = Resolve-MainBranch -ProjectRoot $ProjectRoot
+        $baseBranch = if (-not [string]::IsNullOrWhiteSpace($BaseBranch)) { $BaseBranch } else { Resolve-DotbotBaseBranch -ProjectRoot $ProjectRoot -BotRoot $BotRoot }
         $baseIsUnborn = $false
         if (-not $baseBranch) {
             $baseBranch = Resolve-UnbornBaseBranch -ProjectRoot $ProjectRoot
@@ -1556,7 +1590,7 @@ function Complete-TaskWorktree {
     try {
         # Determine target base branch — prefer the value recorded at worktree creation
         # (immune to HEAD drift on the main repo); fall back to explicit main/master lookup.
-        $baseBranch = $entry.base_branch ?? (Resolve-MainBranch -ProjectRoot $ProjectRoot)
+        $baseBranch = $entry.base_branch ?? (Resolve-MainBranch -ProjectRoot $ProjectRoot -BotRoot $BotRoot)
         if (-not $baseBranch) { throw "Cannot determine base branch for task $TaskId" }
 
         # Kill any processes still running in the worktree (dev servers, file watchers, etc.)
@@ -2120,6 +2154,7 @@ Export-ModuleMember -Function @(
     'Read-WorktreeMap'
     'Write-WorktreeMap'
     'Invoke-WorktreeMapLocked'
+    'Resolve-DotbotBaseBranch'
     'Resolve-MainBranch'
     'Assert-OnBaseBranch'
     'Stop-WorktreeProcesses'

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -121,7 +121,8 @@ function Initialize-DotbotTaskWorktreeForProcess {
         [Parameter(Mandatory)] $Task,
         [Parameter(Mandatory)] [string]$ProjectRoot,
         [Parameter(Mandatory)] [string]$BotRoot,
-        [Parameter(Mandatory)] [string]$ProcessId
+        [Parameter(Mandatory)] [string]$ProcessId,
+        [string]$BaseBranch
     )
 
     Write-Diag "Worktree: required category=$($Task.category)"
@@ -137,11 +138,13 @@ function Initialize-DotbotTaskWorktreeForProcess {
         }
     }
 
-    try { Assert-OnBaseBranch -ProjectRoot $ProjectRoot | Out-Null } catch {
+    $guardArgs = @{ ProjectRoot = $ProjectRoot }
+    if (-not [string]::IsNullOrWhiteSpace($BaseBranch)) { $guardArgs.BranchName = $BaseBranch }
+    try { Assert-OnBaseBranch @guardArgs | Out-Null } catch {
         Write-Status "Branch guard warning: $($_.Exception.Message)" -Type Warn
     }
     $wtResult = New-TaskWorktree -TaskId $Task.id -TaskName $Task.name `
-        -ProjectRoot $ProjectRoot -BotRoot $BotRoot
+        -ProjectRoot $ProjectRoot -BotRoot $BotRoot -BaseBranch $BaseBranch
     if ($wtResult.success) {
         Write-Status "Worktree: $($wtResult.worktree_path)" -Type Info
         return @{
@@ -1178,6 +1181,28 @@ if ($LASTEXITCODE -ne 0) {
 $processData.status = 'running'
 Write-ProcessFile -Id $procId -Data $processData
 
+$integrationBranch = $null
+$resolvedBase = $null
+if ($RunId) {
+    $resolvedBase = Resolve-DotbotBaseBranch -ProjectRoot $projectRoot -BotRoot $botRoot
+    if (-not $resolvedBase) {
+        Write-ProcessActivity -Id $procId -ActivityType "text" -Message "No base branch yet (unborn repo); skipping integration branch — first task uses an orphan worktree."
+    } else {
+        $integrationSlug  = ConvertTo-WorktreeSlug -Text $WorkflowName
+        $integrationShort = Get-ShortId -Id $RunId
+        $integrationBranch = Get-WorktreeBranchName -Slug $integrationSlug -ShortId $integrationShort
+        git -C $projectRoot rev-parse --verify $integrationBranch 2>$null | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            git -C $projectRoot branch $integrationBranch $resolvedBase 2>&1 | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to create integration branch '$integrationBranch' off '$resolvedBase' in $projectRoot."
+            }
+        }
+        Write-Status "Integration branch: $integrationBranch (off $resolvedBase)" -Type Info
+        Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Integration branch $integrationBranch created off $resolvedBase; tasks will squash-merge into it."
+    }
+}
+
 $loopIteration = 0
 try {
     while ($true) {
@@ -1420,7 +1445,7 @@ try {
             $worktreePath = $null
             $branchName = $null
             $worktreeSetup = Initialize-DotbotTaskWorktreeForProcess -Task $task `
-                -ProjectRoot $projectRoot -BotRoot $botRoot -ProcessId $procId
+                -ProjectRoot $projectRoot -BotRoot $botRoot -ProcessId $procId -BaseBranch $integrationBranch
             if ($worktreeSetup) {
                 $worktreePath = $worktreeSetup.worktree_path
                 $branchName = $worktreeSetup.branch_name
@@ -1646,7 +1671,7 @@ try {
         $worktreePath = $null
         $branchName = $null
         $worktreeSetup = Initialize-DotbotTaskWorktreeForProcess -Task $task `
-            -ProjectRoot $projectRoot -BotRoot $botRoot -ProcessId $procId
+            -ProjectRoot $projectRoot -BotRoot $botRoot -ProcessId $procId -BaseBranch $integrationBranch
         if ($worktreeSetup) {
             $worktreePath = $worktreeSetup.worktree_path
             $branchName = $worktreeSetup.branch_name
@@ -2334,6 +2359,39 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
             Write-BotLog -Level Warn -Message "Failed to update WorkflowRun live status for $RunId" -Exception $_
         }
     }
+
+    if ($integrationBranch) {
+        try {
+            $integrationRemote = git -C $projectRoot remote get-url origin 2>$null
+            if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($integrationRemote)) {
+                $pushOutput = git -C $projectRoot push -u origin $integrationBranch 2>&1
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Status "Integration branch pushed: $integrationBranch" -Type Complete
+                    Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Integration branch $integrationBranch pushed to $($integrationRemote.Trim()). Open a PR into $resolvedBase."
+                } else {
+                    $pushError = ($pushOutput | Out-String).Trim()
+                    Write-Status "Integration branch push failed; branch preserved locally." -Type Warn
+                    Write-ProcessActivity -Id $procId -ActivityType "error" -Message "Failed to push integration branch $integrationBranch (preserved locally): $pushError. Push manually with: git push -u origin $integrationBranch"
+                }
+            } else {
+                Write-ProcessActivity -Id $procId -ActivityType "text" -Message "No remote configured; integration branch $integrationBranch preserved locally. Push it and open a PR into $resolvedBase when ready."
+            }
+        } catch {
+            Write-ProcessActivity -Id $procId -ActivityType "error" -Message "Integration branch push step failed (branch $integrationBranch preserved locally): $($_.Exception.Message)"
+        }
+
+        if ($resolvedBase) {
+            try {
+                git -C $projectRoot checkout $resolvedBase 2>&1 | Out-Null
+                if ($LASTEXITCODE -ne 0) {
+                    Write-BotLog -Level Warn -Message "Failed to restore working copy to base branch '$resolvedBase' after run $RunId"
+                }
+            } catch {
+                Write-BotLog -Level Warn -Message "Failed to restore working copy to base branch '$resolvedBase'" -Exception $_
+            }
+        }
+    }
+
     Write-ProcessFile -Id $procId -Data $processData
     Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Process $procId finished ($($processData.status), tasks_completed: $tasksProcessed)"
     Write-Information "process_end: id=$procId status=$($processData.status) tasks_completed=$tasksProcessed" -Tags @('dotbot', 'process', 'lifecycle')

--- a/src/ui/modules/SettingsAPI.psm1
+++ b/src/ui/modules/SettingsAPI.psm1
@@ -444,6 +444,38 @@ function Set-AnalysisConfig {
     }
 }
 
+function Get-GitConfig {
+    $settingsData = Get-MergedSettings -BotRoot $script:Config.BotRoot
+    if ($settingsData.git) {
+        return $settingsData.git
+    }
+    return @{ base_branch = $null }
+}
+
+function Set-GitConfig {
+    param(
+        [Parameter(Mandatory)] $Body
+    )
+    $patch = @{}
+
+    if ($Body.PSObject.Properties.Name -contains 'base_branch') {
+        if ([string]::IsNullOrWhiteSpace([string]$Body.base_branch)) {
+            $patch.base_branch = $null
+        } else {
+            $patch.base_branch = [string]$Body.base_branch
+        }
+    }
+
+    Save-OverrideSection -Key 'git' -Patch $patch
+    Write-Status "Git config updated" -Type Success
+
+    $merged = Get-MergedSettings -BotRoot $script:Config.BotRoot
+    return @{
+        success = $true
+        git = $merged.git
+    }
+}
+
 function Resolve-VerifyConfigPath {
     # Project tier first; framework default fallback. Reads prefer the
     # project override; writes always target the project path so the
@@ -1320,6 +1352,8 @@ Export-ModuleMember -Function @(
     'Set-Settings',
     'Get-AnalysisConfig',
     'Set-AnalysisConfig',
+    'Get-GitConfig',
+    'Set-GitConfig',
     'Get-VerificationConfig',
     'Set-VerificationConfig',
     'Get-CostConfig',

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -309,6 +309,76 @@ if (Test-Path $worktreeManagerModule) {
         Remove-TestProject -Path $resolveMainRepo
     }
 
+    # Resolve-DotbotBaseBranch (#466): configurable base branch with fail-fast on a
+    # configured-but-missing trunk. Group A exercises the no-config fallback (no BotRoot
+    # -> the Get-Command guard skips Get-MergedSettings -> deterministic main/master/null).
+    $rdbbNoCfg = New-TestProject -Prefix 'dotbot-test-rdbb-nocfg'
+    try {
+        Push-Location $rdbbNoCfg
+        & git branch -M main 2>&1 | Out-Null
+        Pop-Location
+        Assert-Equal -Name "#466: Resolve-DotbotBaseBranch defaults to 'main' (no config)" `
+            -Expected "main" -Actual (Resolve-DotbotBaseBranch -ProjectRoot $rdbbNoCfg)
+
+        Push-Location $rdbbNoCfg
+        & git branch -m main master 2>&1 | Out-Null
+        Pop-Location
+        Assert-Equal -Name "#466: Resolve-DotbotBaseBranch falls back to 'master' (no config)" `
+            -Expected "master" -Actual (Resolve-DotbotBaseBranch -ProjectRoot $rdbbNoCfg)
+
+        Push-Location $rdbbNoCfg
+        & git branch -m master legacy-trunk 2>&1 | Out-Null
+        Pop-Location
+        Assert-True -Name "#466: Resolve-DotbotBaseBranch returns null when neither main nor master exists" `
+            -Condition ($null -eq (Resolve-DotbotBaseBranch -ProjectRoot $rdbbNoCfg)) `
+            -Message "Expected null when no main/master and no configured base"
+    } finally {
+        Remove-TestProject -Path $rdbbNoCfg
+    }
+
+    # Group B exercises a configured git.base_branch (read via Get-MergedSettings). A real
+    # .bot is required so the .control/settings.json override layer resolves; import the
+    # settings loader -Global (mirrors the user-settings block below) so the resolver's
+    # Get-Command Get-MergedSettings guard passes.
+    Import-Module (Join-Path $botDir "src/runtime/Modules/Dotbot.Core/Dotbot.Core.psd1") -Force -DisableNameChecking -Global | Out-Null
+    Import-Module (Join-Path $botDir "src/runtime/Modules/Dotbot.Settings/Dotbot.Settings.psd1") -Force -DisableNameChecking -Global | Out-Null
+    $rdbbCfg = New-TestProjectFromGolden -Flavor 'default' -Prefix 'dotbot-test-rdbb-cfg'
+    try {
+        Push-Location $rdbbCfg.ProjectRoot
+        & git branch -M main 2>&1 | Out-Null
+        & git branch develop 2>&1 | Out-Null
+        Pop-Location
+
+        $rdbbControl = Join-Path $rdbbCfg.ControlDir "settings.json"
+        '{ "git": { "base_branch": "develop" } }' | Set-Content -Path $rdbbControl -Encoding UTF8
+
+        Assert-Equal -Name "#466: Resolve-DotbotBaseBranch honours configured git.base_branch" `
+            -Expected "develop" `
+            -Actual (Resolve-DotbotBaseBranch -ProjectRoot $rdbbCfg.ProjectRoot -BotRoot $rdbbCfg.BotDir)
+        Assert-Equal -Name "#466: Resolve-MainBranch delegates and honours git.base_branch" `
+            -Expected "develop" `
+            -Actual (Resolve-MainBranch -ProjectRoot $rdbbCfg.ProjectRoot -BotRoot $rdbbCfg.BotDir)
+
+        # Configured-but-missing trunk must fail fast — no silent fallback to main.
+        '{ "git": { "base_branch": "nonexistent-trunk" } }' | Set-Content -Path $rdbbControl -Encoding UTF8
+        $rdbbThrew = $false
+        $rdbbErr = ""
+        try {
+            Resolve-DotbotBaseBranch -ProjectRoot $rdbbCfg.ProjectRoot -BotRoot $rdbbCfg.BotDir | Out-Null
+        } catch {
+            $rdbbThrew = $true
+            $rdbbErr = $_.Exception.Message
+        }
+        Assert-True -Name "#466: Resolve-DotbotBaseBranch throws when configured base branch is missing" `
+            -Condition $rdbbThrew `
+            -Message "Expected fail-fast throw for a configured-but-missing base branch"
+        Assert-True -Name "#466: Resolve-DotbotBaseBranch fail-fast message names the configured branch" `
+            -Condition ($rdbbErr -match 'nonexistent-trunk') `
+            -Message "Expected error to mention the configured branch, got: $rdbbErr"
+    } finally {
+        Remove-TestProject -Path $rdbbCfg.ProjectRoot
+    }
+
     Assert-True -Name "Dotbot.Worktree has no Get-BaseBranch function (replaced by Resolve-MainBranch for #317)" `
         -Condition (-not (Select-String -Path $worktreeManagerModule -Pattern 'function Get-BaseBranch' -Quiet)) `
         -Message "Get-BaseBranch read HEAD and caused #317 — it must remain deleted"
@@ -2409,6 +2479,19 @@ if (Test-Path $settingsApiModule) {
         Assert-True -Name "#309: Set-EditorConfig success" -Condition ($r.success -eq $true)
         Assert-Equal -Name "#309: EditorConfig writes to .control overrides" -Expected "custom" -Actual (Get-OverridesJson).editor.name
         Assert-Equal -Name "#309: EditorConfig custom_command persisted" -Expected "vi {path}" -Actual (Get-OverridesJson).editor.custom_command
+
+        # --- Get/Set-GitConfig (#466) ---
+        Assert-True -Name "#466: Get-GitConfig base_branch defaults to null (no git section seeded)" `
+            -Condition ($null -eq (Get-GitConfig).base_branch)
+        $r = Set-GitConfig -Body ([PSCustomObject]@{ base_branch = "develop" })
+        Assert-True -Name "#466: Set-GitConfig success" -Condition ($r.success -eq $true)
+        Assert-Equal -Name "#466: GitConfig writes base_branch to .control overrides" -Expected "develop" -Actual (Get-OverridesJson).git.base_branch
+        Assert-Equal -Name "#466: GitConfig merged read returns override" -Expected "develop" -Actual (Get-GitConfig).base_branch
+        # Blank/whitespace clears the override back to null.
+        $r = Set-GitConfig -Body ([PSCustomObject]@{ base_branch = "   " })
+        Assert-True -Name "#466: Set-GitConfig clear success" -Condition ($r.success -eq $true)
+        Assert-True -Name "#466: GitConfig blank base_branch persists null in .control" -Condition ($null -eq (Get-OverridesJson).git.base_branch)
+        Assert-True -Name "#466: GitConfig merged read returns null after clear" -Condition ($null -eq (Get-GitConfig).base_branch)
 
         # --- Set-ActiveProvider (top-level scalar) ---
         $r = Set-ActiveProvider -Body ([PSCustomObject]@{ provider = "claude" })


### PR DESCRIPTION
## Linked issue

Closes #466

## Summary of changes

Workflow runs no longer squash-merge each task straight into the trunk. Instead, every run (any run with a `RunId`) now:

- resolves a **configurable base branch** via the new `git.base_branch` setting (per-project + per-user through `Get-MergedSettings`), falling back to today's `main`/`master` auto-detection. A configured-but-missing branch **fails fast** with an actionable error (no silent fallback).
- creates a single **per-run integration branch** `workflow/<slug>-<short>` off the resolved base,
- routes every task's squash-merge **into that integration branch** (the trunk is never mutated during the run),
- at completion **pushes** the branch to `origin` (`-u`), surfaces the branch name + remote so a human/CI can open one PR (integration → base), and **restores** the working copy to the base branch.

No-remote → branch preserved locally, push skipped, noted. Push failure → logged with a manual-push hint, run is **not** failed (work is already merged locally). Standalone tasks (no `RunId`, completed via UI/MCP) are unchanged.

Core stays provider-agnostic — automatic PR creation (`gh`/`az repos`) remains out of scope.

Key files:

- `src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1` — new `Resolve-DotbotBaseBranch` (fail-fast); `Resolve-MainBranch` delegates + gains `-BotRoot`; `-BaseBranch` override on `New-TaskWorktree`.
- `src/runtime/Scripts/Invoke-WorkflowProcess.ps1` — create the integration branch at run start; thread `-BaseBranch` through task worktrees; push + restore base in the `finally`.
- `content/settings/settings.default.json` — new `git.base_branch` setting.
- `src/ui/modules/SettingsAPI.psm1` — `Get-GitConfig` / `Set-GitConfig`.

## Testing notes

Automated (run from repo root):

- `pwsh -NoProfile -File tests/Test-Components.ps1` → green, including new `#466` assertions for `Resolve-DotbotBaseBranch` (config honored, fail-fast, main/master fallback) and `Get/Set-GitConfig`.
- `pwsh -NoProfile -File tests/Test-Worktree.ps1` → 77/77.
- `pwsh -NoProfile -File tests/Test-ServerStartup.ps1` → 57/57 (server still boots after the `SettingsAPI` change).

Manual testing — including a full end-to-end (E2E) test to confirm the changes are correctly implemented:

- Function-level: integration branch off `develop`, real content squash-merged into it (trunk untouched), pushed to `origin`; configured-but-missing → throws; no-remote and push-failure handled; standalone unchanged.
- End-to-end: clicked RUN on `start-from-prompt` → run minted → `workflow/start-from-prompt-XdIy` created off `develop`, pushed to `origin`, working copy restored to `develop`, trunk not mutated.

## Checklist

- [x] Tests added or updated
- [x] Docs updated (if behaviour changed)
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
