### PR TITLE
fix(product-api): surface pending-review worktree artifacts on Products page

### DIFF
--- a/src/ui/modules/ProductAPI.psm1
+++ b/src/ui/modules/ProductAPI.psm1
@@ -31,6 +31,86 @@ function Initialize-ProductAPI {
     $script:Config.ControlDir = $ControlDir
 }
 
+function Get-PendingReviewProductRoot {
+    $botRoot = $script:Config.BotRoot
+
+    # Collect task IDs in needs-review state from all task layouts:
+    # - schema v2: workflow-runs/{run}/*.json and standalone/*.json (status field)
+    # - legacy flat: workspace/tasks/needs-review/*.json
+    $reviewTaskIds = [System.Collections.Generic.HashSet[string]]@()
+    $tasksRoot = Join-Path $botRoot "workspace/tasks"
+
+    $taskSearchDirs = [System.Collections.Generic.List[string]]@()
+    # v2 layout
+    $wrDir = Join-Path $tasksRoot "workflow-runs"
+    if (Test-Path $wrDir) {
+        Get-ChildItem -Path $wrDir -Directory -ErrorAction SilentlyContinue |
+            ForEach-Object { $taskSearchDirs.Add($_.FullName) }
+    }
+    $saDir = Join-Path $tasksRoot "standalone"
+    if (Test-Path $saDir) { $taskSearchDirs.Add($saDir) }
+    # legacy flat layout
+    $legacyDir = Join-Path $tasksRoot "needs-review"
+    if (Test-Path $legacyDir) { $taskSearchDirs.Add($legacyDir) }
+
+    foreach ($dir in $taskSearchDirs) {
+        Get-ChildItem -Path $dir -Filter "*.json" -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -ne 'run.json' } |
+            ForEach-Object {
+                try {
+                    $t = Get-Content -LiteralPath $_.FullName -Raw | ConvertFrom-Json
+                    # v2 tasks: check status field; legacy tasks: presence in needs-review dir is enough
+                    $isReview = ($t.status -eq 'needs-review') -or ($dir -eq $legacyDir)
+                    if ($isReview -and $t.id) { [void]$reviewTaskIds.Add($t.id) }
+                } catch {
+                    Write-BotLog -Level Debug -Message "Skipping malformed task file '$($_.FullName)'" -Exception $_
+                }
+            }
+    }
+    if ($reviewTaskIds.Count -eq 0) { return @() }
+
+    $mapPath = Join-Path $script:Config.ControlDir "worktree-map.json"
+    if (-not (Test-Path $mapPath)) { return @() }
+    try {
+        $json = Get-Content $mapPath -Raw | ConvertFrom-Json
+    } catch { return @() }
+
+    $roots = [System.Collections.Generic.List[hashtable]]@()
+    foreach ($prop in $json.PSObject.Properties) {
+        $taskId = $prop.Name
+        if (-not $reviewTaskIds.Contains($taskId)) { continue }
+        $entry = $prop.Value
+        $productDir = Join-Path $entry.worktree_path ".bot" "workspace" "product"
+        if (Test-Path $productDir) {
+            $roots.Add(@{
+                ProductDir = $productDir
+                TaskId     = $taskId
+                TaskName   = $entry.task_name
+            })
+        }
+    }
+    return $roots
+}
+
+function New-RawProductResponse {
+    param([Parameter(Mandatory)][string]$FullPath)
+    $ext = [System.IO.Path]::GetExtension($FullPath).ToLowerInvariant()
+    $mimeType = switch ($ext) {
+        '.png'  { 'image/png' }
+        '.jpg'  { 'image/jpeg' }
+        '.jpeg' { 'image/jpeg' }
+        '.gif'  { 'image/gif' }
+        '.svg'  { 'image/svg+xml' }
+        '.txt'  { 'text/plain; charset=utf-8' }
+        default { 'application/octet-stream' }
+    }
+    $isBinary = $ext -in @('.png', '.jpg', '.jpeg', '.gif')
+    if ($isBinary) {
+        return @{ Found = $true; MimeType = $mimeType; BinaryData = [System.IO.File]::ReadAllBytes($FullPath) }
+    }
+    return @{ Found = $true; MimeType = $mimeType; TextContent = (Get-Content -LiteralPath $FullPath -Raw) }
+}
+
 function Resolve-ProductDocumentInfo {
     param(
         [Parameter(Mandatory)] [System.IO.FileInfo]$File,
@@ -257,6 +337,27 @@ function Get-ProductList {
         }
     }
 
+    $existingNames = [System.Collections.Generic.HashSet[string]]($docs | ForEach-Object { $_['name'] })
+    foreach ($root in (Get-PendingReviewProductRoot)) {
+        $pendingFiles = @(Get-ChildItem -Path $root.ProductDir -File -Recurse -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -ne '.gitkeep' })
+        foreach ($file in $pendingFiles) {
+            $doc = Resolve-ProductDocumentInfo -File $file -ProductDir $root.ProductDir
+            if ($existingNames.Contains($doc.Name)) { continue }
+            [void]$existingNames.Add($doc.Name)
+            $docs += @{
+                name           = $doc.Name
+                filename       = $doc.Filename
+                depth          = $doc.Depth
+                type           = $doc.Type
+                size           = $doc.Size
+                pending_review = $true
+                task_id        = $root.TaskId
+                task_name      = $root.TaskName
+            }
+        }
+    }
+
     return @{ docs = $docs }
 }
 
@@ -275,12 +376,20 @@ function Get-ProductDocument {
             name = $resolvedDoc.Name
             content = $docContent
         }
-    } else {
-        return @{
-            _statusCode = 404
-            success = $false
-            error = "Document not found: $Name"
+    }
+
+    foreach ($root in (Get-PendingReviewProductRoot)) {
+        $pendingDoc = Resolve-ProductDocumentPath -Name $Name -ProductDir $root.ProductDir
+        if ($pendingDoc -and (Test-Path -LiteralPath $pendingDoc.FullPath)) {
+            $docContent = Get-Content -LiteralPath $pendingDoc.FullPath -Raw
+            return @{ success = $true; name = $pendingDoc.Name; content = $docContent }
         }
+    }
+
+    return @{
+        _statusCode = 404
+        success = $false
+        error = "Document not found: $Name"
     }
 }
 
@@ -292,35 +401,18 @@ function Get-ProductDocumentRaw {
     $productDir = Join-Path $botRoot "workspace/product"
     $resolvedDoc = Resolve-ProductDocumentPath -Name $Name -ProductDir $productDir
 
-    if (-not $resolvedDoc -or -not (Test-Path -LiteralPath $resolvedDoc.FullPath)) {
-        return @{ Found = $false }
+    if ($resolvedDoc -and (Test-Path -LiteralPath $resolvedDoc.FullPath)) {
+        return New-RawProductResponse -FullPath $resolvedDoc.FullPath
     }
 
-    $ext = [System.IO.Path]::GetExtension($resolvedDoc.FullPath).ToLowerInvariant()
-    $mimeType = switch ($ext) {
-        '.png'  { 'image/png' }
-        '.jpg'  { 'image/jpeg' }
-        '.jpeg' { 'image/jpeg' }
-        '.gif'  { 'image/gif' }
-        '.svg'  { 'image/svg+xml' }
-        '.txt'  { 'text/plain; charset=utf-8' }
-        default { 'application/octet-stream' }
+    foreach ($root in (Get-PendingReviewProductRoot)) {
+        $pendingDoc = Resolve-ProductDocumentPath -Name $Name -ProductDir $root.ProductDir
+        if ($pendingDoc -and (Test-Path -LiteralPath $pendingDoc.FullPath)) {
+            return New-RawProductResponse -FullPath $pendingDoc.FullPath
+        }
     }
 
-    $isBinary = $ext -in @('.png', '.jpg', '.jpeg', '.gif')
-    if ($isBinary) {
-        return @{
-            Found = $true
-            MimeType = $mimeType
-            BinaryData = [System.IO.File]::ReadAllBytes($resolvedDoc.FullPath)
-        }
-    } else {
-        return @{
-            Found = $true
-            MimeType = $mimeType
-            TextContent = (Get-Content -LiteralPath $resolvedDoc.FullPath -Raw)
-        }
-    }
+    return @{ Found = $false }
 }
 
 function Get-PreflightResults {

--- a/src/ui/modules/ProductAPI.psm1
+++ b/src/ui/modules/ProductAPI.psm1
@@ -58,10 +58,10 @@ function Get-PendingReviewProductRoot {
             Where-Object { $_.Name -ne 'run.json' } |
             ForEach-Object {
                 try {
-                    $t = Get-Content -LiteralPath $_.FullName -Raw | ConvertFrom-Json
-                    # v2 tasks: check status field; legacy tasks: presence in needs-review dir is enough
-                    $isReview = ($t.status -eq 'needs-review') -or ($dir -eq $legacyDir)
-                    if ($isReview -and $t.id) { [void]$reviewTaskIds.Add($t.id) }
+                    $taskData = Get-Content -LiteralPath $_.FullName -Raw | ConvertFrom-Json
+                    # v2 tasks: check status field; legacy tasks: presence in needs-review dir is enough (id field required)
+                    $isReview = ($taskData.status -eq 'needs-review') -or ($dir -eq $legacyDir)
+                    if ($isReview -and $taskData.id) { [void]$reviewTaskIds.Add($taskData.id) }
                 } catch {
                     Write-BotLog -Level Debug -Message "Skipping malformed task file '$($_.FullName)'" -Exception $_
                 }
@@ -70,18 +70,22 @@ function Get-PendingReviewProductRoot {
     if ($reviewTaskIds.Count -eq 0) { return @() }
 
     $mapPath = Join-Path $script:Config.ControlDir "worktree-map.json"
-    if (-not (Test-Path $mapPath)) { return @() }
+    if (-not (Test-Path -LiteralPath $mapPath)) { return @() }
     try {
-        $json = Get-Content $mapPath -Raw | ConvertFrom-Json
-    } catch { return @() }
+        $worktreeMap = Get-Content -LiteralPath $mapPath -Raw | ConvertFrom-Json
+    } catch {
+        Write-BotLog -Level Warning -Message "Failed to parse worktree-map.json at '$mapPath'" -Exception $_
+        return @()
+    }
 
     $roots = [System.Collections.Generic.List[hashtable]]@()
-    foreach ($prop in $json.PSObject.Properties) {
+    foreach ($prop in $worktreeMap.PSObject.Properties) {
         $taskId = $prop.Name
         if (-not $reviewTaskIds.Contains($taskId)) { continue }
         $entry = $prop.Value
+        if ([string]::IsNullOrWhiteSpace($entry.worktree_path)) { continue }
         $productDir = Join-Path $entry.worktree_path ".bot" "workspace" "product"
-        if (Test-Path $productDir) {
+        if (Test-Path -LiteralPath $productDir) {
             $roots.Add(@{
                 ProductDir = $productDir
                 TaskId     = $taskId
@@ -92,6 +96,7 @@ function Get-PendingReviewProductRoot {
     return $roots
 }
 
+# Builds response hashtable for raw file download (Found, MimeType, BinaryData|TextContent).
 function New-RawProductResponse {
     param([Parameter(Mandatory)][string]$FullPath)
     $ext = [System.IO.Path]::GetExtension($FullPath).ToLowerInvariant()
@@ -337,7 +342,8 @@ function Get-ProductList {
         }
     }
 
-    $existingNames = [System.Collections.Generic.HashSet[string]]($docs | ForEach-Object { $_['name'] })
+    $existingNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($d in $docs) { [void]$existingNames.Add($d['name']) }
     foreach ($root in (Get-PendingReviewProductRoot)) {
         $pendingFiles = @(Get-ChildItem -Path $root.ProductDir -File -Recurse -ErrorAction SilentlyContinue |
             Where-Object { $_.Name -ne '.gitkeep' })

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -4394,6 +4394,103 @@ if (Test-Path $productApiModule) {
             -Condition ($rawTraversal.Found -eq $false) `
             -Message "Path traversal should return not found"
 
+        # ── Pending-review worktree product tests (issue #519) ──
+
+        $pendingWtRoot  = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-pending-wt-$([guid]::NewGuid().ToString().Substring(0,8))"
+        $pendingWtProductDir = Join-Path $pendingWtRoot ".bot" "workspace" "product"
+        New-Item -Path $pendingWtProductDir -ItemType Directory -Force | Out-Null
+
+        $pendingTaskId = [guid]::NewGuid().ToString()
+        # Use v2 layout: workflow-runs/{run}/*.json with status field
+        $wrRunDir = Join-Path $productBotRoot "workspace/tasks/workflow-runs/wr_test01"
+        New-Item -Path $wrRunDir -ItemType Directory -Force | Out-Null
+        Set-Content -Path (Join-Path $wrRunDir "task-pending.json") `
+            -Value (@{ id = $pendingTaskId; name = "Pending Task"; status = "needs-review"; schema_version = 2 } | ConvertTo-Json) `
+            -Encoding UTF8
+
+        $wtMap = @{ $pendingTaskId = @{ worktree_path = $pendingWtRoot; task_name = "Pending Task"; branch_name = "task/test" } }
+        Set-Content -Path (Join-Path $controlDir "worktree-map.json") `
+            -Value ($wtMap | ConvertTo-Json -Depth 5) -Encoding UTF8
+
+        Set-Content -Path (Join-Path $pendingWtProductDir "feature-spec.md") -Value "# Feature Spec" -Encoding UTF8
+
+        # Re-initialize so the module picks up the new worktree-map + tasks dir
+        Initialize-ProductAPI -BotRoot $productBotRoot -ControlDir $controlDir
+
+        $docsWithPending = @((Get-ProductList).docs)
+        $pendingEntry = $docsWithPending | Where-Object { $_.name -eq 'feature-spec' }
+        Assert-True -Name "ProductAPI includes needs-review worktree artifact in list" `
+            -Condition ($null -ne $pendingEntry) `
+            -Message "Pending artifact 'feature-spec' missing from product list"
+        Assert-True -Name "ProductAPI sets pending_review=true on worktree artifact" `
+            -Condition ($pendingEntry.pending_review -eq $true) `
+            -Message "Expected pending_review=true on 'feature-spec'"
+        Assert-Equal -Name "ProductAPI sets correct task_id on pending artifact" `
+            -Expected $pendingTaskId `
+            -Actual $pendingEntry.task_id
+        Assert-Equal -Name "ProductAPI sets correct task_name on pending artifact" `
+            -Expected "Pending Task" `
+            -Actual $pendingEntry.task_name
+
+        # Main doc takes precedence — mission.md exists in main, should NOT gain pending_review flag
+        Set-Content -Path (Join-Path $pendingWtProductDir "mission.md") -Value "# Pending Mission" -Encoding UTF8
+        $docsDedup = @((Get-ProductList).docs)
+        $missionEntries = @($docsDedup | Where-Object { $_.name -eq 'mission' })
+        Assert-Equal -Name "ProductAPI deduplicates: main doc wins over pending copy" `
+            -Expected 1 `
+            -Actual $missionEntries.Count
+        Assert-True -Name "ProductAPI main doc retains no pending_review flag" `
+            -Condition (-not $missionEntries[0].ContainsKey('pending_review') -or $missionEntries[0].pending_review -ne $true) `
+            -Message "Main workspace doc should not be marked pending_review"
+
+        # Get-ProductDocument falls back to pending worktree
+        $pendingDocResult = Get-ProductDocument -Name "feature-spec"
+        Assert-True -Name "ProductDocument falls back to needs-review worktree" `
+            -Condition ($pendingDocResult.success -eq $true -and $pendingDocResult.content -match 'Feature Spec') `
+            -Message "Get-ProductDocument did not fall back to pending worktree"
+
+        # Get-ProductDocumentRaw falls back to pending worktree
+        Set-Content -Path (Join-Path $pendingWtProductDir "diagram.svg") `
+            -Value '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>' -Encoding UTF8
+        $pendingRaw = Get-ProductDocumentRaw -Name "diagram-pending.svg"
+        Assert-True -Name "ProductDocumentRaw returns Found=false for truly missing file" `
+            -Condition ($pendingRaw.Found -eq $false) `
+            -Message "File not in any worktree should return Found=false"
+
+        # In-progress task (status=in-progress in v2 layout) must not be surfaced
+        $inProgressTaskId = [guid]::NewGuid().ToString()
+        $inProgressWtRoot = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-inprogress-wt-$([guid]::NewGuid().ToString().Substring(0,8))"
+        $inProgressProductDir = Join-Path $inProgressWtRoot ".bot" "workspace" "product"
+        New-Item -Path $inProgressProductDir -ItemType Directory -Force | Out-Null
+        Set-Content -Path (Join-Path $inProgressProductDir "wip-doc.md") -Value "# WIP" -Encoding UTF8
+        # task file in v2 layout with status=in-progress
+        Set-Content -Path (Join-Path $wrRunDir "task-inprogress.json") `
+            -Value (@{ id = $inProgressTaskId; name = "Running Task"; status = "in-progress"; schema_version = 2 } | ConvertTo-Json) `
+            -Encoding UTF8
+
+        $wtMapWithInProgress = @{
+            $pendingTaskId     = @{ worktree_path = $pendingWtRoot; task_name = "Pending Task"; branch_name = "task/test" }
+            $inProgressTaskId  = @{ worktree_path = $inProgressWtRoot; task_name = "Running Task"; branch_name = "task/running" }
+        }
+        Set-Content -Path (Join-Path $controlDir "worktree-map.json") `
+            -Value ($wtMapWithInProgress | ConvertTo-Json -Depth 5) -Encoding UTF8
+
+        $docsNoWip = @((Get-ProductList).docs)
+        $wipEntry = $docsNoWip | Where-Object { $_.name -eq 'wip-doc' }
+        Assert-True -Name "ProductAPI does NOT surface in-progress task artifacts" `
+            -Condition ($null -eq $wipEntry) `
+            -Message "In-progress task artifact 'wip-doc' should not appear in product list"
+
+        # No worktree-map: graceful empty result
+        Remove-Item -Path (Join-Path $controlDir "worktree-map.json") -Force -ErrorAction SilentlyContinue
+        $docsNoMap = @((Get-ProductList).docs)
+        Assert-True -Name "ProductAPI handles missing worktree-map gracefully" `
+            -Condition ($null -ne $docsNoMap) `
+            -Message "Get-ProductList should not throw when worktree-map.json is absent"
+
+        if (Test-Path $pendingWtRoot) { Remove-Item $pendingWtRoot -Recurse -Force -ErrorAction SilentlyContinue }
+        if (Test-Path $inProgressWtRoot) { Remove-Item $inProgressWtRoot -Recurse -Force -ErrorAction SilentlyContinue }
+
         # ═════════════════════════════════════════════════════════════════
         # Get-WorkflowStatus — script-phase probe + process-type filter
         # Regression tests for #244: Overview stuck on Task Group Expansion

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -4450,11 +4450,24 @@ if (Test-Path $productApiModule) {
             -Message "Get-ProductDocument did not fall back to pending worktree"
 
         # Get-ProductDocumentRaw falls back to pending worktree
-        Set-Content -Path (Join-Path $pendingWtProductDir "diagram.svg") `
-            -Value '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>' -Encoding UTF8
-        $pendingRaw = Get-ProductDocumentRaw -Name "diagram-pending.svg"
+        # Use a name absent from main workspace/product so fallback path is exercised
+        $pendingSvgContent = '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>'
+        Set-Content -Path (Join-Path $pendingWtProductDir "pending-only.svg") `
+            -Value $pendingSvgContent -Encoding UTF8
+        $pendingRawSvg = Get-ProductDocumentRaw -Name "pending-only.svg"
+        Assert-True -Name "ProductDocumentRaw falls back to needs-review worktree for SVG" `
+            -Condition ($pendingRawSvg.Found -eq $true) `
+            -Message "Get-ProductDocumentRaw did not fall back to pending worktree for pending-only.svg"
+        Assert-Equal -Name "ProductDocumentRaw returns correct MIME type for pending SVG" `
+            -Expected "image/svg+xml" `
+            -Actual $pendingRawSvg.MimeType
+        Assert-True -Name "ProductDocumentRaw returns correct content for pending SVG" `
+            -Condition ($pendingRawSvg.TextContent -eq $pendingSvgContent) `
+            -Message "Pending SVG content mismatch"
+
+        $pendingRawMissing = Get-ProductDocumentRaw -Name "diagram-pending.svg"
         Assert-True -Name "ProductDocumentRaw returns Found=false for truly missing file" `
-            -Condition ($pendingRaw.Found -eq $false) `
+            -Condition ($pendingRawMissing.Found -eq $false) `
             -Message "File not in any worktree should return Found=false"
 
         # In-progress task (status=in-progress in v2 layout) must not be surfaced

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -4491,6 +4491,46 @@ if (Test-Path $productApiModule) {
         if (Test-Path $pendingWtRoot) { Remove-Item $pendingWtRoot -Recurse -Force -ErrorAction SilentlyContinue }
         if (Test-Path $inProgressWtRoot) { Remove-Item $inProgressWtRoot -Recurse -Force -ErrorAction SilentlyContinue }
 
+        # Empty main workspace/product + pending worktree: regression for HashSet null crash (#534)
+        $emptyBotRoot   = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-empty-$([guid]::NewGuid().ToString().Substring(0,8))"
+        $emptyCtrlDir   = Join-Path $emptyBotRoot ".control"
+        $emptyTasksDir  = Join-Path $emptyBotRoot "workspace" "tasks" "workflow-runs" "wr_empty01"
+        New-Item -Path $emptyCtrlDir  -ItemType Directory -Force | Out-Null
+        New-Item -Path $emptyTasksDir -ItemType Directory -Force | Out-Null
+        # No workspace/product directory — main productDir intentionally absent
+
+        $emptyPendingWtRoot = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-empty-wt-$([guid]::NewGuid().ToString().Substring(0,8))"
+        $emptyPendingProdDir = Join-Path $emptyPendingWtRoot ".bot" "workspace" "product"
+        New-Item -Path $emptyPendingProdDir -ItemType Directory -Force | Out-Null
+        Set-Content -Path (Join-Path $emptyPendingProdDir "fresh-spec.md") -Value "# Fresh Spec" -Encoding UTF8
+
+        $emptyTaskId = [guid]::NewGuid().ToString()
+        Set-Content -Path (Join-Path $emptyTasksDir "task-empty.json") `
+            -Value (@{ id = $emptyTaskId; name = "Empty Task"; status = "needs-review"; schema_version = 2 } | ConvertTo-Json) `
+            -Encoding UTF8
+        $emptyWtMap = @{ $emptyTaskId = @{ worktree_path = $emptyPendingWtRoot; task_name = "Empty Task"; branch_name = "task/empty" } }
+        Set-Content -Path (Join-Path $emptyCtrlDir "worktree-map.json") `
+            -Value ($emptyWtMap | ConvertTo-Json -Depth 5) -Encoding UTF8
+
+        Initialize-ProductAPI -BotRoot $emptyBotRoot -ControlDir $emptyCtrlDir
+        $emptyDocs = $null
+        $emptyListError = $null
+        try { $emptyDocs = @((Get-ProductList).docs) } catch { $emptyListError = $_ }
+
+        Assert-True -Name "ProductAPI does not crash when main workspace/product is absent (HashSet null guard)" `
+            -Condition ($null -eq $emptyListError) `
+            -Message "Get-ProductList threw when main productDir absent: $emptyListError"
+        $freshEntry = if ($emptyDocs) { $emptyDocs | Where-Object { $_.name -eq 'fresh-spec' } } else { $null }
+        Assert-True -Name "ProductAPI surfaces pending artifact when main workspace/product is absent" `
+            -Condition ($null -ne $freshEntry -and $freshEntry.pending_review -eq $true) `
+            -Message "Expected 'fresh-spec' with pending_review=true when main productDir absent"
+
+        if (Test-Path $emptyBotRoot)       { Remove-Item $emptyBotRoot       -Recurse -Force -ErrorAction SilentlyContinue }
+        if (Test-Path $emptyPendingWtRoot) { Remove-Item $emptyPendingWtRoot -Recurse -Force -ErrorAction SilentlyContinue }
+
+        # Restore module to original test fixture for subsequent tests
+        Initialize-ProductAPI -BotRoot $productBotRoot -ControlDir $controlDir
+
         # ═════════════════════════════════════════════════════════════════
         # Get-WorkflowStatus — script-phase probe + process-type filter
         # Regression tests for #244: Overview stuck on Task Group Expansion

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -4453,7 +4453,7 @@ if (Test-Path $productApiModule) {
         # Use a name absent from main workspace/product so fallback path is exercised
         $pendingSvgContent = '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>'
         Set-Content -Path (Join-Path $pendingWtProductDir "pending-only.svg") `
-            -Value $pendingSvgContent -Encoding UTF8
+            -Value $pendingSvgContent -Encoding UTF8 -NoNewline
         $pendingRawSvg = Get-ProductDocumentRaw -Name "pending-only.svg"
         Assert-True -Name "ProductDocumentRaw falls back to needs-review worktree for SVG" `
             -Condition ($pendingRawSvg.Found -eq $true) `


### PR DESCRIPTION
## Linked issue

Closes #519

## Summary of changes

`Get-ProductList`, `Get-ProductDocument`, and `Get-ProductDocumentRaw` only read from the main `workspace/product/`. When a task parks at `needs-review`, its artifacts live in the task's git worktree — invisible to the reviewer.

Added `Get-PendingReviewProductRoot` helper that scans task files for `needs-review` status (both schema-v2 `workflow-runs/` layout and legacy flat layout), cross-references `worktree-map.json`, and returns the product dirs of matching worktrees. All three API functions now fall back to these pending roots. Main location takes precedence — no duplicates. In-progress task artifacts are excluded.

## Screenshots / recordings

| Before (main) | After (fix branch) |
|---|---|
| <img width="281" height="488" alt="image" src="https://github.com/user-attachments/assets/fc3dd86e-a07e-425b-8744-75060b764733" /> | <img width="340" height="664" alt="image" src="https://github.com/user-attachments/assets/9dfa83ea-23a0-4432-9b80-433f2573592d" /> |
<img width="516" height="163" alt="image" src="https://github.com/user-attachments/assets/24bd4c7e-ccc2-4382-89e9-a2c19cd9990b" />

## Testing notes

1. Have a project with commits and an active task worktree containing product files
2. Set the task status to `needs-review` in its task JSON
3. Open the Products page — worktree artifacts appear alongside merged docs
4. Approve/merge the task — artifacts appear via the normal path, no `pending_review` flag

Automated: new test cases added to `tests/Test-Components.ps1` covering pending artifact listing, dedup (main wins), `Get-ProductDocument` fallback, in-progress exclusion, and missing worktree-map graceful handling.

## Checklist

- [x] Tests added or updated
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)