### PR TITLE
fix: align workflow task progress counts between Workflow and Overvie…

### DIFF
--- a/src/ui/server.ps1
+++ b/src/ui/server.ps1
@@ -2236,13 +2236,14 @@ $docContext
                             $wf = Get-CachedTaskWorkflow -File $_
                             $key = if ($wf) { $wf } else { '__default__' }
                             if (-not $tasksByWorkflow.ContainsKey($key)) {
-                                $tasksByWorkflow[$key] = @{ todo = 0; in_progress = 0; done = 0; total = 0 }
+                                $tasksByWorkflow[$key] = @{ todo = 0; in_progress = 0; done = 0; skipped = 0; total = 0 }
                             }
                             $tasksByWorkflow[$key]['total']++
                             switch ($statusDir) {
                                 'todo'        { $tasksByWorkflow[$key]['todo']++ }
                                 'in-progress' { $tasksByWorkflow[$key]['in_progress']++ }
                                 'done'        { $tasksByWorkflow[$key]['done']++ }
+                                'skipped'     { $tasksByWorkflow[$key]['skipped']++ }
                             }
                         }
                     }
@@ -2280,7 +2281,7 @@ $docContext
                             }
                             $seenByName[$wfName] = $true
 
-                            $wfTasks = if ($tasksByWorkflow.ContainsKey($wfName)) { $tasksByWorkflow[$wfName] } else { @{ todo = 0; in_progress = 0; done = 0; total = 0 } }
+                            $wfTasks = if ($tasksByWorkflow.ContainsKey($wfName)) { $tasksByWorkflow[$wfName] } else { @{ todo = 0; in_progress = 0; done = 0; skipped = 0; total = 0 } }
                             $hasRunning = $runningProcs | Where-Object {
                                 Test-WorkflowProcessMatchesName -Process $_ -WorkflowName $wfName
                             }
@@ -2316,7 +2317,7 @@ $docContext
                     # Synthetic "pending-tasks" row — exposes any todo/in-progress tasks that
                     # have no `workflow` field (orphans from workflow phases or manual creation).
                     # Without this, no UI affordance can launch a runner for them. See #324.
-                    $pendingBucket = if ($tasksByWorkflow.ContainsKey('__default__')) { $tasksByWorkflow['__default__'] } else { @{ todo = 0; in_progress = 0; done = 0; total = 0 } }
+                    $pendingBucket = if ($tasksByWorkflow.ContainsKey('__default__')) { $tasksByWorkflow['__default__'] } else { @{ todo = 0; in_progress = 0; done = 0; skipped = 0; total = 0 } }
                     $pendingRunning = $runningProcs | Where-Object {
                         $_.type -eq 'task-runner' -and "$($_.description)" -like $pendingTasksDescriptionPrefix
                     }

--- a/src/ui/static/modules/ui-updates.js
+++ b/src/ui/static/modules/ui-updates.js
@@ -79,7 +79,7 @@ function updateTaskCounts(tasks) {
     // Overview stats
     setElementText('todo-count', tasks.todo);
     setElementText('progress-count', tasks.in_progress);
-    setElementText('done-count', (tasks.done || 0) + (tasks.skipped || 0));
+    setElementText('done-count', getCompletedTaskCount(tasks));
     setElementText('analysing-count', tasks.analysing || 0);
     setElementText('needs-input-count', tasks.needs_input || 0);
     setElementText('analysed-count', tasks.analysed || 0);
@@ -88,7 +88,7 @@ function updateTaskCounts(tasks) {
     setElementText('pipeline-todo-count', tasks.todo);
     setElementText('pipeline-working-count', (tasks.analysing || 0) + (tasks.in_progress || 0));
     setElementText('pipeline-needs-input-count', tasks.needs_input || 0);
-    setElementText('pipeline-done-count', (tasks.done || 0) + (tasks.skipped || 0));
+    setElementText('pipeline-done-count', getCompletedTaskCount(tasks));
     // Legacy pipeline counts (kept for backward compat)
     setElementText('pipeline-analysing-count', tasks.analysing || 0);
     setElementText('pipeline-analysed-count', tasks.analysed || 0);

--- a/src/ui/static/modules/utils.js
+++ b/src/ui/static/modules/utils.js
@@ -744,3 +744,32 @@ function attachFolderToggleHandlers(container) {
         });
     });
 }
+
+/**
+ * Count completed tasks. Across all dotbot progress surfaces "completed" means
+ * done + skipped — a skipped task is a finished task, not an outstanding one.
+ * Single source of truth so the formula can't drift between render paths.
+ * Accepts either a per-workflow `counts`/`tasks` object or the global tasks
+ * object; both expose `done` and `skipped`.
+ * @param {Object} counts - Object exposing `done` and `skipped`
+ * @returns {number} done + skipped
+ */
+function getCompletedTaskCount(counts) {
+    const c = counts || {};
+    return (c.done || 0) + (c.skipped || 0);
+}
+
+/**
+ * Unified task-progress for a workflow's counts. Single source of truth for the
+ * (done + skipped) / total formula used by the Workflow nav tree, the Workflow
+ * metadata row, and the Overview workflow-progress rendering.
+ * @param {Object} counts - Object exposing `done`, `skipped`, and `total`
+ * @returns {{done: number, total: number, percent: number}}
+ */
+function getTaskProgress(counts) {
+    const c = counts || {};
+    const done = getCompletedTaskCount(c);
+    const total = c.total || 0;
+    const percent = total > 0 ? Math.round((done / total) * 100) : 0;
+    return { done, total, percent };
+}

--- a/src/ui/static/modules/workflow-launch.js
+++ b/src/ui/static/modules/workflow-launch.js
@@ -1456,19 +1456,17 @@ function renderOverviewWorkflowPhases(workflows) {
     // Aggregate totals for header
     let totalDone = 0, totalAll = 0;
     workflows.forEach(wf => {
-        const c = wf.counts || {};
-        totalDone += (c.done || 0) + (c.skipped || 0);
-        totalAll += c.total || 0;
+        const { done, total } = getTaskProgress(wf.counts);
+        totalDone += done;
+        totalAll += total;
     });
 
     let html = '';
 
     workflows.forEach((wf, idx) => {
         const counts = wf.counts || {};
-        const doneCount = (counts.done || 0) + (counts.skipped || 0);
-        const totalCount = counts.total || 0;
+        const { done: doneCount, total: totalCount, percent: pct } = getTaskProgress(counts);
         const activeCount = (counts.in_progress || 0) + (counts.analysing || 0);
-        const pct = totalCount > 0 ? Math.round((doneCount / totalCount) * 100) : 0;
 
         // Default: running/incomplete expanded, others collapsed (unless user toggled)
         let isCollapsed;

--- a/src/ui/static/modules/workflow.js
+++ b/src/ui/static/modules/workflow.js
@@ -625,7 +625,7 @@ function renderWorkflowDetailPanel(workflows) {
 
     // Skip re-render if data hasn't changed (compare serialized)
     const dirCount = discoveredDirectories ? discoveredDirectories.length : 0;
-    const dataKey = JSON.stringify({ d: dirCount, w: workflows?.map(w => `${w.name}:${w.status}:${w.tasks?.done}:${w.tasks?.total}`) });
+    const dataKey = JSON.stringify({ d: dirCount, w: workflows?.map(w => `${w.name}:${w.status}:${w.tasks?.done}:${w.tasks?.skipped}:${w.tasks?.total}`) });
     if (dataKey === lastWorkflowNavData) return;
     lastWorkflowNavData = dataKey;
 
@@ -648,7 +648,7 @@ function renderWorkflowDetailPanel(workflows) {
         const isExpanded = expandedWfs.has(wf.name);
         const isRunning = wf.status === 'running' || wf.has_running_process;
         const ledClass = isRunning ? 'led pulse' : 'led off';
-        const done = wf.tasks?.done || 0;
+        const done = (wf.tasks?.done || 0) + (wf.tasks?.skipped || 0);
         const total = wf.tasks?.total || 0;
         const pct = total > 0 ? Math.round((done / total) * 100) : 0;
 
@@ -753,7 +753,7 @@ function renderWorkflowDetailPanel(workflows) {
                     if (authorName) html += `<div class="wf-meta-row"><span class="wf-meta-label">Author</span><span class="wf-meta-value">${escapeHtml(authorName)}</span></div>`;
                 }
                 if (wf.license) html += `<div class="wf-meta-row"><span class="wf-meta-label">License</span><span class="wf-meta-value">${escapeHtml(wf.license)}</span></div>`;
-                if (wf.tasks && wf.tasks.total > 0) html += `<div class="wf-meta-row"><span class="wf-meta-label">Tasks</span><span class="wf-meta-value">${wf.tasks.done}/${wf.tasks.total}</span></div>`;
+                if (wf.tasks && wf.tasks.total > 0) html += `<div class="wf-meta-row"><span class="wf-meta-label">Tasks</span><span class="wf-meta-value">${(wf.tasks.done || 0) + (wf.tasks.skipped || 0)}/${wf.tasks.total}</span></div>`;
                 html += '</div>';
             }
             if (wf.tags && wf.tags.length > 0) {

--- a/src/ui/static/modules/workflow.js
+++ b/src/ui/static/modules/workflow.js
@@ -282,19 +282,17 @@ function renderWorkflowTaskProgress(workflows) {
     // Aggregate totals
     let totalDone = 0, totalAll = 0;
     workflows.forEach(wf => {
-        const c = wf.counts || {};
-        totalDone += (c.done || 0) + (c.skipped || 0);
-        totalAll += c.total || 0;
+        const { done, total } = getTaskProgress(wf.counts);
+        totalDone += done;
+        totalAll += total;
     });
 
     let innerHtml = '';
 
     workflows.forEach(wf => {
         const counts = wf.counts || {};
-        const doneCount = (counts.done || 0) + (counts.skipped || 0);
-        const totalCount = counts.total || 0;
+        const { done: doneCount, total: totalCount, percent: pct } = getTaskProgress(counts);
         const activeCount = (counts.in_progress || 0) + (counts.analysing || 0);
-        const pct = totalCount > 0 ? Math.round((doneCount / totalCount) * 100) : 0;
 
         // Default: running/incomplete expanded, others collapsed (unless user toggled)
         let isCollapsed;
@@ -648,9 +646,7 @@ function renderWorkflowDetailPanel(workflows) {
         const isExpanded = expandedWfs.has(wf.name);
         const isRunning = wf.status === 'running' || wf.has_running_process;
         const ledClass = isRunning ? 'led pulse' : 'led off';
-        const done = (wf.tasks?.done || 0) + (wf.tasks?.skipped || 0);
-        const total = wf.tasks?.total || 0;
-        const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+        const { done, total, percent: pct } = getTaskProgress(wf.tasks);
 
         html += `<div class="wf-section${isExpanded ? '' : ' collapsed'}" data-workflow="${escapeHtml(wf.name)}">`;
 
@@ -753,7 +749,7 @@ function renderWorkflowDetailPanel(workflows) {
                     if (authorName) html += `<div class="wf-meta-row"><span class="wf-meta-label">Author</span><span class="wf-meta-value">${escapeHtml(authorName)}</span></div>`;
                 }
                 if (wf.license) html += `<div class="wf-meta-row"><span class="wf-meta-label">License</span><span class="wf-meta-value">${escapeHtml(wf.license)}</span></div>`;
-                if (wf.tasks && wf.tasks.total > 0) html += `<div class="wf-meta-row"><span class="wf-meta-label">Tasks</span><span class="wf-meta-value">${(wf.tasks.done || 0) + (wf.tasks.skipped || 0)}/${wf.tasks.total}</span></div>`;
+                if (wf.tasks && wf.tasks.total > 0) html += `<div class="wf-meta-row"><span class="wf-meta-label">Tasks</span><span class="wf-meta-value">${getCompletedTaskCount(wf.tasks)}/${wf.tasks.total}</span></div>`;
                 html += '</div>';
             }
             if (wf.tags && wf.tags.length > 0) {


### PR DESCRIPTION
## Summary

The Workflow tab and Overview tab showed different task-progress numbers for the same workflow. Issue #453 reported the Workflow page showing fewer completed tasks than the Overview page.

**Root cause:** the two surfaces are fed by different data sources with different counting rules:

- **Overview** (`renderOverviewWorkflowPhases`) and the Workflow-tab phase widget (`renderWorkflowTaskProgress`) read from `/api/state` and count `(done + skipped) / total`.
- The **Workflow nav tree** (`renderWorkflowDetailPanel`) and meta sidebar read from `/api/workflows/installed`, which counted `done / total` — `skipped` tasks were included in `total` but **not** in `done`.

Result: any workflow with skipped tasks displayed a lower percentage / count in the Workflow nav tree than on Overview.

## Changes

**Backend — `src/ui/server.ps1`** (`/api/workflows/installed`)
- Track `skipped` in the per-workflow task bucket and increment it in the status switch.
- Add `skipped = 0` to the two fallback buckets for shape consistency.

**Frontend — `src/ui/static/modules/workflow.js`**
- Nav-tree progress bar now computes `done = (tasks.done || 0) + (tasks.skipped || 0)`.
- Change-detection cache key now includes `skipped`, so a `todo → skipped` transition triggers a re-render (otherwise the bar would show a stale value).
- Meta sidebar "Tasks" row now shows `(done + skipped) / total`.

All workflow-progress surfaces now use the same `(done + skipped) / total` formula.

Closes #453