### PR TITLE
fix(worktree): support unborn-repo first task on git <2.42 (#513)

### DIFF
--- a/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1
+++ b/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1
@@ -214,6 +214,64 @@ function Resolve-UnbornBaseBranch {
     return 'main'
 }
 
+function Test-GitVersionSupportsWorktreeOrphan {
+    # Pure parser: `git worktree add --orphan` was introduced in git 2.42.0.
+    param([Parameter(Mandatory)][string]$VersionLine)
+    if ($VersionLine -match 'git version (\d+)\.(\d+)') {
+        $major = [int]$Matches[1]
+        $minor = [int]$Matches[2]
+        return ($major -gt 2 -or ($major -eq 2 -and $minor -ge 42))
+    }
+    return $false
+}
+
+function Test-GitWorktreeOrphanSupported {
+    param([Parameter(Mandatory)][string]$ProjectRoot)
+    $raw = (git -C $ProjectRoot --version 2>$null) -as [string]
+    if (-not $raw) { return $false }
+    return Test-GitVersionSupportsWorktreeOrphan -VersionLine $raw
+}
+
+function Add-UnbornTaskWorktree {
+    <#
+    .SYNOPSIS
+    Create the first task worktree when the base branch is unborn (0 commits).
+    On git >= 2.42 an orphan worktree is used so the base stays unborn until the
+    first task completes. On older git, which has no `worktree add --orphan`, a
+    single empty initial commit is seeded on the base branch so a normal worktree
+    can fork from it.
+
+    .OUTPUTS
+    Hashtable with: baseStillUnborn (bool), output (git output). Throws on failure.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [Parameter(Mandatory)][string]$WorktreePath,
+        [Parameter(Mandatory)][string]$BranchName,
+        [Parameter(Mandatory)][string]$BaseBranch,
+        [Parameter(Mandatory)][bool]$OrphanSupported
+    )
+
+    if ($OrphanSupported) {
+        $output = git -C $ProjectRoot worktree add --orphan -b $BranchName $WorktreePath 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "git worktree add --orphan failed: $($output -join ' ')"
+        }
+        return @{ baseStillUnborn = $true; output = $output }
+    }
+
+    git -C $ProjectRoot symbolic-ref HEAD "refs/heads/$BaseBranch" 2>&1 | Out-Null
+    $commitOutput = git -C $ProjectRoot commit --allow-empty -m "chore: initial commit" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to seed initial commit on '$BaseBranch' in ${ProjectRoot}: $($commitOutput -join ' ')"
+    }
+    $output = git -C $ProjectRoot worktree add -b $BranchName $WorktreePath $BaseBranch 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "git worktree add failed: $($output -join ' ')"
+    }
+    return @{ baseStillUnborn = $false; output = $output }
+}
+
 function Assert-OnBaseBranch {
     <#
     .SYNOPSIS
@@ -1437,22 +1495,23 @@ function New-TaskWorktree {
         $baseIsUnborn = $false
         if (-not $baseBranch) {
             $baseBranch = Resolve-UnbornBaseBranch -ProjectRoot $ProjectRoot
-            $baseIsUnborn = [bool]$baseBranch
-        }
-        if (-not $baseBranch) {
-            throw "Cannot create worktree: no 'main' or 'master' branch found in $ProjectRoot. Use a standard integration branch name (main or master)."
-        }
-
-        if ($baseIsUnborn) {
-            $output = git -C $ProjectRoot worktree add --orphan -b $branchName $worktreePath 2>&1
+            if (-not $baseBranch) {
+                throw "Cannot create worktree: no 'main' or 'master' branch found in $ProjectRoot. Use a standard integration branch name (main or master)."
+            }
+            # No commits yet. git >= 2.42 gets an orphan worktree (base stays unborn);
+            # older git seeds one empty initial commit so a normal worktree can fork.
+            $orphanSupported = Test-GitWorktreeOrphanSupported -ProjectRoot $ProjectRoot
+            $addResult = Add-UnbornTaskWorktree -ProjectRoot $ProjectRoot -WorktreePath $worktreePath -BranchName $branchName -BaseBranch $baseBranch -OrphanSupported $orphanSupported
+            $baseIsUnborn = $addResult.baseStillUnborn
+            $output = $addResult.output
         } else {
             $output = git -C $ProjectRoot worktree add -b $branchName $worktreePath $baseBranch 2>&1
-        }
-        if ($LASTEXITCODE -ne 0) {
-            # Branch may already exist from an interrupted run — try without -b
-            $output = git -C $ProjectRoot worktree add $worktreePath $branchName 2>&1
             if ($LASTEXITCODE -ne 0) {
-                throw "git worktree add failed: $($output -join ' ')"
+                # Branch may already exist from an interrupted run — try without -b
+                $output = git -C $ProjectRoot worktree add $worktreePath $branchName 2>&1
+                if ($LASTEXITCODE -ne 0) {
+                    throw "git worktree add failed: $($output -join ' ')"
+                }
             }
         }
 

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -809,6 +809,62 @@ if (Test-Path $worktreeManagerModule) {
         }
         Remove-TestProject -Path $unbornRoot
     }
+
+    Write-Host "--- Unborn worktree: git capability gate (issue #513) ---" -ForegroundColor Cyan
+
+    # `git worktree add --orphan` landed in git 2.42.0. Below that, dotbot must take
+    # the seed-commit fallback instead of emitting `fatal: invalid reference`.
+    $orphanGateCases = @(
+        @{ Line = "git version 2.31.1.windows.1"; Expected = $false }
+        @{ Line = "git version 2.41.0";            Expected = $false }
+        @{ Line = "git version 2.42.0";            Expected = $true }
+        @{ Line = "git version 2.43.0";            Expected = $true }
+        @{ Line = "git version 3.0.0";             Expected = $true }
+    )
+    foreach ($case in $orphanGateCases) {
+        $gateResult = & (Get-Module Dotbot.Worktree) { Test-GitVersionSupportsWorktreeOrphan -VersionLine $args[0] } $case.Line
+        Assert-Equal -Name "Orphan gate: '$($case.Line)' supported=$($case.Expected)" `
+            -Expected $case.Expected -Actual ([bool]$gateResult)
+    }
+
+    Write-Host "--- Unborn worktree: seed-commit fallback for old git (issue #513) ---" -ForegroundColor Cyan
+
+    # On git < 2.42 (OrphanSupported=$false) the first task on a 0-commit repo cannot
+    # use an orphan worktree, so dotbot seeds one empty initial commit on the base
+    # branch and forks the task worktree from it.
+    $seedRoot = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-test-unborn-seed-$([System.Guid]::NewGuid().ToString().Substring(0,8))"
+    $seedWorktree = Join-Path (Split-Path $seedRoot -Parent) "wt-$(Split-Path $seedRoot -Leaf)"
+    try {
+        New-Item -ItemType Directory -Path $seedRoot -Force | Out-Null
+        & git -C $seedRoot init --quiet 2>&1 | Out-Null
+        & git -C $seedRoot config user.email "test@dotbot.dev" 2>&1 | Out-Null
+        & git -C $seedRoot config user.name "Dotbot Test" 2>&1 | Out-Null
+        & git -C $seedRoot symbolic-ref HEAD refs/heads/master 2>&1 | Out-Null
+
+        $seedAdd = & (Get-Module Dotbot.Worktree) {
+            Add-UnbornTaskWorktree -ProjectRoot $args[0] -WorktreePath $args[1] -BranchName $args[2] -BaseBranch $args[3] -OrphanSupported $args[4]
+        } $seedRoot $seedWorktree "task/seed-fallback" "master" $false
+
+        Assert-Equal -Name "Seed fallback: base reported as born after seeding" `
+            -Expected $false -Actual ([bool]$seedAdd.baseStillUnborn)
+
+        & git -C $seedRoot rev-parse --verify "master^{commit}" 2>$null | Out-Null
+        Assert-True -Name "Seed fallback: base branch now has a commit" -Condition ($LASTEXITCODE -eq 0)
+        Assert-Equal -Name "Seed fallback: base branch has exactly one commit" `
+            -Expected "1" -Actual ((& git -C $seedRoot rev-list --count master 2>$null).Trim())
+        Assert-PathExists -Name "Seed fallback: worktree .git marker created" -Path (Join-Path $seedWorktree ".git")
+
+        & git -C $seedRoot rev-parse --verify "task/seed-fallback" 2>$null | Out-Null
+        Assert-True -Name "Seed fallback: task branch created" -Condition ($LASTEXITCODE -eq 0)
+        $seedTaskTip = (& git -C $seedRoot rev-parse "task/seed-fallback" 2>$null).Trim()
+        $seedBaseTip = (& git -C $seedRoot rev-parse "master" 2>$null).Trim()
+        Assert-Equal -Name "Seed fallback: task branch is based on the seed commit" `
+            -Expected $seedBaseTip -Actual $seedTaskTip
+    } finally {
+        if (Test-Path $seedWorktree) { & git -C $seedRoot worktree remove -f $seedWorktree 2>&1 | Out-Null }
+        if (Test-Path $seedWorktree) { Remove-Item -Path $seedWorktree -Recurse -Force -ErrorAction SilentlyContinue }
+        Remove-Item -Path $seedRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
 } else {
     Write-TestResult -Name "Dotbot.Worktree module exists" -Status Fail -Message "Module not found at $worktreeManagerModule"
 }


### PR DESCRIPTION
## Linked issue

Closes #513

## Summary of changes

Since v4 every task runs in a git worktree, so the first task of a brand-new
project (`git init` + `dotbot init`, unborn `HEAD`, 0 commits) must create a
worktree from a base branch that has no commit yet. `New-TaskWorktree` already
handled this with `git worktree add --orphan`, but that flag was only added in
**git 2.42.0**. On older git (the reporter ran **2.31.1**) the flag is rejected,
the code falls through to a retry that cannot fork a non-existent ref, and the
run dies with `fatal: invalid reference: task/...` — blocking the first run of a
fresh project entirely.

This change makes worktree creation work on **all** supported git versions while
keeping the existing behaviour unchanged on git ≥ 2.42:

- Add git-capability detection: `Test-GitVersionSupportsWorktreeOrphan` (pure
  version-line parser) and `Test-GitWorktreeOrphanSupported`.
- Extract the unborn-repo worktree creation into `Add-UnbornTaskWorktree`:
  - **git ≥ 2.42** — unchanged: `git worktree add --orphan` (base stays unborn
    until the first task completes; no synthetic bootstrap commit).
  - **git < 2.42** — seed one empty initial commit (`git commit --allow-empty`)
    on the resolved base branch, then fork the worktree normally.
- Wire it into `New-TaskWorktree` so the post-seed `$baseIsUnborn` state is
  accurate; the rest of the lifecycle (`Complete-TaskWorktree` squash-merge) is
  untouched because the seeded base is then a normal, born base.

Files: `src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1`,
`tests/Test-Components.ps1`.

## Screenshots / recordings

Not applicable (no UI changes).

## Testing notes

**Automated** (`tests/Test-Components.ps1`):

- Version-boundary unit tests for `Test-GitVersionSupportsWorktreeOrphan`
  (2.31.1 → false, 2.41.0 → false, 2.42.0 → true, 2.43.0 → true, 3.0.0 → true).
- Seed-fallback integration test for `Add-UnbornTaskWorktree -OrphanSupported
$false` on a real 0-commit repo: base ends with exactly one commit, the
  worktree is created, and the task branch forks from the seed commit.
- The existing orphan-path unborn regression block (git ≥ 2.42) still passes,
  confirming no behavioural change on modern git.

- `pwsh tests/Run-Tests.ps1` (layers 1-3) is green.

**Real-project verification, both git versions** (git 2.31.1 and git 2.43, fresh
`git init` + real `dotbot init` + first task via the real task-runner):

- git **2.31.1**: first task's worktree created via the seed-commit fallback — no
  `fatal: invalid reference`, no `Worktree setup failed`.
- git **2.43.0**: first task's worktree created via the orphan path (base stays
  unborn) — no error.

## Checklist

- [x] Tests added or updated
- [ ] Docs updated (if behaviour changed)
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
