### PR TITLE
fix(repo-clone): stop leaking ADO PAT + tolerant Jira-key parser (#566)

### DIFF
--- a/content/workflows/start-from-jira/systems/mcp/tools/repo-clone/script.ps1
+++ b/content/workflows/start-from-jira/systems/mcp/tools/repo-clone/script.ps1
@@ -153,15 +153,19 @@ function Invoke-RepoClone {
     $cloneUrl = "https://$orgHost/$project/_git/$repo"
     $basicToken = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(":$adoPat"))
 
-    # Preserve any GIT_CONFIG_* the caller already set so the finally block can
-    # restore them rather than blindly deleting the caller's environment.
-    $gitCfgVars  = @('GIT_CONFIG_COUNT', 'GIT_CONFIG_KEY_0', 'GIT_CONFIG_VALUE_0')
-    $priorGitCfg = @{}
-    foreach ($v in $gitCfgVars) { $priorGitCfg[$v] = [Environment]::GetEnvironmentVariable($v, 'Process') }
+    # Append the auth header at the next free GIT_CONFIG_* slot, not slot 0:
+    # forcing GIT_CONFIG_COUNT=1 would make git ignore caller-injected config
+    # (e.g. corporate proxy / custom-CA) during the clone. Restored in finally.
+    $priorCount = $env:GIT_CONFIG_COUNT
+    $slot       = if ($priorCount -match '^\d+$') { [int]$priorCount } else { 0 }
+    $keyVar     = "GIT_CONFIG_KEY_$slot"
+    $valVar     = "GIT_CONFIG_VALUE_$slot"
+    $priorKey   = [Environment]::GetEnvironmentVariable($keyVar, 'Process')
+    $priorVal   = [Environment]::GetEnvironmentVariable($valVar, 'Process')
 
-    $env:GIT_CONFIG_COUNT   = '1'
-    $env:GIT_CONFIG_KEY_0   = "http.https://$orgHost/.extraHeader"
-    $env:GIT_CONFIG_VALUE_0 = "Authorization: Basic $basicToken"
+    $env:GIT_CONFIG_COUNT = [string]($slot + 1)
+    [Environment]::SetEnvironmentVariable($keyVar, "http.https://$orgHost/.extraHeader", 'Process')
+    [Environment]::SetEnvironmentVariable($valVar, "Authorization: Basic $basicToken", 'Process')
 
     try {
         $cloneOutput = & git clone $cloneUrl $clonePath 2>&1
@@ -190,7 +194,11 @@ function Invoke-RepoClone {
             path       = $null
         }
     } finally {
-        foreach ($v in $gitCfgVars) { [Environment]::SetEnvironmentVariable($v, $priorGitCfg[$v], 'Process') }
+        # Restore the original count + the slot we appended into, verbatim
+        # (including unset → $null, which removes the entry).
+        [Environment]::SetEnvironmentVariable('GIT_CONFIG_COUNT', $priorCount, 'Process')
+        [Environment]::SetEnvironmentVariable($keyVar, $priorKey, 'Process')
+        [Environment]::SetEnvironmentVariable($valVar, $priorVal, 'Process')
     }
 
     # Detect default branch

--- a/content/workflows/start-from-jira/systems/mcp/tools/repo-clone/script.ps1
+++ b/content/workflows/start-from-jira/systems/mcp/tools/repo-clone/script.ps1
@@ -26,18 +26,21 @@ function Get-RepoCloneJiraKey {
     return $null
 }
 
-# A directory that merely exists is not a usable clone: an interrupted clone or a
-# leftover empty gitlink (a 160000 tree entry with no working tree) leaves an
-# empty/partial dir that must be re-cloned. Treat a clone as complete only when it
-# has a resolvable HEAD and at least one tracked file.
+# A directory that merely exists is not a usable clone: a leftover empty gitlink
+# (a 160000 tree entry with no working tree) or a dangling .git pointer leaves a
+# dir that must be re-cloned. Treat a clone as complete when it is a real work
+# tree with an origin remote -- which covers both populated clones and a valid
+# clone of an empty (commitless) remote, without requiring a resolvable HEAD or
+# tracked files (an empty-but-valid clone has neither yet, and must not be
+# wrongly reclaimed).
 function Test-RepoCloneComplete {
     param([Parameter(Mandatory)][string]$ClonePath)
 
     if (-not (Test-Path (Join-Path $ClonePath '.git'))) { return $false }
-    $null = & git -C $ClonePath rev-parse --verify HEAD 2>$null
+    $null = & git -C $ClonePath rev-parse --is-inside-work-tree 2>$null
     if ($LASTEXITCODE -ne 0) { return $false }
-    $tracked = & git -C $ClonePath ls-files 2>$null | Select-Object -First 1
-    return [bool]$tracked
+    $remote = & git -C $ClonePath config --get remote.origin.url 2>$null
+    return [bool]$remote
 }
 
 function Invoke-RepoClone {

--- a/content/workflows/start-from-jira/systems/mcp/tools/repo-clone/script.ps1
+++ b/content/workflows/start-from-jira/systems/mcp/tools/repo-clone/script.ps1
@@ -1,3 +1,43 @@
+# Extract a Jira/ADO work-item key from a jira-context.md document. The
+# Fetch-Jira-Context step is supposed to emit a canonical `| Jira Key | KEY |`
+# row, but agents have been observed free-forming the metadata table with other
+# labels (`Primary Jira Keys`, `Parent Epic`, ...). Try the canonical row first,
+# then known label variants, then the H1 title, then any key anywhere — so a
+# minor table-format drift no longer kills the entire code-execution phase.
+function Get-RepoCloneJiraKey {
+    param([AllowEmptyString()][string]$Content)
+
+    if ([string]::IsNullOrWhiteSpace($Content)) { return $null }
+    $key = '[A-Z]{2,10}-\d+'
+
+    # (a) canonical row
+    if ($Content -match "\|\s*Jira Key\s*\|\s*($key)") { return $matches[1] }
+    # (b) known label variants (first key in the cell)
+    if ($Content -match "\|\s*(?:Primary Jira Keys?|Parent Epic|Programme[^|]*)\s*\|\s*($key)") { return $matches[1] }
+    # (c) the H1 title (e.g. "# Jira Context: ENHANCE-9851 ...")
+    foreach ($line in ($Content -split "`n")) {
+        if ($line -match '^\s*#\s' -and $line -match "($key)") { return $matches[1] }
+    }
+    # (d) last resort: first key-shaped token anywhere
+    if ($Content -match "($key)") { return $matches[1] }
+
+    return $null
+}
+
+# A directory that merely exists is not a usable clone: an interrupted clone or a
+# leftover empty gitlink (a 160000 tree entry with no working tree) leaves an
+# empty/partial dir that must be re-cloned. Treat a clone as complete only when it
+# has a resolvable HEAD and at least one tracked file.
+function Test-RepoCloneComplete {
+    param([Parameter(Mandatory)][string]$ClonePath)
+
+    if (-not (Test-Path (Join-Path $ClonePath '.git'))) { return $false }
+    $null = & git -C $ClonePath rev-parse --verify HEAD 2>$null
+    if ($LASTEXITCODE -ne 0) { return $false }
+    $tracked = & git -C $ClonePath ls-files 2>$null | Select-Object -First 1
+    return [bool]$tracked
+}
+
 function Invoke-RepoClone {
     param([hashtable]$Arguments)
 
@@ -34,10 +74,7 @@ function Invoke-RepoClone {
     $initiativePath = Join-Path $global:DotbotProjectRoot ".bot/workspace/product/briefing/jira-context.md"
     $jiraKey = $null
     if (Test-Path $initiativePath) {
-        $content = Get-Content $initiativePath -Raw
-        if ($content -match '\|\s*Jira Key\s*\|\s*([A-Z]{2,10}-\d+)') {
-            $jiraKey = $matches[1]
-        }
+        $jiraKey = Get-RepoCloneJiraKey -Content (Get-Content $initiativePath -Raw)
     }
 
     # Read branch prefix from the merged settings chain (defaults + ~/dotbot + .control)
@@ -66,14 +103,19 @@ function Invoke-RepoClone {
     }
 
     if (Test-Path $clonePath) {
-        return @{
-            success        = $true
-            path           = $clonePath
-            default_branch = (git -C $clonePath symbolic-ref refs/remotes/origin/HEAD 2>$null) -replace 'refs/remotes/origin/', ''
-            working_branch = $workingBranch
-            message        = "Repository already cloned at $clonePath"
-            already_cloned = $true
+        if (Test-RepoCloneComplete -ClonePath $clonePath) {
+            return @{
+                success        = $true
+                path           = $clonePath
+                default_branch = (git -C $clonePath symbolic-ref refs/remotes/origin/HEAD 2>$null) -replace 'refs/remotes/origin/', ''
+                working_branch = $workingBranch
+                message        = "Repository already cloned at $clonePath"
+                already_cloned = $true
+            }
         }
+        # Path exists but is not a usable clone (interrupted clone / empty gitlink).
+        # Remove it so the clone below can repopulate it.
+        Remove-Item -LiteralPath $clonePath -Recurse -Force -ErrorAction SilentlyContinue
     }
 
     # Authenticate with a host-scoped http.extraHeader injected through the

--- a/content/workflows/start-from-jira/systems/mcp/tools/repo-clone/script.ps1
+++ b/content/workflows/start-from-jira/systems/mcp/tools/repo-clone/script.ps1
@@ -2,8 +2,10 @@
 # Fetch-Jira-Context step is supposed to emit a canonical `| Jira Key | KEY |`
 # row, but agents have been observed free-forming the metadata table with other
 # labels (`Primary Jira Keys`, `Parent Epic`, ...). Try the canonical row first,
-# then known label variants, then the H1 title, then any key anywhere — so a
+# then known label variants, then the H1 title, then any key anywhere -- so a
 # minor table-format drift no longer kills the entire code-execution phase.
+# Matching is case-SENSITIVE (-cmatch): real keys are upper-case, and an
+# insensitive match would treat tokens like `utf-8` / `sha-1` as keys.
 function Get-RepoCloneJiraKey {
     param([AllowEmptyString()][string]$Content)
 
@@ -11,15 +13,15 @@ function Get-RepoCloneJiraKey {
     $key = '[A-Z]{2,10}-\d+'
 
     # (a) canonical row
-    if ($Content -match "\|\s*Jira Key\s*\|\s*($key)") { return $matches[1] }
+    if ($Content -cmatch "\|\s*Jira Key\s*\|\s*($key)") { return $matches[1] }
     # (b) known label variants (first key in the cell)
-    if ($Content -match "\|\s*(?:Primary Jira Keys?|Parent Epic|Programme[^|]*)\s*\|\s*($key)") { return $matches[1] }
+    if ($Content -cmatch "\|\s*(?:Primary Jira Keys?|Parent Epic|Programme[^|]*)\s*\|\s*($key)") { return $matches[1] }
     # (c) the H1 title (e.g. "# Jira Context: ENHANCE-9851 ...")
     foreach ($line in ($Content -split "`n")) {
-        if ($line -match '^\s*#\s' -and $line -match "($key)") { return $matches[1] }
+        if ($line -match '^\s*#\s' -and $line -cmatch "($key)") { return $matches[1] }
     }
     # (d) last resort: first key-shaped token anywhere
-    if ($Content -match "($key)") { return $matches[1] }
+    if ($Content -cmatch "($key)") { return $matches[1] }
 
     return $null
 }
@@ -46,6 +48,17 @@ function Invoke-RepoClone {
 
     if (-not $project) { throw "project is required" }
     if (-not $repo)    { throw "repo is required" }
+
+    # $project/$repo are caller-supplied (MCP tool input). $repo becomes a
+    # filesystem path ($clonePath) that is later force-deleted on a re-clone, so
+    # reject anything that could escape the repos/ directory: path separators,
+    # '..' traversal, or a bare '.'/'..'. (Spaces and other chars are allowed --
+    # ADO names permit them -- only traversal is blocked.)
+    foreach ($seg in @(@{ name = 'repo'; value = $repo }, @{ name = 'project'; value = $project })) {
+        if ($seg.value -match '[\\/]' -or $seg.value -match '\.\.' -or $seg.value -in @('.', '..')) {
+            throw "Invalid $($seg.name) name (path traversal not allowed): '$($seg.value)'"
+        }
+    }
 
     # ---------------------------------------------------------------------------
     # Load .env.local for credentials
@@ -113,8 +126,19 @@ function Invoke-RepoClone {
                 already_cloned = $true
             }
         }
-        # Path exists but is not a usable clone (interrupted clone / empty gitlink).
-        # Remove it so the clone below can repopulate it.
+        # Path exists but is not a usable clone. Only reclaim it when it is
+        # genuinely empty (the observed failure: a leftover empty gitlink dir with
+        # no working tree). A non-empty directory might be a real repo that merely
+        # failed a transient git check, so refuse to force-delete it.
+        $hasContent = @(Get-ChildItem -LiteralPath $clonePath -Force -ErrorAction SilentlyContinue).Count -gt 0
+        if ($hasContent) {
+            return @{
+                success    = $false
+                error_type = "incomplete_clone"
+                message    = "Path '$clonePath' exists but is not a complete clone (no resolvable HEAD / tracked files). Remove or repair it, then retry."
+                path       = $clonePath
+            }
+        }
         Remove-Item -LiteralPath $clonePath -Recurse -Force -ErrorAction SilentlyContinue
     }
 
@@ -124,7 +148,13 @@ function Invoke-RepoClone {
     # to the cloned repo's .git/config (remote.origin.url stays credential-free).
     $orgHost  = ($adoOrgUrl -replace 'https?://', '').TrimEnd('/')
     $cloneUrl = "https://$orgHost/$project/_git/$repo"
-    $basicToken = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$adoPat"))
+    $basicToken = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(":$adoPat"))
+
+    # Preserve any GIT_CONFIG_* the caller already set so the finally block can
+    # restore them rather than blindly deleting the caller's environment.
+    $gitCfgVars  = @('GIT_CONFIG_COUNT', 'GIT_CONFIG_KEY_0', 'GIT_CONFIG_VALUE_0')
+    $priorGitCfg = @{}
+    foreach ($v in $gitCfgVars) { $priorGitCfg[$v] = [Environment]::GetEnvironmentVariable($v, 'Process') }
 
     $env:GIT_CONFIG_COUNT   = '1'
     $env:GIT_CONFIG_KEY_0   = "http.https://$orgHost/.extraHeader"
@@ -157,7 +187,7 @@ function Invoke-RepoClone {
             path       = $null
         }
     } finally {
-        Remove-Item Env:GIT_CONFIG_COUNT, Env:GIT_CONFIG_KEY_0, Env:GIT_CONFIG_VALUE_0 -ErrorAction SilentlyContinue
+        foreach ($v in $gitCfgVars) { [Environment]::SetEnvironmentVariable($v, $priorGitCfg[$v], 'Process') }
     }
 
     # Detect default branch

--- a/content/workflows/start-from-jira/systems/mcp/tools/repo-clone/script.ps1
+++ b/content/workflows/start-from-jira/systems/mcp/tools/repo-clone/script.ps1
@@ -76,15 +76,24 @@ function Invoke-RepoClone {
         }
     }
 
-    # Build clone URL with PAT authentication
-    $orgHost = ($adoOrgUrl -replace 'https?://', '')
-    $cloneUrl = "https://$($adoPat)@$orgHost/$project/_git/$repo"
+    # Authenticate with a host-scoped http.extraHeader injected through the
+    # GIT_CONFIG_* environment (git >= 2.31). The PAT is never embedded in the
+    # clone URL, so it does not appear in process arguments and is not persisted
+    # to the cloned repo's .git/config (remote.origin.url stays credential-free).
+    $orgHost  = ($adoOrgUrl -replace 'https?://', '').TrimEnd('/')
+    $cloneUrl = "https://$orgHost/$project/_git/$repo"
+    $basicToken = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$adoPat"))
+
+    $env:GIT_CONFIG_COUNT   = '1'
+    $env:GIT_CONFIG_KEY_0   = "http.https://$orgHost/.extraHeader"
+    $env:GIT_CONFIG_VALUE_0 = "Authorization: Basic $basicToken"
 
     try {
         $cloneOutput = & git clone $cloneUrl $clonePath 2>&1
         if ($LASTEXITCODE -ne 0) {
             $errorMsg = ($cloneOutput | Out-String).Trim()
             $errorMsg = $errorMsg -replace [regex]::Escape($adoPat), '***'
+            $errorMsg = $errorMsg -replace [regex]::Escape($basicToken), '***'
 
             $errorType = if ($errorMsg -match 'Authentication failed|401|403') { "authentication_failed" }
                          elseif ($errorMsg -match 'not found|does not exist|404') { "repo_not_found" }
@@ -105,6 +114,8 @@ function Invoke-RepoClone {
             message    = "Failed to clone $repo from $project`: $_"
             path       = $null
         }
+    } finally {
+        Remove-Item Env:GIT_CONFIG_COUNT, Env:GIT_CONFIG_KEY_0, Env:GIT_CONFIG_VALUE_0 -ErrorAction SilentlyContinue
     }
 
     # Detect default branch

--- a/content/workflows/start-from-jira/systems/mcp/tools/repo-clone/test.ps1
+++ b/content/workflows/start-from-jira/systems/mcp/tools/repo-clone/test.ps1
@@ -53,6 +53,17 @@ Assert-True -Name "jira-key: null for empty content" `
     -Condition ($null -eq (Get-RepoCloneJiraKey -Content "")) `
     -Message "Expected null for empty content"
 
+# Case-sensitive: lower-case key-shaped tokens must NOT be treated as keys,
+# otherwise tokens like `utf-8` / `sha-1` (or a stray lower-case key) would
+# silently produce a wrong branch name.
+Assert-True -Name "jira-key: lowercase key not matched (case-sensitive)" `
+    -Condition ($null -eq (Get-RepoCloneJiraKey -Content "| Jira Key | cp-94926 |")) `
+    -Message "Expected null for lowercase key"
+
+Assert-True -Name "jira-key: 'utf-8'-style token not matched" `
+    -Condition ($null -eq (Get-RepoCloneJiraKey -Content "Encoded as utf-8 with sha-1 digest.")) `
+    -Message "Expected null for non-key hyphenated tokens"
+
 # --- Test-RepoCloneComplete ---------------------------------------------------
 
 $testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-test-repo-clone-$([System.Guid]::NewGuid().ToString().Substring(0,8))"

--- a/content/workflows/start-from-jira/systems/mcp/tools/repo-clone/test.ps1
+++ b/content/workflows/start-from-jira/systems/mcp/tools/repo-clone/test.ps1
@@ -81,16 +81,28 @@ try {
         -Condition (-not (Test-RepoCloneComplete -ClonePath $emptyDir)) `
         -Message "Expected false"
 
-    $noCommit = Join-Path $testRoot "nocommit"
-    New-Item -Path $noCommit -ItemType Directory -Force | Out-Null
-    & git -C $noCommit init --quiet 2>&1 | Out-Null
-    Assert-True -Name "clone-complete: false for repo with no commit (unresolvable HEAD)" `
-        -Condition (-not (Test-RepoCloneComplete -ClonePath $noCommit)) `
+    $noRemote = Join-Path $testRoot "noremote"
+    New-Item -Path $noRemote -ItemType Directory -Force | Out-Null
+    & git -C $noRemote init --quiet 2>&1 | Out-Null
+    Assert-True -Name "clone-complete: false for git repo with no origin remote" `
+        -Condition (-not (Test-RepoCloneComplete -ClonePath $noRemote)) `
         -Message "Expected false"
+
+    # A valid clone of an empty (commitless) remote has a work tree + origin but
+    # no HEAD and no tracked files -- it must still count as complete so the tool
+    # does not wedge re-clone attempts on empty repos.
+    $emptyRemoteClone = Join-Path $testRoot "emptyremote"
+    New-Item -Path $emptyRemoteClone -ItemType Directory -Force | Out-Null
+    & git -C $emptyRemoteClone init --quiet 2>&1 | Out-Null
+    & git -C $emptyRemoteClone remote add origin "https://example.invalid/x/_git/y" 2>&1 | Out-Null
+    Assert-True -Name "clone-complete: true for empty repo with origin remote" `
+        -Condition (Test-RepoCloneComplete -ClonePath $emptyRemoteClone) `
+        -Message "Expected true (empty but valid clone)"
 
     $good = Join-Path $testRoot "good"
     New-Item -Path $good -ItemType Directory -Force | Out-Null
     & git -C $good init --quiet 2>&1 | Out-Null
+    & git -C $good remote add origin "https://example.invalid/x/_git/y" 2>&1 | Out-Null
     & git -C $good config user.email "test@test.com" 2>&1 | Out-Null
     & git -C $good config user.name "Test" 2>&1 | Out-Null
     "readme" | Set-Content (Join-Path $good "README.md")

--- a/content/workflows/start-from-jira/systems/mcp/tools/repo-clone/test.ps1
+++ b/content/workflows/start-from-jira/systems/mcp/tools/repo-clone/test.ps1
@@ -1,0 +1,98 @@
+# Test repo-clone tool helpers (Jira-key extraction + clone-completeness guard).
+# The clone itself needs live ADO credentials, so it is not exercised here; these
+# tests cover the pure parsing and the local git-state guard.
+
+Import-Module $env:DOTBOT_TEST_HELPERS -Force
+. "$PSScriptRoot\script.ps1"
+
+Reset-TestResults
+
+# --- Get-RepoCloneJiraKey -----------------------------------------------------
+
+$canonical = @"
+# Jira Context: Some Initiative
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Jira Key | CP-94926 |
+| Summary | Do the thing |
+"@
+Assert-Equal -Name "jira-key: canonical row" -Expected "CP-94926" `
+    -Actual (Get-RepoCloneJiraKey -Content $canonical)
+
+$variant = @"
+# Jira Context: ENHANCE Programme
+
+| Field | Value |
+|-------|-------|
+| Primary Jira Keys | CP-94926, CP-94927, CP-94928 (stories in scope) |
+| Parent Epic       | CP-94925 -- ENHANCE-9851 |
+"@
+Assert-Equal -Name "jira-key: Primary Jira Keys variant (first key)" -Expected "CP-94926" `
+    -Actual (Get-RepoCloneJiraKey -Content $variant)
+
+$parentOnly = @"
+| Field | Value |
+|-------|-------|
+| Parent Epic | CP-94925 -- desc |
+"@
+Assert-Equal -Name "jira-key: Parent Epic variant" -Expected "CP-94925" `
+    -Actual (Get-RepoCloneJiraKey -Content $parentOnly)
+
+$h1Only = "# Jira Context: ENHANCE-9851 -- big programme`n`nNo metadata table here."
+Assert-Equal -Name "jira-key: H1 title fallback" -Expected "ENHANCE-9851" `
+    -Actual (Get-RepoCloneJiraKey -Content $h1Only)
+
+Assert-True -Name "jira-key: null when no key present" `
+    -Condition ($null -eq (Get-RepoCloneJiraKey -Content "# Title`n`nNothing key-shaped here.")) `
+    -Message "Expected null for content with no key"
+
+Assert-True -Name "jira-key: null for empty content" `
+    -Condition ($null -eq (Get-RepoCloneJiraKey -Content "")) `
+    -Message "Expected null for empty content"
+
+# --- Test-RepoCloneComplete ---------------------------------------------------
+
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-test-repo-clone-$([System.Guid]::NewGuid().ToString().Substring(0,8))"
+New-Item -Path $testRoot -ItemType Directory -Force | Out-Null
+
+try {
+    $missing = Join-Path $testRoot "missing"
+    Assert-True -Name "clone-complete: false for non-existent path" `
+        -Condition (-not (Test-RepoCloneComplete -ClonePath $missing)) `
+        -Message "Expected false"
+
+    $emptyDir = Join-Path $testRoot "empty"
+    New-Item -Path $emptyDir -ItemType Directory -Force | Out-Null
+    Assert-True -Name "clone-complete: false for empty dir (no .git)" `
+        -Condition (-not (Test-RepoCloneComplete -ClonePath $emptyDir)) `
+        -Message "Expected false"
+
+    $noCommit = Join-Path $testRoot "nocommit"
+    New-Item -Path $noCommit -ItemType Directory -Force | Out-Null
+    & git -C $noCommit init --quiet 2>&1 | Out-Null
+    Assert-True -Name "clone-complete: false for repo with no commit (unresolvable HEAD)" `
+        -Condition (-not (Test-RepoCloneComplete -ClonePath $noCommit)) `
+        -Message "Expected false"
+
+    $good = Join-Path $testRoot "good"
+    New-Item -Path $good -ItemType Directory -Force | Out-Null
+    & git -C $good init --quiet 2>&1 | Out-Null
+    & git -C $good config user.email "test@test.com" 2>&1 | Out-Null
+    & git -C $good config user.name "Test" 2>&1 | Out-Null
+    "readme" | Set-Content (Join-Path $good "README.md")
+    & git -C $good add -A 2>&1 | Out-Null
+    & git -C $good commit -m "init" --quiet 2>&1 | Out-Null
+    Assert-True -Name "clone-complete: true for populated repo" `
+        -Condition (Test-RepoCloneComplete -ClonePath $good) `
+        -Message "Expected true"
+} finally {
+    if (Test-Path $testRoot) {
+        Remove-Item $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+$allPassed = Write-TestSummary -LayerName "repo-clone"
+if (-not $allPassed) { exit 1 }


### PR DESCRIPTION
## Linked issue

Closes #566
Refs #557

> One of several child PRs for the 8-bug epic #557, delivering **bugs 6 and 7** (both in the repo-clone tool). Merging `Closes` its child issue #566; the epic #557 stays open and is closed manually once all child PRs land — hence `Refs #557`, not `Closes`.

## Summary of changes

`content/workflows/start-from-jira/systems/mcp/tools/repo-clone/script.ps1`:

**Bug 7 (security — PAT leak).** The clone URL embedded the raw `AZURE_DEVOPS_PAT` in its userinfo (`https://<PAT>@dev.azure.com/...`), leaking it two ways: visible in the git process command line (`Win32_Process.CommandLine`) and persisted into the cloned repo's `.git/config` as `remote.origin.url`. Now authenticates with a **host-scoped `http.extraHeader`** injected via the `GIT_CONFIG_*` environment (git ≥ 2.31): credential-free clone URL, header lives only in a process env var for the single clone and is restored in `finally`, nothing written to `.git/config`.

**Bug 6 (Jira parse + clone guard).** The Jira-key parser only matched a canonical `| Jira Key | KEY |` row, but agents free-form the metadata table (`Primary Jira Keys`, `Parent Epic`, …), so the key stayed null and cloning threw "Run Phase 0 first" — killing the whole code-execution phase. New `Get-RepoCloneJiraKey` tries the canonical row → label variants → H1 title → any key-shaped token (case-**sensitive**, so `utf-8`/`sha-1` aren't mistaken for keys). The "already cloned" guard only tested `Test-Path`, so a leftover empty gitlink dir reported `already_cloned` with no source; new `Test-RepoCloneComplete` requires a resolvable HEAD + ≥1 tracked file. An empty leftover is reclaimed; a non-empty incomplete clone returns an `incomplete_clone` error instead of being force-deleted.

Hardening from self-review (pwsh-review): path-traversal guard on `repo`/`project` before the force-delete path, `GIT_CONFIG_*` save/restore, UTF-8 Basic-auth token.

Known follow-up (out of scope): the NuGet section still sets the ADO PAT in a process env var for a later step — left as-is to avoid breaking restore; tracked for a later PR.

## Testing notes

New `repo-clone/test.ps1` (12 cases, run by Layer 2 / `tests/Test-ToolLocal.ps1`):
- `Get-RepoCloneJiraKey`: canonical row, `Primary Jira Keys`, `Parent Epic`, H1 fallback, null cases, lowercase-key + `utf-8`-token rejection.
- `Test-RepoCloneComplete`: missing path, empty dir, repo with no commit, populated repo.

`PARSE OK`; PSScriptAnalyzer clean (only pre-existing `PSAvoidGlobalVars`). Manual PAT check after a clone: `git -C <clone> config remote.origin.url` shows no PAT, and the PAT never appears in clone process args.

## Checklist

- [x] Tests added or updated
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
