### PR TITLE
fix(worktree): claim non-prompt tasks before worktree creation to prevent duplicate-worktree race

### DIFF
--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -1375,7 +1375,8 @@ try {
         # --- Multi-slot claim guard ---
         # When running with -Slot (concurrent workflow processes), another slot may
         # have claimed this task between our Get-NextWorkflowTask and this point.
-        # Only needed for prompt tasks — non-prompt tasks are guarded by the slot 0 check above.
+        # Only needed for prompt tasks — non-prompt tasks have their own claim guard
+        # before worktree creation below.
         if ($Slot -ge 0 -and $taskTypeCheck -eq 'prompt') {
             $claimOk = $false
             for ($claimAttempt = 0; $claimAttempt -lt 5; $claimAttempt++) {
@@ -1474,6 +1475,60 @@ try {
             Write-Status "Auto-dispatching $taskTypeVal task: $($task.name)" -Type Process
             Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Auto-dispatch $taskTypeVal task: $($task.name)"
 
+            # --- Non-prompt task claim guard (before worktree) ---
+            # Unconditional (no $Slot guard): covers standalone runners (Slot = null/0)
+            # AND multi-slot runners on slot 0. The prompt-task guard above is $Slot-gated
+            # because prompt concurrency only occurs in multi-slot mode; non-prompt races
+            # also occur between standalone processes sharing the same task pool.
+            $claimOk = $false
+            $claimAttemptsMade = 0
+            for ($claimAttempt = 0; $claimAttempt -lt 5; $claimAttempt++) {
+                $claimAttemptsMade++
+                try {
+                    $claimResult = $null
+                    if ($task.status -notin @('todo', 'needs-input', 'in-progress')) {
+                        throw "Cannot dispatch non-prompt task '$($task.id)' from status '$($task.status)'"
+                    }
+                    if ($task.status -ne 'in-progress') {
+                        $claimResult = Invoke-TaskMarkInProgress -Arguments @{ task_id = $task.id }
+                    }
+                    if ($claimResult -and -not $claimResult.success) {
+                        $errMsg = if ($claimResult.message) { $claimResult.message } else { "HTTP $($claimResult.status_code)" }
+                        throw "Claim failed: $errMsg"
+                    }
+                    if ($claimResult -and $claimResult.body -and $claimResult.body.no_op) {
+                        throw "Task already claimed"
+                    }
+                    if ($claimResult) { $task.status = 'in-progress' }
+                    $claimOk = $true
+                    break
+                } catch {
+                    $errMsg = $_.Exception.Message
+                    if ($errMsg -notmatch 'already claimed|Claim failed') {
+                        Write-Status "Fatal error claiming task $($task.id): $errMsg" -Type Error
+                        throw
+                    }
+                    Write-Diag "Task $($task.id) claimed by another runner, retrying ($taskTypeVal)..."
+                    Start-Sleep -Milliseconds 200
+                    $taskResult = Get-NextWorkflowTask -BotRoot $botRoot -RunId $RunId -WorkflowName $WorkflowName
+                    if (-not $taskResult.task) { break }
+                    $task = $taskResult.task
+                    # Always break on task swap — outer loop re-processes the replacement
+                    # with full task_gen/prompt_template recovery (lines 1434-1473).
+                    # Claiming in-place would bypass that recovery logic.
+                    break
+                }
+            }
+            if (-not $claimOk) {
+                Write-Status "Could not claim a $taskTypeVal task after $claimAttemptsMade attempts" -Type Warn
+                Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Could not claim $taskTypeVal task after $claimAttemptsMade attempts"
+                if ($Continue) { Start-Sleep -Seconds 2; continue } else { break }
+            }
+            # Task may have been replaced during claim retry; re-sync process metadata.
+            $processData.task_id = $task.id
+            $processData.task_name = $task.name
+            $env:DOTBOT_CURRENT_TASK_ID = $task.id
+
             $worktreePath = $null
             $branchName = $null
             $worktreeSetup = Initialize-DotbotTaskWorktreeForProcess -Task $task `
@@ -1484,9 +1539,6 @@ try {
             }
             $executionBotRoot = Join-Path $worktreePath ".bot"
             $executionProductDir = Join-Path (Join-Path $executionBotRoot 'workspace') 'product'
-
-            # Mark in-progress
-            Set-TaskInProgressForExecutorDispatch -Task $task
 
             $typeSuccess = $false
             $typeError = $null

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -1510,12 +1510,9 @@ try {
                     }
                     Write-Diag "Task $($task.id) claimed by another runner, retrying ($taskTypeVal)..."
                     Start-Sleep -Milliseconds 200
-                    $taskResult = Get-NextWorkflowTask -BotRoot $botRoot -RunId $RunId -WorkflowName $WorkflowName
-                    if (-not $taskResult.task) { break }
-                    $task = $taskResult.task
-                    # Always break on task swap — outer loop re-processes the replacement
-                    # with full task_gen/prompt_template recovery (lines 1434-1473).
-                    # Claiming in-place would bypass that recovery logic.
+                    # Break unconditionally — outer loop re-fetches and re-processes the next
+                    # task with full task_gen/prompt_template recovery. Fetching here is dead
+                    # code (result discarded on break) and opens a small race window.
                     break
                 }
             }

--- a/tests/Test-ProcessDispatch.ps1
+++ b/tests/Test-ProcessDispatch.ps1
@@ -193,7 +193,9 @@ Assert-True -Name "Task-runner finalizes WorkflowRun live status" `
     -Message "Workflow runner should update .control/workflow-runs/<run>.json when it exits"
 
 Assert-True -Name "Task-runner uses legal executor status transitions" `
-    -Condition ($workflowProcessContent -match 'Set-TaskInProgressForExecutorDispatch' -and $workflowProcessContent -match 'Set-TaskTerminalFailureForExecutorDispatch') `
+    -Condition ($workflowProcessContent -match 'Invoke-TaskMarkInProgress' -and
+                $workflowProcessContent -match 'Cannot dispatch non-prompt task' -and
+                $workflowProcessContent -match 'Set-TaskTerminalFailureForExecutorDispatch') `
     -Message "Executor tasks must move through in-progress before terminal states"
 
 Assert-True -Name "Task-runner no longer carries a bespoke barrier switch case" `


### PR DESCRIPTION
## Linked issue

Closes #536

## Summary of changes

Non-prompt auto-dispatch tasks (`script`, `mcp`, `task_gen`) claimed in-progress status **after** worktree creation. Two concurrent runners could both observe the same task as `todo` via the lock-free `Get-NextWorkflowTask`, both call `git worktree add` to the same path, and the second would fail with `fatal: '...' already exists`.

**Root fix:** Added a pre-worktree claim guard for non-prompt tasks mirroring the existing prompt-task guard. Calls `Invoke-TaskMarkInProgress` (HTTP POST with server-side mutex) before any worktree I/O. `no_op=true` in the response signals the task was already claimed — the guard fetches a replacement task and breaks to the outer loop so full `task_gen`/prompt-template recovery runs on it. Removed the post-worktree `Set-TaskInProgressForExecutorDispatch` call, now superseded.

**Additional hardening (from code review):**
- Re-syncs `$processData.task_id` / `$env:DOTBOT_CURRENT_TASK_ID` after the guard in case `$task` was replaced during retry
- Fatal errors (unexpected status, non-HTTP exceptions) re-throw instead of silently retrying
- 2s back-off before outer-loop `continue` when all claim attempts exhaust
- On task swap, always breaks to outer loop so the replacement goes through `task_gen`/`prompt_template` recovery
- Updated `Test-ProcessDispatch.ps1` assertion to match `Invoke-TaskMarkInProgress` instead of the removed function name

## Testing notes

1. **Unit** — `pwsh tests/Test-ProcessDispatch.ps1`: the "legal executor status transitions" assertion now validates the claim guard is present.
2. **Race reproduction** — start two task-runner processes against a workflow with at least one pending non-prompt task. Before this fix both runners race to `git worktree add`; after, the second detects `no_op=true` and picks up a different task.
3. **Standalone runner** — verify a single runner (`-Slot` not set) still claims and executes non-prompt tasks normally; the guard is unconditional and must not regress the single-runner path.

## Checklist

- [x] Tests added or updated
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
