### PR TITLE
docs: update README lifecycle docs for single-session task execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ dotbot wraps AI-assisted coding in a managed, transparent workflow where every s
 
 ### Multi-workflow platform
 - **Workflow-driven pipelines** - Define multi-step pipelines in `workflow.json` manifests with tasks, dependencies, form configuration, MCP servers, and environment requirements. A project can have multiple workflows installed simultaneously, each run, re-run, and stopped independently.
-- **Typed task system** - Tasks can be `prompt` (AI-executed), `script` (PowerShell, no LLM), `mcp` (tool call), `task_gen` (generates sub-tasks dynamically), or `prompt_template` (AI with a workflow-specific prompt). Script, MCP, and task_gen tasks bypass the AI entirely - they auto-promote past analysis, skip worktree isolation, and skip verification hooks. This enables deterministic pipeline stages within AI-orchestrated workflows.
+- **Typed task system** - Tasks can be `prompt` (AI-executed), `script` (PowerShell, no LLM), `mcp` (tool call), `task_gen` (generates sub-tasks dynamically), or `prompt_template` (AI with a workflow-specific prompt). Script, MCP, and task_gen tasks bypass the provider session but still execute in the task worktree and complete through the normal task status transition, including verification hooks. This enables deterministic pipeline stages within AI-orchestrated workflows.
 - **Enterprise registries** - Teams publish workflows, stacks, tools, and skills in git-hosted or local registries. `dotbot registry add` links a registry (private or public); `dotbot init -Workflow registry:name` installs from it. Registries are validated against a `registry.json` manifest with version compatibility checks and auth-failure hints for GitHub, Azure DevOps, and GitLab.
 - **Workflows and stacks** - **Workflows** (e.g. `start-from-jira`) define operational pipelines - what dotbot does. **Stacks** (e.g. `dotnet`, `dotnet-blazor`) add tech-specific skills, hooks, and MCP tools - what tech the project uses. Stacks compose additively with `extends` chains. Settings deep-merge across `default -> workflows -> stacks`.
 
 ### Execution engine
-- **Two-phase execution** - Analysis resolves ambiguity, identifies files, and builds a context package. Implementation consumes that package and writes code. Tasks flow: `todo -> analysing -> analysed -> in-progress -> done`.
+- **Single-session execution** - Prompt tasks run discovery, planning, implementation, verification, and completion inside one provider session using `100-single-session-task.md`. The core flow is `todo -> in-progress -> done`, with side paths for `needs-input`, `needs-review`, `failed`, `skipped`, and `cancelled`.
 - **Per-task git worktree isolation** - Each task runs in its own worktree on an isolated branch, squash-merged back to main on completion.
 - **Per-task model selection** - Tasks can specify a model (e.g. Sonnet for simple tasks, Opus for complex ones) that overrides the process-level default. Use cheaper models where they suffice to reduce token spend.
 - **Multi-slot concurrent execution** - The workflow engine runs multiple tasks from the same workflow in parallel with slot-aware locking, shortening wall-clock time for large task queues.
@@ -222,15 +222,17 @@ The runtime resolves framework content lazily: `<BotRoot>/content/<type>/<name>/
 
 ## MCP Tools
 
-The dotbot MCP server exposes 33 tools, auto-discovered from `systems/mcp/tools/`:
+The dotbot MCP server exposes 31 tools, auto-discovered from `src/mcp/tools/`:
 
-**Task Management** (15): `task_create`, `task_create_bulk`, `task_get_next`, `task_get_context`, `task_list`, `task_get_stats`, `task_mark_todo`, `task_mark_analysing`, `task_mark_analysed`, `task_mark_in_progress`, `task_mark_done`, `task_mark_needs_input`, `task_mark_skipped`, `task_answer_question`, `task_approve_split`
+**Task Management** (10): `task_create`, `task_create_bulk`, `task_get`, `task_get_context`, `task_get_next`, `task_list`, `task_mark_needs_review`, `task_set_status`, `task_submit_review`, `task_update`
 
 **Decision Tracking** (7): `decision_create`, `decision_get`, `decision_list`, `decision_update`, `decision_mark_accepted`, `decision_mark_deprecated`, `decision_mark_superseded`
 
 **Session Management** (5): `session_initialize`, `session_get_state`, `session_get_stats`, `session_update`, `session_increment_completed`
 
 **Plans** (3): `plan_create`, `plan_get`, `plan_update`
+
+**Workflow** (3): `workflow_get`, `workflow_list`, `workflow_start`
 
 **Steering**: `steering_heartbeat`
 
@@ -248,7 +250,7 @@ Four-layer test pyramid with ~500 assertions:
 |-------|---------------|-------------|
 | 1 - Structure | Syntax validation, module exports, workflow manifest parsing, task creation, condition evaluation, multi-workflow isolation | None |
 | 2 - Components | MCP tool lifecycle, task types, decision tracking, provider CLI, notification client, workflow integration, UI server startup | None |
-| 3 - Mock Provider | Analysis/execution flows with mock Claude CLI and stream parsing | None |
+| 3 - Mock Provider | Workflow execution flows with mock Claude CLI and stream parsing | None |
 | 4 - E2E | Full end-to-end with real AI provider API | API key |
 
 ```powershell

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,6 @@
 # dotbot - Autonomous Development Framework
 
-A project-agnostic framework for autonomous software development across Claude Code, Codex, and Antigravity CLIs. Provides task management, two-phase execution (analysis + implementation), per-task git worktree isolation, a web dashboard, and a PowerShell MCP server.
+A project-agnostic framework for autonomous software development across Claude Code, Codex, and Antigravity CLIs. Provides task management, single-session task execution, per-task git worktree isolation, a web dashboard, and a PowerShell MCP server.
 
 ## Installation
 
@@ -45,7 +45,7 @@ dotbot go
 ├── recipes/
 │   ├── agents/                   # Agent personas (implementer, planner, reviewer, tester)
 │   ├── skills/                   # Technical guidance (status, verify, write-test-plan, write-unit-tests)
-│   ├── prompts/                  # Numbered step-by-step processes (analysis, implementation, etc.)
+│   ├── prompts/                  # Numbered workflow and task prompt templates
 │   ├── includes/                 # Shared prompt fragments
 │   └── research/                 # Research templates
 ├── systems/
@@ -59,42 +59,29 @@ dotbot go
 └── workspace/
     ├── product/                  # Product docs (mission.md, entity-model.md, tech-stack.md)
     ├── decisions/                # Architecture decision records
-    └── tasks/                    # Task queue (todo/, analysed/, in-progress/, done/)
+    └── tasks/
+        ├── workflow-runs/        # Per-run directories with run.json + task JSON files
+        └── standalone/           # Standalone task JSON files
 ```
+
+Task status is stored in each task JSON file; task files do not move between per-status directories.
 
 ## How It Works
 
-### Two-Phase Task Execution
+### Single-Session Task Execution
 
-Every task goes through two phases, each run by a separate provider CLI instance:
-
-**Phase 1 - Analysis** (`98-analyse-task.md`):
-- Identifies affected entities and files
-- Maps applicable coding standards
-- Validates dependencies
-- Produces concrete implementation guidance (insertion points, pattern snippets, field mappings)
-- Asks clarifying questions or proposes task splits if needed
-
-**Phase 2 - Execution** (`99-autonomous-task.md`):
-- Receives pre-packaged analysis context (no re-exploration needed)
-- Implements changes following the analysis guidance
-- Runs verification scripts (privacy scan, git clean, build, format)
-- Commits with task ID references
+Prompt tasks run in one provider CLI session using `content/prompts/100-single-session-task.md`. That session does discovery, planning, implementation, verification, and completion together, so there is no separate pre-flight analysis process or intermediate handoff state. If the provider needs a human answer, it can pause the task as `needs-input`; after an answer or retry, the task returns to `todo` for another same-task session attempt.
 
 ### Per-Task Git Worktrees
 
 Each task runs in an isolated git worktree:
 
 ```
-Analysis picks up task
+Task runner picks up task
   → Creates branch: task/{short-id}-{slug}
   → Creates worktree: ../worktrees/{repo}/task-{short-id}-{slug}/
-  → Sets up junctions for shared .bot/ directories
-  → Copies essential gitignored files (e.g., .env)
-
-Execution picks up analysed task
-  → Looks up existing worktree
-  → Provider CLI implements and commits to task branch
+  → Materialises provider folders and MCP configuration in the worktree
+  → Provider CLI discovers, implements, verifies, and commits to task branch
 
 On completion
   → Rebases task branch onto main
@@ -107,10 +94,14 @@ This provides full isolation between tasks — a failed task never leaves dirty 
 ### Task Lifecycle
 
 ```
-todo → analysing → analysed → in-progress → done
-         │                                     │
-         ├→ needs-input (question/split)        └→ squash-merged to main
-         └→ skipped (non-recoverable)
+todo → in-progress → done
+  │         │           │
+  │         ├→ needs-input (human answer required, then retry from todo)
+  │         ├→ needs-review (completed work awaiting human review)
+  │         ├→ failed
+  │         ├→ skipped
+  │         └→ cancelled
+  └→ skipped / cancelled
 ```
 
 ### Process Launcher
@@ -119,8 +110,7 @@ todo → analysing → analysed → in-progress → done
 
 | Type | Purpose |
 |------|---------|
-| `analysis` | Pre-flight task analysis |
-| `execution` | Task implementation |
+| `task-runner` | Workflow task execution loop |
 | `planning` | Roadmap generation |
 | `commit` | Git operations |
 | `task-creation` | Bulk task creation |
@@ -131,14 +121,14 @@ Each process gets a registry entry for tracking and is managed through the web d
 
 The PowerShell MCP server (`dotbot-mcp.ps1`) exposes tools via stdio transport:
 
-- **Task tools**: create, create-bulk, list, get-next, get-context, get-stats, answer-question, approve-split, mark-todo, mark-analysing, mark-analysed, mark-in-progress, mark-done, mark-needs-input, mark-skipped
+- **Task tools**: create, create-bulk, get, list, get-next, get-context, update, set-status, mark-needs-review, submit-review
 - **Decision tools**: create, get, list, update, mark-accepted, mark-deprecated, mark-superseded
 - **Session tools**: initialize, update, get-state, get-stats, increment-completed
 - **Plan tools**: create, get, update
 - **Dev tools**: start, stop
 - **Steering**: heartbeat with whisper channel for operator interrupts
 
-Tools are auto-discovered from `.bot/systems/mcp/tools/{tool-name}/` — each tool is a folder with `metadata.json` (schema) and `script.ps1` (implementation).
+Tools are auto-discovered from `src/mcp/tools/{tool-name}/` — each tool is a folder with `metadata.json` (schema) and `script.ps1` (implementation).
 
 ## Usage
 
@@ -150,7 +140,7 @@ dotbot go
 
 Opens the web UI on a random port in the IANA dynamic range (49152–65535) where you can:
 - View and manage tasks
-- Start analysis and execution processes
+- Start and stop workflow task runners
 - Monitor running processes
 - Kick off product planning
 
@@ -163,11 +153,12 @@ From the dashboard, use the start-from-prompt workflow to:
 
 ### Autonomous Execution
 
-Start analysis and execution processes from the dashboard. They run in a loop:
+Start a workflow task runner from the dashboard or CLI. It runs in a loop:
 
-1. **Analysis process** picks up `todo` tasks, analyses them, marks them `analysed`
-2. **Execution process** picks up `analysed` tasks, implements them, marks them `done`
-3. Completed tasks are squash-merged to main automatically
+1. Picks the next eligible `todo` task from the workflow run
+2. Runs the task in a single provider session, moving it to `in-progress`
+3. Marks completed work `done`, or parks it as `needs-input`, `needs-review`, `failed`, `skipped`, or `cancelled`
+4. Squash-merges completed task branches to main automatically
 
 ### Manual Task Management
 

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -6,7 +6,7 @@ A minimal, dependency-free PowerShell web server for monitoring and controlling 
 
 - **CP/M-inspired terminal aesthetic** with Axiome Design amber accents
 - **Real-time monitoring** via auto-polling (3-5 second intervals)
-- **Task queue visualization** (TODO/Analysing/Analysed/In-Progress/Done)
+- **Task queue visualization** for workflow-run and standalone tasks, including Needs Review and legacy analysis buckets when present
 - **Process management** - launch, stop, kill, and whisper to tracked processes
 - **Localhost-only** - no authentication needed
 - **Zero dependencies** - pure PowerShell + vanilla HTML/CSS/JS
@@ -56,12 +56,11 @@ All processes are tracked via JSON files in `.bot/.control/processes/`:
 │   └── activity.jsonl           # Global activity log
 └── workspace/
     └── tasks/
-        ├── todo/
-        ├── analysing/
-        ├── analysed/
-        ├── in-progress/
-        └── done/
+        ├── workflow-runs/        # Per-run directories with run.json + task JSON files
+        └── standalone/           # Standalone task JSON files
 ```
+
+Task status is stored in each task JSON file; task files do not move between per-status directories.
 
 ## API Endpoints
 
@@ -75,7 +74,7 @@ Returns all tracked processes with status.
 Launch a new process:
 ```json
 {
-  "type": "analysis",
+  "type": "task-runner",
   "continue": true,
   "model": "best"
 }


### PR DESCRIPTION
## Summary
- Replace two-phase analysis/execution model description with single-session flow across all README files.
- Update task lifecycle states: `todo -> in-progress -> done` with side paths for `needs-input`, `needs-review`, `failed`, `skipped`, `cancelled`.
- Update MCP tool listings to match current tool names and count (31 tools from `src/mcp/tools/`).
- Update process types: `analysis`/`execution` -> `task-runner`.
- Update workspace task directory structure: status-based folders -> `workflow-runs/` + `standalone/`.

Originally authored by @carlospedreira in #496 (closed without merge). Re-raised on behalf of @ahmed-selim.

Closes #458

## Test plan
- [ ] Review README.md changes match current runtime behaviour
- [ ] Review src/README.md single-session section accuracy
- [ ] Review src/ui/README.md task state list and directory tree
