### PR TITLE
feat(workflow): selective workflow re-run for completed runs

### DIFF
--- a/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psd1
+++ b/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psd1
@@ -26,6 +26,8 @@
         'Resolve-TaskReviewDecision'
         'Test-TaskCompletion'
         'Reset-InProgressTasks'
+        'Reset-WorkflowTasksToTodo'
+        'Get-WorkflowTransitiveDependents'
         'Reset-SkippedTasks'
         'Invoke-PostScript'
         'Invoke-PostScriptFailureEscalation'

--- a/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
+++ b/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
@@ -591,6 +591,189 @@ function Reset-InProgressTasks {
     return ,$resetTasks
 }
 
+function Get-WorkflowTransitiveDependents {
+    <#
+    .SYNOPSIS
+    Return the transitive downstream dependents of one or more tasks within a run.
+
+    .DESCRIPTION
+    Reads every task file in $RunDir, builds the reverse dependency graph from
+    each task's resolved 'dependencies' field, and walks it breadth-first from
+    $TaskIds. Returns the de-duplicated set of dependent task IDs (excluding the
+    seed IDs themselves). Tasks in 'cancelled' status are deliberately abandoned,
+    so they are never added to the set and the walk does not continue through
+    them.
+
+    Pure: reads only, writes nothing.
+
+    .PARAMETER RunDir
+    The resolved workflow run directory (workspace/tasks/workflow-runs/<run>).
+
+    .PARAMETER TaskIds
+    Seed task IDs whose downstream dependents should be collected.
+
+    .OUTPUTS
+    Array of task ID strings.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RunDir,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$TaskIds
+    )
+
+    if (-not (Test-Path -LiteralPath $RunDir)) {
+        return ,@()
+    }
+
+    # depId -> list of task IDs that declare it as a dependency.
+    $reverse = @{}
+    $statusById = @{}
+
+    $taskFiles = @(Get-ChildItem -LiteralPath $RunDir -Filter '*.json' -File -ErrorAction SilentlyContinue |
+                    Where-Object { $_.Name -ne 'run.json' })
+
+    foreach ($taskFile in $taskFiles) {
+        try {
+            $content = Get-Content -LiteralPath $taskFile.FullName -Raw | ConvertFrom-Json
+        } catch {
+            continue
+        }
+
+        $id = [string]$content.id
+        if (-not $id) { continue }
+        $statusById[$id] = [string]$content.status
+
+        $deps = @()
+        if ($content.PSObject.Properties['dependencies'] -and $content.dependencies) {
+            $deps = @($content.dependencies | Where-Object { $_ -and $_ -ne '' })
+        }
+
+        foreach ($dep in $deps) {
+            $depId = [string]$dep
+            if (-not $reverse.ContainsKey($depId)) { $reverse[$depId] = @() }
+            $reverse[$depId] += $id
+        }
+    }
+
+    $seen = [System.Collections.Generic.HashSet[string]]::new()
+    $queue = [System.Collections.Generic.Queue[string]]::new()
+    foreach ($seed in $TaskIds) {
+        $seedId = [string]$seed
+        [void]$seen.Add($seedId)
+        $queue.Enqueue($seedId)
+    }
+
+    $result = [System.Collections.Generic.List[string]]::new()
+    while ($queue.Count -gt 0) {
+        $current = $queue.Dequeue()
+        if (-not $reverse.ContainsKey($current)) { continue }
+
+        foreach ($dependent in $reverse[$current]) {
+            if ($seen.Contains($dependent)) { continue }
+            [void]$seen.Add($dependent)
+
+            if ($statusById[$dependent] -eq 'cancelled') { continue }
+
+            [void]$result.Add($dependent)
+            $queue.Enqueue($dependent)
+        }
+    }
+
+    return ,@($result.ToArray())
+}
+
+function Reset-WorkflowTasksToTodo {
+    <#
+    .SYNOPSIS
+    Reset specific workflow-run tasks back to 'todo' for a targeted re-run.
+
+    .DESCRIPTION
+    For each task file in $RunDir whose id is in $TaskIds and whose current
+    status is in $FromStatuses, flips status to 'todo' via an atomic in-place
+    write. It clears completed_at (the closed schema requires it to be null for a
+    non-terminal status), clears runner residue
+    (extensions.runner.pending_question / skip_reason / skip_detail) so the
+    re-run starts clean, and refreshes updated_at / updated_by. Tasks not in
+    $TaskIds, or whose status is not in $FromStatuses, are left untouched.
+
+    Mirrors Reset-InProgressTasks (crash recovery) but is driven by an explicit
+    target set rather than the in-progress status.
+
+    .PARAMETER RunDir
+    The resolved workflow run directory (workspace/tasks/workflow-runs/<run>).
+
+    .PARAMETER TaskIds
+    The exact task IDs to reset.
+
+    .PARAMETER FromStatuses
+    Only reset a target task when its current status is one of these. Defaults to
+    every status a completed/paused run can leave a task in.
+
+    .OUTPUTS
+    Array of hashtables @{ id; name; file } for each reset task.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RunDir,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$TaskIds,
+
+        [string[]]$FromStatuses = @('done', 'skipped', 'failed', 'needs-input', 'in-progress')
+    )
+
+    $resetTasks = @()
+
+    if (-not (Test-Path -LiteralPath $RunDir)) {
+        return ,$resetTasks
+    }
+
+    $targetSet = [System.Collections.Generic.HashSet[string]]::new()
+    foreach ($id in $TaskIds) { [void]$targetSet.Add([string]$id) }
+
+    $taskFiles = @(Get-ChildItem -LiteralPath $RunDir -Filter '*.json' -File -ErrorAction SilentlyContinue |
+                    Where-Object { $_.Name -ne 'run.json' })
+
+    foreach ($taskFile in $taskFiles) {
+        try {
+            if (-not (Test-Path -LiteralPath $taskFile.FullName)) { continue }
+
+            $taskContent = Get-Content -LiteralPath $taskFile.FullName -Raw | ConvertFrom-Json
+
+            $taskId = [string]$taskContent.id
+            if (-not $targetSet.Contains($taskId)) { continue }
+            if ($FromStatuses -notcontains [string]$taskContent.status) { continue }
+
+            $taskName = if ($taskContent.PSObject.Properties['name'] -and $taskContent.name) { [string]$taskContent.name } else { $taskId }
+
+            $taskContent.status = 'todo'
+            if ($taskContent.PSObject.Properties['completed_at']) { $taskContent.completed_at = $null }
+            if ($taskContent.PSObject.Properties['updated_at'])   { $taskContent.updated_at   = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ') }
+            if ($taskContent.PSObject.Properties['updated_by'])   { $taskContent.updated_by   = 'ui:workflow-rerun' }
+
+            if ($taskContent.PSObject.Properties['extensions'] -and $taskContent.extensions -and
+                $taskContent.extensions.PSObject.Properties['runner'] -and $taskContent.extensions.runner) {
+                $runner = $taskContent.extensions.runner
+                foreach ($residue in @('pending_question', 'skip_reason', 'skip_detail')) {
+                    if ($runner.PSObject.Properties[$residue]) {
+                        $runner.PSObject.Properties.Remove($residue)
+                    }
+                }
+            }
+
+            Write-TaskFileAtomic -Path $taskFile.FullName -Content $taskContent -Depth 20 -TaskId $taskId
+
+            $resetTasks += @{ id = $taskId; name = $taskName; file = $taskFile.Name }
+        } catch {
+            Write-BotLog -Level Warn -Message "Reset-WorkflowTasksToTodo: error processing '$($taskFile.Name)'" -Exception $_
+        }
+    }
+
+    return ,$resetTasks
+}
+
 function Reset-SkippedTasks {
     <#
     .SYNOPSIS
@@ -1685,6 +1868,8 @@ Export-ModuleMember -Function @(
     'Test-TaskCompletion'
     # State recovery
     'Reset-InProgressTasks'
+    'Reset-WorkflowTasksToTodo'
+    'Get-WorkflowTransitiveDependents'
     'Reset-SkippedTasks'
     # Post-script hooks
     'Invoke-PostScript'

--- a/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
+++ b/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
@@ -624,7 +624,7 @@ function Get-WorkflowTransitiveDependents {
     )
 
     if (-not (Test-Path -LiteralPath $RunDir)) {
-        return ,@()
+        return @()
     }
 
     # depId -> list of task IDs that declare it as a dependency.
@@ -681,7 +681,7 @@ function Get-WorkflowTransitiveDependents {
         }
     }
 
-    return ,@($result.ToArray())
+    return $result.ToArray()
 }
 
 function Reset-WorkflowTasksToTodo {
@@ -727,7 +727,7 @@ function Reset-WorkflowTasksToTodo {
     $resetTasks = @()
 
     if (-not (Test-Path -LiteralPath $RunDir)) {
-        return ,$resetTasks
+        return $resetTasks
     }
 
     $targetSet = [System.Collections.Generic.HashSet[string]]::new()
@@ -771,7 +771,7 @@ function Reset-WorkflowTasksToTodo {
         }
     }
 
-    return ,$resetTasks
+    return $resetTasks
 }
 
 function Get-NeedsInputTasksInScope {

--- a/src/ui/server.ps1
+++ b/src/ui/server.ps1
@@ -2620,6 +2620,138 @@ $docContext
                     break
                 }
 
+                "/api/run/rerun" {
+                    if ($method -eq "POST") {
+                        $contentType = "application/json; charset=utf-8"
+                        try {
+                            $body = $null
+                            $rawBody = $null
+                            try {
+                                $reader = New-Object System.IO.StreamReader($request.InputStream)
+                                $rawBody = $reader.ReadToEnd()
+                                $reader.Close()
+                                if ($rawBody) { $body = $rawBody | ConvertFrom-Json }
+                            } catch {
+                                $statusCode = 400
+                                $content = @{ success = $false; error = "Invalid JSON in request body: $($_.Exception.Message)" } | ConvertTo-Json -Compress
+                                break
+                            }
+
+                            $runId = if ($body -and $body.PSObject.Properties['run_id']) { [string]$body.run_id } else { '' }
+                            if ($runId -notmatch '^wr_[A-Za-z0-9]+$') {
+                                $statusCode = 400
+                                $content = @{ success = $false; error = "Invalid or missing run_id" } | ConvertTo-Json -Compress
+                                break
+                            }
+
+                            $requestedTaskIds = @()
+                            if ($body -and $body.PSObject.Properties['task_ids']) {
+                                $requestedTaskIds = @($body.task_ids | Where-Object { $_ -and $_ -ne '' } | ForEach-Object { [string]$_ })
+                            }
+                            if ($requestedTaskIds.Count -eq 0) {
+                                $statusCode = 400
+                                $content = @{ success = $false; error = "task_ids must contain at least one task" } | ConvertTo-Json -Compress
+                                break
+                            }
+                            $targetOnly = [bool]($body -and $body.PSObject.Properties['target_only'] -and $body.target_only)
+
+                            if (-not (Get-Module Dotbot.Task)) {
+                                Import-Module (Join-Path $PSScriptRoot ".." "runtime" "Modules" "Dotbot.Task" "Dotbot.Task.psd1") -DisableNameChecking -Global -ErrorAction SilentlyContinue
+                            }
+
+                            $runDir = Find-WorkflowRunDir -BotRoot $botRoot -RunId $runId
+                            if (-not $runDir) {
+                                $statusCode = 404
+                                $content = @{ success = $false; error = "Run not found: $runId" } | ConvertTo-Json -Compress
+                                break
+                            }
+
+                            $runRecord = $null
+                            try { $runRecord = Get-Content -LiteralPath (Join-Path $runDir 'run.json') -Raw | ConvertFrom-Json } catch { $runRecord = $null }
+                            $wfName = if ($runRecord -and $runRecord.workflow_name) { [string]$runRecord.workflow_name } else { '' }
+                            if (-not $wfName) {
+                                $statusCode = 404
+                                $content = @{ success = $false; error = "Run record missing or unreadable for $runId" } | ConvertTo-Json -Compress
+                                break
+                            }
+
+                            $existingIds = @(Get-ChildItem -LiteralPath $runDir -Filter '*.json' -File -ErrorAction SilentlyContinue |
+                                Where-Object { $_.Name -ne 'run.json' } | ForEach-Object {
+                                    try { [string]((Get-Content -LiteralPath $_.FullName -Raw | ConvertFrom-Json).id) } catch { $null }
+                                } | Where-Object { $_ })
+                            $unknown = @($requestedTaskIds | Where-Object { $existingIds -notcontains $_ })
+                            if ($unknown.Count -gt 0) {
+                                $statusCode = 400
+                                $content = @{ success = $false; error = "Unknown task(s) in run: $($unknown -join ', ')"; available_task_ids = $existingIds } | ConvertTo-Json -Compress
+                                break
+                            }
+
+                            $activeRuns = Get-ActiveWorkflowRuns -BotRoot $botRoot
+                            if (@($activeRuns | Where-Object { $_.run_id -eq $runId }).Count -gt 0) {
+                                $statusCode = 409
+                                $content = @{ success = $false; error = 'run_active'; message = "Run $runId is still active. Stop it before re-running." } | ConvertTo-Json -Compress
+                                break
+                            }
+                            $startDecision = Test-CanStartRun -NewRun @{ workflow_name = $wfName } -ActiveRuns $activeRuns
+                            if (-not $startDecision.ok) {
+                                $statusCode = 409
+                                $content = @{ success = $false; error = $startDecision.reason; message = $startDecision.message; blocking_run_id = $startDecision.blocking_run_id } | ConvertTo-Json -Compress
+                                break
+                            }
+
+                            $gitCheck = Test-GitReadyForWorktree -ProjectRoot $projectRoot
+                            if (-not $gitCheck.ok) {
+                                $statusCode = 422
+                                $content = @{ success = $false; error = 'git_not_ready'; message = $gitCheck.message; reason = $gitCheck.reason } | ConvertTo-Json -Compress
+                                break
+                            }
+
+                            $resetIds = [System.Collections.Generic.List[string]]::new()
+                            foreach ($id in $requestedTaskIds) { $resetIds.Add($id) }
+                            if (-not $targetOnly) {
+                                foreach ($dep in (Get-WorkflowTransitiveDependents -RunDir $runDir -TaskIds $requestedTaskIds)) {
+                                    if (-not $resetIds.Contains($dep)) { $resetIds.Add($dep) }
+                                }
+                            }
+
+                            $reset = @(Reset-WorkflowTasksToTodo -RunDir $runDir -TaskIds ([string[]]$resetIds))
+                            if ($reset.Count -eq 0) {
+                                $statusCode = 409
+                                $content = @{ success = $false; error = 'nothing_to_rerun'; message = 'None of the targeted tasks are in a re-runnable status.' } | ConvertTo-Json -Compress
+                                break
+                            }
+
+                            $liveStatusPath = Join-Path $controlDir (Join-Path 'workflow-runs' "$runId.json")
+                            $nowTs = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+                            $liveStatus = New-WorkflowRunStatus -RunId $runId -Status 'running' -LastHeartbeat $nowTs
+                            $liveStatus | ConvertTo-Json -Depth 20 | Set-Content -Path $liveStatusPath -Encoding utf8NoBOM
+
+                            $launchResult = Start-ProcessLaunch -Type 'task-runner' -Continue $true -Description "Re-run: $wfName" -WorkflowName $wfName -RunId $runId
+                            if (-not $launchResult.success) {
+                                $launchError = if ($launchResult.error) { $launchResult.error } else { 'unknown launch failure' }
+                                throw "Failed to launch re-run for ${runId}: $launchError"
+                            }
+
+                            $content = @{
+                                success = $true
+                                workflow = $wfName
+                                run_id = $runId
+                                reset_task_count = $reset.Count
+                                reset_task_ids = @($reset | ForEach-Object { $_.id })
+                                slots_launched = $launchResult.slots_launched
+                                process_id = $launchResult.process_id
+                            } | ConvertTo-Json -Compress
+                        } catch {
+                            $statusCode = 500
+                            $content = @{ success = $false; error = "Failed to re-run tasks: $($_.Exception.Message)" } | ConvertTo-Json -Compress
+                        }
+                    } else {
+                        $statusCode = 405
+                        $content = @{ success = $false; error = "Method not allowed" } | ConvertTo-Json -Compress
+                    }
+                    break
+                }
+
                 # --- Prompts (inline, uses local helper) ---
 
                 "/api/commands/list" {

--- a/src/ui/static/css/views.css
+++ b/src/ui/static/css/views.css
@@ -2127,6 +2127,61 @@
     letter-spacing: 0.05em;
 }
 
+.run-task-select {
+    accent-color: var(--color-secondary);
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.run-rerun-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px 2px;
+}
+
+.run-rerun-cascade {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-right: auto;
+    font-family: var(--font-ui);
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-muted);
+    cursor: pointer;
+}
+
+.run-rerun-cascade input {
+    accent-color: var(--color-secondary);
+    cursor: pointer;
+}
+
+.run-rerun-btn {
+    padding: 4px 8px;
+    background: var(--bg-screen);
+    border: 1px solid var(--primary-15);
+    border-radius: 3px;
+    color: var(--color-primary-dim);
+    font-family: var(--font-ui);
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.run-rerun-btn:hover:not(:disabled) {
+    border-color: var(--color-secondary);
+    color: var(--color-secondary);
+}
+
+.run-rerun-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
 /* ========== SETTINGS TAB ========== */
 .settings-container {
     max-width: 800px;

--- a/src/ui/static/modules/controls.js
+++ b/src/ui/static/modules/controls.js
@@ -909,6 +909,48 @@ async function stopWorkflow(name) {
     }
 }
 
+const rerunInFlight = new Set();
+
+/**
+ * Re-run selected tasks of a completed workflow run in place, preserving the
+ * outputs of tasks not in scope. The runtime resets the targeted tasks (and,
+ * unless targetOnly, their downstream dependents) to todo and relaunches the
+ * runner scoped to the same run.
+ * @param {string} runId - The wr_ run id to re-run within
+ * @param {string[]} taskIds - Selected task ids to reset
+ * @param {boolean} targetOnly - When true, do not cascade to downstream dependents
+ * @param {HTMLElement} [btn] - The button element; disabled during the call
+ */
+async function rerunSelectedTasks(runId, taskIds, targetOnly, btn) {
+    if (!runId || !Array.isArray(taskIds) || taskIds.length === 0) return;
+    if (rerunInFlight.has(runId)) return;
+    rerunInFlight.add(runId);
+    if (btn) btn.disabled = true;
+
+    try {
+        const response = await fetch(`${API_BASE}/api/run/rerun`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ run_id: runId, task_ids: taskIds, target_only: !!targetOnly })
+        });
+        const data = await response.json();
+        if (data.success) {
+            showSignalFeedback(`Re-running ${data.reset_task_count} task(s) in ${data.workflow}`);
+            showToast(`Re-running ${data.reset_task_count} task(s)`, 'success');
+        } else {
+            showSignalFeedback(`Error: ${data.error || 'Re-run failed'}`);
+            showToast(`Re-run failed: ${data.message || data.error || 'unknown error'}`, 'warning');
+        }
+        await pollState();
+    } catch (error) {
+        console.error('Re-run tasks error:', error);
+        showSignalFeedback(`Error: ${error.message}`);
+    } finally {
+        rerunInFlight.delete(runId);
+        if (btn) btn.disabled = false;
+    }
+}
+
 /**
  * Launch the visual studio for a specific workflow.
  * POSTs to /api/launch-studio which starts the studio server if needed,

--- a/src/ui/static/modules/runs.js
+++ b/src/ui/static/modules/runs.js
@@ -51,6 +51,9 @@ const RUN_CHIP_ORDER = [
     ['cancelled',   'cancelled']
 ];
 
+const RERUNNABLE_RUN_STATUSES = new Set(['completed', 'failed', 'stopped']);
+const RERUNNABLE_TASK_STATUSES = new Set(['done', 'skipped', 'failed', 'needs-input']);
+
 function shortRunId(runId) {
     if (!runId) return '';
     return runId.startsWith('wr_') ? runId.slice(3) : runId;
@@ -77,11 +80,20 @@ function renderWorkflowRuns(state) {
         return;
     }
 
-    // Preserve per-run collapsed state across polls.
     const prevCollapsed = {};
+    const prevSelected = {};
+    const prevCascade = {};
     container.querySelectorAll('.run-card').forEach(card => {
         const rid = card.dataset.runId;
-        if (rid) prevCollapsed[rid] = card.classList.contains('collapsed');
+        if (!rid) return;
+        prevCollapsed[rid] = card.classList.contains('collapsed');
+        const sel = new Set();
+        card.querySelectorAll('.run-task-select:checked').forEach(c => {
+            if (c.dataset.taskId) sel.add(c.dataset.taskId);
+        });
+        if (sel.size) prevSelected[rid] = sel;
+        const cascade = card.querySelector('.run-rerun-cascade-input');
+        if (cascade) prevCascade[rid] = cascade.checked;
     });
 
     let html = '';
@@ -112,11 +124,19 @@ function renderWorkflowRuns(state) {
             if (v > 0) chips += `<span class="run-chip" data-status="${key}">${v} ${label}</span>`;
         });
 
+        const canRerun = RERUNNABLE_RUN_STATUSES.has(run.status);
+        const selectedSet = prevSelected[run.run_id];
+
         let items = '';
         (run.tasks || []).forEach(task => {
             const icon = RUN_TASK_STATUS_ICONS[task.status] || RUN_TASK_STATUS_ICONS['todo'];
+            const selectable = canRerun && task.id && RERUNNABLE_TASK_STATUSES.has(task.status);
+            const checkbox = selectable
+                ? `<input type="checkbox" class="run-task-select" data-task-id="${escapeAttr(task.id)}"${(selectedSet && selectedSet.has(task.id)) ? ' checked' : ''} />`
+                : '';
             items += `
                 <div class="chain-layer-item child-task-item child-task-${escapeAttr(task.status)}">
+                    ${checkbox}
                     ${icon}
                     <span class="item-name">${escapeHtml(task.name || task.id || '')}</span>
                 </div>`;
@@ -125,6 +145,13 @@ function renderWorkflowRuns(state) {
         if (run.tasks_total && run.tasks_total > shown) {
             items += `<div class="run-task-more">+${run.tasks_total - shown} more</div>`;
         }
+
+        const cascadeChecked = (run.run_id in prevCascade) ? prevCascade[run.run_id] : true;
+        const rerunBar = canRerun ? `
+                    <div class="run-rerun-bar">
+                        <label class="run-rerun-cascade"><input type="checkbox" class="run-rerun-cascade-input"${cascadeChecked ? ' checked' : ''} /> include dependents</label>
+                        <button type="button" class="run-rerun-btn" data-run-id="${escapeAttr(run.run_id)}" disabled>Re-run selected</button>
+                    </div>` : '';
 
         html += `
             <div class="run-card${isCollapsed ? ' collapsed' : ''}" data-run-id="${escapeAttr(run.run_id)}" data-status="${escapeAttr(run.status)}">
@@ -146,6 +173,7 @@ function renderWorkflowRuns(state) {
                     <div class="child-task-items run-task-items">
                         ${items || '<div class="empty-state" style="font-size:10px">(no tasks)</div>'}
                     </div>
+                    ${rerunBar}
                 </div>
             </div>`;
     });
@@ -155,6 +183,28 @@ function renderWorkflowRuns(state) {
     container.querySelectorAll('.run-card-header').forEach(header => {
         header.addEventListener('click', () => {
             header.closest('.run-card').classList.toggle('collapsed');
+        });
+    });
+
+    container.querySelectorAll('.run-card').forEach(card => {
+        const btn = card.querySelector('.run-rerun-btn');
+        if (!btn) return;
+
+        const checks = card.querySelectorAll('.run-task-select');
+        const syncDisabled = () => {
+            btn.disabled = !Array.from(checks).some(c => c.checked);
+        };
+        checks.forEach(c => c.addEventListener('change', syncDisabled));
+        syncDisabled();
+
+        btn.addEventListener('click', () => {
+            const taskIds = Array.from(checks).filter(c => c.checked).map(c => c.dataset.taskId);
+            if (taskIds.length === 0) return;
+            const cascade = card.querySelector('.run-rerun-cascade-input');
+            const targetOnly = cascade ? !cascade.checked : false;
+            if (typeof rerunSelectedTasks === 'function') {
+                rerunSelectedTasks(card.dataset.runId, taskIds, targetOnly, btn);
+            }
         });
     });
 }

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -5171,6 +5171,94 @@ if (Test-Path $workflowManifestScript) {
     Write-TestResult -Name "New-WorkflowTask optional propagation" -Status Skip -Message "WorkflowManifest.psm1 not found"
 }
 
+Write-Host "  TARGETED WORKFLOW RE-RUN (C2)" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$rerunTaskManifest = Join-Path $dotbotDir "src/runtime/Modules/Dotbot.Task/Dotbot.Task.psd1"
+if (Test-Path $rerunTaskManifest) {
+    Import-Module $rerunTaskManifest -Force -DisableNameChecking -Global
+    $rerunTmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-rerun-test-$(Get-Random)"
+    $rerunRunDir = Join-Path $rerunTmpDir "run"
+    try {
+        New-Item -Path $rerunRunDir -ItemType Directory -Force | Out-Null
+
+        $rerunRunId = New-WorkflowRunId
+        $idA = New-TaskId; $idB = New-TaskId; $idC = New-TaskId; $idD = New-TaskId
+
+        function New-RerunFixtureTask {
+            param([string]$Id, [string]$Name, [string[]]$Deps, [string]$Status = 'done')
+            $task = New-TaskInstance -Id $Id -Name $Name -Status $Status -Dependencies ([string[]]$Deps) `
+                -Provenance @{ workflow = 'rerun-wf'; run_id = $rerunRunId; definition_name = $Name; expanded_by = 'workflow-expansion' } `
+                -Extensions @{ executor = @{ skip_analysis = $false }; runner = @{ pending_question = @{ id = 'q1' }; skip_reason = 'framework' } }
+            $task | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $rerunRunDir "$Id.json") -Encoding UTF8
+        }
+
+        New-RerunFixtureTask -Id $idA -Name 'A' -Deps @()
+        New-RerunFixtureTask -Id $idB -Name 'B' -Deps @($idA)
+        New-RerunFixtureTask -Id $idC -Name 'C' -Deps @($idB)
+        New-RerunFixtureTask -Id $idD -Name 'D' -Deps @()
+
+        $deps = @(Get-WorkflowTransitiveDependents -RunDir $rerunRunDir -TaskIds @($idA))
+        Assert-True -Name "Get-WorkflowTransitiveDependents: A -> {B, C}" `
+            -Condition (($deps.Count -eq 2) -and ($deps -contains $idB) -and ($deps -contains $idC)) `
+            -Message "Expected B and C, got: $($deps -join ', ')"
+
+        Assert-True -Name "Get-WorkflowTransitiveDependents: leaf C has no dependents" `
+            -Condition ((@(Get-WorkflowTransitiveDependents -RunDir $rerunRunDir -TaskIds @($idC))).Count -eq 0) `
+            -Message "C is downstream-most; expected empty set"
+
+        Assert-True -Name "Get-WorkflowTransitiveDependents: unrelated D has no dependents" `
+            -Condition ((@(Get-WorkflowTransitiveDependents -RunDir $rerunRunDir -TaskIds @($idD))).Count -eq 0) `
+            -Message "D is isolated; expected empty set"
+
+        $rerunCancelDir = Join-Path $rerunTmpDir "run-cancel"
+        New-Item -Path $rerunCancelDir -ItemType Directory -Force | Out-Null
+        $cA = New-TaskId; $cB = New-TaskId; $cC = New-TaskId
+        (New-TaskInstance -Id $cA -Name 'cA' -Status 'done' -Dependencies @() `
+            -Provenance @{ workflow='rerun-wf'; run_id=$rerunRunId; definition_name='cA'; expanded_by='workflow-expansion' } `
+            -Extensions @{ executor = @{ skip_analysis = $false } }) | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $rerunCancelDir "$cA.json") -Encoding UTF8
+        (New-TaskInstance -Id $cB -Name 'cB' -Status 'cancelled' -Dependencies @($cA) `
+            -Provenance @{ workflow='rerun-wf'; run_id=$rerunRunId; definition_name='cB'; expanded_by='workflow-expansion' } `
+            -Extensions @{ executor = @{ skip_analysis = $false } }) | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $rerunCancelDir "$cB.json") -Encoding UTF8
+        (New-TaskInstance -Id $cC -Name 'cC' -Status 'done' -Dependencies @($cB) `
+            -Provenance @{ workflow='rerun-wf'; run_id=$rerunRunId; definition_name='cC'; expanded_by='workflow-expansion' } `
+            -Extensions @{ executor = @{ skip_analysis = $false } }) | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $rerunCancelDir "$cC.json") -Encoding UTF8
+        $cancelDeps = @(Get-WorkflowTransitiveDependents -RunDir $rerunCancelDir -TaskIds @($cA))
+        Assert-True -Name "Get-WorkflowTransitiveDependents: cancelled task excluded and severs chain" `
+            -Condition (($cancelDeps -notcontains $cB) -and ($cancelDeps -notcontains $cC)) `
+            -Message "cancelled cB must not be reset, and cC behind it is unreachable; got: $($cancelDeps -join ', ')"
+
+        $reset = @(Reset-WorkflowTasksToTodo -RunDir $rerunRunDir -TaskIds @($idA, $idB, $idC))
+        Assert-Equal -Name "Reset-WorkflowTasksToTodo: resets exactly the 3 targeted tasks" `
+            -Expected 3 -Actual $reset.Count
+
+        $taskA = Get-Content (Join-Path $rerunRunDir "$idA.json") -Raw | ConvertFrom-Json
+        Assert-Equal -Name "Reset-WorkflowTasksToTodo: A status -> todo" -Expected 'todo' -Actual ([string]$taskA.status)
+        Assert-True -Name "Reset-WorkflowTasksToTodo: A completed_at cleared" `
+            -Condition ($null -eq $taskA.completed_at) -Message "completed_at must be null for a non-terminal status"
+        Assert-True -Name "Reset-WorkflowTasksToTodo: A runner residue cleared" `
+            -Condition (-not $taskA.extensions.runner.PSObject.Properties['pending_question'] -and -not $taskA.extensions.runner.PSObject.Properties['skip_reason']) `
+            -Message "pending_question / skip_reason should be removed"
+        Assert-True -Name "Reset-WorkflowTasksToTodo: reset task still passes schema validation" `
+            -Condition ((@(Test-TaskInstance -Task $taskA)).Count -eq 0) `
+            -Message "reopened task must remain a valid TaskInstance"
+
+        $taskD = Get-Content (Join-Path $rerunRunDir "$idD.json") -Raw | ConvertFrom-Json
+        Assert-Equal -Name "Reset-WorkflowTasksToTodo: out-of-scope D stays done" -Expected 'done' -Actual ([string]$taskD.status)
+
+        $idE = New-TaskId
+        New-RerunFixtureTask -Id $idE -Name 'E' -Deps @() -Status 'todo'
+        $resetTodo = @(Reset-WorkflowTasksToTodo -RunDir $rerunRunDir -TaskIds @($idE))
+        Assert-Equal -Name "Reset-WorkflowTasksToTodo: skips a task already in todo" -Expected 0 -Actual $resetTodo.Count
+    } catch {
+        Write-TestResult -Name "Targeted workflow re-run helpers" -Status Fail -Message $_.Exception.Message
+    } finally {
+        if (Test-Path $rerunTmpDir) { Remove-Item $rerunTmpDir -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+} else {
+    Write-TestResult -Name "Targeted workflow re-run helpers" -Status Skip -Message "Dotbot.Task.psd1 not found"
+}
+
 # Get-RecipeFolders recursive discovery (issue #406)
 # Registry-installed workflows can layer skill folders nested several levels
 # deep under workflow-root skills/. The /api/workflows/installed enumeration must

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -5426,7 +5426,7 @@ if (Test-Path $rerunTaskManifest) {
             -Condition (-not $taskA.extensions.runner.PSObject.Properties['pending_question'] -and -not $taskA.extensions.runner.PSObject.Properties['skip_reason']) `
             -Message "pending_question / skip_reason should be removed"
         Assert-True -Name "Reset-WorkflowTasksToTodo: reset task still passes schema validation" `
-            -Condition ((@(Test-TaskInstance -Task $taskA)).Count -eq 0) `
+            -Condition ((Test-TaskInstance -Task $taskA).Count -eq 0) `
             -Message "reopened task must remain a valid TaskInstance"
 
         $taskD = Get-Content (Join-Path $rerunRunDir "$idD.json") -Raw | ConvertFrom-Json


### PR DESCRIPTION
feat(workflow): selective workflow re-run for completed runs

## Linked issue

Closes #512

## Summary of changes

Adds a **targeted re-run** to the dashboard: from a finished workflow run, an
operator can re-run only selected tasks (and, by default, their downstream
dependents) **in place** — prior task outputs not in scope are preserved, and the
existing full-regeneration ("fresh") run is untouched. This reuses the runner's
existing behaviour: scoped to a run, it only picks up `todo` tasks, so resetting a
subset back to `todo` and relaunching the runner re-runs exactly that subset in
dependency order.

**Backend** (`src/runtime/Modules/Dotbot.Task/`)

- `Get-WorkflowTransitiveDependents` — pure reverse-dependency BFS over a run's
  task files; returns the transitive downstream dependents of the selected tasks
  (excludes `cancelled`, which severs the chain).
- `Reset-WorkflowTasksToTodo` — flips the targeted tasks back to `todo` via atomic
  writes, clearing `completed_at` and runner residue
  (`extensions.runner.pending_question` / `skip_reason` / `skip_detail`) while
  keeping the closed TaskInstance schema valid. Mirrors the trusted
  `Reset-InProgressTasks` crash-recovery path.
- Both functions exported from `Dotbot.Task.psd1` / `.psm1`.

**Endpoint** (`src/ui/server.ps1`)

- `POST /api/run/rerun` `{ run_id, task_ids[], target_only }`: validates the run
  and task ids, guards concurrency (refuses a still-active run; honours
  same-workflow policy) and the git/worktree precondition, computes the reset set
  (`task_ids` ∪ transitive dependents unless `target_only`), resets them, re-arms
  the run's live status to `running`, and relaunches the task-runner scoped to the
  same run. The fresh-run path (`/api/workflows/{name}/run`) is unchanged.

**Dashboard UI** (`src/ui/static/`)

- `modules/runs.js` — per-task checkboxes and a "Re-run selected" bar with an
  "include dependents" toggle, shown only on terminal runs; selection is preserved
  across state polls.
- `modules/controls.js` — `rerunSelectedTasks()` posts to the endpoint and
  refreshes state.
- `css/views.css` — styling for the new controls using existing design tokens.

## Screenshots / recordings

**Completed run — per-task checkboxes + "Re-run selected" + "include dependents"**

<img width="1090" height="204" alt="01-completed-run" src="https://github.com/user-attachments/assets/c4f88025-19a1-4630-8933-de4432629431" />

**Task selected — button enabled**

<img width="1090" height="204" alt="02-tasks-selected" src="https://github.com/user-attachments/assets/1d05efbd-25ba-4492-a0de-3b342158130f" />

**After re-run (cascade) — run flips to RUNNING; selected task + dependents back to `todo`; unrelated task stays `done`**

<img width="1090" height="175" alt="03-rerun-cascade" src="https://github.com/user-attachments/assets/edc77ddf-fcb1-4f96-8436-8fd7121fd0f2" />

**Dashboard context (Workflows tab)**

<img width="1440" height="960" alt="00-dashboard" src="https://github.com/user-attachments/assets/4deee423-d5e6-4c40-a7fe-7925dbbc15c3" />

## Testing notes

- All tests pass green.
- End-to-end testing was performed to confirm the feature works.

## Checklist

- [x] Tests added or updated
- [ ] Docs updated (if behaviour changed)
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
