### PR TITLE
fix(task): keep runner alive when needs-input task blocks queue

### DIFF
--- a/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psd1
+++ b/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psd1
@@ -25,6 +25,7 @@
         'Build-TaskPrompt'
         'Test-TaskCompletion'
         'Reset-InProgressTasks'
+        'Get-NeedsInputTasksInScope'
         'Reset-SkippedTasks'
         'Invoke-PostScript'
         'Invoke-PostScriptFailureEscalation'

--- a/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
+++ b/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
@@ -519,12 +519,13 @@ function Get-NeedsInputTasksInScope {
         ForEach-Object {
             try {
                 $c = Get-Content -LiteralPath $_.FullName -Raw | ConvertFrom-Json
-                if ([string]$c.status -ne 'needs-input') { return }
-                if ($WorkflowName) {
-                    $tw = if ($c.PSObject.Properties['provenance'] -and $c.provenance) { [string]$c.provenance.workflow } else { $null }
-                    if ($tw -ne $WorkflowName) { return }
+                if ([string]$c.status -eq 'needs-input') {
+                    $matchesWorkflow = -not $WorkflowName -or (
+                        $c.PSObject.Properties['provenance'] -and $c.provenance -and
+                        [string]$c.provenance.workflow -eq $WorkflowName
+                    )
+                    if ($matchesWorkflow) { $c }
                 }
-                $c
             } catch {
                 Write-BotLog -Level Debug -Message "Get-NeedsInputTasksInScope: error reading '$($_.Name)'" -Exception $_
             }

--- a/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
+++ b/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
@@ -507,7 +507,9 @@ function Get-NeedsInputTasksInScope {
         [Parameter(Mandatory)]
         [string]$RunDir,
 
-        [switch]$Recurse
+        [switch]$Recurse,
+
+        [string]$WorkflowName = ''
     )
 
     if (-not (Test-Path -LiteralPath $RunDir)) { return @() }
@@ -517,7 +519,12 @@ function Get-NeedsInputTasksInScope {
         ForEach-Object {
             try {
                 $c = Get-Content -LiteralPath $_.FullName -Raw | ConvertFrom-Json
-                if ([string]$c.status -eq 'needs-input') { $c }
+                if ([string]$c.status -ne 'needs-input') { return }
+                if ($WorkflowName) {
+                    $tw = if ($c.PSObject.Properties['provenance'] -and $c.provenance) { [string]$c.provenance.workflow } else { $null }
+                    if ($tw -ne $WorkflowName) { return }
+                }
+                $c
             } catch {
                 Write-BotLog -Level Debug -Message "Get-NeedsInputTasksInScope: error reading '$($_.Name)'" -Exception $_
             }

--- a/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
+++ b/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
@@ -489,6 +489,41 @@ function Reset-InProgressTasks {
     return ,$resetTasks
 }
 
+function Get-NeedsInputTasksInScope {
+    <#
+    .SYNOPSIS
+    Returns task content objects for all tasks in needs-input status within the given scope.
+
+    .PARAMETER RunDir
+    Directory to scan (same semantics as Reset-InProgressTasks).
+
+    .PARAMETER Recurse
+    When set, scans recursively.
+
+    .OUTPUTS
+    Array of PSCustomObject task content. Empty array when none found.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$RunDir,
+
+        [switch]$Recurse
+    )
+
+    if (-not (Test-Path -LiteralPath $RunDir)) { return @() }
+
+    @(Get-ChildItem -LiteralPath $RunDir -Filter '*.json' -File -Recurse:$Recurse -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -ne 'run.json' } |
+        ForEach-Object {
+            try {
+                $c = Get-Content -LiteralPath $_.FullName -Raw | ConvertFrom-Json
+                if ([string]$c.status -eq 'needs-input') { $c }
+            } catch {
+                Write-BotLog -Level Debug -Message "Get-NeedsInputTasksInScope: error reading '$($_.Name)'" -Exception $_
+            }
+        } | Where-Object { $_ })
+}
+
 function Reset-SkippedTasks {
     <#
     .SYNOPSIS
@@ -1581,6 +1616,7 @@ Export-ModuleMember -Function @(
     'Test-TaskCompletion'
     # State recovery
     'Reset-InProgressTasks'
+    'Get-NeedsInputTasksInScope'
     'Reset-SkippedTasks'
     # Post-script hooks
     'Invoke-PostScript'

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -1123,7 +1123,7 @@ if ($recovered.Count -gt 0) {
     Write-Status "Crash recovery: reset $($recovered.Count) in-progress task(s) to todo: $recoveredNames" -Type Warn
     Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Crash recovery: reset $($recovered.Count) in-progress task(s) to todo"
 }
-$needsInputOnStart = @(Get-NeedsInputTasksInScope -RunDir $runDir -Recurse:$taskSnapshotRecurse)
+$needsInputOnStart = @(Get-NeedsInputTasksInScope -RunDir $runDir -Recurse:$taskSnapshotRecurse -WorkflowName $WorkflowName)
 if ($needsInputOnStart.Count -gt 0) {
     $niNames = ($needsInputOnStart | ForEach-Object { if ($_.PSObject.Properties['name'] -and $_.name) { [string]$_.name } else { [string]$_.id } }) -join ', '
     Write-Status "Resuming: $($needsInputOnStart.Count) task(s) awaiting user input: $niNames. Open ACTION REQUIRED in the control panel." -Type Warn
@@ -1246,7 +1246,7 @@ try {
                 break
             }
             if (-not $RunId) {
-                $needsInputNow = @(Get-NeedsInputTasksInScope -RunDir $runDir -Recurse:$taskSnapshotRecurse)
+                $needsInputNow = @(Get-NeedsInputTasksInScope -RunDir $runDir -Recurse:$taskSnapshotRecurse -WorkflowName $WorkflowName)
                 if ($needsInputNow.Count -gt 0) {
                     $niNames = ($needsInputNow | ForEach-Object { if ($_.PSObject.Properties['name'] -and $_.name) { [string]$_.name } else { [string]$_.id } }) -join ', '
                     Write-Status "Waiting for user input on $($needsInputNow.Count) task(s): $niNames. Answer in ACTION REQUIRED." -Type Info
@@ -1254,16 +1254,23 @@ try {
                     $foundTask = $false
                     while ($true) {
                         Start-Sleep -Seconds 5
-                        if (Test-ProcessStopSignal -Id $procId) { break }
+                        if (Test-ProcessStopSignal -Id $procId) {
+                            $processData.status = 'stopped'
+                            $processData.failed_at = (Get-Date).ToUniversalTime().ToString('o')
+                            Write-ProcessFile -Id $procId -Data $processData
+                            Write-ProcessActivity -Id $procId -ActivityType 'text' -Message 'Process stopped by user'
+                            break
+                        }
                         $processData.last_heartbeat = (Get-Date).ToUniversalTime().ToString("o")
                         Write-ProcessFile -Id $procId -Data $processData
                         $taskResult = Get-NextWorkflowTask -BotRoot $botRoot -RunId $RunId -WorkflowName $WorkflowName
                         if ($taskResult.task) { $foundTask = $true; break }
-                        $needsInputNow = @(Get-NeedsInputTasksInScope -RunDir $runDir -Recurse:$taskSnapshotRecurse)
+                        $needsInputNow = @(Get-NeedsInputTasksInScope -RunDir $runDir -Recurse:$taskSnapshotRecurse -WorkflowName $WorkflowName)
                         if ($needsInputNow.Count -eq 0) { break }
                     }
                     if ($foundTask) { continue }
-                    break
+                    if ($processData.status -eq 'stopped') { break }
+                    continue
                 }
                 $completeMsg = "No pending tasks available. Exiting pending-tasks runner."
                 Write-Status $completeMsg -Type Info

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -1123,6 +1123,12 @@ if ($recovered.Count -gt 0) {
     Write-Status "Crash recovery: reset $($recovered.Count) in-progress task(s) to todo: $recoveredNames" -Type Warn
     Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Crash recovery: reset $($recovered.Count) in-progress task(s) to todo"
 }
+$needsInputOnStart = @(Get-NeedsInputTasksInScope -RunDir $runDir -Recurse:$taskSnapshotRecurse)
+if ($needsInputOnStart.Count -gt 0) {
+    $niNames = ($needsInputOnStart | ForEach-Object { if ($_.PSObject.Properties['name'] -and $_.name) { [string]$_.name } else { [string]$_.id } }) -join ', '
+    Write-Status "Resuming: $($needsInputOnStart.Count) task(s) awaiting user input: $niNames. Open ACTION REQUIRED in the control panel." -Type Warn
+    Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Resuming with $($needsInputOnStart.Count) task(s) awaiting user input: $niNames"
+}
 
 $todoCount = 0
 foreach ($f in @(Get-ChildItem -LiteralPath $runDir -Filter '*.json' -File -Recurse:$taskSnapshotRecurse -ErrorAction SilentlyContinue |
@@ -1240,6 +1246,25 @@ try {
                 break
             }
             if (-not $RunId) {
+                $needsInputNow = @(Get-NeedsInputTasksInScope -RunDir $runDir -Recurse:$taskSnapshotRecurse)
+                if ($needsInputNow.Count -gt 0) {
+                    $niNames = ($needsInputNow | ForEach-Object { if ($_.PSObject.Properties['name'] -and $_.name) { [string]$_.name } else { [string]$_.id } }) -join ', '
+                    Write-Status "Waiting for user input on $($needsInputNow.Count) task(s): $niNames. Answer in ACTION REQUIRED." -Type Info
+                    Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Waiting for user input on: $niNames"
+                    $foundTask = $false
+                    while ($true) {
+                        Start-Sleep -Seconds 5
+                        if (Test-ProcessStopSignal -Id $procId) { break }
+                        $processData.last_heartbeat = (Get-Date).ToUniversalTime().ToString("o")
+                        Write-ProcessFile -Id $procId -Data $processData
+                        $taskResult = Get-NextWorkflowTask -BotRoot $botRoot -RunId $RunId -WorkflowName $WorkflowName
+                        if ($taskResult.task) { $foundTask = $true; break }
+                        $needsInputNow = @(Get-NeedsInputTasksInScope -RunDir $runDir -Recurse:$taskSnapshotRecurse)
+                        if ($needsInputNow.Count -eq 0) { break }
+                    }
+                    if ($foundTask) { continue }
+                    break
+                }
                 $completeMsg = "No pending tasks available. Exiting pending-tasks runner."
                 Write-Status $completeMsg -Type Info
                 Write-ProcessActivity -Id $procId -ActivityType "text" -Message $completeMsg


### PR DESCRIPTION
## Linked issue

Closes #493

## Summary of changes

Runner exited with "No pending tasks available" on resume when a `needs-input` task blocked all downstream `todo` tasks. `Get-NextWorkflowTask` returns null in that state → runner treated it as drained and exited.

- Added `Get-NeedsInputTasksInScope` to `Dotbot.Task` — scans run dir for tasks in `needs-input` status
- Startup warning when `needs-input` tasks detected on resume
- Wait loop injected before the pending-tasks exit path: polls every 5s, resumes normal processing once the user answers via ACTION REQUIRED, exits cleanly on stop signal

## Testing notes

1. Start a `start-from-prompt` workflow with an ambiguous prompt so a task enters `needs-input`
2. Close the runner before answering
3. Restart the runner — confirm it logs the waiting message instead of exiting
4. Submit the answer in ACTION REQUIRED — confirm runner picks up the next task and continues

Compilation and runtime test suites pass (`Test-Compilation.ps1`, `Test-Runtime.ps1`, `Test-StartFromPromptClarification.ps1`).

## Checklist

- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
