### PR TITLE
fix(ci): use pull_request_target so fork PRs get Discord notification

### DIFF
--- a/.github/workflows/notify-pr.yml
+++ b/.github/workflows/notify-pr.yml
@@ -1,7 +1,7 @@
 name: "Notify: PR activity → #pull-requests"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, closed]
 
 permissions:


### PR DESCRIPTION
## Linked issue
Closes #487

## Summary of changes
Changes `.github/workflows/notify-pr.yml` event trigger from `pull_request` to `pull_request_target` so fork PRs receive Discord notifications in `#pull-requests`.

`pull_request` runs in the fork's context — GitHub blocks repository secrets from fork PRs, so `DISCORD_PR_WEBHOOK` is always empty and the notification is silently skipped. `pull_request_target` runs in the base repo context with secrets available.

**Security note:** safe here — the workflow does not checkout or execute any code from the PR branch, only reads metadata from `context.payload`. Some security scanners (CodeQL, OpenSSF Scorecard) flag `pull_request_target` automatically regardless; the repo may receive an alert even though the usage is safe.

**Backend / UI:** no changes — GitHub Actions only.

## Testing notes
Cannot be tested locally; verified by inspecting the root cause (secret source is `None` under `pull_request` for fork PRs) and the GitHub docs confirming `pull_request_target` runs in the base repo context.

## Checklist
- [ ] Tests added or updated
- [x] Docs updated (if behaviour changed)
- [x] Linked issue exists
- [x] Follows the contribution guide