### PR TITLE
docs: add release notes for v4.0.1 under docs/release-notes/

### DIFF
--- a/docs/release-notes/v4.0.1.md
+++ b/docs/release-notes/v4.0.1.md
@@ -1,0 +1,159 @@
+# dotbot v4.0.1 — Release Notes
+
+**Released:** July 3, 2026
+**Previous version:** v4.0.0 (June 4, 2026)
+**Type:** Patch release
+
+> 27 bugs fixed · 14 enhancements · 41 issues closed
+
+---
+
+## Highlights
+
+**Worktree concurrency hardened** — [#536](https://github.com/andresharpe/dotbot/issues/536) [#537](https://github.com/andresharpe/dotbot/issues/537) [#520](https://github.com/andresharpe/dotbot/issues/520) [#516](https://github.com/andresharpe/dotbot/issues/516) [#517](https://github.com/andresharpe/dotbot/issues/517) [#514](https://github.com/andresharpe/dotbot/issues/514) [#515](https://github.com/andresharpe/dotbot/issues/515)
+Parallel workloads are now safe. Duplicate worktree creation, mass-deletion of active worktrees, and filesystem corruption on orphan cleanup are all resolved.
+
+**Task resume is reliable** — [#470](https://github.com/andresharpe/dotbot/issues/470) [#493](https://github.com/andresharpe/dotbot/issues/493) [#494](https://github.com/andresharpe/dotbot/issues/494) [#518](https://github.com/andresharpe/dotbot/issues/518)
+Runner no longer exits silently on resume. Handoff manifests survive reopen. Output delta validation no longer fails on re-approval.
+
+**Question & Response API live** — [#451](https://github.com/andresharpe/dotbot/issues/451) [#445](https://github.com/andresharpe/dotbot/issues/445) [#29](https://github.com/andresharpe/dotbot/issues/29)
+Mothership and outpost now share a structured Q&A envelope contract. Approvals, document review, and roles unified under one API surface.
+
+**"Revise" — give feedback without losing your work** — [#465](https://github.com/andresharpe/dotbot/issues/465)
+New Revise button on needs-review tasks lets reviewers inject feedback and trigger partial regeneration in place. Worktree preserved — no full restart, no lost context.
+
+**Workflow inheritance** — [#427](https://github.com/andresharpe/dotbot/issues/427)
+`extends:` in `workflow.yaml` lets workflows inherit from a base definition, at parity with stack inheritance.
+
+**New install model**
+`bootstrap.ps1` replaces the old copy-based installer. One `git clone` + `pwsh bootstrap.ps1` is the full setup. `dotbot status` surfaces framework state at any time.
+
+**Needs-review tasks visible in the pipeline** — [#500](https://github.com/andresharpe/dotbot/issues/500)
+Tasks waiting for review now appear in the Needs Input pipeline section — no more hunting for pending work.
+
+---
+
+## Stabilization — 27 bugs fixed
+
+### Worktree & Concurrency
+
+| Issue | Fix |
+|---|---|
+| [#536](https://github.com/andresharpe/dotbot/issues/536) | Non-atomic task claim was creating duplicate worktrees under concurrent runs |
+| [#537](https://github.com/andresharpe/dotbot/issues/537) | Orphan worktree partial setup was corrupting the filesystem on retry |
+| [#520](https://github.com/andresharpe/dotbot/issues/520) | `Remove-OrphanWorktrees` mass-deleted all active worktrees due to task schema mismatch post-v4 |
+| [#516](https://github.com/andresharpe/dotbot/issues/516) | `interview-answers.json` caused squash-merge conflicts when parallel tasks wrote simultaneously |
+| [#517](https://github.com/andresharpe/dotbot/issues/517) | Untracked task files blocked squash-merge retry after first attempt failed |
+| [#514](https://github.com/andresharpe/dotbot/issues/514) | `Test-DotbotMcpReadiness` crashed on task retry due to stale worktree junction |
+| [#515](https://github.com/andresharpe/dotbot/issues/515) | Same stale junction crash — separate code path, both now resolved |
+
+### Task Lifecycle & Runner
+
+| Issue | Fix |
+|---|---|
+| [#470](https://github.com/andresharpe/dotbot/issues/470) | Task stuck in-progress indefinitely when runner process was killed mid-execution |
+| [#493](https://github.com/andresharpe/dotbot/issues/493) | Runner exited silently on resume when a needs-input task blocked the queue |
+| [#494](https://github.com/andresharpe/dotbot/issues/494) | Handoff manifest deleted on runner reopen — answer submission failed with "manifest not found" |
+| [#518](https://github.com/andresharpe/dotbot/issues/518) | Output delta validation failed on resume-after-approval when artifact already existed |
+
+### Dashboard & UI
+
+| Issue | Fix |
+|---|---|
+| [#471](https://github.com/andresharpe/dotbot/issues/471) | STOP button gave no feedback — tooltip and notification now wired; hard kill available via Processes tab |
+| [#519](https://github.com/andresharpe/dotbot/issues/519) | Products page blank for reviewers — task artifacts were hidden before approval |
+| [#453](https://github.com/andresharpe/dotbot/issues/453) | Workflow task showing wrong phase during execution |
+| [#454](https://github.com/andresharpe/dotbot/issues/454) | Roadmap "Done" section not showing all completed tasks |
+| [#463](https://github.com/andresharpe/dotbot/issues/463) | Roadmap page dropdown missing workflows |
+| [#477](https://github.com/andresharpe/dotbot/issues/477) | `escapeHtml` misused in HTML attribute context — XSS surface in actions.js resolved |
+
+### Auth & Notifications
+
+| Issue | Fix |
+|---|---|
+| [#467](https://github.com/andresharpe/dotbot/issues/467) | Auth expiry was dead code — tasks never re-authenticated after token expiry; `AuthError` now wired to needs-input re-auth |
+| [#468](https://github.com/andresharpe/dotbot/issues/468) | Entering `needs-review` emitted no notification — reviewers were never alerted |
+
+### CI & Release Pipeline
+
+| Issue | Fix |
+|---|---|
+| [#460](https://github.com/andresharpe/dotbot/issues/460) | CI broken post-v4 restructure — .yml extensions stripped from `.github/workflows/` |
+| [#475](https://github.com/andresharpe/dotbot/issues/475) | Bump-release workflow failing — `dotbot.psd1` missing after installer removal |
+| [#487](https://github.com/andresharpe/dotbot/issues/487) | Discord release notification silently skipped for fork PRs |
+| [#393](https://github.com/andresharpe/dotbot/issues/393) | Bump-and-release blocked by protected branch preventing direct push to main |
+| [#476](https://github.com/andresharpe/dotbot/issues/476) | Layer 2 integration test was launching a real Claude process instead of a mock |
+| [#474](https://github.com/andresharpe/dotbot/issues/474) | macOS CI Layer 1–3 tests had timing flakes |
+| [#484](https://github.com/andresharpe/dotbot/issues/484) | Flaky Layer 5 UI E2E tests — Playwright retries now enabled |
+| [#482](https://github.com/andresharpe/dotbot/issues/482) | Issue template chooser broken by JSON refactor |
+
+---
+
+## Enhancements — 14 items
+
+### Install & Operations
+
+| | Enhancement |
+|---|---|
+| NEW | **`bootstrap.ps1`** — one-step install replacing the old copy-based installer; works on Windows, macOS, and Linux |
+| NEW | **`dotbot status`** — surfaces resolved `DOTBOT_HOME`, framework branch/SHA, active workflow, provider and stacks; `--json` for CI scripts |
+| NEW | **`MIGRATING.md`** — v3 → v4 migration guide covering shim install, `.bot/` rewrite, `.mcp.json` repointing, and retired entry points |
+
+### Task Execution
+
+| Issue | Enhancement |
+|---|---|
+| [#465](https://github.com/andresharpe/dotbot/issues/465) | **"Revise" review verb** — reviewer feedback injected in place; only affected section regenerates, worktree preserved |
+| [#466](https://github.com/andresharpe/dotbot/issues/466) | Per-run integration branch — configurable base branch, provider-agnostic |
+| [#521](https://github.com/andresharpe/dotbot/issues/521) | `MCP_TIMEOUT` / `MCP_TOOL_TIMEOUT` injected per-task so `claude.exe` survives slow MCP cold-starts |
+
+### Workflow Engine
+
+| Issue | Enhancement |
+|---|---|
+| [#427](https://github.com/andresharpe/dotbot/issues/427) | **`extends:` in `workflow.yaml`** — workflow inheritance from a base definition, at parity with stack inheritance |
+
+### Approvals & Q&A
+
+| Issue | Enhancement |
+|---|---|
+| [#451](https://github.com/andresharpe/dotbot/issues/451) | **Question & Response API** — structured Q&A envelope contract on mothership and outpost |
+| [#445](https://github.com/andresharpe/dotbot/issues/445) | Merge approval and document review consolidated into one unified approval type |
+| [#500](https://github.com/andresharpe/dotbot/issues/500) | Needs-review tasks now surfaced in the Needs Input pipeline section |
+| [#29](https://github.com/andresharpe/dotbot/issues/29) | Expanded QuestionService — artifact approvals, roles, and new question types |
+
+### Dashboard & Integrations
+
+| Issue | Enhancement |
+|---|---|
+| [#469](https://github.com/andresharpe/dotbot/issues/469) | Resizable table columns and draggable panel separators — layout persisted across sessions |
+| [#435](https://github.com/andresharpe/dotbot/issues/435) | Azurite blob storage emulator support for local mothership server testing |
+
+### AP Registry & Workflows
+
+| Issue | Enhancement |
+|---|---|
+| [#506](https://github.com/andresharpe/dotbot/issues/506) | QA-specific workflow definitions added to registry |
+| [#507](https://github.com/andresharpe/dotbot/issues/507) / [#508](https://github.com/andresharpe/dotbot/issues/508) | AP Registry v4 compatibility check + classified registry restructured (default / client / role) |
+
+---
+
+## Get this release
+
+```bash
+# Homebrew (macOS / Linux)
+brew upgrade dotbot
+
+# Scoop (Windows)
+scoop update dotbot
+
+# From source
+git pull && pwsh bootstrap.ps1
+```
+
+Run `dotbot status` after updating to confirm you're on v4.0.1.
+
+---
+
+*Next patch release: ~July 10, 2026*
+*Release notes template: [`docs/release-notes/`](../release-notes/)*


### PR DESCRIPTION
## Summary

Adds the first structured release notes document as `docs/release-notes/v4.0.1.md`.

This establishes the `docs/release-notes/` folder as the canonical home for versioned release notes going forward, one file per patch/minor/major release.

## What's in this file

- Release highlights with issue references
- Stabilization section (27 bugs, grouped by area)
- Enhancements section (14 items, grouped by area)
- Install instructions for all platforms
- Links to next release

## Related

Closes #580

## Checklist

- [x] File follows a reusable template structure
- [x] All issue numbers link to GitHub
- [x] Highlights match the email release notes
- [ ] Reviewer sign-off