### PR TITLE
fix(worktree): prevent zombie worktree and map leak on partial cleanup failure

### DIFF
--- a/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1
+++ b/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1
@@ -1577,12 +1577,17 @@ function Complete-TaskWorktree {
 
     .OUTPUTS
     Hashtable with:
-      success        — $true on full merge+commit+cleanup, $false otherwise
+      success        — $true when merge+commit succeeded. NOTE: $true does NOT
+                       guarantee worktree cleanup succeeded — if the directory
+                       could not be removed (e.g. Windows open handles), success
+                       stays $true, failure_kind stays $null, and the cleanup
+                       failure is reported only via 'message' and an Error log.
       merge_commit   — SHA of the resulting commit (success only) or $null
       message        — human-readable summary
       conflict_files — array of conflicting paths (only populated for
                        failure_kind='rebase_conflict')
-      failure_kind   — one of: $null (on success), 'rebase_conflict',
+      failure_kind   — one of: $null (merge succeeded; see 'success' re: cleanup),
+                       'rebase_conflict',
                        'branch_missing', 'merge_command_failed', 'commit_failed',
                        'exception'. Drives the kind-specific pending_question
                        built by Move-TaskToMergeFailureNeedsInput.
@@ -1896,16 +1901,18 @@ function Complete-TaskWorktree {
         # targets (shared task state, product workspace). If junctions survived,
         # skip the delete; the entry is kept below for manual cleanup.
         $worktreeParentDir = Join-Path (Split-Path $ProjectRoot -Parent) "worktrees" (Split-Path $ProjectRoot -Leaf)
+        $rmErr = $null
         if ((Test-Path $worktreePath) -and $junctionsClean -and -not (Test-JunctionsExist -WorktreePath $worktreePath)) {
             Assert-PathWithinBounds -Path $worktreePath -ExpectedRoot $worktreeParentDir
-            Remove-Item -Path $worktreePath -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path $worktreePath -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable rmErr
             git -C $ProjectRoot worktree prune 2>$null
         }
 
         if (Test-Path $worktreePath) {
             # Keep map entry to preserve tracking. NOTE: Remove-OrphanWorktrees skips done-status tasks,
             # so no automatic retry fires. Manual cleanup required: remove $worktreePath and the map entry.
-            Write-BotLog -Level Error -Message "Worktree removal incomplete — path still exists: $worktreePath. Map entry kept. Manual cleanup required (Remove-OrphanWorktrees will not retry done-status tasks)."
+            $rmDetail = if ($rmErr) { " Last delete error: $(($rmErr | Select-Object -First 1).Exception.Message)" } else { "" }
+            Write-BotLog -Level Error -Message "Worktree removal incomplete — path still exists: $worktreePath. Map entry kept. Manual cleanup required (Remove-OrphanWorktrees will not retry done-status tasks).$rmDetail"
             return @{
                 success        = $true
                 merge_commit   = $mergeCommit
@@ -2215,15 +2222,26 @@ function Remove-OrphanWorktrees {
         # targets (shared task state, product workspace). If junctions survived,
         # skip the delete; the entry is kept below for next-startup retry.
         $worktreeParentDir = Join-Path (Split-Path $ProjectRoot -Parent) "worktrees" (Split-Path $ProjectRoot -Leaf)
+        $rmErr = $null
         if ($worktreePath -and (Test-Path $worktreePath) -and $junctionsClean -and -not (Test-JunctionsExist -WorktreePath $worktreePath)) {
-            Assert-PathWithinBounds -Path $worktreePath -ExpectedRoot $worktreeParentDir
-            Remove-Item -Path $worktreePath -Recurse -Force -ErrorAction SilentlyContinue
-            git -C $ProjectRoot worktree prune 2>$null
+            try {
+                Assert-PathWithinBounds -Path $worktreePath -ExpectedRoot $worktreeParentDir
+                Remove-Item -Path $worktreePath -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable rmErr
+                git -C $ProjectRoot worktree prune 2>$null
+            } catch {
+                # A bounds-check failure (e.g. a legacy/non-canonical map entry) must
+                # never abort the whole sweep or skip the map prune below — keep the
+                # entry and move on to the next orphan.
+                Write-BotLog -Level Error -Message "Orphan worktree cleanup error for $taskId ($worktreePath): $($_.Exception.Message). Entry kept in map."
+                $null = $failedOrphanIds.Add($taskId)
+                continue
+            }
         }
 
         if ($worktreePath -and (Test-Path $worktreePath)) {
             # Directory survived all removal attempts — keep in map so next startup retries
-            Write-BotLog -Level Error -Message "Orphan worktree removal incomplete — path still exists: $worktreePath. Entry kept in map for next-startup retry."
+            $rmDetail = if ($rmErr) { " Last delete error: $(($rmErr | Select-Object -First 1).Exception.Message)" } else { "" }
+            Write-BotLog -Level Error -Message "Orphan worktree removal incomplete — path still exists: $worktreePath. Entry kept in map for next-startup retry.$rmDetail"
             $null = $failedOrphanIds.Add($taskId)
         } else {
             git -C $ProjectRoot branch -D $branchName 2>$null

--- a/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1
+++ b/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1
@@ -1890,9 +1890,13 @@ function Complete-TaskWorktree {
             }
             git -C $ProjectRoot worktree remove $worktreePath 2>$null
         }
-        # Fallback: direct filesystem delete when git worktree remove leaves dir behind (e.g. Windows open handles)
+        # Fallback: direct filesystem delete when git worktree remove leaves the dir
+        # behind (e.g. Windows open handles). Gated on junctions being gone — on
+        # Windows Remove-Item -Recurse follows junctions and would delete link
+        # targets (shared task state, product workspace). If junctions survived,
+        # skip the delete; the entry is kept below for manual cleanup.
         $worktreeParentDir = Join-Path (Split-Path $ProjectRoot -Parent) "worktrees" (Split-Path $ProjectRoot -Leaf)
-        if (Test-Path $worktreePath) {
+        if ((Test-Path $worktreePath) -and $junctionsClean -and -not (Test-JunctionsExist -WorktreePath $worktreePath)) {
             Assert-PathWithinBounds -Path $worktreePath -ExpectedRoot $worktreeParentDir
             Remove-Item -Path $worktreePath -Recurse -Force -ErrorAction SilentlyContinue
             git -C $ProjectRoot worktree prune 2>$null
@@ -2205,9 +2209,13 @@ function Remove-OrphanWorktrees {
             git -C $ProjectRoot worktree remove $worktreePath 2>$null
         }
 
-        # Fallback: direct filesystem delete when git worktree remove leaves dir behind (e.g. Windows open handles)
+        # Fallback: direct filesystem delete when git worktree remove leaves the dir
+        # behind (e.g. Windows open handles). Gated on junctions being gone — on
+        # Windows Remove-Item -Recurse follows junctions and would delete link
+        # targets (shared task state, product workspace). If junctions survived,
+        # skip the delete; the entry is kept below for next-startup retry.
         $worktreeParentDir = Join-Path (Split-Path $ProjectRoot -Parent) "worktrees" (Split-Path $ProjectRoot -Leaf)
-        if ($worktreePath -and (Test-Path $worktreePath)) {
+        if ($worktreePath -and (Test-Path $worktreePath) -and $junctionsClean -and -not (Test-JunctionsExist -WorktreePath $worktreePath)) {
             Assert-PathWithinBounds -Path $worktreePath -ExpectedRoot $worktreeParentDir
             Remove-Item -Path $worktreePath -Recurse -Force -ErrorAction SilentlyContinue
             git -C $ProjectRoot worktree prune 2>$null

--- a/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1
+++ b/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1
@@ -1425,6 +1425,14 @@ function New-TaskWorktree {
             Remove-Item -Path $worktreePath -Recurse -Force -ErrorAction SilentlyContinue
             # Also prune git's worktree list so it doesn't think it still exists
             git -C $ProjectRoot worktree prune 2>$null
+            if (Test-Path $worktreePath) {
+                return @{
+                    worktree_path = $worktreePath
+                    branch_name   = $branchName
+                    success       = $false
+                    message       = "Stale worktree directory could not be removed: $worktreePath"
+                }
+            }
         }
     }
 
@@ -1882,12 +1890,30 @@ function Complete-TaskWorktree {
             }
             git -C $ProjectRoot worktree remove $worktreePath 2>$null
         }
-        # Verify worktree is actually gone (Fix: silent removal failures)
+        # Fallback: direct filesystem delete when git worktree remove leaves dir behind (e.g. Windows open handles)
+        $worktreeParentDir = Join-Path (Split-Path $ProjectRoot -Parent) "worktrees" (Split-Path $ProjectRoot -Leaf)
         if (Test-Path $worktreePath) {
-            Write-BotLog -Level Warn -Message "Worktree removal incomplete — path still exists: $worktreePath. Will be retried on next startup."
+            Assert-PathWithinBounds -Path $worktreePath -ExpectedRoot $worktreeParentDir
+            Remove-Item -Path $worktreePath -Recurse -Force -ErrorAction SilentlyContinue
+            git -C $ProjectRoot worktree prune 2>$null
         }
-        git -C $ProjectRoot branch -D $branchName 2>$null
 
+        if (Test-Path $worktreePath) {
+            # Keep map entry to preserve tracking. NOTE: Remove-OrphanWorktrees skips done-status tasks,
+            # so no automatic retry fires. Manual cleanup required: remove $worktreePath and the map entry.
+            Write-BotLog -Level Error -Message "Worktree removal incomplete — path still exists: $worktreePath. Map entry kept. Manual cleanup required (Remove-OrphanWorktrees will not retry done-status tasks)."
+            return @{
+                success        = $true
+                merge_commit   = $mergeCommit
+                message        = "Squash-merged to $baseBranch (worktree directory cleanup failed — manual removal required: $worktreePath)"
+                conflict_files = @()
+                failure_kind   = $null
+                failure_detail = ""
+                push_result    = $pushResult
+            }
+        }
+
+        git -C $ProjectRoot branch -D $branchName 2>$null
         # Remove from registry (locked read-modify-write to prevent concurrent entry loss)
         Invoke-WorktreeMapLocked -BotRoot $BotRoot -Action {
             $lockedMap = Read-WorktreeMap -BotRoot $BotRoot
@@ -2146,6 +2172,7 @@ function Remove-OrphanWorktrees {
 
     $orphanIds = @($map.Keys | Where-Object { -not $activeIds.Contains($_) })
 
+    $failedOrphanIds = [System.Collections.Generic.List[string]]::new()
     foreach ($taskId in $orphanIds) {
         $entry = $map[$taskId]
         $worktreePath = $entry.worktree_path
@@ -2177,18 +2204,30 @@ function Remove-OrphanWorktrees {
             }
             git -C $ProjectRoot worktree remove $worktreePath 2>$null
         }
-        # Verify worktree is actually gone (Fix: silent removal failures)
+
+        # Fallback: direct filesystem delete when git worktree remove leaves dir behind (e.g. Windows open handles)
+        $worktreeParentDir = Join-Path (Split-Path $ProjectRoot -Parent) "worktrees" (Split-Path $ProjectRoot -Leaf)
         if ($worktreePath -and (Test-Path $worktreePath)) {
-            Write-BotLog -Level Warn -Message "Orphan worktree removal incomplete — path still exists: $worktreePath"
+            Assert-PathWithinBounds -Path $worktreePath -ExpectedRoot $worktreeParentDir
+            Remove-Item -Path $worktreePath -Recurse -Force -ErrorAction SilentlyContinue
+            git -C $ProjectRoot worktree prune 2>$null
         }
-        git -C $ProjectRoot branch -D $branchName 2>$null
+
+        if ($worktreePath -and (Test-Path $worktreePath)) {
+            # Directory survived all removal attempts — keep in map so next startup retries
+            Write-BotLog -Level Error -Message "Orphan worktree removal incomplete — path still exists: $worktreePath. Entry kept in map for next-startup retry."
+            $null = $failedOrphanIds.Add($taskId)
+        } else {
+            git -C $ProjectRoot branch -D $branchName 2>$null
+        }
     }
 
-    if ($orphanIds.Count -gt 0) {
+    $removedOrphanIds = @($orphanIds | Where-Object { -not $failedOrphanIds.Contains($_) })
+    if ($removedOrphanIds.Count -gt 0) {
         # Locked read-modify-write — prevents concurrent processes from losing map entries
         Invoke-WorktreeMapLocked -BotRoot $BotRoot -Action {
             $lockedMap = Read-WorktreeMap -BotRoot $BotRoot
-            foreach ($id in $orphanIds) { $lockedMap.Remove($id) }
+            foreach ($id in $removedOrphanIds) { $lockedMap.Remove($id) }
             Write-WorktreeMap -Map $lockedMap -BotRoot $BotRoot
         }
     }


### PR DESCRIPTION
## Linked issue

Closes #537

## Summary of changes

Four bugs in `Dotbot.Worktree.psm1` that cause orphan worktree partial setup to corrupt the filesystem on retry:

**Bug A** — `Remove-OrphanWorktrees` deleted map entry even when the worktree directory survived removal. Next startup: dir not in map → invisible to retry machinery → permanent zombie.

**Bug B** — No `Remove-Item` fallback after `git worktree remove --force` in `Remove-OrphanWorktrees`. On Windows, open file handles cause silent failure. Added fallback + `git worktree prune`. Map entry now kept only when dir actually survives both attempts.

**Bug C** — `New-TaskWorktree` called `Remove-Item -ErrorAction SilentlyContinue` on stale leftover dir but never checked the result. Fell through to `git worktree add`, which failed with a path-collision error. Added early return with `success=$false` when removal fails.

**Bug D** — `Complete-TaskWorktree` had the same pattern as Bug A: removed map entry even when dir survived. Added `Remove-Item` fallback + conditional map removal. Also fixed misleading return message ("cleaned up" now only emitted when dir is actually gone) and corrected a false comment claiming `Remove-OrphanWorktrees` would retry `done`-status tasks on next startup (it doesn't — `done` is in `$activeIds`).

`Assert-PathWithinBounds` calls at new fallback sites use the canonical worktree parent dir derived from `$ProjectRoot`, matching the pre-existing pattern in `New-TaskWorktree`.

## Testing notes

1. Create a task worktree. Lock a file inside it to prevent `git worktree remove --force` from succeeding.
2. Trigger `Remove-OrphanWorktrees` (restart the bot process). Verify:
   - Log emits `Error` level: "Orphan worktree removal incomplete — path still exists"
   - Map entry is **retained** (not deleted)
3. Release the file handle. Restart again. Verify:
   - Dir removed, map entry purged, branch deleted
   - No "Worktree already exists" or path-collision errors on next task pick-up
4. Run existing dispatch regression tests (`Test-ProcessDispatch.ps1`) — must pass clean.

## Checklist

- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
