### PR TITLE
fix(harness): inject MCP_TIMEOUT/MCP_TOOL_TIMEOUT for per-task claude.exe to survive dotbot MCP cold-start

### DIFF
--- a/src/runtime/Modules/Dotbot.Harness/Adapters/ClaudeCodeAdapter.ps1
+++ b/src/runtime/Modules/Dotbot.Harness/Adapters/ClaudeCodeAdapter.ps1
@@ -206,6 +206,16 @@ function Invoke-ClaudeCodeAdapterStream {
         if ($frameworkRootForMcp) { $psi.Environment["DOTBOT_HOME"] = $frameworkRootForMcp }
         if ($mcpProjectRoot) { $psi.Environment["DOTBOT_PROJECT_ROOT"] = $mcpProjectRoot }
 
+        # Claude Code's MCP client has a short default connection timeout (~5s). The dotbot stdio MCP
+        # server cold-starts in 12-30s, so claude.exe's own MCP init fires before mcp__dotbot__* tools
+        # load -- making them permanently unavailable for that task session. This is independent of the
+        # preflight check (Test-DotbotMcpReadiness) which uses a separate standalone process (#521).
+        # MCP_TIMEOUT 60s: 2x buffer over worst-case 30s cold-start.
+        # MCP_TOOL_TIMEOUT 30s: dotbot MCP tools are fast (file I/O / JSON); 30s surfaces hangs early.
+        # ContainsKey guard keeps both operator-overridable: a pre-set env var wins.
+        if (-not $psi.Environment.ContainsKey('MCP_TIMEOUT'))      { $psi.Environment['MCP_TIMEOUT']      = '60000' }
+        if (-not $psi.Environment.ContainsKey('MCP_TOOL_TIMEOUT')) { $psi.Environment['MCP_TOOL_TIMEOUT'] = '30000' }
+
         $claudeProc = New-Object System.Diagnostics.Process
         $claudeProc.StartInfo = $psi
         $claudeProc.Start() | Out-Null


### PR DESCRIPTION
## Problem

When the dotbot stdio MCP server takes longer than Claude Code's internal
connection timeout to initialize, all `mcp__dotbot__*` tools become
**permanently unavailable** for that task session.

- Claude Code's MCP client uses a short default connection timeout (~5s).
- The dotbot stdio MCP server cold-starts in **12–30s** on typical hardware.
- The per-task `claude.exe` fires its own MCP init before the dotbot tools
  load, so the tools never register for the rest of the task.

This is **independent** of the preflight readiness check
(`Test-DotbotMcpReadiness`, fixed in #479), which runs in a separate
standalone process — so the preflight passes and no error surfaces, yet the
in-task tools are silently missing.

## Fix

Inject MCP timeout environment variables into the per-task `claude.exe`
process in `ClaudeCodeAdapter.ps1`, before the process is started:

| Variable | Value | Rationale |
|---|---|---|
| `MCP_TIMEOUT` | `60000` (60s) | 2× buffer over the worst-case 30s cold-start |
| `MCP_TOOL_TIMEOUT` | `30000` (30s) | dotbot MCP tools are fast (file I/O / JSON); 30s surfaces genuine hangs early |

Both are guarded by `ContainsKey`, so a pre-set environment variable wins and
operators retain full override control.

## Scope

- One-file change in `src/runtime/Modules/Dotbot.Harness/Adapters/ClaudeCodeAdapter.ps1`.
- No behavioral change when the MCP server starts quickly; only widens the
  tolerance window for slow cold-starts.

Closes #521