### PR TITLE
fix(runtime): verify-hook-blocked done escalates to needs-input (#571)

### DIFF
--- a/src/runtime/Modules/Dotbot.Runtime/Private/HttpServer.psm1
+++ b/src/runtime/Modules/Dotbot.Runtime/Private/HttpServer.psm1
@@ -1232,6 +1232,14 @@ function Invoke-TaskStatusHandler {
             }
         }
 
+        # A transition that is about to proceed resolves any prior hook-blocked-done
+        # breadcrumb (set on the abort-revert path below). Clearing it here means a
+        # stale marker never lingers once the task makes forward progress.
+        if ($task['extensions'] -and ($task['extensions']['runner'] -is [System.Collections.IDictionary]) -and
+            $task['extensions']['runner'].ContainsKey('done_transition_block')) {
+            [void]$task['extensions']['runner'].Remove('done_transition_block')
+        }
+
         try {
             Assert-TaskInstance -Task $task
         } catch {
@@ -1286,6 +1294,18 @@ function Invoke-TaskStatusHandler {
                 $task['completed_at'] = $task['updated_at']
             } else {
                 $task['completed_at'] = $null
+            }
+            # Breadcrumb the task-runner reads to escalate a hook-blocked done to
+            # needs-input instead of skipped(max-retries). Under extensions.runner
+            # (schema rejects unknown top-level fields); cleared on next success.
+            if ($to -eq 'done') {
+                if (-not $task['extensions'])           { $task['extensions'] = @{} }
+                if (-not $task['extensions']['runner']) { $task['extensions']['runner'] = @{} }
+                $task['extensions']['runner']['done_transition_block'] = @{
+                    hook    = [string]$hookResult.failing_hook
+                    message = [string]$hookResult.failing_message
+                    at      = $task['updated_at']
+                }
             }
             _Write-TaskFileAtomic -Path $path -Content $task
 

--- a/src/runtime/Modules/Dotbot.Runtime/Private/HttpServer.psm1
+++ b/src/runtime/Modules/Dotbot.Runtime/Private/HttpServer.psm1
@@ -1299,11 +1299,17 @@ function Invoke-TaskStatusHandler {
             # needs-input instead of skipped(max-retries). Under extensions.runner
             # (schema rejects unknown top-level fields); cleared on next success.
             if ($to -eq 'done') {
-                if (-not $task['extensions'])           { $task['extensions'] = @{} }
-                if (-not $task['extensions']['runner']) { $task['extensions']['runner'] = @{} }
+                # Type-guard both levels (extensions content is not schema-validated):
+                # a non-dict extensions/runner would make the index-assign below throw.
+                if ($task['extensions'] -isnot [System.Collections.IDictionary])           { $task['extensions'] = @{} }
+                if ($task['extensions']['runner'] -isnot [System.Collections.IDictionary]) { $task['extensions']['runner'] = @{} }
+                # Truncate the persisted message — hook output is unbounded; the full
+                # text stays in the 422 response + activity log (matches AuthError cap).
+                $failingMsg = [string]$hookResult.failing_message
+                if ($failingMsg.Length -gt 1000) { $failingMsg = $failingMsg.Substring(0, 1000) + " … [truncated, showing 1000 of $($failingMsg.Length) chars]" }
                 $task['extensions']['runner']['done_transition_block'] = @{
                     hook    = [string]$hookResult.failing_hook
-                    message = [string]$hookResult.failing_message
+                    message = $failingMsg
                     at      = $task['updated_at']
                 }
             }

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -2049,6 +2049,9 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
             if ($doneHookBlock) {
                 $hookName = [string]$doneHookBlock.hook
                 $hookMsg  = [string]$doneHookBlock.message
+                # Defensive cap (breadcrumb is already truncated at the source) so an
+                # oversized hook message can't bloat the task record / handoff — mirrors AuthError.
+                if ($hookMsg.Length -gt 1000) { $hookMsg = $hookMsg.Substring(0, 1000) + " … [truncated, showing 1000 of $($hookMsg.Length) chars]" }
                 $blockContext = "The done-transition was blocked by verify hook '$hookName': $hookMsg`nThe task's declared work may already be complete — resolve the flagged content (e.g. redact absolute local paths from the committed artifact), then re-run or approve. The retry budget was not consumed."
                 Write-Status "Done-transition blocked by verify hook — parking for operator: $($task.name)" -Type Warn
                 Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task '$($task.name)' parked (needs-input): verify hook '$hookName' blocked the done-transition"

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -2015,12 +2015,19 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
             # Task not completed - log diagnostic to help distinguish failure modes.
             $stillInProgress = $false
             $nowNeedsInput   = $false
+            $doneHookBlock   = $null
             try {
                 $currentTask = Get-WorkflowTaskContent -Task $task -RunDir $runDir
                 if ($currentTask -and $currentTask.Content) {
                     $currentStatus = [string]$currentTask.Content.status
                     $stillInProgress = ($currentStatus -eq 'in-progress')
                     $nowNeedsInput = ($currentStatus -eq 'needs-input')
+                    # Breadcrumb left by the transition layer when a verify hook
+                    # aborted this task's done-transition (e.g. privacy scan).
+                    $ext = $currentTask.Content.extensions
+                    if ($ext -and $ext.runner -and $ext.runner.done_transition_block) {
+                        $doneHookBlock = $ext.runner.done_transition_block
+                    }
                 }
             } catch { Write-BotLog -Level Debug -Message "Failed to parse data" -Exception $_ }
 
@@ -2030,6 +2037,25 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
             if ($nowNeedsInput) {
                 Write-Status "Task paused for human input: $($task.name)" -Type Info
                 Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task '$($task.name)' paused — waiting for human input (needs-input)"
+                $taskParked = $true
+                break
+            }
+
+            # A verify hook (e.g. privacy scan) blocked the done-transition: park to
+            # needs-input so the operator fixes the flagged content, instead of
+            # burning retries and mislabeling a done task skipped(max-retries).
+            # Checked before the harness-error classification so this definitive
+            # on-disk signal isn't pre-empted by heuristic text matching.
+            if ($doneHookBlock) {
+                $hookName = [string]$doneHookBlock.hook
+                $hookMsg  = [string]$doneHookBlock.message
+                $blockContext = "The done-transition was blocked by verify hook '$hookName': $hookMsg`nThe task's declared work may already be complete — resolve the flagged content (e.g. redact absolute local paths from the committed artifact), then re-run or approve. The retry budget was not consumed."
+                Write-Status "Done-transition blocked by verify hook — parking for operator: $($task.name)" -Type Warn
+                Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task '$($task.name)' parked (needs-input): verify hook '$hookName' blocked the done-transition"
+                Set-WorkflowTaskNeedsInput -Task $task -RunDir $runDir `
+                    -QuestionId "verify-hook-block-$($task.id)" `
+                    -Question "Verify hook blocked completion of '$($task.name)'" `
+                    -Context $blockContext | Out-Null
                 $taskParked = $true
                 break
             }

--- a/tests/Test-Hooks.ps1
+++ b/tests/Test-Hooks.ps1
@@ -372,6 +372,17 @@ try {
     Assert-Equal -Name "After abort: GET returns 200"               -Expected 200 -Actual $r.status_code
     Assert-Equal -Name "After abort: status reverted to in-progress" -Expected 'in-progress' -Actual $r.body.task.status
 
+    # #571: a done-transition abort leaves a breadcrumb under extensions.runner so
+    # the task-runner can escalate to needs-input instead of burning retries.
+    $blockAfterAbort = $null
+    try { $blockAfterAbort = $r.body.task.extensions.runner.done_transition_block } catch { $blockAfterAbort = $null }
+    Assert-True  -Name "#571 After abort: done_transition_block marker present" `
+        -Condition ($null -ne $blockAfterAbort) `
+        -Message "Expected extensions.runner.done_transition_block, got task: $($r.body.task | ConvertTo-Json -Depth 8 -Compress)"
+    Assert-Equal -Name "#571 After abort: marker names the failing hook" -Expected 'enter-done' -Actual "$($blockAfterAbort.hook)"
+    Assert-True  -Name "#571 After abort: marker carries the failing message" `
+        -Condition ("$($blockAfterAbort.message)" -match 'verify says no')
+
     # Activity log carries hook_failed.
     $logPath = Get-ActivityLogPath -BotRoot $bot
     $hookFailedLines = 0
@@ -392,6 +403,13 @@ try {
     Assert-Equal -Name "With non-aborting hook: in-progress → done → 200" -Expected 200 -Actual $r.status_code
     Assert-Equal -Name "Task status now done"                              -Expected 'done' -Actual $r.body.task.status
     Assert-True  -Name "Response includes hook_results"                    -Condition ($r.body.hook_results.Count -ge 1)
+
+    # #571: a successful transition clears the stale hook-block breadcrumb.
+    $blockAfterDone = $null
+    try { $blockAfterDone = $r.body.task.extensions.runner.done_transition_block } catch { $blockAfterDone = $null }
+    Assert-True -Name "#571 After successful done: done_transition_block marker cleared" `
+        -Condition ($null -eq $blockAfterDone) `
+        -Message "Expected marker cleared, got: $($blockAfterDone | ConvertTo-Json -Compress)"
 } finally {
     if ($start) { Stop-DotbotRuntime -BotRoot $bot -Listener $start.listener -ErrorAction SilentlyContinue }
     try { Remove-Item -Recurse -Force (Split-Path -Parent $bot) } catch { }


### PR DESCRIPTION
## Linked issue

Closes #571
Closes #557

> Final child PR of the 8-bug epic #557 (bug 8). Merging `Closes` #571 and #557.

## Summary of changes

When `enter-done`'s verify chain (e.g. `00-privacy-scan.ps1`) aborts the done-transition, `HttpServer` reverts the task to `in-progress`. The runner's retry loop couldn't tell that apart from "agent didn't finish", so it burned the retry budget and finalized `skipped(max-retries)` — mislabeling a task whose external work (branches/PRs/Jira) had actually succeeded.

- **`HttpServer.psm1`** (`Invoke-TaskStatusHandler`) — on a **done**-transition abort, stamp a breadcrumb `extensions.runner.done_transition_block = @{ hook; message; at }` on the reverted task (under `extensions.runner` because the schema rejects unknown top-level fields; status still reverts to `in-progress`, preserving the tested contract). Clear it on the next successful transition.
- **`Invoke-WorkflowProcess.ps1`** (retry loop) — read the breadcrumb off the already-loaded task and, when present, park to **`needs-input`** via the existing `Set-WorkflowTaskNeedsInput` (mirrors the AuthError park) — **without consuming the retry budget, never `skipped`**. Checked **before** the harness-error classification so this definitive on-disk signal isn't pre-empted by heuristic text matching.

The operator then sees "verify hook blocked done: <violation>", redacts the flagged content, and re-runs.

**Deliberately not changed:** the privacy scan still flags absolute `C:\Users\<name>` paths in tracked deliverables — that is a *genuine* leak, and excluding `.bot/workspace/product/` (the report's suggested fix) would mask real leaks. The fix makes the block **recoverable**, not silent. (The report's cited `outcomes.md` lands in the *target* cloned repo, which the dotbot verify-hook scan never sees.)

## Testing notes

`tests/Test-Hooks.ps1` (E2E, extends the existing enter-done abort test): asserts the reverted task carries `extensions.runner.done_transition_block` with the failing hook + message, and that a subsequent successful done **clears** it. Reviewed with `/pwsh-review` (diff-bug + idioms + history): ship, 0 blockers/majors — one minor (escalation ordering) applied by moving the breadcrumb check ahead of the error classifier. `PARSE OK`; PSScriptAnalyzer shows only pre-existing findings.

To verify manually: run a task that commits an absolute local path into a tracked `.bot/workspace/product/**` deliverable → `task_set_status(done)` is blocked by the privacy scan → task lands in `needs-input` (not `skipped`), retry budget intact; redact the path and re-run → completes.

## Checklist

- [x] Tests added or updated
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)