### PR TITLE
fix(process): dep-gated conditions + barriers wait for spawned children (#569)

### DIFF
--- a/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
+++ b/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
@@ -623,6 +623,51 @@ function Get-NextWorkflowTask {
         }
         return $true
     }
+    function _HasOutstandingGeneratedChildren { param($Task, $All)
+        # True when any non-terminal task was generated/expanded by one of $Task's
+        # dependencies. Children stamp extensions.runner.generated_by = <parent id>
+        # and provenance.expanded_by = "task:<parent id>"; a barrier's dependencies
+        # are canonical parent ids, so this is a direct id match (with a slug
+        # fallback for name-based deps). Scope note: this is invoked only for
+        # type=barrier tasks and matches direct children (not nested descendants);
+        # widening is a one-line change at the call site.
+        $deps = @($Task.dependencies) | Where-Object { $_ } | ForEach-Object { [string]$_ }
+        if ($deps.Count -eq 0) { return $false }
+        $depSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($d in $deps) {
+            [void]$depSet.Add($d)
+            $slug = ($d -replace '[^a-zA-Z0-9\s-]','' -replace '\s+','-').ToLowerInvariant()
+            if ($slug) { [void]$depSet.Add($slug) }
+        }
+        foreach ($t in $All) {
+            $c = $t.Content
+            # "Complete" uses the SAME rule as the dependency done-set above: a
+            # skipped child counts as complete only when its skip reason is
+            # intentional. A framework-error skip (max-retries / non-recoverable)
+            # is NOT complete — Reset-SkippedTasks retries it — so the barrier must
+            # keep waiting rather than fire over failed/​retried work. needs-input /
+            # needs-review children are likewise outstanding until resolved.
+            $childComplete = switch ([string]$c.status) {
+                'done'      { $true }
+                'cancelled' { $true }
+                'split'     { $true }
+                'skipped'   { $r = Get-DotbotTaskSkipReason -TaskContent $c; [bool]($r -and $intentionalSkips -contains $r) }
+                default     { $false }
+            }
+            if ($childComplete) { continue }
+            $gen = Get-DotbotTaskNestedProp -Object $c -Path @('extensions','runner','generated_by')
+            $exp = Get-DotbotTaskNestedProp -Object $c -Path @('provenance','expanded_by')
+            if ($exp -and "$exp" -match '^task:(.+)$') { $exp = $Matches[1] }
+            foreach ($ref in @($gen, $exp)) {
+                if (-not $ref) { continue }
+                $refStr = [string]$ref
+                if ($depSet.Contains($refStr)) { return $true }
+                $refSlug = ($refStr -replace '[^a-zA-Z0-9\s-]','' -replace '\s+','-').ToLowerInvariant()
+                if ($refSlug -and $depSet.Contains($refSlug)) { return $true }
+            }
+        }
+        return $false
+    }
     function _IsTaskIgnored { param($Task)
         if ($Task.PSObject.Properties['ignore'] -and $Task.ignore -and
             $Task.ignore.PSObject.Properties['manual'] -and $Task.ignore.manual -eq $true) {
@@ -662,7 +707,18 @@ function Get-NextWorkflowTask {
     foreach ($cand in $candidates) {
         $c = $cand.Content
         if (_IsTaskIgnored -Task $c) { continue }
+        # Dependencies gate the manifest condition. Evaluating the condition first
+        # (as this loop used to) permanently skipped a task whose condition points
+        # at a file its own upstream dependency produces — the file does not exist
+        # yet at launch, so the task was marked condition-not-met before the
+        # producer ran, and that skip cascaded (condition-not-met satisfies
+        # dependents). Checking deps first keeps such a task 'todo' (blocked); the
+        # condition is re-evaluated on a later selection pass once the producer has
+        # completed (Get-NextWorkflowTask reloads task state from disk each call).
+        if (-not (_AreDepsMet -Task $c -Set $doneSet)) { $blockedCount++; continue }
         if (-not (_IsManifestConditionMet -Task $c)) {
+            # Deps are satisfied but the condition is genuinely unmet, so the
+            # producing task has already had its turn — a real condition-skip.
             try {
                 _MarkConditionNotMet -Candidate $cand
             } catch {
@@ -673,7 +729,16 @@ function Get-NextWorkflowTask {
             }
             continue
         }
-        if (-not (_AreDepsMet -Task $c -Set $doneSet)) { $blockedCount++; continue }
+        # A barrier must not fire while work its dependencies spawned into
+        # tasks/todo is still outstanding. Its explicit deps (the generator) go
+        # done the instant generation finishes, but the spawned children run after.
+        if (([string]$c.type -eq 'barrier') -and (_HasOutstandingGeneratedChildren -Task $c -All $allTasks)) {
+            if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
+                Write-BotLog -Level Debug -Message "Barrier '$($c.name)' blocked: generated children of its dependencies are not yet complete."
+            }
+            $blockedCount++
+            continue
+        }
         $eligible += $cand
     }
     if ($eligible.Count -gt 0) {

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -1675,6 +1675,126 @@ finally {
     }
 }
 
+# ─── Get-NextWorkflowTask scheduling: condition-order + barrier wiring (#569) ──
+# Bug 4: a task whose manifest condition points at a file its own upstream
+# dependency produces must stay 'todo' (blocked) until the producer runs — not be
+# skipped condition-not-met at launch. Bug 5: a barrier must not fire while work
+# its dependencies spawned into tasks/todo is still outstanding.
+
+$testProject569 = $null
+$savedDotbotProjectRoot569 = $global:DotbotProjectRoot
+try {
+    $testProject569 = New-SourceBackedTestProject -RepoRoot $repoRoot
+    Push-Location $testProject569
+    $botDir569 = Join-Path $testProject569 ".bot"
+    $runDir569 = Join-Path $botDir569 "workspace\tasks\workflow-runs\run-569"
+    New-Item -ItemType Directory -Path $runDir569 -Force | Out-Null
+    $global:DotbotProjectRoot = $testProject569
+
+    Import-Module (Join-Path $botDir569 "src/runtime/Modules/Dotbot.Task/Dotbot.Task.psd1")     -Force -DisableNameChecking
+    Import-Module (Join-Path $botDir569 "src/runtime/Modules/Dotbot.Workflow/Dotbot.Workflow.psd1") -Force -DisableNameChecking
+    Import-Module (Join-Path $botDir569 "src/runtime/Modules/Dotbot.Process/Dotbot.Process.psd1")  -Force -DisableNameChecking
+
+    function New-SchedTaskFixture {
+        param(
+            [Parameter(Mandatory)][string]$TaskId,
+            [Parameter(Mandatory)][string]$Status,
+            [string]$Type = 'prompt',
+            [int]$Priority = 50,
+            [string[]]$Dependencies = @(),
+            [string]$Condition,
+            [string]$GeneratedBy
+        )
+        $task = [ordered]@{
+            id           = $TaskId
+            name         = "Fixture $TaskId"
+            description  = "scheduling fixture"
+            status       = $Status
+            type         = $Type
+            priority     = $Priority
+            dependencies = @($Dependencies)
+            provenance   = [ordered]@{ workflow = 'sched569-cond'; run_id = 'run-569' }
+            updated_at   = "2026-01-01T00:00:00Z"
+        }
+        $ext = [ordered]@{}
+        if ($Condition)   { $ext['workflow'] = [ordered]@{ condition = $Condition } }
+        if ($GeneratedBy) { $ext['runner']   = [ordered]@{ generated_by = $GeneratedBy } }
+        if ($ext.Count -gt 0) { $task['extensions'] = $ext }
+        $task | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $runDir569 "$TaskId.json") -Encoding UTF8
+    }
+
+    # ── Bug 4: condition gated behind dependencies ──
+    $gateRel  = ".bot/workspace/product/gate-569.md"
+    $gateFull = Join-Path $testProject569 $gateRel
+    New-Item -ItemType Directory -Path (Split-Path $gateFull -Parent) -Force | Out-Null
+    if (Test-Path $gateFull) { Remove-Item $gateFull -Force }
+
+    New-SchedTaskFixture -TaskId "prod-569"  -Status "todo" -Priority 90
+    New-SchedTaskFixture -TaskId "cond-569"  -Status "todo" -Priority 50 -Dependencies @("prod-569") -Condition $gateRel
+
+    # Pass 1: gate file absent, producer not done. The conditioned task must NOT be
+    # selected and must NOT be marked skipped — it stays todo (blocked on deps).
+    $p1 = Get-NextWorkflowTask -BotRoot $botDir569 -WorkflowName 'sched569-cond'
+    Assert-True -Name "#569 bug4: producer selected first (conditioned task blocked)" `
+        -Condition ($p1.success -and $p1.task -and $p1.task['id'] -eq 'prod-569') `
+        -Message "Expected prod-569, got: $($p1 | ConvertTo-Json -Compress)"
+    $condOnDisk1 = (Get-Content (Join-Path $runDir569 "cond-569.json") -Raw | ConvertFrom-Json)
+    Assert-Equal -Name "#569 bug4: conditioned task stays todo (not condition-not-met) while deps unmet" `
+        -Expected "todo" -Actual ([string]$condOnDisk1.status)
+
+    # Producer completes and creates the gated artifact.
+    $prodDisk = Get-Content (Join-Path $runDir569 "prod-569.json") -Raw | ConvertFrom-Json
+    $prodDisk.status = "done"
+    $prodDisk | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $runDir569 "prod-569.json") -Encoding UTF8
+    Set-Content -Path $gateFull -Value "gate" -Encoding UTF8
+
+    # Pass 2: deps met and condition now true → conditioned task becomes eligible.
+    $p2 = Get-NextWorkflowTask -BotRoot $botDir569 -WorkflowName 'sched569-cond'
+    Assert-True -Name "#569 bug4: conditioned task runs once producer done + condition met" `
+        -Condition ($p2.success -and $p2.task -and $p2.task['id'] -eq 'cond-569') `
+        -Message "Expected cond-569, got: $($p2 | ConvertTo-Json -Compress)"
+
+    # ── Bug 5: barrier waits for its dependency's spawned children ──
+    $barRun = Join-Path $botDir569 "workspace\tasks\workflow-runs\run-569b"
+    New-Item -ItemType Directory -Path $barRun -Force | Out-Null
+    function New-BarrierFixture {
+        param([string]$TaskId,[string]$Status,[string]$Type='prompt',[int]$Priority=50,[string[]]$Dependencies=@(),[string]$GeneratedBy)
+        $task = [ordered]@{
+            id=$TaskId; name="Fixture $TaskId"; description="barrier fixture"; status=$Status; type=$Type
+            priority=$Priority; dependencies=@($Dependencies)
+            provenance=[ordered]@{ workflow='sched569-barrier'; run_id='run-569b' }; updated_at="2026-01-01T00:00:00Z"
+        }
+        if ($GeneratedBy) { $task['extensions'] = [ordered]@{ runner = [ordered]@{ generated_by = $GeneratedBy } } }
+        $task | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $barRun "$TaskId.json") -Encoding UTF8
+    }
+    New-BarrierFixture -TaskId "gen-569"   -Status "done" -Type "task_gen" -Priority 90
+    New-BarrierFixture -TaskId "child-569" -Status "todo" -Type "prompt"   -Priority 10 -GeneratedBy "gen-569"
+    New-BarrierFixture -TaskId "barr-569"  -Status "todo" -Type "barrier"  -Priority 80 -Dependencies @("gen-569")
+
+    # Barrier has higher priority than the child and its explicit dep (gen) is done,
+    # so without the fix it would be selected first. It must instead stay blocked
+    # while the generated child is non-terminal → the child is selected.
+    $b1 = Get-NextWorkflowTask -BotRoot $botDir569 -WorkflowName 'sched569-barrier'
+    Assert-True -Name "#569 bug5: barrier blocked while generated child is todo (child selected)" `
+        -Condition ($b1.success -and $b1.task -and $b1.task['id'] -eq 'child-569') `
+        -Message "Expected child-569 (barrier must wait), got: $($b1 | ConvertTo-Json -Compress)"
+
+    # Child completes → barrier's generated work is done → barrier becomes eligible.
+    $childDisk = Get-Content (Join-Path $barRun "child-569.json") -Raw | ConvertFrom-Json
+    $childDisk.status = "done"
+    $childDisk | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $barRun "child-569.json") -Encoding UTF8
+
+    $b2 = Get-NextWorkflowTask -BotRoot $botDir569 -WorkflowName 'sched569-barrier'
+    Assert-True -Name "#569 bug5: barrier fires once generated children complete" `
+        -Condition ($b2.success -and $b2.task -and $b2.task['id'] -eq 'barr-569') `
+        -Message "Expected barr-569, got: $($b2 | ConvertTo-Json -Compress)"
+}
+finally {
+    $global:DotbotProjectRoot = $savedDotbotProjectRoot569
+    Pop-Location -ErrorAction SilentlyContinue
+    if ($testProject569) { Remove-TestProject -Path $testProject569 }
+}
+
 # ─── task-get-next runtime condition evaluation ──────────────────────────────
 # task-get-next is a thin HTTP wrapper around GET /tasks/next. Condition
 # evaluation is covered by handler-level runtime tests.


### PR DESCRIPTION
## Linked issue

Closes #569
Refs #557

> Child PR of the 8-bug epic #557, delivering **bugs 4 and 5**. Merging `Closes` #569; #557 stays open until the last child lands.

## Summary of changes

`src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1` — both fixes in the `Get-NextWorkflowTask` candidate loop:

**Bug 4 — premature, cascading condition-skip.** The loop evaluated `_IsManifestConditionMet` *before* `_AreDepsMet`, so a task whose manifest `condition` points at a file its own upstream dependency produces was marked `skipped`/`condition-not-met` at launch (the file doesn't exist yet), added to the done-set, and — since `condition-not-met` satisfies dependents — cascaded the skip down the chain (observed live: 6 implementation-chain tasks skipped in `start-from-jira`). Now `_AreDepsMet` is checked **first**: a task with unmet deps stays `todo` (blocked, never marked), and because `Get-NextWorkflowTask` reloads from disk each call, its condition re-evaluates once the producer completes. A genuinely-false condition on a dep-met task is still a real `condition-not-met` skip.

**Bug 5 — barriers ignored dynamically-spawned children.** `_AreDepsMet` only inspects the explicit `dependencies` array, so a `barrier` fired the instant its generator dependency went `done` — while the children the generator spawned into `tasks/todo` (stamped `extensions.runner.generated_by` / `provenance.expanded_by`) were still running. New `_HasOutstandingGeneratedChildren` blocks a `type=barrier` candidate while any non-complete task was generated by one of its dependencies. "Complete" reuses the **same rule as the dependency done-set** (done/cancelled/split, or `skipped` only with an intentional reason), so a framework-error skip (`max-retries`, which `Reset-SkippedTasks` retries) or a `needs-input`/`needs-review` child keeps the barrier waiting rather than firing over unfinished work. Barrier-scoped, direct children only — verified complete for all shipped workflows; widening is a one-line scope-predicate change.

## Testing notes

`tests/Test-TaskActions.ps1` (Layer 2) adds behavioral coverage calling the exported `Get-NextWorkflowTask` against on-disk task fixtures:
- **Bug 4:** producer + a dependent conditioned on the producer's output. Pass 1 (file absent): producer is selected and the conditioned task **stays `todo`** (not `condition-not-met`). Mark producer done + create the file → pass 2 selects the conditioned task.
- **Bug 5:** `done` generator + a `todo` child stamped `generated_by`, plus a higher-priority `barrier` depending on the generator. Assert the barrier is **not** selected while the child is non-terminal (child selected); mark child `done` → barrier is then selected.

Run: `pwsh ./tests/Test-TaskActions.ps1` (or `./tests/Run-Tests.ps1 -Layer 2`). `PARSE OK`; PSScriptAnalyzer clean on the changed region; reviewed with `/pwsh-review` (diff-bug + idioms + history) — one major (child-complete semantics) applied, no blockers.

## Checklist

- [x] Tests added or updated
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
