### PR TITLE
fix(workflow): recipe resolver + output path normalize (#568)

### DIFF
--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -720,11 +720,12 @@ function Test-TaskOutput {
         foreach ($f in $taskOutputs) {
             $entry = ([string]$f -replace '\\', '/').Trim()
             if ([string]::IsNullOrWhiteSpace($entry)) { continue }
-            # Only a drive-qualified (C:/...) or UNC (//host/...) path is absolute.
-            # NB: [IO.Path]::IsPathRooted treats a bare leading "/" as rooted on
-            # Windows, which would mis-resolve a relative entry against the current
-            # drive — so match explicitly instead.
-            $target = if ($entry -match '^[A-Za-z]:/' -or $entry -match '^//') {
+            # IsPathFullyQualified is the cross-platform "truly absolute" test:
+            # on Windows "C:/x" and "//host/x" are fully qualified but a bare "/x"
+            # is only drive-relative (correctly treated as relative here); on
+            # Linux/macOS "/tmp/x" is fully qualified. This avoids [IO.Path]::
+            # IsPathRooted, which treats a bare leading "/" as rooted on Windows.
+            $target = if ([System.IO.Path]::IsPathFullyQualified($entry)) {
                 $entry
             } elseif ($entry -match '^\.bot/') {
                 Join-Path $projectRoot $entry

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -710,8 +710,31 @@ function Test-TaskOutput {
         $taskOutputsDir = if ($Task -is [System.Collections.IDictionary]) { $Task['required_outputs_dir'] } else { $Task.required_outputs_dir }
     }
     if ($taskOutputs) {
+        # Output entries may be a bare filename ("x.md"), a repo-rooted path
+        # (".bot/workspace/product/x.md" — e.g. emitted by the deep-research
+        # generator), or an absolute path. $ProductDir is already
+        # <botroot>/workspace/product, so naively Join-Path'ing a rooted entry
+        # double-joins (PowerShell only defers to the 2nd arg when it is
+        # drive-absolute) and validation always fails. Normalise first.
+        $projectRoot = Split-Path -Parent $BotRoot
         foreach ($f in $taskOutputs) {
-            if (-not (Test-Path (Join-Path $ProductDir $f))) {
+            $entry = ([string]$f -replace '\\', '/').Trim()
+            if ([string]::IsNullOrWhiteSpace($entry)) { continue }
+            # Only a drive-qualified (C:/...) or UNC (//host/...) path is absolute.
+            # NB: [IO.Path]::IsPathRooted treats a bare leading "/" as rooted on
+            # Windows, which would mis-resolve a relative entry against the current
+            # drive — so match explicitly instead.
+            $target = if ($entry -match '^[A-Za-z]:/' -or $entry -match '^//') {
+                $entry
+            } elseif ($entry -match '^\.bot/') {
+                Join-Path $projectRoot $entry
+            } else {
+                Join-Path $ProductDir ($entry.TrimStart('/'))
+            }
+            # -LiteralPath: task-authored entries are untrusted; without it a
+            # filename containing [ ] would be treated as a wildcard (mis-validated),
+            # and it avoids a wildcard/existence probe on a crafted entry.
+            if (-not (Test-Path -LiteralPath $target)) {
                 return "Task output not produced: $f"
             }
         }
@@ -949,15 +972,20 @@ function Invoke-TaskClarificationLoopIfPresent {
             Set-Content -Path $summaryPath -Value $newSummary -NoNewline
         }
 
-        # Forward slashes for cross-platform Join-Path safety (PostScriptRunner.psm1
-        # uses the same normalisation — Windows accepts either separator, Unix does not).
-        $adjustPromptPath = Join-Path $BotRoot "recipes/includes/adjust-after-answers.md"
-        if (-not (Test-Path $adjustPromptPath)) {
-            # Escalate via the postScriptFailed path so the worktree merge is
-            # blocked. Without the adjust prompt the answers cannot be applied
-            # to artifacts; merging would be incorrect.
+        # Resolve the adjust-after-answers recipe through the canonical content
+        # resolver (project .bot/content/recipes -> user -> $DOTBOT_HOME/content
+        # /recipes). A hardcoded "$BotRoot/recipes/..." never resolves: content
+        # install never populates a .bot/recipes tree (the worktree recipe-link is
+        # gated on that same non-existent dir), so inside a task worktree the file
+        # was always missing and the apply-answers step wrongly escalated.
+        $adjustPromptPath = Resolve-DotbotContent -BotRoot $BotRoot -Type recipes -Name 'includes/adjust-after-answers.md'
+        if (-not $adjustPromptPath) {
+            # Only reachable when the recipe is absent from every content tier —
+            # i.e. a broken framework install, which no operator "needs-input"
+            # answer can fix. Fail loud with a clear message rather than parking
+            # the task in needs-input (and never silently skip the adjust pass).
             Reset-ClarificationState -PD $ProcessData -Id $ProcId -TaskName $Task.name
-            return "Adjust prompt not found at $adjustPromptPath — cannot apply clarification answers"
+            return "Adjust-after-answers recipe not found in project or framework content (content/recipes/includes/adjust-after-answers.md) — framework install may be broken."
         }
         $adjustContent = Get-Content $adjustPromptPath -Raw
         $adjustPrompt = @"

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1539,6 +1539,13 @@ if ($ttoFn) {
             -Message "A repo-rooted output entry must resolve under ProductDir, not double-join to .bot/workspace/product/.bot/workspace/product/..."
         Assert-True -Name "Test-TaskOutput: nested rooted .bot/ path validates" `
             -Condition ($null -eq (Test-TaskOutput -Task @{ outputs = @('.bot/workspace/product/briefing/repos/Foo.md') } -BotRoot $ttoBot -ProductDir $ttoProd))
+        # A fully-qualified absolute path (platform-native: C:\... on Windows,
+        # /tmp/... on Linux/macOS) must be used as-is, not trimmed and re-joined
+        # under ProductDir. Build a real absolute path to an existing fixture file.
+        $absOut = (Resolve-Path (Join-Path $ttoProd "research-repos.md")).Path
+        Assert-True -Name "Test-TaskOutput: fully-qualified absolute path validates" `
+            -Condition ($null -eq (Test-TaskOutput -Task @{ outputs = @($absOut) } -BotRoot $ttoBot -ProductDir $ttoProd)) `
+            -Message "An absolute output path must be tested as-is (regression: POSIX /tmp/... was treated as relative and joined under ProductDir)."
         Assert-True -Name "Test-TaskOutput: genuinely missing output is reported" `
             -Condition ((Test-TaskOutput -Task @{ outputs = @('does-not-exist.md') } -BotRoot $ttoBot -ProductDir $ttoProd) -match 'not produced')
     } finally {

--- a/tests/Test-WorkflowManifest.ps1
+++ b/tests/Test-WorkflowManifest.ps1
@@ -1516,6 +1516,43 @@ Assert-True -Name "Test-TaskOutput supports outputs_dir + min_output_count" `
 Assert-True -Name "Test-TaskOutput falls back to absolute count for non-tasks/ on zero delta" `
     -Condition ($workflowSrc -match 'if\s*\(\$isTasksOutput\s+-or\s+\$fileCount\s+-lt\s+\$minCount\)') `
     -Message "Resume-after-approval would fail when delta is 0 and the artifact already exists unless non-tasks/ outputs fall back to the absolute file count."
+# #568 bug 3 (behavioral): an output declared as a repo-rooted path
+# (".bot/workspace/product/x.md") must resolve to the SAME file as a bare "x.md",
+# not double-join onto $ProductDir (which already ends in workspace/product).
+# Extract just Test-TaskOutput from the script and exercise it against a temp tree.
+$ttoAst = [System.Management.Automation.Language.Parser]::ParseFile($workflowProcessPath, [ref]$null, [ref]$null)
+$ttoFn = $ttoAst.Find({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq 'Test-TaskOutput' }, $true)
+Assert-True -Name "Test-TaskOutput function is extractable" -Condition ([bool]$ttoFn)
+if ($ttoFn) {
+    . ([ScriptBlock]::Create($ttoFn.Extent.Text))
+    $ttoRoot = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-tto-$([System.Guid]::NewGuid().ToString().Substring(0,8))"
+    $ttoBot = Join-Path $ttoRoot ".bot"
+    $ttoProd = Join-Path $ttoBot "workspace/product"
+    New-Item -ItemType Directory -Force -Path (Join-Path $ttoProd "briefing/repos") | Out-Null
+    Set-Content -Path (Join-Path $ttoProd "research-repos.md") -Value "x"
+    Set-Content -Path (Join-Path $ttoProd "briefing/repos/Foo.md") -Value "x"
+    try {
+        Assert-True -Name "Test-TaskOutput: bare filename validates" `
+            -Condition ($null -eq (Test-TaskOutput -Task @{ outputs = @('research-repos.md') } -BotRoot $ttoBot -ProductDir $ttoProd))
+        Assert-True -Name "Test-TaskOutput: rooted .bot/ path validates (no double-join)" `
+            -Condition ($null -eq (Test-TaskOutput -Task @{ outputs = @('.bot/workspace/product/research-repos.md') } -BotRoot $ttoBot -ProductDir $ttoProd)) `
+            -Message "A repo-rooted output entry must resolve under ProductDir, not double-join to .bot/workspace/product/.bot/workspace/product/..."
+        Assert-True -Name "Test-TaskOutput: nested rooted .bot/ path validates" `
+            -Condition ($null -eq (Test-TaskOutput -Task @{ outputs = @('.bot/workspace/product/briefing/repos/Foo.md') } -BotRoot $ttoBot -ProductDir $ttoProd))
+        Assert-True -Name "Test-TaskOutput: genuinely missing output is reported" `
+            -Condition ((Test-TaskOutput -Task @{ outputs = @('does-not-exist.md') } -BotRoot $ttoBot -ProductDir $ttoProd) -match 'not produced')
+    } finally {
+        Remove-Item $ttoRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# #568 bug 1: the clarification apply-answers recipe must resolve through the content
+# resolver (project -> user -> framework), not a hardcoded $BotRoot/recipes path that
+# dotbot never materialises (which made the file always missing inside a worktree).
+Assert-True -Name "Clarification apply-answers resolves recipe via Resolve-DotbotContent" `
+    -Condition (($workflowSrc -match "Resolve-DotbotContent\s+-BotRoot\s+\`$BotRoot\s+-Type\s+recipes\s+-Name\s+'includes/adjust-after-answers\.md'") -and
+                (-not ($workflowSrc -match 'Join-Path\s+\$BotRoot\s+"recipes/includes/adjust-after-answers\.md"'))) `
+    -Message "adjust-after-answers.md must be resolved via Resolve-DotbotContent, not a hardcoded .bot/recipes path that is never materialised."
 Assert-True -Name "Measure-TaskFile counts workflow-run task files" `
     -Condition (($workflowSrc -match 'Get-ChildItem\s+-LiteralPath\s+\$tasksRoot\s+-Recurse\s+-Filter\s+''\*\.json''') -and
                 ($workflowSrc -match "\$_.Name\s+-ne\s+'run\.json'")) `


### PR DESCRIPTION
## Linked issue

Closes #568
Refs #557

> Child PR of the 8-bug epic #557, delivering **bugs 1 and 3**. Merging `Closes` #568; #557 stays open until the last child lands.

## Summary of changes

`src/runtime/Scripts/Invoke-WorkflowProcess.ps1`:

**Bug 1 — clarification apply-answers recipe.** The step resolved the recipe at a hardcoded `$BotRoot/recipes/includes/adjust-after-answers.md`. Content-install never populates a `.bot/recipes` tree (recipes live in `content/recipes` / `$DOTBOT_HOME`; the worktree recipe-link is gated on that same non-existent dir), so inside a task worktree the file was always missing and the step wrongly escalated to `needs-input`. Now resolved via **`Resolve-DotbotContent`** (project → user → framework), matching the pattern already used for prompt templates in this script. If the recipe is absent from every tier (broken framework install), it **hard-fails with a clear message** instead of parking the task in `needs-input` (which no operator answer could recover), and never silently skips the adjust pass.

**Bug 3 — output-path double-join.** `Test-TaskOutput` did `Test-Path (Join-Path $ProductDir $f)`, but `$ProductDir` already ends in `workspace/product`, so a repo-rooted output entry (`.bot/workspace/product/x.md`, as the deep-research generator emits) double-joined to `…/product/.bot/workspace/product/…` and never validated. Entries are now normalized: drive/UNC-absolute used as-is, `.bot/`-rooted resolved from the project root, everything else joined under `$ProductDir`. Matches drive/UNC absolutes explicitly (not `[IO.Path]::IsPathRooted`, which treats a bare leading `/` as rooted on Windows), coerces entries to string, skips empties, and uses `Test-Path -LiteralPath` (untrusted input; also fixes `[`/`]`-in-filename).

Follow-up (separate PR off `main`): the same `.bot/recipes` mismatch also affects the standards-dir lookup (L1085), the dead worktree recipe-link (`Dotbot.Worktree.psm1`), and an identical dead path in `Dotbot.Task.psm1:1445` — tracked separately to keep this diff tight.

## Testing notes

`tests/Test-WorkflowManifest.ps1` (Layer 1): **545 pass, 0 fail**. Added behavioral coverage for `Test-TaskOutput` (AST-extracts the function and runs it): bare filename, repo-rooted `.bot/…`, nested rooted path, and genuinely-missing output — plus a guard that the adjust recipe resolves via `Resolve-DotbotContent`. `PARSE OK`; PSScriptAnalyzer clean on the diff (only pre-existing warnings). Reviewed with `/pwsh-review` (5 agents + static): ship, 0 blockers/majors; minor findings applied.

To verify manually: run a `start-from-jira` clarification round in a worktree — the apply-answers step completes instead of escalating to `needs-input`; and a task declaring `outputs: [".bot/workspace/product/x.md"]` validates once the file exists.

## Checklist

- [x] Tests added or updated
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
