### PR TITLE
feat(runtime): gate task execution on input/output artifacts (#510)

### DIFF
--- a/src/mcp/tools/task-create/metadata.json
+++ b/src/mcp/tools/task-create/metadata.json
@@ -68,6 +68,13 @@
           "type": "string"
         }
       },
+      "inputs": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Artifact files this task requires as input. Validated for presence, non-emptiness, and (for .json) well-formedness before the task runs; a missing/empty/malformed input blocks the task with needs-input."
+      },
       "provenance": {
         "type": "object",
         "description": "Optional provenance bag (workflow / run_id / source). Standalone tasks omit this."

--- a/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
+++ b/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
@@ -383,6 +383,7 @@ function _FlattenTask {
         description           = $Content.description
         dependencies          = $Content.dependencies
         outputs               = $Content.outputs
+        inputs                = $Content.inputs
         acceptance_criteria   = $Content.acceptance_criteria
         created_at            = $Content.created_at
         updated_at            = $Content.updated_at

--- a/src/runtime/Modules/Dotbot.Runtime/Private/HttpServer.psm1
+++ b/src/runtime/Modules/Dotbot.Runtime/Private/HttpServer.psm1
@@ -998,6 +998,10 @@ function Invoke-CreateTaskHandler {
         $vals = @($Body.outputs | Where-Object { $_ -and $_ -ne '' })
         if ($vals.Count -gt 0) { $params['Outputs'] = [string[]]$vals }
     }
+    if ($Body.PSObject.Properties['inputs']) {
+        $vals = @($Body.inputs | Where-Object { $_ -and $_ -ne '' })
+        if ($vals.Count -gt 0) { $params['Inputs'] = [string[]]$vals }
+    }
     if ($Body.PSObject.Properties['provenance']) {
         # Convert PSCustomObject → hashtable for the builder.
         $bag = @{}
@@ -1107,7 +1111,7 @@ function Invoke-PatchTaskHandler {
         $forbidden = @('id', 'status', 'schema_version', 'created_at', 'completed_at')
         # Single-string values for list-shaped fields are coerced to a
         # one-element array so the schema assert downstream accepts them.
-        $listFields = @('dependencies', 'acceptance_criteria', 'outputs')
+        $listFields = @('dependencies', 'acceptance_criteria', 'outputs', 'inputs')
         foreach ($prop in $Body.PSObject.Properties) {
             if ($prop.Name -in @('actor')) { continue }
             if ($prop.Name -in $forbidden) {

--- a/src/runtime/Modules/Dotbot.Task/Private/TaskInstance.psm1
+++ b/src/runtime/Modules/Dotbot.Task/Private/TaskInstance.psm1
@@ -29,6 +29,7 @@ $script:DotbotTaskInstanceFields = @(
     'dependencies',
     'acceptance_criteria',
     'outputs',
+    'inputs',
     'created_at',
     'updated_at',
     'completed_at',
@@ -294,8 +295,8 @@ function Test-TaskInstance {
         }
     }
 
-    # acceptance_criteria / outputs — arrays of strings.
-    foreach ($listField in 'acceptance_criteria','outputs') {
+    # acceptance_criteria / outputs / inputs — arrays of strings.
+    foreach ($listField in 'acceptance_criteria','outputs','inputs') {
         if (-not (_Has-DotbotProp $Task $listField)) { continue }
         if ($Task -is [System.Collections.IDictionary]) {
             $valRaw = $Task[$listField]
@@ -416,6 +417,8 @@ function New-TaskInstance {
 
         [string[]]$Outputs = @(),
 
+        [string[]]$Inputs = @(),
+
         [hashtable]$Extensions,
 
         [string]$UpdatedBy = 'system',
@@ -461,6 +464,7 @@ function New-TaskInstance {
         dependencies        = @($Dependencies)
         acceptance_criteria = @($AcceptanceCriteria)
         outputs             = @($Outputs)
+        inputs              = @($Inputs)
         created_at          = $now
         updated_at          = $now
         completed_at        = $completedAt

--- a/src/runtime/Modules/Dotbot.Workflow/Dotbot.Workflow.psm1
+++ b/src/runtime/Modules/Dotbot.Workflow/Dotbot.Workflow.psm1
@@ -1050,6 +1050,9 @@ function New-WorkflowTask {
     $outputs = @()
     if ($TaskDef['outputs']) { $outputs = @($TaskDef['outputs'] | Where-Object { $_ -and $_ -ne '' }) }
 
+    $inputs = @()
+    if ($TaskDef['inputs']) { $inputs = @($TaskDef['inputs'] | Where-Object { $_ -and $_ -ne '' }) }
+
     $acceptance = @()
     if ($TaskDef['acceptance_criteria']) { $acceptance = @($TaskDef['acceptance_criteria'] | Where-Object { $_ -and $_ -ne '' }) }
 
@@ -1069,6 +1072,7 @@ function New-WorkflowTask {
         -Dependencies ([string[]]$deps) `
         -AcceptanceCriteria ([string[]]$acceptance) `
         -Outputs ([string[]]$outputs) `
+        -Inputs ([string[]]$inputs) `
         -Provenance @{
             workflow        = $workflowName
             run_id          = $runId

--- a/src/runtime/Modules/Dotbot.Workflow/Private/TaskDefinition.psm1
+++ b/src/runtime/Modules/Dotbot.Workflow/Private/TaskDefinition.psm1
@@ -8,6 +8,7 @@ TaskDefinition shape (a single entry in workflow.json's `tasks` array):
   - depends_on     : array of strings (other TaskDefinition names), optional
   - prompt         : string (path or inline text), optional
   - outputs        : array of strings, optional
+  - inputs         : array of strings, optional
   - priority       : int or named (low/normal/high/critical), optional
   - optional       : bool, optional (default false)
 
@@ -16,7 +17,7 @@ front_matter_docs, post_script. (post_script is a transition-hook concern.)
 #>
 
 $script:DotbotTaskDefFields = @(
-    'name', 'type', 'depends_on', 'prompt', 'outputs', 'priority', 'optional'
+    'name', 'type', 'depends_on', 'prompt', 'outputs', 'inputs', 'priority', 'optional'
 )
 
 # Fields that legacy manifests may still carry; explicitly rejected so a
@@ -150,6 +151,28 @@ function Test-TaskDefinition {
                 foreach ($o in @($outsRaw)) {
                     if ($o -isnot [string]) {
                         [void]$errors.Add("outputs[$i]: must be a string")
+                    }
+                    $i++
+                }
+            }
+        }
+    }
+
+    # inputs — array of strings.
+    if (_Has-Prop $TaskDef 'inputs') {
+        if ($TaskDef -is [System.Collections.IDictionary]) {
+            $insRaw = $TaskDef['inputs']
+        } else {
+            $insRaw = $TaskDef.inputs
+        }
+        if ($null -ne $insRaw) {
+            if ($insRaw -is [string]) {
+                [void]$errors.Add('inputs: must be an array of strings, not a single string')
+            } else {
+                $i = 0
+                foreach ($inp in @($insRaw)) {
+                    if ($inp -isnot [string]) {
+                        [void]$errors.Add("inputs[$i]: must be a string")
                     }
                     $i++
                 }

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -681,6 +681,26 @@ function Get-TaskOutputBaseline {
     return 0
 }
 
+function Test-DotbotArtifact {
+    param([Parameter(Mandatory)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return 'absent'
+    }
+    $raw = Get-Content -LiteralPath $Path -Raw -ErrorAction SilentlyContinue
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return 'empty'
+    }
+    if ([System.IO.Path]::GetExtension($Path) -ieq '.json') {
+        try {
+            $null = $raw | ConvertFrom-Json -ErrorAction Stop
+        } catch {
+            return 'malformed JSON (possibly partially written)'
+        }
+    }
+    return $null
+}
+
 function Test-TaskOutput {
     param(
         [Parameter(Mandatory)]$Task,
@@ -700,8 +720,9 @@ function Test-TaskOutput {
     }
     if ($taskOutputs) {
         foreach ($f in $taskOutputs) {
-            if (-not (Test-Path (Join-Path $ProductDir $f))) {
-                return "Task output not produced: $f"
+            $reason = Test-DotbotArtifact -Path (Join-Path $ProductDir $f)
+            if ($reason) {
+                return "Task output not produced: $f ($reason)"
             }
         }
     } elseif ($taskOutputsDir) {
@@ -737,6 +758,24 @@ function Test-TaskOutput {
             }
         } elseif ($fileCount -lt $minCount) {
             return "Task output directory '$taskOutputsDir' has $fileCount file(s), expected at least $minCount"
+        }
+    }
+    return $null
+}
+
+function Test-TaskInput {
+    param(
+        [Parameter(Mandatory)]$Task,
+        [Parameter(Mandatory)][string]$ProductDir
+    )
+    $taskInputs = if ($Task -is [System.Collections.IDictionary]) { $Task['inputs'] } else { $Task.inputs }
+    if (-not $taskInputs) {
+        return $null
+    }
+    foreach ($f in $taskInputs) {
+        $reason = Test-DotbotArtifact -Path (Join-Path $ProductDir $f)
+        if ($reason) {
+            return "Required input '$f' is $reason"
         }
     }
     return $null
@@ -1485,6 +1524,38 @@ try {
             $executionBotRoot = Join-Path $worktreePath ".bot"
             $executionProductDir = Join-Path (Join-Path $executionBotRoot 'workspace') 'product'
 
+            $inputErr = Test-TaskInput -Task $task -ProductDir $executionProductDir
+            if ($inputErr) {
+                Write-Status "Input validation failed for $($task.name): $inputErr" -Type Warn
+                Write-ProcessActivity -Id $procId -ActivityType "error" -Message "Input gate failed for $($task.name): $inputErr"
+                if ($worktreePath) {
+                    try {
+                        Remove-Junctions -WorktreePath $worktreePath -ErrorOnFailure $false | Out-Null
+                        git -C $projectRoot worktree remove $worktreePath --force 2>$null
+                        if ($branchName) { git -C $projectRoot branch -D $branchName 2>$null }
+                    } finally {
+                        Invoke-WorktreeMapLocked -BotRoot $botRoot -Action {
+                            $cleanupMap = Read-WorktreeMap -BotRoot $botRoot
+                            $cleanupMap.Remove($task.id)
+                            Write-WorktreeMap -Map $cleanupMap -BotRoot $botRoot
+                        }
+                        try { Assert-OnBaseBranch -ProjectRoot $projectRoot | Out-Null } catch { Write-BotLog -Level Warn -Message "Task operation failed" -Exception $_ }
+                    }
+                }
+                try {
+                    Set-WorkflowTaskNeedsInput `
+                        -Task $task `
+                        -RunDir $runDir `
+                        -QuestionId "input-missing-$($task.id)" `
+                        -Question "Required input artifact missing for task '$($task.name)'" `
+                        -Context $inputErr | Out-Null
+                } catch { Write-BotLog -Level Warn -Message "Failed to escalate task" -Exception $_ }
+                $TaskId = $null
+                $processData.task_id = $null
+                $processData.task_name = $null
+                continue
+            }
+
             # Mark in-progress
             Set-TaskInProgressForExecutorDispatch -Task $task
 
@@ -1773,6 +1844,38 @@ try {
                     Copy-Item -LiteralPath $bf.FullName -Destination $destBriefingDir -Recurse -Force -ErrorAction SilentlyContinue
                 }
             }
+        }
+
+        $inputErr = Test-TaskInput -Task $task -ProductDir $executionProductDir
+        if ($inputErr) {
+            Write-Status "Input validation failed for $($task.name): $inputErr" -Type Warn
+            Write-ProcessActivity -Id $procId -ActivityType "error" -Message "Input gate failed for $($task.name): $inputErr"
+            if ($worktreePath) {
+                try {
+                    Remove-Junctions -WorktreePath $worktreePath -ErrorOnFailure $false | Out-Null
+                    git -C $projectRoot worktree remove $worktreePath --force 2>$null
+                    if ($branchName) { git -C $projectRoot branch -D $branchName 2>$null }
+                } finally {
+                    Invoke-WorktreeMapLocked -BotRoot $botRoot -Action {
+                        $cleanupMap = Read-WorktreeMap -BotRoot $botRoot
+                        $cleanupMap.Remove($task.id)
+                        Write-WorktreeMap -Map $cleanupMap -BotRoot $botRoot
+                    }
+                    try { Assert-OnBaseBranch -ProjectRoot $projectRoot | Out-Null } catch { Write-BotLog -Level Warn -Message "Task operation failed" -Exception $_ }
+                }
+            }
+            try {
+                Set-WorkflowTaskNeedsInput `
+                    -Task $task `
+                    -RunDir $runDir `
+                    -QuestionId "input-missing-$($task.id)" `
+                    -Question "Required input artifact missing for task '$($task.name)'" `
+                    -Context $inputErr | Out-Null
+            } catch { Write-BotLog -Level Warn -Message "Failed to escalate task" -Exception $_ }
+            $TaskId = $null
+            $processData.task_id = $null
+            $processData.task_name = $null
+            continue
         }
 
         # Use task-level model override > execution model from settings > default

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -5404,6 +5404,85 @@ if (Test-Path $workflowProcessScript) {
     Write-TestResult -Name "Test-TaskIsMandatory tests" -Status Skip -Message "Invoke-WorkflowProcess.ps1 not found"
 }
 
+if (Test-Path $workflowProcessScript) {
+    $artAst = [System.Management.Automation.Language.Parser]::ParseFile($workflowProcessScript, [ref]$null, [ref]$null)
+    $wanted = @('Test-DotbotArtifact', 'Test-TaskInput', 'Test-TaskOutput')
+    $found = @{}
+    foreach ($fn in $artAst.FindAll({
+        $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $wanted -contains $args[0].Name
+    }, $false)) {
+        $found[$fn.Name] = $fn.Extent.Text
+    }
+
+    if ($found.Count -eq $wanted.Count) {
+        foreach ($fn in $wanted) { Invoke-Expression $found[$fn] }
+
+        $artTmp = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-artifact-test-$(Get-Random)"
+        $artProductDir = Join-Path $artTmp "workspace/product"
+        New-Item -Path $artProductDir -ItemType Directory -Force | Out-Null
+        try {
+            # --- Test-DotbotArtifact ---
+            Assert-True -Name "Test-DotbotArtifact: absent file → 'absent'" `
+                -Condition ((Test-DotbotArtifact -Path (Join-Path $artProductDir 'nope.md')) -eq 'absent')
+
+            $emptyFile = Join-Path $artProductDir 'empty.md'
+            Set-Content -Path $emptyFile -Value "   `n  " -Encoding UTF8 -NoNewline
+            Assert-True -Name "Test-DotbotArtifact: whitespace-only → 'empty'" `
+                -Condition ((Test-DotbotArtifact -Path $emptyFile) -eq 'empty')
+
+            $badJson = Join-Path $artProductDir 'bad.json'
+            Set-Content -Path $badJson -Value '{ "a": 1, ' -Encoding UTF8
+            Assert-True -Name "Test-DotbotArtifact: truncated .json → malformed" `
+                -Condition ((Test-DotbotArtifact -Path $badJson) -match 'malformed')
+
+            $goodJson = Join-Path $artProductDir 'good.json'
+            Set-Content -Path $goodJson -Value '{ "a": 1 }' -Encoding UTF8
+            Assert-True -Name "Test-DotbotArtifact: valid .json → null" `
+                -Condition ($null -eq (Test-DotbotArtifact -Path $goodJson))
+
+            $goodMd = Join-Path $artProductDir 'good.md'
+            Set-Content -Path $goodMd -Value "# Heading`nbody" -Encoding UTF8
+            Assert-True -Name "Test-DotbotArtifact: non-empty .md → null" `
+                -Condition ($null -eq (Test-DotbotArtifact -Path $goodMd))
+
+            # --- Test-TaskInput (consumer-entry gate) ---
+            $taskNoInputs = @{ id = 't_aaaaaaaa'; name = 'no-inputs' }
+            Assert-True -Name "Test-TaskInput: no inputs declared → null (unaffected)" `
+                -Condition ($null -eq (Test-TaskInput -Task $taskNoInputs -ProductDir $artProductDir))
+
+            $taskGoodInputs = @{ id = 't_bbbbbbbb'; name = 'good-inputs'; inputs = @('good.md', 'good.json') }
+            Assert-True -Name "Test-TaskInput: all inputs present → null" `
+                -Condition ($null -eq (Test-TaskInput -Task $taskGoodInputs -ProductDir $artProductDir))
+
+            $taskMissingInput = @{ id = 't_cccccccc'; name = 'missing-input'; inputs = @('good.md', 'gone.md') }
+            $missErr = Test-TaskInput -Task $taskMissingInput -ProductDir $artProductDir
+            Assert-True -Name "Test-TaskInput: missing input → actionable error naming the artifact" `
+                -Condition ($missErr -match "gone\.md" -and $missErr -match 'absent')
+
+            $taskEmptyInput = @{ id = 't_dddddddd'; name = 'empty-input'; inputs = @('empty.md') }
+            Assert-True -Name "Test-TaskInput: empty input → 'empty' error" `
+                -Condition ((Test-TaskInput -Task $taskEmptyInput -ProductDir $artProductDir) -match 'empty')
+
+            # --- Test-TaskOutput upgrade: empty declared output now fails (AC#1) ---
+            $taskEmptyOutput = @{ id = 't_eeeeeeee'; name = 'empty-output'; outputs = @('empty.md') }
+            Assert-True -Name "Test-TaskOutput: declared output exists but empty → fails" `
+                -Condition ((Test-TaskOutput -Task $taskEmptyOutput -BotRoot $artTmp -ProductDir $artProductDir) -match 'empty\.md')
+
+            $taskGoodOutput = @{ id = 't_ffffffff'; name = 'good-output'; outputs = @('good.md') }
+            Assert-True -Name "Test-TaskOutput: declared output present + non-empty → passes" `
+                -Condition ($null -eq (Test-TaskOutput -Task $taskGoodOutput -BotRoot $artTmp -ProductDir $artProductDir))
+        } finally {
+            if (Test-Path $artTmp) { Remove-Item $artTmp -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+    } else {
+        Write-TestResult -Name "Artifact contract gate function extraction" -Status Fail `
+            -Message "Expected $($wanted -join ', ') in $workflowProcessScript; found $($found.Keys -join ', ')"
+    }
+} else {
+    Write-TestResult -Name "Artifact contract gate tests" -Status Skip -Message "Invoke-WorkflowProcess.ps1 not found"
+}
+
 # New-WorkflowTask: tasks land under workflow-runs/<dir>/t_<id>.json with
 # 'optional' under extensions.workflow (closed schema keeps the top level
 # constrained). Initialize-WorkflowRun mints the run first.
@@ -5436,6 +5515,20 @@ if (Test-Path $workflowManifestScript) {
         Assert-True -Name "New-WorkflowTask: optional absent when not declared" `
             -Condition (-not $hasOptional) `
             -Message "optional should not be present when not declared"
+
+        $inputsTask = @{ name = 'consumer-step'; type = 'prompt'; inputs = @('briefing/repo-scan.md', 'mission.md') }
+        $r3 = New-WorkflowTask -Run $run -TaskDef $inputsTask
+        $taskJson3 = Get-Content -Path $r3.file_path -Raw | ConvertFrom-Json
+        Assert-True -Name "New-WorkflowTask: inputs lands as a top-level array" `
+            -Condition (@($taskJson3.inputs).Count -eq 2 -and $taskJson3.inputs -contains 'mission.md') `
+            -Message "inputs should survive onto the task record at the top level"
+
+        $noInputsTask = @{ name = 'no-input-step'; type = 'prompt' }
+        $r4 = New-WorkflowTask -Run $run -TaskDef $noInputsTask
+        $taskJson4 = Get-Content -Path $r4.file_path -Raw | ConvertFrom-Json
+        Assert-True -Name "New-WorkflowTask: inputs defaults to empty array when not declared" `
+            -Condition (@($taskJson4.inputs).Count -eq 0) `
+            -Message "inputs should be an empty array (not absent) when not declared"
     } catch {
         Write-TestResult -Name "New-WorkflowTask optional propagation" -Status Fail -Message $_.Exception.Message
     } finally {

--- a/tests/Test-DataModel.ps1
+++ b/tests/Test-DataModel.ps1
@@ -540,6 +540,14 @@ $errs = Test-TaskDefinition -TaskDef $badDeps
 Assert-True -Name "TaskDefinition: depends_on as a single string is rejected" `
     -Condition (($errs | Where-Object { $_ -match 'depends_on' }).Count -gt 0)
 
+$goodInputs = @{ name = 'X'; type = 'prompt'; inputs = @('briefing/repo-scan.md', 'mission.md') }
+Assert-Equal -Name "TaskDefinition: inputs as array of strings → 0 errors" `
+    -Expected 0 -Actual (Test-TaskDefinition -TaskDef $goodInputs).Count
+$badInputs = @{ name = 'X'; type = 'prompt'; inputs = 'a-single-string' }
+$errs = Test-TaskDefinition -TaskDef $badInputs
+Assert-True -Name "TaskDefinition: inputs as a single string is rejected" `
+    -Condition (($errs | Where-Object { $_ -match 'inputs' }).Count -gt 0)
+
 # Removed-fields list exposed
 $removed = Get-TaskDefinitionRemovedFields
 foreach ($f in 'skip_worktree','working_dir','external_repo','commit','front_matter_docs','post_script') {

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1495,6 +1495,16 @@ Assert-True -Name "Invoke-WorkflowProcess defines Add-TaskFrontMatter helper" `
 $outputCallCount = ([regex]::Matches($workflowSrc, 'Test-TaskOutput\s+(-Task|@\w)')).Count
 Assert-True -Name "Test-TaskOutput called from both task paths (>=2 sites)" `
     -Condition ($outputCallCount -ge 2)
+
+Assert-True -Name "Invoke-WorkflowProcess defines Test-DotbotArtifact helper" `
+    -Condition ($workflowSrc -match 'function\s+Test-DotbotArtifact\b')
+Assert-True -Name "Invoke-WorkflowProcess defines Test-TaskInput helper" `
+    -Condition ($workflowSrc -match 'function\s+Test-TaskInput\b')
+$inputCallCount = ([regex]::Matches($workflowSrc, 'Test-TaskInput\s+(-Task|@\w)')).Count
+Assert-True -Name "Test-TaskInput called from both task paths (>=2 sites)" `
+    -Condition ($inputCallCount -ge 2)
+Assert-True -Name "Input gate escalates via Set-WorkflowTaskNeedsInput (input-missing question)" `
+    -Condition ($workflowSrc -match 'input-missing-\$\(\$task\.id\)')
 $frontMatterCallCount = ([regex]::Matches($workflowSrc, 'Add-TaskFrontMatter\s+(-Task|@\w)')).Count
 Assert-True -Name "Add-TaskFrontMatter called from both task paths (>=2 sites)" `
     -Condition ($frontMatterCallCount -ge 2)


### PR DESCRIPTION
## Linked issue

Closes #510

## Summary of changes

Adds a **task input/output artifact contract** so a task can no longer be marked
`done`, nor silently feed a broken context downstream, when a required artifact
is absent, empty, or malformed.

- **Shared predicate `Test-DotbotArtifact`** (`src/runtime/Scripts/Invoke-WorkflowProcess.ps1`):
  `exists → non-empty → (for .json) parses`. Minimal, toolchain-free; Markdown/
  source bottom out at the non-empty check by design.
- **Producer-exit gate strengthened**: `Test-TaskOutput` now rejects empty/
  malformed declared outputs (previously existence-only), satisfying the issue's
  "absent, empty, or fails shape validation".
- **Consumer-entry gate added**: new `Test-TaskInput` validates a task's declared
  `inputs` before it runs. On failure the task is escalated to `needs-input` with
  a specific, actionable message (e.g. `Required input 'briefing/repo-scan.md' is absent`)
  via the existing `Set-WorkflowTaskNeedsInput`. The gate runs **before** any
  provider session, so a blocked task wastes no tokens.
- **New first-class `inputs` task field** threaded through the closed schemas and
  builders (`TaskDefinition`, `TaskInstance`/`New-TaskInstance`, `New-WorkflowTask`,
  `_FlattenTask`) plus API/MCP parity (`HttpServer` POST/PATCH `/tasks`,
  `task-create` MCP tool).
- **Downstream blocking + resume** reuse existing machinery: a `needs-input` task
  isn't reselected and its `depends_on` dependents stay blocked; answering
  "retry" requeues it and the gate re-validates — no full workflow restart.
- Tasks without `inputs`/`outputs` are unaffected (existing behaviour preserved).

## Screenshots / recordings

**Required input artifacts surfaced in ACTION REQUIRED, with retry/skip:**

![Action required slideout showing missing input artifacts with retry/skip options](https://github.com/user-attachments/assets/8a652c1f-708d-4e11-ab1a-864113707280)

**Resume: after answering "Investigate logs and retry", the task requeues with no error and runs to done:**

![Task resuming after the retry answer with no error](https://github.com/user-attachments/assets/eec3aabe-0761-45c1-9ff8-58a20b7d24c9)

## Testing notes

- All tests green (`pwsh tests/Run-Tests.ps1`).
- New tests added for the input/output gate, the `inputs` schema, and gate wiring.

## Checklist

- [x] Tests added or updated
- [x] Docs updated (if behaviour changed) — schema doc-comments updated; no user docs needed
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
