### PR TITLE
Surface needs-review tasks in the Needs Input pipeline section (#500)

### DIFF
--- a/src/ui/modules/StateBuilder.psm1
+++ b/src/ui/modules/StateBuilder.psm1
@@ -526,6 +526,32 @@ function Get-BotState {
             } | Where-Object { $_ -ne $null }
     }
 
+    # Get needs-review tasks list. These are parked on a human reviewer, so they
+    # join the "waiting on a person" view (Needs Input column) alongside
+    # needs-input tasks (#500). Review-specific metadata (commit, reason,
+    # feedback) is still served by the Review Required panel's own endpoint,
+    # which reads the raw task content; here we only need enough for the card.
+    $needsReviewTasksList = @()
+    if ($needsReviewTasks.Count -gt 0) {
+        $needsReviewTasksList = $needsReviewTasks |
+            ForEach-Object {
+                try {
+                    $taskContent = $_
+                    @{
+                        id = $taskContent.id
+                        name = $taskContent.name
+                        description = $taskContent.description
+                        category = $taskContent.category
+                        priority = $taskContent.priority
+                        effort = $taskContent.effort
+                        status = $taskContent.status
+                        workflow = $taskContent.workflow
+                        type = $taskContent.type
+                    }
+                } catch { $null }
+            } | Where-Object { $_ -ne $null }
+    }
+
     # Get analysed tasks list
     $analysedTasksList = @()
     if ($analysedTasks.Count -gt 0) {
@@ -954,6 +980,7 @@ function Get-BotState {
             todo = $todoTasks.Count
             analysing = $analysingTasks.Count
             needs_input = $needsInputTasks.Count
+            needs_review = $needsReviewTasks.Count
             analysed = $analysedTasks.Count
             split = $splitTasks.Count
             in_progress = $inProgressTasks.Count
@@ -965,6 +992,7 @@ function Get-BotState {
             upcoming_total = if ($todoTasks.Count) { $todoTasks.Count } else { 0 }
             analysing_list = @($analysingTasksList)
             needs_input_list = @($needsInputTasksList)
+            needs_review_list = @($needsReviewTasksList)
             analysed_list = @($analysedTasksList)
             in_progress_list = @($inProgressTasksList)
             recent_completed = @($recentCompleted)

--- a/src/ui/static/css/views.css
+++ b/src/ui/static/css/views.css
@@ -262,6 +262,13 @@
     color: var(--color-primary-dim);
 }
 
+/* Review-waiting tasks share the "Needs Input" column but are flagged with a
+   warning-toned chip to distinguish them from input-waiting tasks (#500). */
+.pipeline-task .task-tag.tag-review {
+    color: var(--color-warning);
+    background: rgb(var(--color-warning-rgb) / 0.12);
+}
+
 .pipeline-task:has(.completed-date) {
     padding-bottom: 24px;
 }

--- a/src/ui/static/modules/tabs.js
+++ b/src/ui/static/modules/tabs.js
@@ -98,7 +98,9 @@ function updateTaskSummary(tasks) {
     // Update count badges in context panel
     setElementText('context-todo-count', tasks.todo || 0);
     setElementText('context-analysing-count', tasks.analysing || 0);
-    setElementText('context-needs-input-count', tasks.needs_input || 0);
+    // "Needs Input" surfaces everything waiting on a person — input-waiting plus
+    // review-waiting tasks — matching the unified pipeline column (#500).
+    setElementText('context-needs-input-count', (tasks.needs_input || 0) + (tasks.needs_review || 0));
     setElementText('context-analysed-count', tasks.analysed || 0);
     setElementText('context-progress-count', tasks.in_progress || 0);
     setElementText('context-done-count', tasks.done || 0);
@@ -107,7 +109,8 @@ function updateTaskSummary(tasks) {
 
     // Update progress bar - include all statuses in total
     const total = (tasks.todo || 0) + (tasks.analysing || 0) + (tasks.needs_input || 0) +
-                  (tasks.analysed || 0) + (tasks.in_progress || 0) + (tasks.done || 0);
+                  (tasks.needs_review || 0) + (tasks.analysed || 0) + (tasks.in_progress || 0) +
+                  (tasks.done || 0);
     const percent = total > 0 ? Math.round((tasks.done / total) * 100) : 0;
 
     const progressBar = document.getElementById('context-progress-bar');

--- a/src/ui/static/modules/tasks.js
+++ b/src/ui/static/modules/tasks.js
@@ -64,6 +64,9 @@ function findTaskById(id) {
     const needsInput = lastState.tasks.needs_input_list?.find(t => t.id === id);
     if (needsInput) return needsInput;
 
+    const needsReview = lastState.tasks.needs_review_list?.find(t => t.id === id);
+    if (needsReview) return needsReview;
+
     const analysed = lastState.tasks.analysed_list?.find(t => t.id === id);
     if (analysed) return analysed;
 

--- a/src/ui/static/modules/ui-updates.js
+++ b/src/ui/static/modules/ui-updates.js
@@ -87,7 +87,7 @@ function updateTaskCounts(tasks) {
     // Pipeline counts - Unified pipeline
     setElementText('pipeline-todo-count', tasks.todo);
     setElementText('pipeline-working-count', (tasks.analysing || 0) + (tasks.in_progress || 0));
-    setElementText('pipeline-needs-input-count', tasks.needs_input || 0);
+    setElementText('pipeline-needs-input-count', (tasks.needs_input || 0) + (tasks.needs_review || 0));
     setElementText('pipeline-done-count', getCompletedTaskCount(tasks));
     // Legacy pipeline counts (kept for backward compat)
     setElementText('pipeline-analysing-count', tasks.analysing || 0);
@@ -107,8 +107,9 @@ function updateTaskCounts(tasks) {
  */
 function updateProgressPercent(tasks) {
     // Include all statuses in total for accurate progress
-    const total = (tasks.todo || 0) + (tasks.analysing || 0) + (tasks.needs_input || 0) + 
-                  (tasks.analysed || 0) + (tasks.in_progress || 0) + (tasks.done || 0);
+    const total = (tasks.todo || 0) + (tasks.analysing || 0) + (tasks.needs_input || 0) +
+                  (tasks.needs_review || 0) + (tasks.analysed || 0) + (tasks.in_progress || 0) +
+                  (tasks.done || 0);
     const percent = total > 0 ? Math.round((tasks.done / total) * 100) : 0;
     setElementText('progress-percent', `${percent}%`);
 }
@@ -401,6 +402,7 @@ function updatePipelineView(tasks) {
     let completed = Array.isArray(tasks.recent_completed) ? tasks.recent_completed : [];
     let analysing = Array.isArray(tasks.analysing_list) ? tasks.analysing_list : [];
     let needsInput = Array.isArray(tasks.needs_input_list) ? tasks.needs_input_list : [];
+    let needsReview = Array.isArray(tasks.needs_review_list) ? tasks.needs_review_list : [];
     let analysed = Array.isArray(tasks.analysed_list) ? tasks.analysed_list : [];
     let inProgress = Array.isArray(tasks.in_progress_list)
         ? tasks.in_progress_list
@@ -413,6 +415,7 @@ function updatePipelineView(tasks) {
         completed = completed.filter(t => t.workflow === wf);
         analysing = analysing.filter(t => t.workflow === wf);
         needsInput = needsInput.filter(t => t.workflow === wf);
+        needsReview = needsReview.filter(t => t.workflow === wf);
         analysed = analysed.filter(t => t.workflow === wf);
         inProgress = inProgress.filter(t => t.workflow === wf);
     }
@@ -433,7 +436,12 @@ function updatePipelineView(tasks) {
     });
     updatePipelineColumn('pipeline-working', working, 'active');
 
-    updatePipelineColumn('pipeline-needs-input', needsInput, 'needs-input');
+    // "Needs Input" surfaces everything waiting on a person: tasks parked for
+    // human input plus tasks parked for human review. Tag review tasks so the
+    // card renders a distinct chip (#500). The Review Required panel is unchanged.
+    needsReview.forEach(t => { t._waitKind = 'review'; });
+    const waitingOnPerson = [...needsInput, ...needsReview];
+    updatePipelineColumn('pipeline-needs-input', waitingOnPerson, 'needs-input');
     const skipped = Array.isArray(tasks.skipped_list) ? tasks.skipped_list : [];
     const doneAndSkipped = [...completed, ...skipped];
     updatePipelineColumn('pipeline-done', doneAndSkipped, 'done');
@@ -491,6 +499,11 @@ function updatePipelineColumn(containerId, tasks, type) {
 
         // Show phase sub-label for tasks in the "Working" column
         const phaseLabel = task._phase ? `<span class="task-tag phase-tag">${escapeHtml(task._phase)}</span>` : '';
+        // Distinguish review-waiting tasks from input-waiting tasks in the
+        // shared "Needs Input" column (#500).
+        const waitKindLabel = task._waitKind === 'review'
+            ? `<span class="task-tag tag-review">⚲ review</span>`
+            : '';
         const roadmapStateTags = typeof buildRoadmapTaskStatusTags === 'function'
             ? buildRoadmapTaskStatusTags(task, type)
             : '';
@@ -510,6 +523,7 @@ function updatePipelineColumn(containerId, tasks, type) {
                     ${task.workflow ? `<span class="task-tag tag-workflow">${escapeHtml(task.workflow)}</span>` : ''}
                     ${task.type && task.type !== 'prompt' ? `<span class="task-tag tag-type">${escapeHtml(task.type)}</span>` : ''}
                     ${phaseLabel}
+                    ${waitKindLabel}
                     ${type === 'active' && !task._phase ? '<span class="task-tag">↻ agent</span>' : ''}
                     ${roadmapStateTags}
                 </div>

--- a/src/ui/static/modules/workflow-launch.js
+++ b/src/ui/static/modules/workflow-launch.js
@@ -1347,6 +1347,7 @@ function buildWorkflowPanelData(state) {
         { list: state.tasks.analysed_list || [], status: 'analysed' },
         { list: state.tasks.analysing_list || [], status: 'analysing' },
         { list: state.tasks.needs_input_list || [], status: 'needs-input' },
+        { list: state.tasks.needs_review_list || [], status: 'needs-review' },
         { list: state.tasks.recent_completed || [], status: 'done' },
         { list: state.tasks.skipped_list || [], status: 'skipped' }
     ];
@@ -1382,8 +1383,10 @@ function buildWorkflowPanelData(state) {
         });
 
         // Determine resume state
+        // needs_review counts as pending: the task is parked on a human reviewer,
+        // not finished — so the workflow is resumable, not "completed" (#500).
         const pending = (wf.todo || 0) + (wf.analysing || 0) + (wf.needs_input || 0) +
-                        (wf.analysed || 0) + (wf.in_progress || 0);
+                        (wf.needs_review || 0) + (wf.analysed || 0) + (wf.in_progress || 0);
         const processRunning = !!wf.process_alive;
         const allDone = pending === 0 && wf.total > 0;
 
@@ -1440,6 +1443,7 @@ function renderOverviewWorkflowPhases(workflows) {
         'in-progress': '<span class="led pulse"></span>',
         'analysing':   '<span class="led pulse"></span>',
         'needs-input': '<span class="led amber"></span>',
+        'needs-review': '<span class="led amber"></span>',
         'analysed':    '<span class="phase-icon phase-pending">&#9675;</span>',
         'todo':        '<span class="phase-icon phase-pending">&#9675;</span>',
         'skipped':     '<span class="phase-icon phase-skipped">&#8211;</span>',


### PR DESCRIPTION
## Summary

Closes #500.

Tasks awaiting human review (`needs-review`) previously surfaced **only** in the
"Review Required" panel, while the "Needs Input" pipeline column showed only
`needs-input` tasks. Both represent work blocked on a person, so this PR
consolidates them: `needs-review` tasks now also appear in the **Needs Input**
column and feed the "waiting on a person" dashboard counts — while the
**Review Required** panel stays untouched and remains the place to approve /
reject / revise.

## Changes

**Backend — `StateBuilder.psm1`**
- Build a `needs_review_list` (id, name, description, category, priority,
  effort, status, workflow, type) — mirrors `needs_input_list` minus the
  input-only `pending_question` / `questions_resolved` fields.
- Expose `needs_review` count and `needs_review_list` in bot state.

**Frontend**
- `ui-updates.js` — merge `needs_review_list` into the Needs Input column
  (`waitingOnPerson = [...needsInput, ...needsReview]`), tag review items with
  `_waitKind = 'review'`, and include `needs_review` in pipeline counts and
  progress totals.
- `tabs.js` — context-panel Needs Input count and progress total now include
  `needs_review`.
- `tasks.js` — `findTaskById` searches `needs_review_list` so review cards open
  the task detail modal.
- `workflow-launch.js` — treat `needs-review` as **pending** (resumable, not
  "completed") in workflow panel data, and add a `needs-review` amber LED.
- `views.css` — `.task-tag.tag-review` warning-toned chip to visually
  distinguish review-waiting from input-waiting cards.

## Acceptance criteria

- [x] needs-review tasks appear under the Needs Input section of the pipeline/dashboard
- [x] Review tasks remain actionable in the existing Review Required panel (unchanged)
- [x] Visual distinction differentiates review-waiting from input-waiting tasks (`⚲ review` chip)
- [x] Dashboard counts reflect the combined "waiting on a person" metric