### PR TITLE
fix(ci): PR-based bump-release and repair v4 release pipeline

### DIFF
--- a/.github/workflows/bump-release.yml
+++ b/.github/workflows/bump-release.yml
@@ -13,14 +13,16 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   bump:
-    name: Bump version and tag
+    name: Open version-bump PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
+          fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install PowerShell
@@ -29,8 +31,28 @@ jobs:
             sudo apt-get update && sudo apt-get install -y powershell
           fi
 
+      - name: Check for changes since last release
+        id: gate
+        shell: bash
+        run: |
+          LAST_TAG="$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)"
+          if [ -z "$LAST_TAG" ]; then
+            echo "No prior version tag found — treating as releasable."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          COUNT="$(git rev-list "${LAST_TAG}..HEAD" --count)"
+          echo "Last tag: $LAST_TAG — $COUNT commit(s) since."
+          if [ "${{ github.event_name }}" = "schedule" ] && [ "$COUNT" -eq 0 ]; then
+            echo "Nothing merged since $LAST_TAG — nothing to release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Bump version
         id: bump
+        if: steps.gate.outputs.release == 'true'
         shell: pwsh
         run: |
           $bump = "${{ github.event.inputs.bump || 'patch' }}"
@@ -43,16 +65,94 @@ jobs:
             'patch' { $parts[2] = [int]$parts[2] + 1 }
           }
           $new = $parts -join '.'
+
+          $existingTag = git tag --list "v$new"
+          if ($existingTag) {
+            Write-Error "Tag v$new already exists — aborting to avoid a duplicate release."
+            exit 1
+          }
+          $existingBranch = git ls-remote --heads origin "release/v$new"
+          if ($existingBranch) {
+            Write-Error "Branch release/v$new already exists on origin — aborting."
+            exit 1
+          }
+
           @{ version = $new } | ConvertTo-Json | Set-Content $versionFile
           Write-Host "Bumped $current -> $new ($bump)"
           "version=$new" >> $env:GITHUB_OUTPUT
 
-      - name: Commit and tag
+      - name: Promote CHANGELOG Unreleased block
+        id: changelog
+        if: steps.gate.outputs.release == 'true'
+        shell: pwsh
         run: |
+          $version = "${{ steps.bump.outputs.version }}"
+          $date = (Get-Date).ToString('yyyy-MM-dd')
+          $path = "CHANGELOG.md"
+          $lines = Get-Content $path
+
+          $anchor = ($lines | Select-String -Pattern '^## \[Unreleased\]' -SimpleMatch:$false | Select-Object -First 1)
+          if (-not $anchor) {
+            Write-Error "No '## [Unreleased]' section found in $path"
+            exit 1
+          }
+          $idx = $anchor.LineNumber - 1
+          $bodyStart = $idx + 1
+          $next = $lines.Length
+          for ($i = $bodyStart; $i -lt $lines.Length; $i++) {
+            if ($lines[$i] -match '^## \[') { $next = $i; break }
+          }
+
+          $notes = ($lines[$bodyStart..($next - 1)] -join "`n").Trim()
+          $hasContent = $notes -split "`n" | Where-Object { $_ -notmatch '^\s*(#{2,6}\s|$)' }
+          if (-not $hasContent) {
+            $notes = "Maintenance release."
+          }
+          Set-Content -Path "release-notes.md" -Value $notes
+
+          $scaffold = @(
+            '## [Unreleased]',
+            '',
+            '### Added',
+            '',
+            '### Changed',
+            '',
+            '### Fixed',
+            '',
+            '### Removed',
+            '',
+            "## [$version] - $date"
+          )
+
+          $rebuilt = @()
+          $rebuilt += $lines[0..($idx - 1)]
+          $rebuilt += $scaffold
+          $rebuilt += $lines[$bodyStart..($lines.Length - 1)]
+          Set-Content -Path $path -Value $rebuilt
+          Write-Host "Promoted [Unreleased] -> [$version] - $date"
+
+      - name: Create branch, commit, open PR
+        if: steps.gate.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
           VERSION="${{ steps.bump.outputs.version }}"
+          BRANCH="release/v${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add version.json
-          git commit -m "Bump version to v${VERSION}"
-          git tag "v${VERSION}"
-          git push origin main --tags
+          git checkout -b "$BRANCH"
+          git add version.json CHANGELOG.md
+          git commit -m "chore(release): bump version to v${VERSION}"
+          git push -u origin "$BRANCH"
+          {
+            cat release-notes.md
+            printf '\n\n---\n_Merging this PR cuts v%s — **Release & Publish** runs automatically on merge._\n' "$VERSION"
+          } > pr-body.md
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(release): v${VERSION}" \
+            --body-file pr-body.md \
+            --label no-issue

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release & Publish
 
 on:
   push:
-    tags: ['v*']
+    branches: [main]
+    paths: ['version.json']
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -20,7 +22,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install PowerShell (Linux)
         if: runner.os == 'Linux'
@@ -63,11 +65,6 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install dotbot globally
-        shell: pwsh
-        run: |
-          pwsh -NoProfile -ExecutionPolicy Bypass -File install.ps1
-
       - name: Run tests (layers 1-3)
         shell: pwsh
         run: |
@@ -83,7 +80,7 @@ jobs:
       sha256_tar: ${{ steps.hashes.outputs.sha256_tar }}
       sha256_zip: ${{ steps.hashes.outputs.sha256_zip }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install PowerShell
         run: |
@@ -91,49 +88,83 @@ jobs:
             sudo apt-get update && sudo apt-get install -y powershell
           fi
 
-      - name: Extract version from tag
+      - name: Resolve version from version.json
         id: version
+        shell: bash
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="$(pwsh -NoProfile -Command '(Get-Content version.json | ConvertFrom-Json).version')"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing v$VERSION"
 
-      - name: Validate version matches version.json
+      - name: Skip if release already exists
+        id: exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if gh release view "v${VERSION}" >/dev/null 2>&1 || git ls-remote --exit-code --tags origin "v${VERSION}" >/dev/null 2>&1; then
+            echo "Release/tag v${VERSION} already exists — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract release notes from CHANGELOG
+        if: steps.exists.outputs.skip != 'true'
         shell: pwsh
         run: |
-          $expected = "${{ steps.version.outputs.version }}"
-          $actual = (Get-Content version.json | ConvertFrom-Json).version
-          if ($expected -ne $actual) {
-            Write-Error "Tag version ($expected) does not match version.json ($actual)"
-            exit 1
+          $version = "${{ steps.version.outputs.version }}"
+          $path = "CHANGELOG.md"
+          $notes = ""
+          if (Test-Path $path) {
+            $lines = Get-Content $path
+            $start = -1
+            for ($i = 0; $i -lt $lines.Length; $i++) {
+              if ($lines[$i] -match "^## \[$([regex]::Escape($version))\]") { $start = $i + 1; break }
+            }
+            if ($start -ge 0) {
+              $end = $lines.Length
+              for ($i = $start; $i -lt $lines.Length; $i++) {
+                if ($lines[$i] -match '^## \[') { $end = $i; break }
+              }
+              $notes = ($lines[$start..($end - 1)] -join "`n").Trim()
+              $hasContent = $notes -split "`n" | Where-Object { $_ -notmatch '^\s*(#{2,6}\s|$)' }
+              if (-not $hasContent) { $notes = "Maintenance release." }
+            }
           }
+          Set-Content -Path "release-notes.md" -Value $notes
 
       - name: Setup Node.js
+        if: steps.exists.outputs.skip != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Build Studio UI
-        working-directory: studio-ui
+        if: steps.exists.outputs.skip != 'true'
+        working-directory: src/studio-ui
         run: npm ci && npm run build
 
       - name: Build archives
+        if: steps.exists.outputs.skip != 'true'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           STAGING="${ARCHIVE_PREFIX}-${VERSION}"
           mkdir "$STAGING"
-          cp -r install.ps1 install-remote.ps1 scripts/ workflows/ stacks/ LICENSE README.md \
-                version.json dotbot.psd1 dotbot.psm1 "$STAGING/"
 
-          # Include studio-ui runtime files (no Node source)
-          mkdir -p "$STAGING/studio-ui/"
-          cp studio-ui/server.ps1 studio-ui/StudioAPI.psm1 "$STAGING/studio-ui/"
-          cp -r studio-ui/static/ "$STAGING/studio-ui/static/"
+          cp -r bin src content bootstrap.ps1 version.json LICENSE README.md "$STAGING/"
+
+          rm -rf "$STAGING/src/studio-ui"
+          mkdir -p "$STAGING/src/studio-ui"
+          cp src/studio-ui/server.ps1 src/studio-ui/StudioAPI.psm1 "$STAGING/src/studio-ui/"
+          cp -r src/studio-ui/static "$STAGING/src/studio-ui/"
 
           tar czf "${STAGING}.tar.gz" "$STAGING"
           zip -r "${STAGING}.zip" "$STAGING"
 
       - name: Compute SHA256
         id: hashes
+        if: steps.exists.outputs.skip != 'true'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           echo "sha256_tar=$(sha256sum ${ARCHIVE_PREFIX}-${VERSION}.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
@@ -142,66 +173,35 @@ jobs:
           sha256sum ${ARCHIVE_PREFIX}-${VERSION}.zip > ${ARCHIVE_PREFIX}-${VERSION}.zip.sha256
 
       - name: Create GitHub Release
+        if: steps.exists.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          if grep -q '[^[:space:]]' release-notes.md 2>/dev/null; then
+            cat release-notes.md > final-notes.md
+            {
+              printf '\n## Install\n\n'
+              printf '```\n'
+              printf '# Homebrew (macOS / Linux)\n'
+              printf 'brew install andresharpe/dotbot/dotbot\n\n'
+              printf '# Scoop (Windows)\n'
+              printf 'scoop bucket add dotbot https://github.com/andresharpe/scoop-dotbot\n'
+              printf 'scoop install dotbot\n\n'
+              printf '# From source\n'
+              printf 'git clone https://github.com/andresharpe/dotbot ~/dotbot\n'
+              printf 'pwsh ~/dotbot/bootstrap.ps1\n'
+              printf '```\n'
+            } >> final-notes.md
+            NOTES_ARGS=(--notes-file final-notes.md)
+          else
+            NOTES_ARGS=(--generate-notes)
+          fi
           gh release create "v${VERSION}" \
             --title "v${VERSION}" \
-            --generate-notes \
+            --target "${GITHUB_SHA}" \
+            "${NOTES_ARGS[@]}" \
             "${ARCHIVE_PREFIX}-${VERSION}.tar.gz" \
             "${ARCHIVE_PREFIX}-${VERSION}.zip" \
             "${ARCHIVE_PREFIX}-${VERSION}.tar.gz.sha256" \
             "${ARCHIVE_PREFIX}-${VERSION}.zip.sha256"
-
-  # ── Publish to PowerShell Gallery ──────────────────────────
-  publish-psgallery:
-    name: Publish to PSGallery
-    needs: release
-    runs-on: ubuntu-latest
-    if: vars.ENABLE_PSGALLERY == 'true'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install PowerShell
-        run: |
-          if ! command -v pwsh &> /dev/null; then
-            sudo apt-get update && sudo apt-get install -y powershell
-          fi
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Build Studio UI
-        working-directory: studio-ui
-        run: npm ci && npm run build
-
-      - name: Prepare module
-        shell: pwsh
-        run: |
-          $version = "${{ needs.release.outputs.version }}"
-          $staging = "publish-staging/Dotbot"
-          New-Item -ItemType Directory -Path $staging -Force
-          Copy-Item dotbot.psd1, dotbot.psm1, install.ps1, install-remote.ps1, LICENSE, README.md -Destination $staging
-          Copy-Item -Recurse scripts, workflows, stacks -Destination $staging
-          # Include studio-ui runtime files
-          $studioStaging = Join-Path $staging 'studio-ui'
-          New-Item -ItemType Directory -Path $studioStaging -Force
-          Copy-Item studio-ui/server.ps1, studio-ui/StudioAPI.psm1 -Destination $studioStaging
-          Copy-Item -Recurse studio-ui/static -Destination (Join-Path $studioStaging 'static')
-          # Rename to PascalCase for PSGallery convention
-          Rename-Item "$staging/dotbot.psd1" "Dotbot.psd1"
-          Rename-Item "$staging/dotbot.psm1" "Dotbot.psm1"
-          $psd1 = Get-Content "$staging/Dotbot.psd1" -Raw
-          $psd1 = $psd1 -replace "RootModule = 'dotbot.psm1'", "RootModule = 'Dotbot.psm1'"
-          $psd1 = $psd1 -replace "ModuleVersion = '.*?'", "ModuleVersion = '$version'"
-          $psd1 | Set-Content "$staging/Dotbot.psd1" -NoNewline
-
-      - name: Publish
-        shell: pwsh
-        env:
-          PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
-        run: |
-          Publish-Module -Path "publish-staging/Dotbot" -NuGetApiKey $env:PSGALLERY_API_KEY -Verbose


### PR DESCRIPTION
## Linked issue

Closes #393

## Summary of changes

The scheduled **Bump & Release** workflow has failed 9 weeks straight because it pushed the
version commit + tag directly to protected `main` (`GH006`), and stale tags caused
`tag already exists` on re-runs. This reworks the pipeline to the PR-based flow and repairs
`release.yml` for the v4 (git-checkout + shim) layout.

**`bump-release.yml`** — no longer pushes to `main`:

- Opens a `release/vX.Y.Z` **PR** instead (branch push is allowed; only `main` is protected).
- Skips the scheduled run when nothing merged since the last tag; manual `workflow_dispatch` always bumps.
- Aborts if the target tag/branch already exists (guards the duplicate-tag failure).
- Promotes the `CHANGELOG.md` `[Unreleased]` block to a dated section and re-seeds a fresh scaffold.

**`release.yml`** — triggers on the merge and repairs the v4 build:

- Trigger is now `push: main` filtered to `version.json` (+ `workflow_dispatch` for manual re-cuts).
- Resolves the version from `version.json`; **idempotency guard** skips if the release/tag exists.
- Drops the dead `pwsh install.ps1` test step; builds Studio UI from `src/studio-ui`.
- Deletes the retired PowerShell Gallery publish job.
- Release notes = promoted CHANGELOG block + v4 install footer, falling back to `--generate-notes`;
  `gh release create --target $GITHUB_SHA` creates the tag itself.

**Resulting flow:** bump PR opens → a maintainer approves + merges → the `version.json` change lands
on `main` → `release.yml` fires on that push and cuts `vX.Y.Z`. No direct push to `main`.

## Testing notes

Post-merge, to validate on the real repo: `workflow_dispatch` **Bump & Release** → approve + merge the
PR → confirm **Release & Publish** fires on the `version.json` push and creates the release; re-run it
for the same version to confirm the idempotency guard skips.

## Checklist

- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
- [ ] Tests added or updated — N/A
- [ ] Docs updated (if behaviour changed)
