### PR TITLE
fix(workflow): pass output validation on resume-after-approval (#518)

### DIFF
--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -733,7 +733,19 @@ function Test-TaskOutput {
         if ($BaselineCount -ge 0) {
             $delta = $fileCount - $BaselineCount
             if ($delta -lt $minCount) {
-                return "Task output directory '$taskOutputsDir' produced $delta new file(s), expected at least $minCount"
+                # Resume-after-approval: on a resumed run the worktree already
+                # holds the artifact from the prior run, so the agent correctly
+                # calls task_set_status(done) without re-writing files that
+                # already exist — delta is 0 even though the required output is
+                # present and correct. For non-tasks/ outputs, fall back to the
+                # absolute file count: if the required files are already there
+                # (absolute count >= min), pass. tasks/ outputs keep strict
+                # delta enforcement because manifest pre-creation makes the
+                # absolute count always look satisfied, leaving delta the only
+                # meaningful signal.
+                if ($isTasksOutput -or $fileCount -lt $minCount) {
+                    return "Task output directory '$taskOutputsDir' produced $delta new file(s), expected at least $minCount"
+                }
             }
         } elseif ($fileCount -lt $minCount) {
             return "Task output directory '$taskOutputsDir' has $fileCount file(s), expected at least $minCount"

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1509,6 +1509,13 @@ Assert-True -Name "Test-TaskOutput supports legacy required_outputs alias" `
     -Condition ($workflowSrc -match "'required_outputs'")
 Assert-True -Name "Test-TaskOutput supports outputs_dir + min_output_count" `
     -Condition (($workflowSrc -match 'outputs_dir') -and ($workflowSrc -match 'min_output_count'))
+# Resume-after-approval: when the delta is below min_output_count, non-tasks/
+# outputs must fall back to the absolute file count so a resumed run whose
+# artifact already exists in the worktree passes validation instead of being
+# escalated to needs-input. tasks/ outputs keep strict delta enforcement.
+Assert-True -Name "Test-TaskOutput falls back to absolute count for non-tasks/ on zero delta" `
+    -Condition ($workflowSrc -match 'if\s*\(\$isTasksOutput\s+-or\s+\$fileCount\s+-lt\s+\$minCount\)') `
+    -Message "Resume-after-approval would fail when delta is 0 and the artifact already exists unless non-tasks/ outputs fall back to the absolute file count."
 Assert-True -Name "Measure-TaskFile counts workflow-run task files" `
     -Condition (($workflowSrc -match 'Get-ChildItem\s+-LiteralPath\s+\$tasksRoot\s+-Recurse\s+-Filter\s+''\*\.json''') -and
                 ($workflowSrc -match "\$_.Name\s+-ne\s+'run\.json'")) `


### PR DESCRIPTION
## Summary

Fixes #518 — output delta validation incorrectly failed on resume-after-approval when the artifact already existed in the worktree from the prior run.

`Test-TaskOutput` validates by counting **new** files produced during the current run (delta vs. a baseline captured before the agent starts). On a resumed run after an approval gate, the worktree already holds the artifact, so the agent correctly calls `task_set_status(done)` without re-writing existing files — the delta is `0`. Validation then failed with `produced 0 new file(s), expected at least 1`, escalating a correctly-completed task to `needs-input`.

## Fix

In `Test-TaskOutput` ([Invoke-WorkflowProcess.ps1](src/runtime/Scripts/Invoke-WorkflowProcess.ps1)): when the delta is below `min_output_count`, **non-`tasks/` outputs fall back to the absolute file count**. If the required files already exist (absolute count ≥ min), validation passes.

`tasks/` outputs keep strict delta enforcement, because manifest pre-creation means the absolute count always looks satisfied there — leaving delta as the only meaningful signal.

```powershell
if ($delta -lt $minCount) {
    # non-tasks/: fall back to absolute count (resume-after-approval).
    # tasks/: keep strict delta enforcement.
    if ($isTasksOutput -or $fileCount -lt $minCount) {
        return "Task output directory '$taskOutputsDir' produced $delta new file(s), expected at least $minCount"
    }
}
```

## Behaviour

| Scenario | `tasks/`? | delta | absolute vs. min | Result |
|---|---|---|---|---|
| Resume-after-approval, artifact present | no | 0 | ≥ min | ✅ passes |
| `tasks/` output on resume | yes | 0 | — | ❌ fails (strict delta, unchanged) |
| First run, genuinely no output | no | 0 | < min | ❌ fails (unchanged) |