### PR TITLE
fix(worktree): classify orphan unrelated-history merge conflicts (#570)

### DIFF
--- a/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
+++ b/src/runtime/Modules/Dotbot.Task/Dotbot.Task.psm1
@@ -1022,6 +1022,25 @@ function New-MergeFailurePendingQuestion {
                 asked_at       = $askedAt
             }
         }
+        'unrelated_history' {
+            # Two task worktrees were both cut before the project had any commits,
+            # so they are orphan roots with no common ancestor. Both added the same
+            # file(s) with different content — there is no base to auto-merge
+            # against, so the operator must choose which version wins.
+            $conflictDetail = if ($ConflictFiles.Count -gt 0) { $ConflictFiles -join '; ' } else { '(none reported)' }
+            return @{
+                id             = "merge-unrelated-history"
+                question       = "Unrelated-history merge conflict — this task predates the project's first commit"
+                context        = "This task's worktree was created before the project had any commits, so it shares no history with main. It and an earlier task both produced these file(s): $conflictDetail. There is no common ancestor to auto-merge, so choose which version to keep. Worktree preserved at: $WorktreePath"
+                options        = @(
+                    @{ key = "A"; label = "Open the worktree and merge manually (recommended)"; rationale = "Inspect both versions at $WorktreePath, reconcile the file(s), then retry merge" }
+                    @{ key = "B"; label = "Keep this task's version"; rationale = "Overwrite main's copy of the conflicting file(s) with this task's version" }
+                    @{ key = "C"; label = "Keep main's version (discard this task's changes to those files)"; rationale = "Abandon this task's copy of the conflicting file(s) and keep what is already on main" }
+                )
+                recommendation = "A"
+                asked_at       = $askedAt
+            }
+        }
         'branch_missing' {
             return @{
                 id             = "branch-missing"

--- a/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1
+++ b/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1
@@ -1808,11 +1808,9 @@ function Complete-TaskWorktree {
             # conflict on <file>" pending_question instead of a generic
             # "Squash-merge command failed". Falls back to merge_command_failed
             # for non-conflict apply failures (no patch context, etc.).
-            # $mergeResult is a hashtable (Apply-TaskBranchPatch returns @{...}), and
-            # a hashtable's keys are NOT surfaced via .PSObject.Properties[...] — that
-            # check silently returned empty, dropping conflict_files for every merge
-            # failure routed through here (incl. rebase_conflict). Use key/member
-            # access, mirroring Move-TaskToMergeFailureNeedsInput's dual check.
+            # $mergeResult is a hashtable — its keys aren't surfaced via
+            # .PSObject.Properties[...], which silently dropped conflict_files for
+            # every merge failure (rebase_conflict and unrelated_history). Use key access.
             $applyConflicts = if ($mergeResult -is [hashtable]) {
                 if ($mergeResult.ContainsKey('conflict_files')) { @($mergeResult['conflict_files'] | Where-Object { $_ }) } else { @() }
             } elseif ($mergeResult -and $mergeResult.PSObject.Properties['conflict_files']) {

--- a/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1
+++ b/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1
@@ -1252,6 +1252,11 @@ function Apply-TaskBranchPatch {
         [Parameter(Mandatory)][string]$BranchName
     )
 
+    # When two task branches were both cut while the project had no commits, they
+    # are unrelated orphan roots with no merge-base. Track that so a resulting
+    # conflict can be reported as 'unrelated_history' (an operator-recoverable,
+    # no-common-ancestor collision) rather than the generic 'rebase_conflict'.
+    $unrelatedHistory = $false
     $mergeBase = (git -C $ProjectRoot merge-base $BaseBranch $BranchName 2>$null)
     if ($LASTEXITCODE -ne 0 -or -not $mergeBase) {
         git -C $ProjectRoot rev-parse --verify "$BranchName^{commit}" 2>$null | Out-Null
@@ -1266,6 +1271,7 @@ function Apply-TaskBranchPatch {
         # task branches still have no merge-base; replay them as changes from
         # the empty tree so any task can be the first one completed.
         $mergeBase = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+        $unrelatedHistory = $true
     }
 
     $patchPath = [System.IO.Path]::GetTempFileName()
@@ -1357,11 +1363,18 @@ function Apply-TaskBranchPatch {
                 Remove-Item -LiteralPath $targetPath -Force -ErrorAction SilentlyContinue
             }
 
+            # An empty-tree (unrelated-history) base means the conflict is an
+            # add/add between two orphan branches with no common ancestor — there
+            # is no automatic correct merge, so surface it as its own kind so the
+            # operator gets an actionable choice instead of an opaque conflict.
+            $failureKind = if ($conflictFiles.Count -gt 0) {
+                if ($unrelatedHistory) { 'unrelated_history' } else { 'rebase_conflict' }
+            } else { $null }
             return @{
                 success        = $false
                 output         = @($applyOutput | ForEach-Object { "$_" })
                 conflict_files = $conflictFiles
-                failure_kind   = if ($conflictFiles.Count -gt 0) { 'rebase_conflict' } else { $null }
+                failure_kind   = $failureKind
             }
         }
 
@@ -1795,15 +1808,22 @@ function Complete-TaskWorktree {
             # conflict on <file>" pending_question instead of a generic
             # "Squash-merge command failed". Falls back to merge_command_failed
             # for non-conflict apply failures (no patch context, etc.).
-            $applyConflicts = if ($mergeResult.PSObject.Properties['conflict_files']) {
+            # $mergeResult is a hashtable (Apply-TaskBranchPatch returns @{...}), and
+            # a hashtable's keys are NOT surfaced via .PSObject.Properties[...] — that
+            # check silently returned empty, dropping conflict_files for every merge
+            # failure routed through here (incl. rebase_conflict). Use key/member
+            # access, mirroring Move-TaskToMergeFailureNeedsInput's dual check.
+            $applyConflicts = if ($mergeResult -is [hashtable]) {
+                if ($mergeResult.ContainsKey('conflict_files')) { @($mergeResult['conflict_files'] | Where-Object { $_ }) } else { @() }
+            } elseif ($mergeResult -and $mergeResult.PSObject.Properties['conflict_files']) {
                 @($mergeResult.conflict_files | Where-Object { $_ })
             } else { @() }
             $applyKind = [string]$mergeResult.failure_kind
             $resolvedKind = if ($applyKind) { $applyKind } else { 'merge_command_failed' }
-            $resolvedMessage = if ($resolvedKind -eq 'rebase_conflict') {
-                "Merge conflict during squash-merge: $($applyConflicts -join ', ')"
-            } else {
-                "Task branch patch failed: $($mergeOutput -join ' ')"
+            $resolvedMessage = switch ($resolvedKind) {
+                'rebase_conflict'    { "Merge conflict during squash-merge: $($applyConflicts -join ', ')" }
+                'unrelated_history'  { "Unrelated-history merge conflict (task predates the project's first commit): $($applyConflicts -join ', ')" }
+                default              { "Task branch patch failed: $($mergeOutput -join ' ')" }
             }
             return @{
                 success        = $false

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -154,7 +154,8 @@ if (Test-Path $worktreeManagerModule) {
         -Message "Genuinely divergent untracked local files must still block patch replay (guard intact), but the blob comparison must NOT use --no-filters: on Windows with core.autocrlf=true a raw hash of a CRLF working-tree leftover never matches the LF branch blob, falsely flagging EOL-only-stale artifacts as divergent and permanently blocking squash-merge retries (issue #517)."
     Assert-True -Name "Apply-TaskBranchPatch surfaces conflict_files + 'rebase_conflict' kind on 3-way apply failure" `
         -Condition (($worktreeManagerSrc -match 'diff\s+--name-only\s+--diff-filter=U') -and
-                    ($worktreeManagerSrc -match "failure_kind\s*=\s*if\s*\(\s*\`$conflictFiles\.Count\s*-gt\s*0\s*\)\s*\{\s*'rebase_conflict'") -and
+                    ($worktreeManagerSrc -match "\`$conflictFiles\.Count\s*-gt\s*0") -and
+                    ($worktreeManagerSrc -match "'rebase_conflict'") -and
                     ($worktreeManagerSrc -match "Merge conflict during squash-merge")) `
         -Message "An add/add conflict on a single file (e.g. .gitignore) must reach the operator as a 'rebase_conflict' pending_question naming the file, not a generic 'merge_command_failed' with empty conflict_files. See botdot task d954f7e7 incident on 2026-05-14."
 
@@ -820,6 +821,77 @@ if (Test-Path $worktreeManagerModule) {
             Remove-Item -Path $unbornWorktreeRoot -Recurse -Force -ErrorAction SilentlyContinue
         }
         Remove-TestProject -Path $unbornRoot
+    }
+
+    # #570: two orphan tasks (both cut while main was unborn) that write the SAME
+    # file collide on merge with no common ancestor. The second merge must be
+    # classified 'unrelated_history' (an actionable operator prompt) rather than
+    # the opaque, unrecoverable 'rebase_conflict'.
+    $collRoot = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-test-orphan-collide-$([System.Guid]::NewGuid().ToString().Substring(0,8))"
+    $collBot  = Join-Path $collRoot ".bot"
+    $collA = $null; $collB = $null
+    try {
+        New-Item -ItemType Directory -Path $collRoot -Force | Out-Null
+        & git -C $collRoot init --quiet 2>&1 | Out-Null
+        & git -C $collRoot config user.email "test@dotbot.dev" 2>&1 | Out-Null
+        & git -C $collRoot config user.name "Dotbot Test" 2>&1 | Out-Null
+        & git -C $collRoot symbolic-ref HEAD refs/heads/main 2>&1 | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $collBot ".control") -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $collBot "workspace/tasks") -Force | Out-Null
+        ".control/`n" | Set-Content -Path (Join-Path $collBot ".gitignore") -Encoding UTF8
+
+        # Task B is cut first (earlier orphan), then task A — both while main is unborn.
+        $collB = New-TaskWorktree -TaskId "t_collide0" -TaskName "earlier orphan writes shared file" -ProjectRoot $collRoot -BotRoot $collBot
+        $collA = New-TaskWorktree -TaskId "t_collide2" -TaskName "later orphan writes shared file" -ProjectRoot $collRoot -BotRoot $collBot
+
+        if ($collA -and $collA.success -and $collB -and $collB.success) {
+            $collRun = Join-Path $collBot "workspace/tasks/workflow-runs/2026-07-02-collide"
+            New-Item -ItemType Directory -Force -Path $collRun | Out-Null
+            @{ id = "wr_collide1"; workflow = "start-from-prompt"; status = "running" } |
+                ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $collRun "run.json") -Encoding UTF8
+            @{ id = "t_collide2"; name = "Later orphan"; status = "done"; completed_at = "2026-07-02T12:10:00Z"
+               provenance = @{ workflow = "start-from-prompt"; run_id = "wr_collide1"; definition_name = "Later orphan"; expanded_by = $null } } |
+                ConvertTo-Json -Depth 20 | Set-Content -Path (Join-Path $collRun "t_collide2.json") -Encoding UTF8
+            @{ id = "t_collide0"; name = "Earlier orphan"; status = "in-progress"
+               provenance = @{ workflow = "start-from-prompt"; run_id = "wr_collide1"; definition_name = "Earlier orphan"; expanded_by = $null } } |
+                ConvertTo-Json -Depth 20 | Set-Content -Path (Join-Path $collRun "t_collide0.json") -Encoding UTF8
+
+            # BOTH tasks write the same path with different content.
+            "content from later task A" | Set-Content -Path (Join-Path $collA.worktree_path "shared-artifact.txt") -Encoding UTF8
+            "content from earlier task B" | Set-Content -Path (Join-Path $collB.worktree_path "shared-artifact.txt") -Encoding UTF8
+
+            # Merge A first — initializes unborn main with A's shared-artifact.txt.
+            $collMergeA = Complete-TaskWorktree -TaskId "t_collide2" -ProjectRoot $collRoot -BotRoot $collBot
+            Assert-True -Name "#570 orphan-collision: first orphan merges (initializes main)" `
+                -Condition ($collMergeA.success -eq $true) `
+                -Message "Expected success, got: $($collMergeA | ConvertTo-Json -Depth 8 -Compress)"
+
+            # Merge B — same file, no common ancestor -> unrelated-history collision.
+            $collTaskB = Join-Path $collRun "t_collide0.json"
+            $tb = Get-Content -LiteralPath $collTaskB -Raw | ConvertFrom-Json
+            $tb.status = "done"; $tb | ConvertTo-Json -Depth 20 | Set-Content -Path $collTaskB -Encoding UTF8
+
+            $collMergeB = Complete-TaskWorktree -TaskId "t_collide0" -ProjectRoot $collRoot -BotRoot $collBot
+            Assert-True -Name "#570 orphan-collision: second orphan same-file merge fails (not silent success)" `
+                -Condition ($collMergeB.success -eq $false) `
+                -Message "Expected failure, got: $($collMergeB | ConvertTo-Json -Depth 8 -Compress)"
+            Assert-Equal -Name "#570 orphan-collision: classified unrelated_history (not opaque rebase_conflict)" `
+                -Expected "unrelated_history" `
+                -Actual "$($collMergeB.failure_kind)"
+            Assert-True -Name "#570 orphan-collision: conflict file reported" `
+                -Condition (@($collMergeB.conflict_files | Where-Object { $_ -match 'shared-artifact\.txt' }).Count -gt 0) `
+                -Message "Expected shared-artifact.txt in conflict_files, got: $($collMergeB.conflict_files -join ', ')"
+        } else {
+            Write-TestResult -Name "#570 orphan-collision: setup" -Status Fail -Message "worktree setup failed: A=$($collA | ConvertTo-Json -Compress) B=$($collB | ConvertTo-Json -Compress)"
+        }
+    } finally {
+        foreach ($r in @($collA, $collB)) {
+            if ($r -and $r.worktree_path -and (Test-Path $r.worktree_path)) { & git -C $collRoot worktree remove -f $r.worktree_path 2>&1 | Out-Null }
+            if ($r -and $r.branch_name) { & git -C $collRoot branch -D $r.branch_name 2>&1 | Out-Null }
+        }
+        $collWtRoot = Join-Path (Split-Path $collRoot -Parent) "worktrees/$(Split-Path $collRoot -Leaf)"
+        if (Test-Path $collWtRoot) { Remove-Item -Path $collWtRoot -Recurse -Force -ErrorAction SilentlyContinue }
+        Remove-TestProject -Path $collRoot
     }
 } else {
     Write-TestResult -Name "Dotbot.Worktree module exists" -Status Fail -Message "Module not found at $worktreeManagerModule"
@@ -3287,6 +3359,7 @@ if (Test-Path $mergeEscModule) {
     # kind → template mapping. Test it directly: cheap, deterministic, no FS I/O.
     $kindCases = @(
         @{ Kind = 'rebase_conflict';      ExpectedId = 'merge-conflict';   ExpectedOptionCount = 3 }
+        @{ Kind = 'unrelated_history';    ExpectedId = 'merge-unrelated-history'; ExpectedOptionCount = 3 }
         @{ Kind = 'branch_missing';       ExpectedId = 'branch-missing';   ExpectedOptionCount = 2 }
         @{ Kind = 'merge_command_failed'; ExpectedId = 'merge-failed';     ExpectedOptionCount = 3 }
         @{ Kind = 'commit_failed';        ExpectedId = 'commit-failed';    ExpectedOptionCount = 2 }
@@ -3320,7 +3393,7 @@ if (Test-Path $mergeEscModule) {
         # rebase_conflict puts file names in context (canonical "conflict files"
         # phrasing). All other kinds put the message + failure_detail in context
         # so the operator sees git output / exception text.
-        if ($kind -eq 'rebase_conflict') {
+        if ($kind -in @('rebase_conflict', 'unrelated_history')) {
             Assert-True -Name "Kind dispatch ($kind): context lists conflict files" `
                 -Condition ($pq.context -match 'src/foo\.cs' -and $pq.context -match 'src/bar\.cs') `
                 -Message "Expected conflict files in context"


### PR DESCRIPTION
## Linked issue

Closes #570
Refs #557

> Child PR of the 8-bug epic #557, delivering **bug 2**. Merging `Closes` #570; #557 stays open until the last child lands.

## Summary of changes

Two task worktrees both cut while the project has **no commits** are unrelated orphan roots (`--orphan` is intentional — the base is the user's repo, so no synthetic bootstrap commit). The first task initializes `main`; a second orphan then has no merge-base, so `Apply-TaskBranchPatch` falls back to the empty-tree base. When both tasks touched the **same file**, the `git apply --3way` add/add conflict was returned as the generic, **unrecoverable** `rebase_conflict`. (Different-file orphans already merge cleanly — unchanged.)

- **`Dotbot.Worktree.psm1`** — flag the empty-tree fallback and classify the resulting conflict as **`unrelated_history`** (vs `rebase_conflict`), with a distinct completion message.
- **`Dotbot.Task.psm1`** — new `unrelated_history` `pending_question` arm: the task predates the first commit and collides with an earlier task on `<files>`; operator chooses **keep task / keep main / merge by hand** (advisory labels).
- **Latent bug fixed en route:** `Complete-TaskWorktree` read `conflict_files` via `$mergeResult.PSObject.Properties[...]`, which is always empty for the **hashtable** `Apply-TaskBranchPatch` returns — so conflict file lists were silently dropped for **every** merge failure (incl. `rebase_conflict`). Now uses hashtable-safe access.

**Future work (deferred, not in this PR):** auto-merge non-overlapping same-file orphan edits by rebasing the orphan branch `--onto <base> --root` (by completion time `main` holds the earlier task's file → a real 3-way base). Deferred because it's the riskiest merge-path change and its payoff is uncertain for full-rewrite doc collisions (which fall back to this PR's prompt anyway). Revisit only if real runs show frequent auto-resolvable collisions.

## Testing notes

`tests/Test-Components.ps1` (Layer 2): new end-to-end same-file orphan-collision test (two orphan worktrees write the same file; first merges → initializes `main`; second → asserts `failure_kind = 'unrelated_history'` and non-empty `conflict_files`), a `unrelated_history` kind-dispatch case, and an updated source-pin for the refactored `failure_kind` assignment. Regression guard: different-file orphans still merge clean (pre-existing test). Reviewed with `/pwsh-review` (diff-bug + idioms + history): ship, 0 blockers/majors. `PARSE OK`.

## Checklist

- [x] Tests added or updated
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
