### PR TITLE
feat(runtime): add task_append_evidence for on-demand evidence injection (#503)

### DIFF
--- a/src/mcp/tools/task-append-evidence/metadata.json
+++ b/src/mcp/tools/task-append-evidence/metadata.json
@@ -1,0 +1,40 @@
+{
+  "name": "task_append_evidence",
+  "description": "Attach structured evidence (an inline note and/or file artifacts) to any queued or in-flight task WITHOUT changing its status, so the task can re-poll its context via task_get_context and incorporate the new context without pausing. Decoupled from the needs-input question/answer flow; evidence is recorded under extensions.evidence and never touches extensions.runner. POST /tasks/<id>/evidence.",
+  "inputSchema": {
+    "type": "object",
+    "additionalProperties": true,
+    "properties": {
+      "task_id": {
+        "type": "string",
+        "description": "Canonical task ID (t_XXXXXXXX) to attach evidence to."
+      },
+      "label": {
+        "type": "string",
+        "description": "Short human-readable label for this evidence batch."
+      },
+      "evidence_type": {
+        "type": "string",
+        "description": "Optional semantic category, e.g. 'analysis', 'log', 'screenshot', 'reference', 'other'."
+      },
+      "note": {
+        "type": "string",
+        "description": "Optional inline evidence content (text or markdown). Provide a note and/or attachments."
+      },
+      "attachments": {
+        "type": "array",
+        "description": "Optional file artifacts. Allowed extensions: .md, .docx, .xlsx, .pdf, .txt.",
+        "items": {
+          "type": "object",
+          "required": ["name", "content"],
+          "properties": {
+            "name": { "type": "string", "description": "Filename with extension." },
+            "size": { "type": "integer", "description": "Byte size (optional; computed from content when omitted)." },
+            "content": { "type": "string", "description": "Base64-encoded file content." }
+          }
+        }
+      }
+    },
+    "required": ["task_id", "label"]
+  }
+}

--- a/src/mcp/tools/task-append-evidence/script.ps1
+++ b/src/mcp/tools/task-append-evidence/script.ps1
@@ -1,0 +1,10 @@
+function Invoke-TaskAppendEvidence {
+    param([hashtable]$Arguments)
+    $taskId = $Arguments['task_id']
+    if (-not $taskId) { throw "task_id is required" }
+    $body = @{ actor = Get-McpActor }
+    foreach ($k in @('label', 'evidence_type', 'note', 'attachments')) {
+        if ($Arguments.ContainsKey($k)) { $body[$k] = $Arguments[$k] }
+    }
+    Invoke-McpRuntimeRequest -Method POST -Path "/tasks/$taskId/evidence" -Body $body
+}

--- a/src/runtime/Modules/Dotbot.Runtime/Private/HttpServer.psm1
+++ b/src/runtime/Modules/Dotbot.Runtime/Private/HttpServer.psm1
@@ -38,6 +38,7 @@ function _New-RouteTable {
         @{ method = 'GET';   pattern = '^/tasks/(?<id>t_[A-Za-z0-9]{8})$';                     handler = 'Invoke-GetTaskHandler' }
         @{ method = 'PATCH'; pattern = '^/tasks/(?<id>t_[A-Za-z0-9]{8})$';                     handler = 'Invoke-PatchTaskHandler' }
         @{ method = 'POST';  pattern = '^/tasks/(?<id>t_[A-Za-z0-9]{8})/status$';              handler = 'Invoke-TaskStatusHandler' }
+        @{ method = 'POST';  pattern = '^/tasks/(?<id>t_[A-Za-z0-9]{8})/evidence$';            handler = 'Invoke-AppendTaskEvidenceHandler' }
         @{ method = 'GET';   pattern = '^/tasks/(?<id>t_[A-Za-z0-9]{8})/context$';             handler = 'Invoke-GetTaskContextHandler' }
         @{ method = 'GET';   pattern = '^/tasks$';                                             handler = 'Invoke-ListTasksHandler' }
 
@@ -1388,6 +1389,124 @@ function Invoke-GetNextTaskHandler {
     _Send-JsonResponse -Response $Response -Status 200 -Body @{ task = $next }
 }
 
+function Invoke-AppendTaskEvidenceHandler {
+    <#
+    .SYNOPSIS
+    Append evidence (an inline note and/or file attachments) to a task WITHOUT
+    changing its status. Backs the `task_append_evidence` MCP tool (#503).
+
+    .DESCRIPTION
+    Evidence is recorded as an entry appended to extensions.evidence (an open
+    namespace) and any file attachments are decoded and written under
+    workspace/attachments/<taskId>/evidence/<evidenceId>/ — deliberately
+    decoupled from the needs-input question/answer flow. The task status is
+    never touched, so the receiving task does not park and can pick up the new
+    evidence on its next task_get_context poll. extensions.runner (the answer/
+    inbox flow) is left untouched.
+    #>
+    [CmdletBinding()] param($BotRoot, $Response, $Request, $RouteParams, $Query, $Body)
+
+    $taskId = $RouteParams['id']
+    if (-not $Body) {
+        _Send-ErrorResponse -Response $Response -Status 400 -Code 'missing_body' -Message 'POST /tasks/<id>/evidence requires a JSON body.'
+        return
+    }
+    $label = if ($Body.PSObject.Properties['label']) { [string]$Body.label } else { '' }
+    if ([string]::IsNullOrWhiteSpace($label)) {
+        _Send-ErrorResponse -Response $Response -Status 400 -Code 'missing_field' -Message 'label is required.'
+        return
+    }
+    $note = if ($Body.PSObject.Properties['note']) { [string]$Body.note } else { $null }
+    $hasAttachments = $Body.PSObject.Properties['attachments'] -and @($Body.attachments).Count -gt 0
+    if ([string]::IsNullOrWhiteSpace($note) -and -not $hasAttachments) {
+        _Send-ErrorResponse -Response $Response -Status 400 -Code 'missing_field' -Message 'Provide at least one of: note, attachments.'
+        return
+    }
+    $actor = if ($Body.PSObject.Properties['actor']) { [string]$Body.actor } else { 'system' }
+    $evidenceType = if ($Body.PSObject.Properties['evidence_type']) { [string]$Body.evidence_type } else { $null }
+
+    $evidenceId = "ev_$([guid]::NewGuid().ToString('N').Substring(0,8))"
+
+    Lock-TaskMutex -TaskId $taskId | Out-Null
+    try {
+        $path = _Find-TaskFileById -BotRoot $BotRoot -TaskId $taskId
+        if (-not $path) {
+            _Send-ErrorResponse -Response $Response -Status 404 -Code 'not_found' -Message "Task $taskId not found."
+            return
+        }
+        $task = _Read-TaskFile -Path $path
+
+        # Decode + persist any file attachments under the attachments root, in an
+        # evidence/<evidenceId>/ subtree (decoupled from the needs-input flow).
+        $attachmentMeta = @()
+        if ($hasAttachments) {
+            $allowedExtensions = @('.md', '.docx', '.xlsx', '.pdf', '.txt')
+            $evidenceDir = Join-Path $BotRoot "workspace/attachments/$taskId/evidence/$evidenceId"
+            foreach ($att in @($Body.attachments)) {
+                $safeName = [System.IO.Path]::GetFileName([string]$att.name)
+                if ([string]::IsNullOrWhiteSpace($safeName)) { continue }
+                $ext = [System.IO.Path]::GetExtension($safeName).ToLowerInvariant()
+                if ($ext -notin $allowedExtensions) {
+                    _Send-ErrorResponse -Response $Response -Status 400 -Code 'unsupported_attachment' -Message "Attachment '$safeName' has unsupported extension '$ext' (allowed: $($allowedExtensions -join ', '))."
+                    return
+                }
+                try {
+                    $bytes = [System.Convert]::FromBase64String([string]$att.content)
+                } catch {
+                    _Send-ErrorResponse -Response $Response -Status 400 -Code 'invalid_attachment' -Message "Attachment '$safeName' content is not valid base64."
+                    return
+                }
+                if (-not (Test-Path -LiteralPath $evidenceDir)) {
+                    New-Item -ItemType Directory -Force -Path $evidenceDir | Out-Null
+                }
+                [System.IO.File]::WriteAllBytes((Join-Path $evidenceDir $safeName), $bytes)
+                $size = if ($att.PSObject.Properties['size'] -and $att.size) { [int]$att.size } else { $bytes.Length }
+                $attachmentMeta += @{
+                    name = $safeName
+                    size = $size
+                    path = ".bot/workspace/attachments/$taskId/evidence/$evidenceId/$safeName"
+                }
+            }
+        }
+
+        # Append the evidence entry. extensions is an open namespace; we never
+        # touch extensions.runner (the answer/inbox flow) or the task status.
+        if (-not $task.ContainsKey('extensions') -or -not $task['extensions']) {
+            $task['extensions'] = @{}
+        }
+        $ext = $task['extensions']
+        $existing = @()
+        if ($ext.ContainsKey('evidence') -and $ext['evidence']) { $existing = @($ext['evidence']) }
+        $entry = [ordered]@{
+            id            = $evidenceId
+            label         = $label
+            evidence_type = $evidenceType
+            note          = $note
+            attachments   = $attachmentMeta
+            added_at      = _Now-Utc
+            added_by      = $actor
+        }
+        $ext['evidence'] = @($existing + $entry)
+
+        $task['updated_at'] = _Now-Utc
+        $task['updated_by'] = $actor
+
+        try {
+            Assert-TaskInstance -Task $task
+        } catch {
+            _Send-ErrorResponse -Response $Response -Status 400 -Code 'schema_error' -Message $_.Exception.Message
+            return
+        }
+
+        _Write-TaskFileAtomic -Path $path -Content $task
+        Write-ActivityEvent -BotRoot $BotRoot -Type 'task_updated' -TaskId $taskId -Actor $actor -Reason 'evidence appended'
+    } finally {
+        Unlock-TaskMutex -TaskId $taskId
+    }
+
+    _Send-JsonResponse -Response $Response -Status 200 -Body @{ success = $true; evidence_id = $evidenceId; task = $task }
+}
+
 function Invoke-GetTaskContextHandler {
     [CmdletBinding()] param($BotRoot, $Response, $Request, $RouteParams, $Query, $Body)
 
@@ -1401,11 +1520,13 @@ function Invoke-GetTaskContextHandler {
 
     $runner = $null
     $analysis = $null
+    $evidence = $null
     if ($task.ContainsKey('extensions') -and $task['extensions']) {
         $extensions = $task['extensions']
         if ($extensions -is [System.Collections.IDictionary]) {
             if ($extensions.Contains('runner')) { $runner = $extensions['runner'] }
             if ($extensions.Contains('analysis')) { $analysis = $extensions['analysis'] }
+            if ($extensions.Contains('evidence')) { $evidence = $extensions['evidence'] }
         }
     }
 
@@ -1424,6 +1545,7 @@ function Invoke-GetTaskContextHandler {
         session_policy    = 'single_unblocked_attempt'
         has_analysis      = ($null -ne $analysis)
         analysis          = $analysis
+        evidence          = $evidence
         active_attempt_id = if ($runner -and $runner.Contains('active_attempt_id')) { $runner['active_attempt_id'] } else { $null }
         current_handoff   = if ($runner -and $runner.Contains('current_handoff')) { $runner['current_handoff'] } else { $null }
         resume_context    = $resumeContext

--- a/tests/Test-McpSurface.ps1
+++ b/tests/Test-McpSurface.ps1
@@ -44,6 +44,7 @@ $NewTools = @(
     @{ folder = 'task-set-status';  name = 'task_set_status';  func = 'Invoke-TaskSetStatus' }
     @{ folder = 'task-get-next';    name = 'task_get_next';    func = 'Invoke-TaskGetNext' }
     @{ folder = 'task-get-context'; name = 'task_get_context'; func = 'Invoke-TaskGetContext' }
+    @{ folder = 'task-append-evidence'; name = 'task_append_evidence'; func = 'Invoke-TaskAppendEvidence' }
     @{ folder = 'workflow-start';   name = 'workflow_start';   func = 'Invoke-WorkflowStart' }
     @{ folder = 'workflow-get';     name = 'workflow_get';     func = 'Invoke-WorkflowGet' }
     @{ folder = 'workflow-list';    name = 'workflow_list';    func = 'Invoke-WorkflowList' }
@@ -403,6 +404,32 @@ try {
         -Expected 'ready' -Actual $r.body.reason
     Assert-Equal -Name "task_set_status: body.actor" `
         -Expected 'mcp:test-session-42' -Actual $r.body.actor
+
+    # ------------------------------------------------------------------------
+    # task_append_evidence — POST /tasks/<id>/evidence (no status change)
+    # ------------------------------------------------------------------------
+    $fake.next_response = @{ status = 200; body = @{ success = $true; evidence_id = 'ev_abcd1234'; task = @{ id = 't_abcd1234' } } }
+    $null = Invoke-TaskAppendEvidence -Arguments @{
+        task_id = 't_abcd1234'
+        label = 'API findings'
+        evidence_type = 'analysis'
+        note = 'The endpoint returns 200 on success.'
+        attachments = @(@{ name = 'finding.md'; size = 12; content = 'aGVsbG8gd29ybGQ=' })
+    }
+    $r = $fake.last_request
+    Assert-Equal -Name "task_append_evidence: method POST" -Expected 'POST' -Actual $r.method
+    Assert-Equal -Name "task_append_evidence: path /tasks/<id>/evidence" `
+        -Expected '/tasks/t_abcd1234/evidence' -Actual $r.path
+    Assert-Equal -Name "task_append_evidence: body.actor" `
+        -Expected 'mcp:test-session-42' -Actual $r.body.actor
+    Assert-Equal -Name "task_append_evidence: body.label" -Expected 'API findings' -Actual $r.body.label
+    Assert-Equal -Name "task_append_evidence: body.note forwarded" `
+        -Expected 'The endpoint returns 200 on success.' -Actual $r.body.note
+    Assert-Equal -Name "task_append_evidence: attachment name forwarded" `
+        -Expected 'finding.md' -Actual $r.body.attachments[0].name
+    Assert-True  -Name "task_append_evidence: no task_id in body" `
+        -Condition (-not ($r.body.PSObject.Properties.Name -contains 'task_id')) `
+        -Message "task_id belongs in the path, not the body"
 
     # ------------------------------------------------------------------------
     # task_get_next — GET /tasks/next with optional status query

--- a/tests/Test-Runtime.ps1
+++ b/tests/Test-Runtime.ps1
@@ -440,6 +440,44 @@ try {
     Assert-Equal -Name "GET /tasks/<id>/context: session policy" -Expected 'single_unblocked_attempt' -Actual $r.body.session_policy
     Assert-True  -Name "GET /tasks/<id>/context: resume context present in envelope" -Condition ($null -ne $r.body.PSObject.Properties['resume_context'])
 
+    $r = Invoke-RuntimeRaw -Url $start.url -Method POST -Path "/tasks/$newTaskId/evidence" -Token $start.token -Body @{
+        label = 'first finding'; evidence_type = 'analysis'
+        note = 'Endpoint returns 200 on success.'
+        attachments = @(@{ name = 'finding.md'; content = 'aGVsbG8='; size = 5 })
+        actor = 'mcp:test'
+    }
+    Assert-Equal -Name "POST /tasks/<id>/evidence → 200" -Expected 200 -Actual $r.status_code
+    Assert-True  -Name "evidence: response success"        -Condition ($r.body.success -eq $true)
+    Assert-True  -Name "evidence: response carries ev_ id"  -Condition ($r.body.evidence_id -cmatch '^ev_[A-Za-z0-9]{8}$')
+    Assert-Equal -Name "evidence: status unchanged (in-progress, not parked)" -Expected 'in-progress' -Actual $r.body.task.status
+    Assert-Equal -Name "evidence: one entry recorded"       -Expected 1 -Actual @($r.body.task.extensions.evidence).Count
+    Assert-Equal -Name "evidence: entry label persisted"    -Expected 'first finding' -Actual $r.body.task.extensions.evidence[0].label
+    Assert-Equal -Name "evidence: attachment name recorded" -Expected 'finding.md' -Actual $r.body.task.extensions.evidence[0].attachments[0].name
+
+    $evAbs = Join-Path (Split-Path -Parent $bot) $r.body.task.extensions.evidence[0].attachments[0].path
+    Assert-True  -Name "evidence: attachment file written to disk" -Condition (Test-Path -LiteralPath $evAbs)
+
+    $r = Invoke-RuntimeRaw -Url $start.url -Method GET -Path "/tasks/$newTaskId/context" -Token $start.token
+    Assert-Equal -Name "evidence: context re-poll → 200" -Expected 200 -Actual $r.status_code
+    Assert-Equal -Name "evidence: context envelope surfaces evidence" -Expected 'first finding' -Actual $r.body.evidence[0].label
+    Assert-Equal -Name "evidence: context task still in-progress" -Expected 'in-progress' -Actual $r.body.task.status
+    Assert-True  -Name "evidence: AC#3 runner untouched (no pending_question)" -Condition ($null -eq $r.body.task.extensions.runner.pending_question)
+
+    $r = Invoke-RuntimeRaw -Url $start.url -Method POST -Path "/tasks/$newTaskId/evidence" -Token $start.token -Body @{
+        label = 'second finding'; note = 'More context.'; actor = 'mcp:test'
+    }
+    Assert-Equal -Name "evidence: second append → 200" -Expected 200 -Actual $r.status_code
+    Assert-Equal -Name "evidence: array grew to 2 (append, not replace)" -Expected 2 -Actual @($r.body.task.extensions.evidence).Count
+
+    $r = Invoke-RuntimeRaw -Url $start.url -Method POST -Path "/tasks/$newTaskId/evidence" -Token $start.token -Body @{ note = 'no label' }
+    Assert-Equal -Name "evidence: missing label → 400" -Expected 400 -Actual $r.status_code
+    $r = Invoke-RuntimeRaw -Url $start.url -Method POST -Path "/tasks/$newTaskId/evidence" -Token $start.token -Body @{ label = 'empty' }
+    Assert-Equal -Name "evidence: no note and no attachments → 400" -Expected 400 -Actual $r.status_code
+    $r = Invoke-RuntimeRaw -Url $start.url -Method POST -Path "/tasks/$newTaskId/evidence" -Token $start.token -Body @{ label = 'bad'; attachments = @(@{ name = 'x.exe'; content = 'AAAA' }) }
+    Assert-Equal -Name "evidence: unsupported attachment extension → 400" -Expected 400 -Actual $r.status_code
+    $r = Invoke-RuntimeRaw -Url $start.url -Method POST -Path '/tasks/t_99999999/evidence' -Token $start.token -Body @{ label = 'x'; note = 'y' }
+    Assert-Equal -Name "evidence: append to missing task → 404" -Expected 404 -Actual $r.status_code
+
     # POST /tasks/<id>/status — active task can be intentionally skipped after discovery.
     $r = Invoke-RuntimeRaw -Url $start.url -Method POST -Path '/tasks' -Token $start.token -Body @{
         name = 'skip after discovery'; actor = 'test:ci'


### PR DESCRIPTION
## Linked issue

Closes #503

## Summary of changes

Adds a way to inject evidence into a specific **in-flight or queued task without
forcing it into `needs-input`**, so the task can re-poll its context and continue.
Until now the only attachment path was bound to the question/answer needs-input
flow.

- **New MCP tool `task_append_evidence`** (`src/mcp/tools/task-append-evidence/`):
  attaches an inline `note` and/or file `attachments` (base64) to any task,
  identified by `task_id`, with a `label` and optional `evidence_type`. Mirrors
  `task-create`; forwards to the runtime with the MCP actor.
- **New runtime endpoint `POST /tasks/<id>/evidence`**
  (`Invoke-AppendTaskEvidenceHandler` in `HttpServer.psm1`): under the task mutex,
  it decodes/writes attachments to
  `.bot/workspace/attachments/<taskId>/evidence/<evidenceId>/` (same allowed
  extensions as the answer flow, but decoupled from any question), **appends** an
  entry to `extensions.evidence`, writes the task atomically, and emits a
  `task_updated` activity event. It **never changes the task status** — so the
  task is not parked.
  - A dedicated endpoint (not PATCH) because PATCH's deep-merge _replaces_ arrays
    (lossy for appends) and the base64 decode/file-write belongs server-side.
- **Re-poll surfaces evidence**: `GET /tasks/<id>/context` (the existing
  `task_get_context` tool) now includes an `evidence` field, so a running agent
  picks up new evidence on its next poll without stopping.
- **Answer/inbox flow unchanged** (AC#3): evidence lives in its own open
  `extensions.evidence` namespace; `extensions.runner`, NotificationPoller,
  InboxWatcher, `Submit-TaskAnswer`, and `task-update` are untouched. No
  `TaskInstance` schema change (extensions namespace is open).

## Testing notes

- All tests green (`pwsh tests/Run-Tests.ps1`).
- New tests added: `task_append_evidence` tool contract (Test-McpSurface) and a
  live-runtime integration suite (Test-Runtime) covering append, status-unchanged,
  context re-poll, append-not-replace, runner-untouched, and validation/404.

## Checklist

- [x] Tests added or updated
- [x] Docs updated (if behaviour changed) — tool/endpoint self-documented; no user docs needed
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
