### PR TITLE
feat(events): in-process event bus with folder-discovered sinks (#93)

### DIFF
--- a/bin/dotbot.ps1
+++ b/bin/dotbot.ps1
@@ -657,7 +657,7 @@ function Invoke-Go {
     } finally {
         Pop-Location
         if ($runtimeStartedHere -and $runtimeStart -and $runtimeStart.listener) {
-            Stop-DotbotRuntime -BotRoot $botDir -Listener $runtimeStart.listener -ErrorAction SilentlyContinue
+            Stop-DotbotRuntime -BotRoot $botDir -Listener $runtimeStart.listener -ControlPlaneRegistration $runtimeStart.control_plane -EventConsumer $runtimeStart.events_consumer -ErrorAction SilentlyContinue
         }
     }
 }

--- a/content/settings/settings.default.json
+++ b/content/settings/settings.default.json
@@ -104,5 +104,21 @@
         "description": "New document in product briefing"
       }
     ]
+  },
+  "events": {
+    "enabled": true,
+    "webhooks": {
+      "enabled": false,
+      "endpoints": [
+        {
+          "url": "https://hooks.example.com/dotbot",
+          "events": ["task.*", "workflow.*"],
+          "secret": ""
+        }
+      ]
+    },
+    "mothership": {
+      "enabled": false
+    }
   }
 }

--- a/src/cli/serve.ps1
+++ b/src/cli/serve.ps1
@@ -89,7 +89,7 @@ $cleanupRan = $false
 $cleanup = {
     if ($script:cleanupRan) { return }
     $script:cleanupRan = $true
-    try { Stop-DotbotRuntime -BotRoot $botRoot -Listener $start.listener -ControlPlaneRegistration $start.control_plane -ErrorAction SilentlyContinue } catch { $null = $_ }
+    try { Stop-DotbotRuntime -BotRoot $botRoot -Listener $start.listener -ControlPlaneRegistration $start.control_plane -EventConsumer $start.events_consumer -ErrorAction SilentlyContinue } catch { $null = $_ }
 }
 try {
     [Console]::CancelKeyPress.Add({ param($s, $e) $e.Cancel = $true; & $cleanup })

--- a/src/runtime/Modules/Dotbot.Events/Dotbot.Events.psd1
+++ b/src/runtime/Modules/Dotbot.Events/Dotbot.Events.psd1
@@ -7,10 +7,10 @@
     PowerShellVersion = '7.0'
 
     # Concerns live as nested modules so each is findable in isolation.
-    # Dispatch (child-runspace execution) and the background Consumer are added
-    # in later steps.
+    # The background Consumer is added in a later step.
     NestedModules     = @(
-        'Private/Discovery.psm1'
+        'Private/Discovery.psm1',
+        'Private/Dispatch.psm1'
     )
 
     FunctionsToExport = @(
@@ -19,6 +19,10 @@
         'Read-SinkMetadata'
         'Get-SinkRegistry'
         'Get-SinksForEvent'
+
+        # Dispatch
+        'Invoke-SingleSink'
+        'Invoke-EventSinks'
     )
 
     CmdletsToExport   = @()

--- a/src/runtime/Modules/Dotbot.Events/Dotbot.Events.psd1
+++ b/src/runtime/Modules/Dotbot.Events/Dotbot.Events.psd1
@@ -1,0 +1,27 @@
+@{
+    RootModule        = 'Dotbot.Events.psm1'
+    ModuleVersion     = '1.0.0'
+    GUID              = 'c4e1f8a2-3b6d-4e9c-8a17-2f5b9d3c7e04'
+    Author            = 'dotbot contributors'
+    Description       = 'Event-bus sinks. Folder-discovered subscribers that react to bus events on the activity log. Discovery scans <runtime>/Plugins/Events/Sinks/*/metadata.json; Dispatch runs Invoke-Sink in a time-boxed child runspace, non-aborting and out-of-band; a background consumer tails activity.jsonl by persisted byte cursor.'
+    PowerShellVersion = '7.0'
+
+    # Concerns live as nested modules so each is findable in isolation.
+    # Dispatch (child-runspace execution) and the background Consumer are added
+    # in later steps.
+    NestedModules     = @(
+        'Private/Discovery.psm1'
+    )
+
+    FunctionsToExport = @(
+        # Discovery
+        'Get-DefaultSinksDirectory'
+        'Read-SinkMetadata'
+        'Get-SinkRegistry'
+        'Get-SinksForEvent'
+    )
+
+    CmdletsToExport   = @()
+    VariablesToExport = @()
+    AliasesToExport   = @()
+}

--- a/src/runtime/Modules/Dotbot.Events/Dotbot.Events.psd1
+++ b/src/runtime/Modules/Dotbot.Events/Dotbot.Events.psd1
@@ -7,10 +7,10 @@
     PowerShellVersion = '7.0'
 
     # Concerns live as nested modules so each is findable in isolation.
-    # The background Consumer is added in a later step.
     NestedModules     = @(
         'Private/Discovery.psm1',
-        'Private/Dispatch.psm1'
+        'Private/Dispatch.psm1',
+        'Private/Consumer.psm1'
     )
 
     FunctionsToExport = @(
@@ -23,6 +23,16 @@
         # Dispatch
         'Invoke-SingleSink'
         'Invoke-EventSinks'
+
+        # Consumer
+        'Get-EventCursorPath'
+        'Read-EventCursor'
+        'Save-EventCursor'
+        'Initialize-EventConsumerCursor'
+        'Read-EventBatch'
+        'Invoke-EventConsumerTick'
+        'Start-EventConsumer'
+        'Stop-EventConsumer'
     )
 
     CmdletsToExport   = @()

--- a/src/runtime/Modules/Dotbot.Events/Dotbot.Events.psm1
+++ b/src/runtime/Modules/Dotbot.Events/Dotbot.Events.psm1
@@ -1,0 +1,12 @@
+<#
+.SYNOPSIS
+Dotbot.Events root module — event-bus sinks.
+
+The actual surface lives under Private/*.psm1 (Discovery today; Dispatch and
+the background Consumer land in later steps). This root file exists so the psd1
+has a RootModule to point at; it deliberately exports nothing of its own. The
+plugin contract and shipped sinks live on disk under
+<runtime>/Plugins/Events/Sinks/* and are picked up at dispatch time.
+#>
+
+# Intentionally empty: nested modules carry the surface.

--- a/src/runtime/Modules/Dotbot.Events/Private/Consumer.psm1
+++ b/src/runtime/Modules/Dotbot.Events/Private/Consumer.psm1
@@ -167,15 +167,14 @@ function Read-EventBatch {
 
 # ─── One delivery tick ──────────────────────────────────────────────────────
 
-function _Get-EventsSettingsSection {
-    # Resolve the `events` settings section for the sink Context. Guarded so
-    # the tick still works when Dotbot.Settings isn't loaded (isolated tests).
+function _Get-MergedSettingsSafe {
+    # Resolve the full merged settings for the sink Context. Guarded so the
+    # tick still works when Dotbot.Settings isn't loaded (isolated tests).
     param([Parameter(Mandatory)] [string]$BotRoot)
 
     if (-not (Get-Command Get-MergedSettings -ErrorAction SilentlyContinue)) { return $null }
     try {
-        $settings = Get-MergedSettings -BotRoot $BotRoot
-        if ($null -ne $settings) { return $settings.events }
+        return Get-MergedSettings -BotRoot $BotRoot
     } catch {
         $null = $_
     }
@@ -211,8 +210,10 @@ function Invoke-EventConsumerTick {
     $batch = Read-EventBatch -LogPath $LogPath -Offset $offset
 
     # Resolve the sink Context once per tick (fresh settings each cycle so an
-    # operator's config edit takes effect without a restart).
-    $context = @{ BotRoot = $BotRoot; Events = (_Get-EventsSettingsSection -BotRoot $BotRoot) }
+    # operator's config edit takes effect without a restart). Sinks read the
+    # section they need: webhooks → Settings.events.webhooks, mothership →
+    # Settings.mothership + Settings.events.mothership.
+    $context = @{ BotRoot = $BotRoot; Settings = (_Get-MergedSettingsSafe -BotRoot $BotRoot) }
 
     $dispatchedTotal = 0
     foreach ($evt in $batch.events) {

--- a/src/runtime/Modules/Dotbot.Events/Private/Consumer.psm1
+++ b/src/runtime/Modules/Dotbot.Events/Private/Consumer.psm1
@@ -167,6 +167,21 @@ function Read-EventBatch {
 
 # ─── One delivery tick ──────────────────────────────────────────────────────
 
+function _Get-EventsSettingsSection {
+    # Resolve the `events` settings section for the sink Context. Guarded so
+    # the tick still works when Dotbot.Settings isn't loaded (isolated tests).
+    param([Parameter(Mandatory)] [string]$BotRoot)
+
+    if (-not (Get-Command Get-MergedSettings -ErrorAction SilentlyContinue)) { return $null }
+    try {
+        $settings = Get-MergedSettings -BotRoot $BotRoot
+        if ($null -ne $settings) { return $settings.events }
+    } catch {
+        $null = $_
+    }
+    return $null
+}
+
 function Invoke-EventConsumerTick {
     <#
     .SYNOPSIS
@@ -195,12 +210,16 @@ function Invoke-EventConsumerTick {
 
     $batch = Read-EventBatch -LogPath $LogPath -Offset $offset
 
+    # Resolve the sink Context once per tick (fresh settings each cycle so an
+    # operator's config edit takes effect without a restart).
+    $context = @{ BotRoot = $BotRoot; Events = (_Get-EventsSettingsSection -BotRoot $BotRoot) }
+
     $dispatchedTotal = 0
     foreach ($evt in $batch.events) {
         # Invoke-EventSinks is non-aborting and never throws, but guard anyway
         # so a single event can never wedge the cursor.
         try {
-            $r = Invoke-EventSinks -Event $evt -Registry $Registry -BotRoot $BotRoot
+            $r = Invoke-EventSinks -Event $evt -Registry $Registry -BotRoot $BotRoot -Context $context
             $dispatchedTotal += [int]$r.dispatched
         } catch {
             $null = $_
@@ -263,15 +282,20 @@ function Start-EventConsumer {
     Initialize-EventConsumerCursor -BotRoot $BotRoot | Out-Null
 
     $modulePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'Dotbot.Events.psd1'
+    # Dotbot.Settings sits alongside Dotbot.Events under Modules/. Import it in
+    # the loop so Invoke-EventConsumerTick can resolve the sink Context's
+    # `events` config each cycle.
+    $settingsPath = Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) (Join-Path 'Dotbot.Settings' 'Dotbot.Settings.psd1')
 
     # Single-element bool array passed by reference into the runspace as the
     # cooperative stop signal.
     $stopFlag = [bool[]]::new(1)
 
     $loop = {
-        param([string]$BotRoot, $Registry, [double]$IntervalSeconds, [string]$ModulePath, [bool[]]$StopFlag)
+        param([string]$BotRoot, $Registry, [double]$IntervalSeconds, [string]$ModulePath, [string]$SettingsPath, [bool[]]$StopFlag)
 
         Import-Module $ModulePath -DisableNameChecking -Global -ErrorAction SilentlyContinue
+        Import-Module $SettingsPath -DisableNameChecking -Global -ErrorAction SilentlyContinue
 
         while (-not $StopFlag[0]) {
             try {
@@ -297,6 +321,7 @@ function Start-EventConsumer {
     $null = $ps.AddArgument($registry)
     $null = $ps.AddArgument($IntervalSeconds)
     $null = $ps.AddArgument($modulePath)
+    $null = $ps.AddArgument($settingsPath)
     $null = $ps.AddArgument($stopFlag)
     $async = $ps.BeginInvoke()
 

--- a/src/runtime/Modules/Dotbot.Events/Private/Consumer.psm1
+++ b/src/runtime/Modules/Dotbot.Events/Private/Consumer.psm1
@@ -1,0 +1,341 @@
+<#
+.SYNOPSIS
+Background consumer for the event bus.
+
+Tails <BotRoot>/.control/activity.jsonl by BYTE CURSOR — the same read
+technique the /api/activity/tail endpoint uses — and dispatches each event to
+its matching sinks (out-of-band: only after the event is durably on disk).
+
+Delivery is AT-LEAST-ONCE: the persisted cursor advances only AFTER a batch has
+been dispatched, so a crash mid-batch re-delivers that batch on the next tick
+rather than dropping it. The cursor lives at <BotRoot>/.control/events-cursor.json
+and survives restarts, so events appended while no runtime was running (e.g. a
+detached CLI `tasks run`) are delivered from the persisted offset when the next
+runtime starts — delayed, never dropped.
+
+This module is self-contained: it computes the activity-log path itself rather
+than importing Dotbot.Runtime, so the dependency stays one-directional
+(Dotbot.Runtime hosts Dotbot.Events, never the reverse).
+
+The runspace lifecycle (Start/Stop-EventConsumer) mirrors the runtime's
+ControlPlaneClient: a cooperative stop flag + explicit Stop()/Dispose().
+#>
+
+# ─── Paths ──────────────────────────────────────────────────────────────────
+
+function _Get-EventActivityLogPath {
+    # Duplicated (not imported from Dotbot.Runtime) to keep the dependency
+    # one-directional. Must stay in sync with Get-ActivityLogPath.
+    param([Parameter(Mandatory)] [string]$BotRoot)
+    return Join-Path $BotRoot (Join-Path '.control' 'activity.jsonl')
+}
+
+function Get-EventCursorPath {
+    <#
+    .SYNOPSIS
+    Resolve <BotRoot>/.control/events-cursor.json (the persisted byte offset).
+    #>
+    param([Parameter(Mandatory)] [string]$BotRoot)
+    return Join-Path $BotRoot (Join-Path '.control' 'events-cursor.json')
+}
+
+# ─── Cursor persistence ─────────────────────────────────────────────────────
+
+function Read-EventCursor {
+    <#
+    .SYNOPSIS
+    Return the persisted byte offset, or $null when no cursor exists yet.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string]$BotRoot)
+
+    $path = Get-EventCursorPath -BotRoot $BotRoot
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { return $null }
+    try {
+        $obj = Get-Content -LiteralPath $path -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+        if ($null -ne $obj -and $null -ne $obj.offset) { return [long]$obj.offset }
+    } catch {
+        # Corrupt cursor → treat as fresh; the caller re-initialises.
+    }
+    return $null
+}
+
+function Save-EventCursor {
+    <#
+    .SYNOPSIS
+    Persist the byte offset. Atomic (temp + move) so a crash can't leave a
+    half-written cursor.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$BotRoot,
+        [Parameter(Mandatory)] [long]$Offset
+    )
+
+    $path = Get-EventCursorPath -BotRoot $BotRoot
+    $dir  = Split-Path -Parent $path
+    if (-not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    $json = ([ordered]@{ offset = $Offset } | ConvertTo-Json -Compress)
+    $tmp  = "$path.tmp"
+    [System.IO.File]::WriteAllText($tmp, $json, [System.Text.UTF8Encoding]::new($false))
+    Move-Item -LiteralPath $tmp -Destination $path -Force
+}
+
+function Initialize-EventConsumerCursor {
+    <#
+    .SYNOPSIS
+    Ensure a cursor exists. On the very first start (no cursor) seed it to the
+    current end of the activity log so historical events are NOT replayed to
+    sinks (a webhook re-POSTing the whole history would be surprising). From
+    then on the persisted cursor carries forward across restarts.
+
+    .OUTPUTS
+    The byte offset the consumer will start reading from.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string]$BotRoot)
+
+    $existing = Read-EventCursor -BotRoot $BotRoot
+    if ($null -ne $existing) { return $existing }
+
+    $logPath = _Get-EventActivityLogPath -BotRoot $BotRoot
+    $eof = 0L
+    if (Test-Path -LiteralPath $logPath -PathType Leaf) {
+        $eof = [long]((Get-Item -LiteralPath $logPath).Length)
+    }
+    Save-EventCursor -BotRoot $BotRoot -Offset $eof
+    return $eof
+}
+
+# ─── Byte-cursor read ───────────────────────────────────────────────────────
+
+function Read-EventBatch {
+    <#
+    .SYNOPSIS
+    Read all complete JSON lines from $Offset to EOF and report the new byte
+    position. Mirrors the /api/activity/tail streaming read (FileStream opened
+    ReadWrite-shared, Seek to the offset, read to EOF, report Position).
+
+    .OUTPUTS
+        @{ events = @(<parsed pscustomobject>, ...); position = <long> }
+
+    Malformed lines are skipped. A cursor past EOF (log truncated/rotated)
+    restarts from 0.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$LogPath,
+        [Parameter(Mandatory)] [long]$Offset
+    )
+
+    if (-not (Test-Path -LiteralPath $LogPath -PathType Leaf)) {
+        return @{ events = @(); position = $Offset }
+    }
+
+    $events = @()
+    $newPos = $Offset
+    $fs = $null
+    $reader = $null
+    try {
+        $fs = [System.IO.FileStream]::new(
+            $LogPath,
+            [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::Read,
+            [System.IO.FileShare]::ReadWrite)
+
+        $start = if ($Offset -gt $fs.Length) { 0L } else { $Offset }
+        [void]$fs.Seek($start, [System.IO.SeekOrigin]::Begin)
+
+        $reader = [System.IO.StreamReader]::new($fs, [System.Text.UTF8Encoding]::new($false))
+        $text = $reader.ReadToEnd()
+        $newPos = $fs.Position
+
+        foreach ($line in ($text -split "`n")) {
+            $trimmed = $line.Trim()
+            if (-not $trimmed) { continue }
+            try { $events += ($trimmed | ConvertFrom-Json -ErrorAction Stop) } catch { }
+        }
+    } finally {
+        # Disposing the reader disposes the underlying stream too.
+        if ($reader) { $reader.Dispose() } elseif ($fs) { $fs.Dispose() }
+    }
+
+    return @{ events = @($events); position = $newPos }
+}
+
+# ─── One delivery tick ──────────────────────────────────────────────────────
+
+function Invoke-EventConsumerTick {
+    <#
+    .SYNOPSIS
+    Read the batch since the persisted cursor, dispatch each event to its
+    sinks, then advance the cursor. At-least-once: the cursor is saved only
+    after dispatch.
+
+    .PARAMETER Registry
+    Pre-discovered sink registry (Get-SinkRegistry). Passed in so the tick does
+    not re-scan disk on every cycle.
+
+    .OUTPUTS
+        @{ processed = <int events>; dispatched = <int sink invocations>; position = <long> }
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$BotRoot,
+        $Registry,
+        [string]$LogPath
+    )
+
+    if (-not $LogPath) { $LogPath = _Get-EventActivityLogPath -BotRoot $BotRoot }
+
+    $offset = Read-EventCursor -BotRoot $BotRoot
+    if ($null -eq $offset) { $offset = 0L }
+
+    $batch = Read-EventBatch -LogPath $LogPath -Offset $offset
+
+    $dispatchedTotal = 0
+    foreach ($evt in $batch.events) {
+        # Invoke-EventSinks is non-aborting and never throws, but guard anyway
+        # so a single event can never wedge the cursor.
+        try {
+            $r = Invoke-EventSinks -Event $evt -Registry $Registry -BotRoot $BotRoot
+            $dispatchedTotal += [int]$r.dispatched
+        } catch {
+            $null = $_
+        }
+    }
+
+    # Advance the cursor only after dispatch (at-least-once).
+    Save-EventCursor -BotRoot $BotRoot -Offset $batch.position
+
+    return @{
+        processed  = @($batch.events).Count
+        dispatched = $dispatchedTotal
+        position   = $batch.position
+    }
+}
+
+# ─── Runspace lifecycle (mirrors ControlPlaneClient) ────────────────────────
+
+function _Test-EventConsumerEnabled {
+    # Master kill-switch: events.enabled. Defaults to on when settings are
+    # unavailable (e.g. isolated unit tests import only Dotbot.Events).
+    param([Parameter(Mandatory)] [string]$BotRoot)
+
+    if (-not (Get-Command Get-MergedSettings -ErrorAction SilentlyContinue)) { return $true }
+    try {
+        $settings = Get-MergedSettings -BotRoot $BotRoot
+        if ($null -ne $settings -and $null -ne $settings.events -and $settings.events.enabled -eq $false) {
+            return $false
+        }
+    } catch {
+        $null = $_
+    }
+    return $true
+}
+
+function Start-EventConsumer {
+    <#
+    .SYNOPSIS
+    Start the background consumer on a dedicated runspace. Returns a handle for
+    Stop-EventConsumer, or $null when the bus is disabled.
+
+    .DESCRIPTION
+    Discovers sinks once, seeds the cursor to EOF on first-ever start, then
+    loops Invoke-EventConsumerTick on the runspace until the stop flag is set.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$BotRoot,
+        [double]$IntervalSeconds = 2
+    )
+
+    if (-not (_Test-EventConsumerEnabled -BotRoot $BotRoot)) {
+        return $null
+    }
+
+    # Discover sinks once in the parent (fail-loud happens here at startup).
+    $registry = @(Get-SinkRegistry -BotRoot $BotRoot)
+
+    # Seed the cursor so we never replay history to sinks on first-ever start.
+    Initialize-EventConsumerCursor -BotRoot $BotRoot | Out-Null
+
+    $modulePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'Dotbot.Events.psd1'
+
+    # Single-element bool array passed by reference into the runspace as the
+    # cooperative stop signal.
+    $stopFlag = [bool[]]::new(1)
+
+    $loop = {
+        param([string]$BotRoot, $Registry, [double]$IntervalSeconds, [string]$ModulePath, [bool[]]$StopFlag)
+
+        Import-Module $ModulePath -DisableNameChecking -Global -ErrorAction SilentlyContinue
+
+        while (-not $StopFlag[0]) {
+            try {
+                Invoke-EventConsumerTick -BotRoot $BotRoot -Registry $Registry | Out-Null
+            } catch {
+                $null = $_
+            }
+            # Chunked sleep so a stop request is honoured promptly.
+            $slept = 0.0
+            while ($slept -lt $IntervalSeconds -and -not $StopFlag[0]) {
+                Start-Sleep -Milliseconds 200
+                $slept += 0.2
+            }
+        }
+    }
+
+    $runspace = [runspacefactory]::CreateRunspace()
+    $runspace.Open()
+    $ps = [powershell]::Create()
+    $ps.Runspace = $runspace
+    $null = $ps.AddScript($loop)
+    $null = $ps.AddArgument($BotRoot)
+    $null = $ps.AddArgument($registry)
+    $null = $ps.AddArgument($IntervalSeconds)
+    $null = $ps.AddArgument($modulePath)
+    $null = $ps.AddArgument($stopFlag)
+    $async = $ps.BeginInvoke()
+
+    return @{
+        enabled    = $true
+        stop_flag  = $stopFlag
+        ps         = $ps
+        runspace   = $runspace
+        async      = $async
+        registry   = $registry
+        bot_root   = $BotRoot
+    }
+}
+
+function Stop-EventConsumer {
+    <#
+    .SYNOPSIS
+    Signal the consumer loop to stop and dispose its runspace. Idempotent.
+    #>
+    [CmdletBinding()]
+    param($Consumer)
+
+    if ($null -eq $Consumer) { return }
+
+    # Use `$null -ne` explicitly: a [bool[]] of length 1 evaluates to its single
+    # element in a boolean context, so `if ($Consumer.stop_flag)` would be
+    # $false when the flag is still down and never set it.
+    try { if ($null -ne $Consumer.stop_flag) { $Consumer.stop_flag[0] = $true } } catch { $null = $_ }
+    try { if ($null -ne $Consumer.ps)        { $Consumer.ps.Stop(); $Consumer.ps.Dispose() } }        catch { $null = $_ }
+    try { if ($null -ne $Consumer.runspace)  { $Consumer.runspace.Close(); $Consumer.runspace.Dispose() } } catch { $null = $_ }
+}
+
+Export-ModuleMember -Function @(
+    'Get-EventCursorPath'
+    'Read-EventCursor'
+    'Save-EventCursor'
+    'Initialize-EventConsumerCursor'
+    'Read-EventBatch'
+    'Invoke-EventConsumerTick'
+    'Start-EventConsumer'
+    'Stop-EventConsumer'
+)

--- a/src/runtime/Modules/Dotbot.Events/Private/Discovery.psm1
+++ b/src/runtime/Modules/Dotbot.Events/Private/Discovery.psm1
@@ -1,0 +1,250 @@
+<#
+.SYNOPSIS
+Discovery for event-bus sinks.
+
+Sinks live one-folder-per-sink under a stable directory. Each folder must
+contain metadata.json + script.ps1. Discovery scans the folder, parses each
+metadata.json, and returns a list of sink records sorted alphabetically by
+folder name — dispatch order is the declaration order in the directory listing.
+
+A malformed metadata.json is reported as an error rather than silently
+skipped, so a fixture directory with valid sinks + one malformed produces a
+startup error (parity with the Dotbot.Hook engine).
+
+Sinks differ from transition hooks in two ways enforced elsewhere (Dispatch):
+dispatch is non-aborting and out-of-band. Consequently a sink's metadata has
+no `abort_on_failure` field — every sink is non-aborting by contract.
+#>
+
+# ─── Configurable schema ────────────────────────────────────────────────────
+
+$script:DotbotSinkMetadataRequiredFields = @(
+    'name',
+    'subscribed_events',
+    'max_duration'
+)
+
+# ─── Default sinks directory resolution ─────────────────────────────────────
+
+function Get-DefaultSinksDirectory {
+    <#
+    .SYNOPSIS
+    Resolve the canonical "where do sinks live" path for a project.
+
+    .DESCRIPTION
+    Sinks live under runtime/Plugins/Events/Sinks/.
+    After dotbot init, this is <BotRoot>/src/runtime/Plugins/Events/Sinks/.
+    When running against an uninstalled source tree (dev tests), the sinks
+    live next to this module in <repo>/src/runtime/Plugins/Events/Sinks/.
+
+    Resolution order:
+      1. <BotRoot>/src/runtime/Plugins/Events/Sinks/   ← per-project framework copy
+      2. <module-source>/../../Plugins/Events/Sinks/   ← dev/repo fallback
+
+    Returns $null if neither exists. Callers can pass an explicit -SinksDir
+    to Get-SinkRegistry to override.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$BotRoot
+    )
+
+    if ($BotRoot) {
+        $projectCopy = Join-Path $BotRoot (Join-Path 'src' (Join-Path 'runtime' (Join-Path 'Plugins' (Join-Path 'Events' 'Sinks'))))
+        if (Test-Path -LiteralPath $projectCopy -PathType Container) {
+            return $projectCopy
+        }
+    }
+
+    # Dev fallback: this file lives at
+    # <root>/src/runtime/Modules/Dotbot.Events/Private/Discovery.psm1,
+    # so the sinks sit at <root>/src/runtime/Plugins/Events/Sinks/.
+    $repoCopy = Join-Path (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))) (Join-Path 'Plugins' (Join-Path 'Events' 'Sinks'))
+    if (Test-Path -LiteralPath $repoCopy -PathType Container) {
+        return $repoCopy
+    }
+
+    return $null
+}
+
+# ─── Metadata parsing ───────────────────────────────────────────────────────
+
+function _Parse-SinkMetadataJson {
+    <#
+    .SYNOPSIS
+    Parse a metadata.json string into a hashtable.
+    #>
+    param([Parameter(Mandatory)] [string]$Content)
+
+    try {
+        return ($Content | ConvertFrom-Json -AsHashtable)
+    } catch {
+        throw "Invalid metadata.json: $($_.Exception.Message)"
+    }
+}
+
+function Read-SinkMetadata {
+    <#
+    .SYNOPSIS
+    Parse and validate a single sink's metadata.json.
+
+    .OUTPUTS
+    Hashtable record:
+        @{
+            name              = 'webhooks'
+            description       = '...'
+            subscribed_events = @('task.*', 'workflow.*')
+            max_duration      = 10
+            metadata_path     = '/path/to/metadata.json'
+            script_path       = '/path/to/script.ps1'
+            dir               = '/path/to/webhooks'
+        }
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$SinkDir
+    )
+
+    if (-not (Test-Path -LiteralPath $SinkDir -PathType Container)) {
+        throw "Read-SinkMetadata: sink directory not found: $SinkDir"
+    }
+
+    $metaPath   = Join-Path $SinkDir 'metadata.json'
+    $scriptPath = Join-Path $SinkDir 'script.ps1'
+
+    if (-not (Test-Path -LiteralPath $metaPath -PathType Leaf)) {
+        throw "Read-SinkMetadata: '$SinkDir' is missing metadata.json."
+    }
+    if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
+        throw "Read-SinkMetadata: '$SinkDir' is missing script.ps1."
+    }
+
+    $raw = Get-Content -LiteralPath $metaPath -Raw
+    $parsed = _Parse-SinkMetadataJson -Content $raw
+    if (-not $parsed -or $parsed.Count -eq 0) {
+        throw "Read-SinkMetadata: '$metaPath' did not parse to any fields."
+    }
+
+    foreach ($req in $script:DotbotSinkMetadataRequiredFields) {
+        if (-not $parsed.ContainsKey($req)) {
+            throw "Read-SinkMetadata: '$metaPath' is missing required field '$req'."
+        }
+    }
+
+    # Normalise subscribed_events → string[]. Entries are glob patterns matched
+    # against a concrete dotted event type (e.g. 'task.*' matches 'task.created').
+    # No closed vocabulary: the bus is extensible, so any non-empty pattern is
+    # legal here — an unknown family just never matches until it is published.
+    $events = @($parsed['subscribed_events'])
+    if ($events.Count -eq 0) {
+        throw "Read-SinkMetadata: '$metaPath' has empty subscribed_events (must list at least one glob pattern)."
+    }
+    foreach ($e in $events) {
+        if ([string]::IsNullOrWhiteSpace([string]$e)) {
+            throw "Read-SinkMetadata: '$metaPath' has a blank entry in subscribed_events."
+        }
+    }
+
+    # Normalise max_duration → int seconds
+    $maxDur = [int]$parsed['max_duration']
+    if ($maxDur -le 0) {
+        throw "Read-SinkMetadata: '$metaPath' has non-positive max_duration ($($parsed['max_duration']))."
+    }
+
+    $description = if ($parsed.ContainsKey('description')) { [string]$parsed['description'] } else { '' }
+
+    return [ordered]@{
+        name              = [string]$parsed['name']
+        description       = $description
+        subscribed_events = [string[]]$events
+        max_duration      = $maxDur
+        metadata_path     = $metaPath
+        script_path       = $scriptPath
+        dir               = $SinkDir
+    }
+}
+
+# ─── Registry assembly ──────────────────────────────────────────────────────
+
+function Get-SinkRegistry {
+    <#
+    .SYNOPSIS
+    Scan the sinks directory, parse each sink's metadata, return a sorted
+    list of sink records.
+
+    .DESCRIPTION
+    Discovery is deterministic and reproducible. Order is alphabetical by
+    directory name. A malformed sink (bad/missing metadata, missing script.ps1)
+    throws — discovery is "either all parse correctly or fail loudly" so a typo
+    at startup is impossible to miss.
+
+    .PARAMETER SinksDir
+    Override the sinks root. When omitted, Get-DefaultSinksDirectory chooses.
+
+    .PARAMETER BotRoot
+    Project bot root, used by Get-DefaultSinksDirectory to find the per-project
+    framework copy.
+
+    .OUTPUTS
+    @(<sinkRecord>, ...). Empty array if no sinks dir exists.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$SinksDir,
+        [string]$BotRoot
+    )
+
+    if (-not $SinksDir) {
+        $SinksDir = Get-DefaultSinksDirectory -BotRoot $BotRoot
+    }
+    if (-not $SinksDir) { return @() }
+    if (-not (Test-Path -LiteralPath $SinksDir -PathType Container)) { return @() }
+
+    # Collect with a foreach statement (not ForEach-Object) so accumulation
+    # stays in this scope, and emit the elements normally — callers wrap the
+    # result in @() so 0/1/many sinks all read back as an array.
+    $registry = @()
+    foreach ($dir in (Get-ChildItem -LiteralPath $SinksDir -Directory -ErrorAction SilentlyContinue | Sort-Object -Property Name)) {
+        # Read-SinkMetadata throws on malformed entries; let it propagate.
+        $registry += (Read-SinkMetadata -SinkDir $dir.FullName)
+    }
+    return $registry
+}
+
+function Get-SinksForEvent {
+    <#
+    .SYNOPSIS
+    Filter a sink registry down to sinks subscribed to a concrete event type.
+
+    .DESCRIPTION
+    A sink matches when any of its subscribed_events glob patterns matches the
+    given event type (PowerShell -like), so a sink subscribed to 'task.*'
+    matches 'task.created', and one subscribed to the exact 'workflow.run_completed'
+    matches only that type.
+
+    .PARAMETER Registry
+    The output of Get-SinkRegistry.
+
+    .PARAMETER EventType
+    The concrete dotted event type of a published event (e.g. 'task.created').
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Registry,
+        [Parameter(Mandatory)] [string]$EventType
+    )
+    $out = @()
+    foreach ($s in $Registry) {
+        foreach ($pattern in $s.subscribed_events) {
+            if ($EventType -like $pattern) { $out += $s; break }
+        }
+    }
+    return $out
+}
+
+Export-ModuleMember -Function @(
+    'Get-DefaultSinksDirectory'
+    'Read-SinkMetadata'
+    'Get-SinkRegistry'
+    'Get-SinksForEvent'
+)

--- a/src/runtime/Modules/Dotbot.Events/Private/Dispatch.psm1
+++ b/src/runtime/Modules/Dotbot.Events/Private/Dispatch.psm1
@@ -13,10 +13,12 @@ from transition hooks:
 
 Each sink runs in a child runspace so max_duration can be enforced via Stop().
 
-The Invoke-Sink contract from each sink's script.ps1: a single function taking
-$Event (the event envelope) and optionally returning a hashtable with
-Success/Message. A sink that returns nothing is treated as success — its work
-is the side effect (POST a webhook, forward to the mothership, …).
+The Invoke-Sink contract from each sink's script.ps1: a function taking
+$Event (the event envelope) and $Context (a hashtable with BotRoot and the
+resolved `events` settings section — so a sink can read its own config without
+importing anything into its isolated runspace). A sink may return a hashtable
+with Success/Message; returning nothing is treated as success — its work is the
+side effect (POST a webhook, forward to the mothership, …).
 
 Loading note: a bare .ps1 with a top-level Export-ModuleMember isn't a real
 module. We turn it into one at dispatch time via New-Module against a
@@ -41,11 +43,13 @@ function Invoke-SingleSink {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)] $Sink,     # one element from Get-SinkRegistry
-        [Parameter(Mandatory)] $Event     # the event envelope (hashtable or pscustomobject)
+        [Parameter(Mandatory)] $Event,    # the event envelope (hashtable or pscustomobject)
+        $Context                          # @{ BotRoot; Events } passed to the sink
     )
 
     $name = [string]$Sink.name
     $maxDuration = [int]$Sink.max_duration
+    if ($null -eq $Context) { $Context = @{} }
 
     # Read the script once; pass the contents into the child runspace rather
     # than re-reading from disk inside it (avoids coupling to a working dir).
@@ -63,7 +67,7 @@ function Invoke-SingleSink {
     }
 
     $runner = {
-        param([string]$Content, [string]$SinkName, $Event)
+        param([string]$Content, [string]$SinkName, $Event, $Context)
 
         $sw = [System.Diagnostics.Stopwatch]::StartNew()
         try {
@@ -72,7 +76,7 @@ function Invoke-SingleSink {
             # module — Export-ModuleMember inside the script works, and we can
             # invoke its function via `& $mod <Name>`.
             $mod = New-Module -Name ("DotbotSink_" + $SinkName) -ScriptBlock $sb
-            $sinkResult = & $mod Invoke-Sink -Event $Event
+            $sinkResult = & $mod Invoke-Sink -Event $Event -Context $Context
         } catch {
             $sw.Stop()
             return @{
@@ -107,6 +111,7 @@ function Invoke-SingleSink {
     $null = $ps.AddArgument($scriptContent)
     $null = $ps.AddArgument($name)
     $null = $ps.AddArgument($Event)
+    $null = $ps.AddArgument($Context)
 
     $outerSw = [System.Diagnostics.Stopwatch]::StartNew()
     $async = $ps.BeginInvoke()
@@ -171,6 +176,10 @@ function Invoke-EventSinks {
     registry is discovered from -SinksDir / -BotRoot. The consumer discovers
     once at startup and passes it here per event to avoid re-scanning disk.
 
+    .PARAMETER Context
+    The @{ BotRoot; Events } context handed to each sink. When omitted, a
+    minimal @{ BotRoot = $BotRoot } is built.
+
     .OUTPUTS
         @{
             event_type = '<type>' | $null
@@ -183,8 +192,11 @@ function Invoke-EventSinks {
         [Parameter(Mandatory)] $Event,
         $Registry,
         [string]$BotRoot,
-        [string]$SinksDir
+        [string]$SinksDir,
+        $Context
     )
+
+    if ($null -eq $Context) { $Context = @{ BotRoot = $BotRoot } }
 
     $eventType = if ($Event -is [hashtable]) { [string]$Event['type'] } else { [string]$Event.type }
     if ([string]::IsNullOrWhiteSpace($eventType)) {
@@ -204,7 +216,7 @@ function Invoke-EventSinks {
         # never stop the others.
         $r = $null
         try {
-            $r = Invoke-SingleSink -Sink $s -Event $Event
+            $r = Invoke-SingleSink -Sink $s -Event $Event -Context $Context
         } catch {
             $r = @{
                 name      = [string]$s.name

--- a/src/runtime/Modules/Dotbot.Events/Private/Dispatch.psm1
+++ b/src/runtime/Modules/Dotbot.Events/Private/Dispatch.psm1
@@ -1,0 +1,230 @@
+<#
+.SYNOPSIS
+Dispatch for event-bus sinks.
+
+Runs each sink subscribed to a published event. Two rules distinguish sinks
+from transition hooks:
+
+  - NON-ABORTING: a sink that fails or times out is logged and skipped. It
+    never rolls back a task and never stops the other sinks for the same event.
+  - OUT-OF-BAND: dispatch happens AFTER the event is durably logged, driven by
+    the background consumer (a later step) — never inside a task's
+    state-transition path.
+
+Each sink runs in a child runspace so max_duration can be enforced via Stop().
+
+The Invoke-Sink contract from each sink's script.ps1: a single function taking
+$Event (the event envelope) and optionally returning a hashtable with
+Success/Message. A sink that returns nothing is treated as success — its work
+is the side effect (POST a webhook, forward to the mothership, …).
+
+Loading note: a bare .ps1 with a top-level Export-ModuleMember isn't a real
+module. We turn it into one at dispatch time via New-Module against a
+ScriptBlock built from the file contents, matching the Dotbot.Hook engine.
+#>
+
+function Invoke-SingleSink {
+    <#
+    .SYNOPSIS
+    Run one sink's Invoke-Sink function under a timeout. Catches all faults and
+    normalises the return to a single hashtable. Never throws.
+
+    .OUTPUTS
+        @{
+            name      = '<sink name>'
+            success   = $true|$false
+            message   = '<string>'
+            duration  = <TimeSpan>
+            timed_out = $true|$false
+        }
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Sink,     # one element from Get-SinkRegistry
+        [Parameter(Mandatory)] $Event     # the event envelope (hashtable or pscustomobject)
+    )
+
+    $name = [string]$Sink.name
+    $maxDuration = [int]$Sink.max_duration
+
+    # Read the script once; pass the contents into the child runspace rather
+    # than re-reading from disk inside it (avoids coupling to a working dir).
+    $scriptContent = $null
+    try {
+        $scriptContent = Get-Content -LiteralPath $Sink.script_path -Raw -ErrorAction Stop
+    } catch {
+        return @{
+            name      = $name
+            success   = $false
+            message   = "Sink '$name': could not read script.ps1 — $($_.Exception.Message)"
+            duration  = [TimeSpan]::Zero
+            timed_out = $false
+        }
+    }
+
+    $runner = {
+        param([string]$Content, [string]$SinkName, $Event)
+
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+        try {
+            $sb = [ScriptBlock]::Create($Content)
+            # New-Module against the script block produces a real dynamic
+            # module — Export-ModuleMember inside the script works, and we can
+            # invoke its function via `& $mod <Name>`.
+            $mod = New-Module -Name ("DotbotSink_" + $SinkName) -ScriptBlock $sb
+            $sinkResult = & $mod Invoke-Sink -Event $Event
+        } catch {
+            $sw.Stop()
+            return @{
+                success  = $false
+                message  = $_.Exception.Message
+                duration = $sw.Elapsed
+            }
+        }
+        $sw.Stop()
+
+        # A sink that returns nothing is a success (the work is the side
+        # effect). If it returns a hashtable, honour Success/Message (PascalCase
+        # per contract, lowercase tolerated).
+        $success = $true
+        $message = ''
+        $sinkDuration = $sw.Elapsed
+        if ($sinkResult -is [hashtable]) {
+            if ($sinkResult.ContainsKey('Success'))      { $success = [bool]$sinkResult['Success'] }
+            elseif ($sinkResult.ContainsKey('success'))  { $success = [bool]$sinkResult['success'] }
+            if ($sinkResult.ContainsKey('Message'))      { $message = [string]$sinkResult['Message'] }
+            elseif ($sinkResult.ContainsKey('message'))  { $message = [string]$sinkResult['message'] }
+        }
+        return @{
+            success  = $success
+            message  = $message
+            duration = $sinkDuration
+        }
+    }
+
+    $ps = [PowerShell]::Create()
+    $null = $ps.AddScript($runner)
+    $null = $ps.AddArgument($scriptContent)
+    $null = $ps.AddArgument($name)
+    $null = $ps.AddArgument($Event)
+
+    $outerSw = [System.Diagnostics.Stopwatch]::StartNew()
+    $async = $ps.BeginInvoke()
+
+    $completed = $async.AsyncWaitHandle.WaitOne([TimeSpan]::FromSeconds($maxDuration))
+    $outerSw.Stop()
+
+    if (-not $completed) {
+        # Timeout — forcibly stop the runspace. Non-aborting: the sink is
+        # marked failed/timed-out and the caller moves on to the next sink.
+        try { $ps.Stop() } catch { $null = $_ }
+        try { $ps.Dispose() } catch { $null = $_ }
+        return @{
+            name      = $name
+            success   = $false
+            message   = "Sink '$name' exceeded max_duration of ${maxDuration}s and was stopped."
+            duration  = $outerSw.Elapsed
+            timed_out = $true
+        }
+    }
+
+    $result = $null
+    try {
+        $result = $ps.EndInvoke($async) | Select-Object -First 1
+    } catch {
+        $result = @{ success = $false; message = $_.Exception.Message; duration = $outerSw.Elapsed }
+    } finally {
+        try { $ps.Dispose() } catch { $null = $_ }
+    }
+
+    if ($null -eq $result) {
+        $result = @{ success = $false; message = "Sink '$name' produced no result."; duration = $outerSw.Elapsed }
+    }
+
+    return @{
+        name      = $name
+        success   = [bool]$result.success
+        message   = [string]$result.message
+        duration  = if ($result.duration -is [TimeSpan]) { $result.duration } else { $outerSw.Elapsed }
+        timed_out = $false
+    }
+}
+
+function Invoke-EventSinks {
+    <#
+    .SYNOPSIS
+    Dispatch every sink subscribed to a single event's type. Non-aborting:
+    every matching sink runs regardless of what the others do.
+
+    .DESCRIPTION
+    Extracts the event's dotted `type`, finds the subscribed sinks, and runs
+    each in its own time-boxed child runspace. A sink failure or timeout is
+    captured in the results and never stops the remaining sinks — nor does it
+    ever propagate back to the caller.
+
+    .PARAMETER Event
+    The event envelope — a hashtable (as published) or a pscustomobject (as
+    parsed from the activity log by the consumer).
+
+    .PARAMETER Registry
+    A pre-discovered sink registry (from Get-SinkRegistry). When omitted, the
+    registry is discovered from -SinksDir / -BotRoot. The consumer discovers
+    once at startup and passes it here per event to avoid re-scanning disk.
+
+    .OUTPUTS
+        @{
+            event_type = '<type>' | $null
+            dispatched = <int matching sinks>
+            results    = @( <perSinkResult>, ... )
+        }
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Event,
+        $Registry,
+        [string]$BotRoot,
+        [string]$SinksDir
+    )
+
+    $eventType = if ($Event -is [hashtable]) { [string]$Event['type'] } else { [string]$Event.type }
+    if ([string]::IsNullOrWhiteSpace($eventType)) {
+        return @{ event_type = $null; dispatched = 0; results = @() }
+    }
+
+    if ($null -eq $Registry) {
+        $Registry = @(Get-SinkRegistry -SinksDir $SinksDir -BotRoot $BotRoot)
+    }
+
+    $matching = @(Get-SinksForEvent -Registry $Registry -EventType $eventType)
+
+    $results = @()
+    foreach ($s in $matching) {
+        # Non-aborting belt-and-braces: Invoke-SingleSink already swallows sink
+        # faults, but guard the dispatch call itself too so one bad sink can
+        # never stop the others.
+        $r = $null
+        try {
+            $r = Invoke-SingleSink -Sink $s -Event $Event
+        } catch {
+            $r = @{
+                name      = [string]$s.name
+                success   = $false
+                message   = "Sink dispatch error: $($_.Exception.Message)"
+                duration  = [TimeSpan]::Zero
+                timed_out = $false
+            }
+        }
+        $results += ,$r
+    }
+
+    return @{
+        event_type = $eventType
+        dispatched = $matching.Count
+        results    = $results
+    }
+}
+
+Export-ModuleMember -Function @(
+    'Invoke-SingleSink'
+    'Invoke-EventSinks'
+)

--- a/src/runtime/Modules/Dotbot.Runtime/Dotbot.Runtime.psd1
+++ b/src/runtime/Modules/Dotbot.Runtime/Dotbot.Runtime.psd1
@@ -43,6 +43,12 @@
         'Get-ActivityLogPath'
         'Get-DotbotProjectId'
 
+        # Event bus (publish side)
+        'Publish-DotBotEvent'
+        'Register-DotBotEventType'
+        'Get-DotBotEventTypeRegistry'
+        'Test-DotBotEventTypeRegistered'
+
         # Control plane
         'Get-ControlPlaneSettings'
         'Start-ControlPlaneRegistration'

--- a/src/runtime/Modules/Dotbot.Runtime/Dotbot.Runtime.psd1
+++ b/src/runtime/Modules/Dotbot.Runtime/Dotbot.Runtime.psd1
@@ -42,6 +42,7 @@
         'Write-ActivityEvent'
         'Get-ActivityLogPath'
         'Get-DotbotProjectId'
+        'Get-ActivityLogEventTypes'
 
         # Event bus (publish side)
         'Publish-DotBotEvent'

--- a/src/runtime/Modules/Dotbot.Runtime/Private/ActivityLog.psm1
+++ b/src/runtime/Modules/Dotbot.Runtime/Private/ActivityLog.psm1
@@ -8,11 +8,14 @@ line — the runtime is the sole writer, and a per-process SemaphoreSlim
 guards the writer so two listener threads on the same runtime can't
 interleave bytes.
 
-Event shape:
+Event shape (dotted type so each line is a bus event matching task.* /
+workflow.* sink globs):
 {
+  "id":          "evt_xxxxxxxx",
+  "type":        "task.created" | "task.status_changed" | "workflow.run_started" | ...
   "timestamp":   "2026-05-18T10:00:00Z",
+  "source":      "runtime",
   "project_id":  "p_AbCd1234",
-  "type":        "task_created" | "task_status_changed" | ...
   "task_id":     "t_xxxxxxxx",     // when relevant
   "run_id":      "wr_xxxxxxxx",    // when relevant
   "from":        "in-progress",    // on transitions
@@ -124,14 +127,14 @@ function Test-DotBotEventTypeRegistered {
 }
 
 $script:DotbotActivityLogEventTypes = @(
-    'task_created'
-    'task_updated'
-    'task_status_changed'
-    'workflow_run_started'
-    'workflow_run_completed'
-    'workflow_run_failed'
-    'workflow_run_cancelled'
-    'hook_failed'
+    'task.created'
+    'task.updated'
+    'task.status_changed'
+    'workflow.run_started'
+    'workflow.run_completed'
+    'workflow.run_failed'
+    'workflow.run_cancelled'
+    'hook.failed'
 )
 
 function Get-ActivityLogPath {
@@ -343,13 +346,16 @@ function Write-ActivityEvent {
         [string]$From,
         [string]$To,
         [string]$Actor = 'system',
-        [string]$Reason
+        [string]$Reason,
+        [string]$Source = 'runtime'
     )
 
     $event = [ordered]@{
-        timestamp  = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
-        project_id = Get-DotbotProjectId -BotRoot $BotRoot
+        id         = _New-DotBotEventId
         type       = $Type
+        timestamp  = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        source     = $Source
+        project_id = Get-DotbotProjectId -BotRoot $BotRoot
     }
     if ($TaskId) { $event['task_id'] = $TaskId }
     if ($RunId)  { $event['run_id']  = $RunId }

--- a/src/runtime/Modules/Dotbot.Runtime/Private/ActivityLog.psm1
+++ b/src/runtime/Modules/Dotbot.Runtime/Private/ActivityLog.psm1
@@ -43,6 +43,86 @@ function _Get-ActivityLogLock {
     }
     return $lock
 }
+
+# ---------------------------------------------------------------------------
+# Event-type registry (extensible)
+#
+# Publish-DotBotEvent validates a dotted event type (e.g. 'task.completed')
+# against this registry. Entries are wildcard patterns, so a family like
+# 'task.*' registers a whole namespace. An unregistered type is LOGGED and
+# STILL DELIVERED — never rejected — so new families (e.g. 'nudge.*') need no
+# publisher change; they just append to the registry when their producer loads.
+#
+# Stored on the AppDomain (like the writer lock) so a registration made in one
+# runspace is visible to publishers in the per-request runspaces.
+# ---------------------------------------------------------------------------
+$script:DotbotEventTypeRegistryKey = 'Dotbot.Runtime.EventTypeRegistry'
+$script:DotbotDefaultEventTypes    = @(
+    'task.*'
+    'workflow.*'
+)
+
+function _Get-EventTypeRegistry {
+    $registry = [System.AppDomain]::CurrentDomain.GetData($script:DotbotEventTypeRegistryKey)
+    if ($null -eq $registry) {
+        $registry = [System.Collections.Generic.List[string]]::new()
+        foreach ($t in $script:DotbotDefaultEventTypes) { $registry.Add($t) }
+        [System.AppDomain]::CurrentDomain.SetData($script:DotbotEventTypeRegistryKey, $registry)
+    }
+    # Unary comma prevents PowerShell from unrolling the List on return, so
+    # callers get the live List object (needed for .Add / .ToArray), not its
+    # enumerated elements.
+    return ,$registry
+}
+
+function Register-DotBotEventType {
+    <#
+    .SYNOPSIS
+    Register an event type (or a wildcard family such as 'nudge.*') so that
+    Publish-DotBotEvent treats it as a known type.
+
+    .DESCRIPTION
+    Idempotent: registering the same pattern twice is a no-op. Registration is
+    process-wide (AppDomain-backed) so producers loaded in any runspace share
+    one registry.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string]$Type)
+
+    $registry = _Get-EventTypeRegistry
+    if (-not ($registry -contains $Type)) {
+        $registry.Add($Type)
+    }
+}
+
+function Get-DotBotEventTypeRegistry {
+    <#
+    .SYNOPSIS
+    Return the current event-type registry (array of patterns). For tests and
+    diagnostics.
+    #>
+    return ,@((_Get-EventTypeRegistry).ToArray())
+}
+
+function Test-DotBotEventTypeRegistered {
+    <#
+    .SYNOPSIS
+    Return $true when the given concrete type matches any registered pattern.
+
+    .DESCRIPTION
+    Registry entries are treated as wildcard patterns, so 'task.completed'
+    matches the registered family 'task.*', and an exactly-registered concrete
+    type matches itself.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string]$Type)
+
+    foreach ($pattern in (_Get-EventTypeRegistry)) {
+        if ($Type -like $pattern) { return $true }
+    }
+    return $false
+}
+
 $script:DotbotActivityLogEventTypes = @(
     'task_created'
     'task_updated'
@@ -124,6 +204,114 @@ function Get-ActivityLogEventTypes {
     return ,@($script:DotbotActivityLogEventTypes)
 }
 
+function _New-DotBotEventId {
+    # Reuse the runtime's nanoid generator (imported globally via Dotbot.Task)
+    # so event ids share the house 'prefix_ + 8 chars' convention (t_, wr_, p_).
+    if (-not (Get-Command New-DotbotNanoId -ErrorAction SilentlyContinue)) {
+        throw "Publish-DotBotEvent requires New-DotbotNanoId (Dotbot.Task IdGen) — module not loaded."
+    }
+    return 'evt_' + (New-DotbotNanoId)
+}
+
+function _Append-ActivityLogLine {
+    <#
+    .SYNOPSIS
+    Append one already-serialized JSON line to <BotRoot>/.control/activity.jsonl
+    under the process-wide writer lock. Shared by Write-ActivityEvent and
+    Publish-DotBotEvent so both use the SAME SemaphoreSlim and can never
+    interleave bytes with each other.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$BotRoot,
+        [Parameter(Mandatory)] [string]$Line
+    )
+
+    $path = Get-ActivityLogPath -BotRoot $BotRoot
+    $dir  = Split-Path -Parent $path
+    if (-not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+
+    $lock = _Get-ActivityLogLock
+    $lock.Wait()
+    try {
+        # AppendAllText opens / appends / closes per call. On POSIX this is
+        # atomic for sub-PIPE_BUF writes (any line we produce here). On NTFS
+        # it's atomic for sub-4KB writes. The +newline keeps lines separated.
+        [System.IO.File]::AppendAllText(
+            $path,
+            $Line + [System.Environment]::NewLine,
+            [System.Text.UTF8Encoding]::new($false)
+        )
+    } finally {
+        [void]$lock.Release()
+    }
+}
+
+function Publish-DotBotEvent {
+    <#
+    .SYNOPSIS
+    Publish a typed event onto the event bus.
+
+    .DESCRIPTION
+    Stamps a well-formed envelope — id, type, timestamp, source, data, plus the
+    project id and actor — and appends it as one JSON line to
+    <BotRoot>/.control/activity.jsonl. Publishing to the activity log means the
+    /api/activity/tail byte-cursor endpoint carries bus events to the browser
+    with no new transport.
+
+    The Type is validated against the extensible event-type registry. An
+    UNREGISTERED type is logged and STILL DELIVERED (never rejected), so new
+    event families need no change to this publisher.
+
+    .PARAMETER Type
+    The dotted event type, e.g. 'task.completed' or 'workflow.run_failed'.
+
+    .PARAMETER Source
+    Where the event originated, e.g. 'runtime'.
+
+    .PARAMETER Data
+    Arbitrary event payload; serialized as the envelope's nested 'data' object.
+
+    .OUTPUTS
+    The envelope hashtable that was written (so callers/tests can inspect the id).
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$BotRoot,
+        [Parameter(Mandatory)] [string]$Type,
+        [Parameter(Mandatory)] [string]$Source,
+        [hashtable]$Data,
+        [string]$Actor = 'system'
+    )
+
+    if (-not (Test-DotBotEventTypeRegistered -Type $Type)) {
+        # Logged, not rejected — the registry is extensible by design. Debug
+        # level: Write-BotLog only mirrors Info+ into activity.jsonl, so this
+        # note never pollutes the bus itself. Guarded so the module stays
+        # usable when Dotbot.Logging isn't loaded.
+        if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
+            Write-BotLog -Level Debug -Message "Publish-DotBotEvent: unregistered event type '$Type' — delivering anyway."
+        }
+    }
+
+    $envelope = [ordered]@{
+        id         = _New-DotBotEventId
+        type       = $Type
+        timestamp  = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        source     = $Source
+        data       = if ($null -ne $Data) { $Data } else { @{} }
+        project_id = Get-DotbotProjectId -BotRoot $BotRoot
+        actor      = $Actor
+    }
+
+    $line = $envelope | ConvertTo-Json -Depth 10 -Compress
+    _Append-ActivityLogLine -BotRoot $BotRoot -Line $line
+
+    return $envelope
+}
+
 function Write-ActivityEvent {
     <#
     .SYNOPSIS
@@ -174,31 +362,15 @@ function Write-ActivityEvent {
     # one entry = one physical line, which is what the UI's FileWatcher
     # consumer assumes.
     $line = $event | ConvertTo-Json -Depth 6 -Compress
-
-    $path = Get-ActivityLogPath -BotRoot $BotRoot
-    $dir  = Split-Path -Parent $path
-    if (-not (Test-Path -LiteralPath $dir)) {
-        New-Item -ItemType Directory -Path $dir -Force | Out-Null
-    }
-
-    $lock = _Get-ActivityLogLock
-    $lock.Wait()
-    try {
-        # AppendAllText opens / appends / closes per call. On POSIX this is
-        # atomic for sub-PIPE_BUF writes (any line we produce here). On NTFS
-        # it's atomic for sub-4KB writes. The +newline keeps lines separated.
-        [System.IO.File]::AppendAllText(
-            $path,
-            $line + [System.Environment]::NewLine,
-            [System.Text.UTF8Encoding]::new($false)
-        )
-    } finally {
-        [void]$lock.Release()
-    }
+    _Append-ActivityLogLine -BotRoot $BotRoot -Line $line
 }
 
 Export-ModuleMember -Function @(
     'Write-ActivityEvent'
+    'Publish-DotBotEvent'
+    'Register-DotBotEventType'
+    'Get-DotBotEventTypeRegistry'
+    'Test-DotBotEventTypeRegistered'
     'Get-ActivityLogPath'
     'Get-DotbotProjectId'
     'Get-ActivityLogEventTypes'

--- a/src/runtime/Modules/Dotbot.Runtime/Private/HttpServer.psm1
+++ b/src/runtime/Modules/Dotbot.Runtime/Private/HttpServer.psm1
@@ -1034,7 +1034,7 @@ function Invoke-CreateTaskHandler {
     Lock-TaskMutex -TaskId $task.id | Out-Null
     try {
         _Write-TaskFileAtomic -Path $filePath -Content $task
-        Write-ActivityEvent -BotRoot $BotRoot -Type 'task_created' -TaskId $task.id -Actor $actor
+        Write-ActivityEvent -BotRoot $BotRoot -Type 'task.created' -TaskId $task.id -Actor $actor
     } finally {
         Unlock-TaskMutex -TaskId $task.id
     }
@@ -1139,7 +1139,7 @@ function Invoke-PatchTaskHandler {
         }
 
         _Write-TaskFileAtomic -Path $path -Content $task
-        Write-ActivityEvent -BotRoot $BotRoot -Type 'task_updated' -TaskId $task.id -Actor $actor
+        Write-ActivityEvent -BotRoot $BotRoot -Type 'task.updated' -TaskId $task.id -Actor $actor
     } finally {
         Unlock-TaskMutex -TaskId $taskId
     }
@@ -1242,7 +1242,7 @@ function Invoke-TaskStatusHandler {
         # Write the new status FIRST so hooks observe a consistent on-disk
         # view.
         _Write-TaskFileAtomic -Path $path -Content $task
-        Write-ActivityEvent -BotRoot $BotRoot -Type 'task_status_changed' -TaskId $task.id -From $from -To $to -Actor $actor -Reason $reason
+        Write-ActivityEvent -BotRoot $BotRoot -Type 'task.status_changed' -TaskId $task.id -From $from -To $to -Actor $actor -Reason $reason
 
         # Transition-hook dispatch. Hooks run synchronously, inline with
         # this handler, inside the task mutex. A failing hook with
@@ -1291,7 +1291,7 @@ function Invoke-TaskStatusHandler {
 
             Write-ActivityEvent `
                 -BotRoot $BotRoot `
-                -Type    'hook_failed' `
+                -Type    'hook.failed' `
                 -TaskId  $task.id `
                 -From    $to `
                 -To      $from `
@@ -1319,7 +1319,7 @@ function Invoke-TaskStatusHandler {
             # response is honest about the half-finished state.
             Write-ActivityEvent `
                 -BotRoot $BotRoot `
-                -Type    'hook_failed' `
+                -Type    'hook.failed' `
                 -TaskId  $task.id `
                 -To      $to `
                 -Actor   $actor `
@@ -1507,7 +1507,7 @@ function Invoke-CreateRunHandler {
         _Write-TaskFileAtomic -Path $layout.run_record_path -Content $record
         _Write-TaskFileAtomic -Path $layout.live_status_path -Content $status
 
-        Write-ActivityEvent -BotRoot $BotRoot -Type 'workflow_run_started' -RunId $runId -Actor $startedBy
+        Write-ActivityEvent -BotRoot $BotRoot -Type 'workflow.run_started' -RunId $runId -Actor $startedBy
     } finally {
         Unlock-RunMutex -RunId $runId
     }

--- a/src/runtime/Modules/Dotbot.Runtime/Private/Imports.ps1
+++ b/src/runtime/Modules/Dotbot.Runtime/Private/Imports.ps1
@@ -8,3 +8,4 @@ Import-Module (Join-Path $runtimeModules 'Dotbot.Process' 'Dotbot.Process.psd1')
 Import-Module (Join-Path $runtimeModules 'Dotbot.Hook' 'Dotbot.Hook.psd1') -DisableNameChecking -Global
 Import-Module (Join-Path $runtimeModules 'Dotbot.Settings' 'Dotbot.Settings.psd1') -DisableNameChecking -Global
 Import-Module (Join-Path $runtimeModules 'Dotbot.Handoff' 'Dotbot.Handoff.psd1') -DisableNameChecking -Global
+Import-Module (Join-Path $runtimeModules 'Dotbot.Events' 'Dotbot.Events.psd1') -DisableNameChecking -Global

--- a/src/runtime/Modules/Dotbot.Runtime/Private/Lifecycle.psm1
+++ b/src/runtime/Modules/Dotbot.Runtime/Private/Lifecycle.psm1
@@ -204,6 +204,7 @@ function Start-DotbotRuntime {
             attached   = $true
             listener   = $null
             control_plane = $null
+            events_consumer = $null
         }
     }
 
@@ -242,6 +243,7 @@ function Start-DotbotRuntime {
         attached   = $false
         listener   = $listener
         control_plane = $null
+        events_consumer = $null
     }
 
     $runtimeRegistration = @{
@@ -257,6 +259,16 @@ function Start-DotbotRuntime {
         $result.control_plane = [ordered]@{ enabled = $true; registered = $false; error = $_.Exception.Message }
     }
 
+    # Event-bus consumer — hosted here so there is exactly one per project in
+    # every mode (both `dotbot go` and `dotbot serve` launch the runtime
+    # server; the UI server never hosts it). Start-EventConsumer returns $null
+    # when the bus is disabled.
+    try {
+        $result.events_consumer = Start-EventConsumer -BotRoot $BotRoot
+    } catch {
+        $result.events_consumer = [ordered]@{ enabled = $true; started = $false; error = $_.Exception.Message }
+    }
+
     if ($Foreground) {
         # The listener loop runs on a background ThreadPool job. In foreground
         # mode we block in this caller until someone signals shutdown — that
@@ -268,7 +280,7 @@ function Start-DotbotRuntime {
                 Start-Sleep -Milliseconds 250
             }
         } finally {
-            Stop-DotbotRuntime -BotRoot $BotRoot -Listener $listener -ControlPlaneRegistration $result.control_plane -ErrorAction SilentlyContinue
+            Stop-DotbotRuntime -BotRoot $BotRoot -Listener $listener -ControlPlaneRegistration $result.control_plane -EventConsumer $result.events_consumer -ErrorAction SilentlyContinue
         }
     }
 
@@ -290,7 +302,8 @@ function Stop-DotbotRuntime {
     param(
         [Parameter(Mandatory)] [string]$BotRoot,
         [System.Net.HttpListener]$Listener,
-        [object]$ControlPlaneRegistration
+        [object]$ControlPlaneRegistration,
+        [object]$EventConsumer
     )
 
     if ($Listener) {
@@ -303,6 +316,10 @@ function Stop-DotbotRuntime {
 
     if ($ControlPlaneRegistration) {
         try { Stop-ControlPlaneRegistration -BotRoot $BotRoot -Registration $ControlPlaneRegistration } catch { $null = $_ }
+    }
+
+    if ($EventConsumer) {
+        try { Stop-EventConsumer -Consumer $EventConsumer } catch { $null = $_ }
     }
 
     Remove-RuntimeConnectionFile -BotRoot $BotRoot

--- a/src/runtime/Plugins/Events/Sinks/mothership/metadata.json
+++ b/src/runtime/Plugins/Events/Sinks/mothership/metadata.json
@@ -1,0 +1,6 @@
+{
+  "name": "mothership",
+  "description": "Forward selected events to the mothership fleet server. Gated on mothership + events.mothership settings and honours mothership.sync_events. Ships as a gated no-op until the server-side fleet events endpoint (#599/#544) exists.",
+  "subscribed_events": ["*"],
+  "max_duration": 10
+}

--- a/src/runtime/Plugins/Events/Sinks/mothership/script.ps1
+++ b/src/runtime/Plugins/Events/Sinks/mothership/script.ps1
@@ -1,0 +1,83 @@
+<#
+.SYNOPSIS
+mothership sink — forward selected bus events to the mothership fleet server.
+
+GATED NO-OP (by design, for now): the server-side fleet events endpoint
+(POST /api/fleet/{instance_id}/events) is owned by #599/#544 and does not exist
+yet. Until it lands this sink evaluates all its gates and then no-ops instead of
+POSTing, so enabling it is safe. When the endpoint ships, the forward step wires
+through Dotbot.Notification (the existing mothership client) — the decision
+logic here (Test-MothershipShouldForward) does not change.
+
+Gates (all must pass to forward):
+  - mothership.enabled              (the fleet connection is configured/on)
+  - events.mothership.enabled       (the sink itself is turned on)
+  - mothership.server_url is set
+  - event type matches mothership.sync_events (glob list; empty → all)
+
+Config is handed in via $Context.Settings (full merged settings).
+#>
+
+function Test-MothershipShouldForward {
+    <#
+    .SYNOPSIS
+    Decide whether an event should be forwarded to the mothership. Pure logic
+    (no network) so it is unit-testable. Returns @{ forward = $bool; reason = '...' }.
+    #>
+    param(
+        [Parameter(Mandatory)] $Event,
+        [Parameter(Mandatory)] $Settings
+    )
+
+    $ms = $null
+    $sink = $null
+    if ($null -ne $Settings) {
+        $ms = $Settings.mothership
+        if ($null -ne $Settings.events) { $sink = $Settings.events.mothership }
+    }
+
+    $msEnabled = $false
+    try { $msEnabled = [bool]$ms.enabled } catch { $msEnabled = $false }
+    if (-not $msEnabled) { return @{ forward = $false; reason = 'mothership_disabled' } }
+
+    $sinkEnabled = $false
+    try { $sinkEnabled = [bool]$sink.enabled } catch { $sinkEnabled = $false }
+    if (-not $sinkEnabled) { return @{ forward = $false; reason = 'sink_disabled' } }
+
+    $serverUrl = ''
+    try { $serverUrl = [string]$ms.server_url } catch { $serverUrl = '' }
+    if ([string]::IsNullOrWhiteSpace($serverUrl)) { return @{ forward = $false; reason = 'no_server_url' } }
+
+    $type = if ($Event -is [hashtable]) { [string]$Event['type'] } else { [string]$Event.type }
+    $sync = @($ms.sync_events)
+    $matched = $sync.Count -eq 0
+    foreach ($s in $sync) {
+        if ($type -like [string]$s) { $matched = $true; break }
+    }
+    if (-not $matched) { return @{ forward = $false; reason = 'not_in_sync_events' } }
+
+    return @{ forward = $true; reason = 'ok' }
+}
+
+function Invoke-Sink {
+    param($Event, $Context)
+
+    $settings = if ($null -ne $Context) { $Context.Settings } else { $null }
+    if ($null -eq $settings) { return @{ Success = $true; Message = 'mothership: no settings' } }
+
+    $decision = Test-MothershipShouldForward -Event $Event -Settings $settings
+    if (-not $decision.forward) {
+        return @{ Success = $true; Message = "mothership: skipped ($($decision.reason))" }
+    }
+
+    # GATED NO-OP: the fleet events endpoint (#599/#544) does not exist yet.
+    # When it does, forward here via Dotbot.Notification. Until then this is a
+    # deliberate no-op — the gates above still run so the behaviour is correct
+    # the moment the endpoint ships.
+    return @{ Success = $true; Message = 'mothership: would forward (fleet events endpoint pending #599/#544)' }
+}
+
+Export-ModuleMember -Function @(
+    'Invoke-Sink'
+    'Test-MothershipShouldForward'
+)

--- a/src/runtime/Plugins/Events/Sinks/webhooks/metadata.json
+++ b/src/runtime/Plugins/Events/Sinks/webhooks/metadata.json
@@ -1,0 +1,6 @@
+{
+  "name": "webhooks",
+  "description": "POST matching events to configured HTTPS endpoints, HMAC-signed per endpoint. HTTPS-only with SSRF URL validation; each endpoint honours its own event filter.",
+  "subscribed_events": ["*"],
+  "max_duration": 15
+}

--- a/src/runtime/Plugins/Events/Sinks/webhooks/script.ps1
+++ b/src/runtime/Plugins/Events/Sinks/webhooks/script.ps1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 webhooks sink — POST matching bus events to configured HTTPS endpoints.
 
-Config (from settings' events.webhooks section, handed in via $Context.Events):
+Config (from settings' events.webhooks section, handed in via $Context.Settings.events):
     {
       "enabled": true,
       "endpoints": [
@@ -172,7 +172,9 @@ function Invoke-Sink {
     param($Event, $Context)
 
     $cfg = $null
-    if ($null -ne $Context -and $null -ne $Context.Events) { $cfg = $Context.Events.webhooks }
+    if ($null -ne $Context -and $null -ne $Context.Settings -and $null -ne $Context.Settings.events) {
+        $cfg = $Context.Settings.events.webhooks
+    }
     if ($null -eq $cfg) { return @{ Success = $true; Message = 'webhooks: no config' } }
 
     $enabled = $false

--- a/src/runtime/Plugins/Events/Sinks/webhooks/script.ps1
+++ b/src/runtime/Plugins/Events/Sinks/webhooks/script.ps1
@@ -1,0 +1,215 @@
+<#
+.SYNOPSIS
+webhooks sink — POST matching bus events to configured HTTPS endpoints.
+
+Config (from settings' events.webhooks section, handed in via $Context.Events):
+    {
+      "enabled": true,
+      "endpoints": [
+        { "url": "https://hooks.example.com/dotbot", "events": ["task.*"], "secret": "…" }
+      ]
+    }
+
+For each configured endpoint whose `events` filter matches the event type AND
+whose URL passes HTTPS + SSRF validation, the event JSON is POSTed with an
+HMAC-SHA256 signature (header X-DotBot-Signature: sha256=<hex>) derived from the
+endpoint's `secret`.
+
+Helpers are exported alongside Invoke-Sink so they can be unit-tested without a
+live endpoint (the actual POST is integration-only).
+#>
+
+function Test-IpBlocked {
+    <#
+    .SYNOPSIS
+    $true when an IP is loopback / private / link-local / metadata / otherwise
+    not a safe public destination (SSRF guard).
+    #>
+    param([Parameter(Mandatory)] [System.Net.IPAddress]$IpAddress)
+
+    $ip = $IpAddress
+    # Collapse IPv4-mapped IPv6 (::ffff:a.b.c.d) down to IPv4 for range checks.
+    if ($ip.IsIPv4MappedToIPv6) { $ip = $ip.MapToIPv4() }
+
+    if ([System.Net.IPAddress]::IsLoopback($ip)) { return $true }
+
+    if ($ip.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetwork) {
+        $b = $ip.GetAddressBytes()   # 4 bytes
+        if ($b[0] -eq 0)   { return $true }                                   # 0.0.0.0/8 "this network"
+        if ($b[0] -eq 10)  { return $true }                                   # 10/8 private
+        if ($b[0] -eq 127) { return $true }                                   # loopback
+        if ($b[0] -eq 169 -and $b[1] -eq 254) { return $true }                # 169.254/16 link-local (incl. 169.254.169.254 metadata)
+        if ($b[0] -eq 172 -and $b[1] -ge 16 -and $b[1] -le 31) { return $true } # 172.16/12 private
+        if ($b[0] -eq 192 -and $b[1] -eq 168) { return $true }                # 192.168/16 private
+        if ($b[0] -eq 100 -and $b[1] -ge 64 -and $b[1] -le 127) { return $true } # 100.64/10 CGNAT
+        if ($b[0] -ge 224) { return $true }                                   # 224/4 multicast + 240/4 reserved
+        return $false
+    }
+
+    if ($ip.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetworkV6) {
+        if ($ip.IsIPv6LinkLocal -or $ip.IsIPv6Multicast -or $ip.IsIPv6SiteLocal) { return $true }
+        if ($ip.Equals([System.Net.IPAddress]::IPv6Loopback)) { return $true }
+        if ($ip.Equals([System.Net.IPAddress]::IPv6Any)) { return $true }
+        # fc00::/7 unique-local
+        $bytes = $ip.GetAddressBytes()
+        if (($bytes[0] -band 0xFE) -eq 0xFC) { return $true }
+        return $false
+    }
+
+    return $true  # unknown address family → treat as unsafe
+}
+
+function Test-WebhookUrlAllowed {
+    <#
+    .SYNOPSIS
+    Validate a webhook URL: HTTPS-only + SSRF guard. Returns
+    @{ allowed = $bool; reason = '<why>' }.
+    #>
+    param([Parameter(Mandatory)] [string]$Url)
+
+    $uri = $null
+    if (-not [System.Uri]::TryCreate($Url, [System.UriKind]::Absolute, [ref]$uri)) {
+        return @{ allowed = $false; reason = 'malformed_url' }
+    }
+    if ($uri.Scheme -ne 'https') {
+        return @{ allowed = $false; reason = 'not_https' }
+    }
+
+    $hostName = $uri.DnsSafeHost
+    $lower = $hostName.ToLowerInvariant()
+    if ($lower -eq 'localhost' -or $lower.EndsWith('.localhost') -or
+        $lower.EndsWith('.local') -or $lower.EndsWith('.internal')) {
+        return @{ allowed = $false; reason = 'internal_hostname' }
+    }
+
+    # IP-literal host → check ranges directly (no DNS).
+    $literal = $null
+    if ([System.Net.IPAddress]::TryParse($hostName, [ref]$literal)) {
+        if (Test-IpBlocked -IpAddress $literal) {
+            return @{ allowed = $false; reason = 'blocked_ip_range' }
+        }
+        return @{ allowed = $true; reason = 'ok' }
+    }
+
+    # Hostname → resolve and check every resolved address. Fail closed if it
+    # can't be resolved (a webhook to an unresolvable host is undeliverable
+    # anyway, and failing closed avoids surprises).
+    try {
+        $addresses = [System.Net.Dns]::GetHostAddresses($hostName)
+    } catch {
+        return @{ allowed = $false; reason = 'dns_resolution_failed' }
+    }
+    if (-not $addresses -or $addresses.Count -eq 0) {
+        return @{ allowed = $false; reason = 'dns_no_addresses' }
+    }
+    foreach ($addr in $addresses) {
+        if (Test-IpBlocked -IpAddress $addr) {
+            return @{ allowed = $false; reason = 'resolves_to_blocked_ip' }
+        }
+    }
+    return @{ allowed = $true; reason = 'ok' }
+}
+
+function New-WebhookSignature {
+    <#
+    .SYNOPSIS
+    HMAC-SHA256 of the body keyed by the endpoint secret, as 'sha256=<hex>'.
+    #>
+    param(
+        [Parameter(Mandatory)] [string]$Body,
+        [Parameter(Mandatory)] [AllowEmptyString()] [string]$Secret
+    )
+    $hmac = [System.Security.Cryptography.HMACSHA256]::new([System.Text.Encoding]::UTF8.GetBytes($Secret))
+    try {
+        $hash = $hmac.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Body))
+    } finally {
+        $hmac.Dispose()
+    }
+    $hex = -join ($hash | ForEach-Object { $_.ToString('x2') })
+    return "sha256=$hex"
+}
+
+function Get-WebhookDeliveryPlan {
+    <#
+    .SYNOPSIS
+    Return the endpoints that WOULD receive this event: those whose `events`
+    filter matches the event type AND whose URL passes HTTPS/SSRF validation.
+    Pure decision logic (no network), so it is unit-testable.
+    #>
+    param(
+        [Parameter(Mandatory)] $Event,
+        [Parameter(Mandatory)] $Config
+    )
+
+    $type = if ($Event -is [hashtable]) { [string]$Event['type'] } else { [string]$Event.type }
+    $plan = @()
+    foreach ($ep in @($Config.endpoints)) {
+        if ($null -eq $ep) { continue }
+        $url = [string]$ep.url
+        if ([string]::IsNullOrWhiteSpace($url)) { continue }
+
+        # Per-endpoint event filter. Empty/missing → match everything.
+        $filters = @($ep.events)
+        $matched = $filters.Count -eq 0
+        foreach ($f in $filters) {
+            if ($type -like [string]$f) { $matched = $true; break }
+        }
+        if (-not $matched) { continue }
+
+        $check = Test-WebhookUrlAllowed -Url $url
+        if (-not $check.allowed) { continue }
+
+        $plan += ,([pscustomobject]@{
+            url    = $url
+            secret = [string]$ep.secret
+            events = $filters
+        })
+    }
+    return $plan
+}
+
+function Invoke-Sink {
+    param($Event, $Context)
+
+    $cfg = $null
+    if ($null -ne $Context -and $null -ne $Context.Events) { $cfg = $Context.Events.webhooks }
+    if ($null -eq $cfg) { return @{ Success = $true; Message = 'webhooks: no config' } }
+
+    $enabled = $false
+    try { $enabled = [bool]$cfg.enabled } catch { $enabled = $false }
+    if (-not $enabled) { return @{ Success = $true; Message = 'webhooks: disabled' } }
+
+    $plan = @(Get-WebhookDeliveryPlan -Event $Event -Config $cfg)
+    if ($plan.Count -eq 0) { return @{ Success = $true; Message = 'webhooks: no matching endpoints' } }
+
+    $type = if ($Event -is [hashtable]) { [string]$Event['type'] } else { [string]$Event.type }
+    $body = $Event | ConvertTo-Json -Depth 12 -Compress
+
+    $sent = 0
+    $failed = 0
+    foreach ($ep in $plan) {
+        $sig = New-WebhookSignature -Body $body -Secret $ep.secret
+        try {
+            Invoke-WebRequest -Uri $ep.url -Method POST -Body $body `
+                -ContentType 'application/json; charset=utf-8' `
+                -Headers @{ 'X-DotBot-Event' = $type; 'X-DotBot-Signature' = $sig } `
+                -TimeoutSec 10 -SkipHttpErrorCheck -UseBasicParsing | Out-Null
+            $sent++
+        } catch {
+            $failed++
+        }
+    }
+
+    return @{
+        Success = ($failed -eq 0)
+        Message = "webhooks: sent=$sent failed=$failed of $($plan.Count)"
+    }
+}
+
+Export-ModuleMember -Function @(
+    'Invoke-Sink'
+    'Test-IpBlocked'
+    'Test-WebhookUrlAllowed'
+    'New-WebhookSignature'
+    'Get-WebhookDeliveryPlan'
+)

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -2403,6 +2403,7 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
         $processData.completed_at = (Get-Date).ToUniversalTime().ToString("o")
     }
     if ($RunId) {
+        $runStatus = 'running'
         try {
             $runStatus = switch ([string]$processData.status) {
                 'completed' { 'completed' }
@@ -2413,6 +2414,14 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
             Set-WorkflowRunLiveStatus -RunId $RunId -Status $runStatus -CurrentTaskId $processData.task_id -ErrorMessage $processData.error
         } catch {
             Write-BotLog -Level Warn -Message "Failed to update WorkflowRun live status for $RunId" -Exception $_
+        }
+
+        if ($runStatus -in @('completed', 'failed', 'cancelled')) {
+            try {
+                Write-ActivityEvent -BotRoot $botRoot -Type "workflow.run_$runStatus" -RunId $RunId -From 'running' -To $runStatus -Actor 'system' -Reason $processData.error
+            } catch {
+                Write-BotLog -Level Warn -Message "Failed to emit workflow.run_$runStatus event for $RunId" -Exception $_
+            }
         }
     }
 

--- a/src/ui/server.ps1
+++ b/src/ui/server.ps1
@@ -2577,7 +2577,12 @@ $docContext
                                         @{ run_id = $run.run_id; status = 'failed'; completed_at = $failTs; last_heartbeat = $failTs; error = $_.Exception.Message }
                                     }
                                     $failStatus | ConvertTo-Json -Depth 20 | Set-Content -Path $run.live_status_path -Encoding utf8NoBOM
-                                } catch { Write-BotLog -Level Debug -Message "Failed to mark orphaned run failed" -Exception $_ }
+                                    $orphanFailReason = $_.Exception.Message
+                                    if (-not (Get-Command Write-ActivityEvent -ErrorAction SilentlyContinue)) {
+                                        Import-Module (Join-Path $PSScriptRoot ".." "runtime" "Modules" "Dotbot.Runtime" "Dotbot.Runtime.psd1") -DisableNameChecking -Global -ErrorAction Stop
+                                    }
+                                    Write-ActivityEvent -BotRoot $botRoot -Type 'workflow.run_failed' -RunId $run.run_id -From 'running' -To 'failed' -Actor 'system' -Reason $orphanFailReason
+                                } catch { Write-BotLog -Level Debug -Message "Failed to mark orphaned run failed or emit event" -Exception $_ }
                             }
                             $statusCode = 500
                             $content = @{ success = $false; error = "Failed to run workflow: $($_.Exception.Message)" } | ConvertTo-Json -Compress

--- a/src/ui/static/modules/aether.js
+++ b/src/ui/static/modules/aether.js
@@ -20,9 +20,6 @@ const Aether = (function() {
     const BOND_POLL_INTERVAL = 1000; // Poll every second during bonding
 
     // State tracking for event detection
-    let _lastTaskId = null;
-    let _lastFailures = 0;
-    let _initialized = false;
     let _linked = false;
 
     // Stats tracking
@@ -334,72 +331,71 @@ const Aether = (function() {
     }
 
     /**
-     * Process state update from polling - detect events and trigger effects
-     * Oscilloscope effects work regardless of light connection
-     */
-    function processState(state) {
-        const currentTaskId = state.tasks?.current?.id || null;
-        const failures = state.session?.consecutive_failures || 0;
-
-        // First poll establishes baseline - don't fire events
-        if (!_initialized) {
-            _lastTaskId = currentTaskId;
-            _lastFailures = failures;
-            _initialized = true;
-            return;
-        }
-
-        // Task start: new task ID appears (different from last seen)
-        if (currentTaskId && currentTaskId !== _lastTaskId) {
-            _stats.starts++;
-            _lastEvent = { type: 'START', time: new Date(), taskId: currentTaskId };
-            updateStatsUI();
-            if (_linked && _selectedNodes.length > 0) {
-                celebrateColors();  // Dramatic cycle through all theme colors
-            }
-            if (typeof activityScope !== 'undefined' && activityScope) {
-                activityScope.injectPulse(1.5, 40);
-            }
-        }
-
-        // Task complete: task ID disappears without new failures
-        if (_lastTaskId && !currentTaskId && failures <= _lastFailures) {
-            _stats.completes++;
-            _lastEvent = { type: 'COMPLETE', time: new Date(), taskId: _lastTaskId };
-            updateStatsUI();
-            if (_linked && _selectedNodes.length > 0) {
-                celebrateColors();  // Dramatic cycle through all theme colors
-            }
-            if (typeof activityScope !== 'undefined' && activityScope) {
-                activityScope.injectSweep(1.0);
-            }
-        }
-
-        // Error: failures increased
-        if (failures > _lastFailures) {
-            _stats.errors++;
-            _lastEvent = { type: 'ERROR', time: new Date(), failures };
-            updateStatsUI();
-            if (_linked && _selectedNodes.length > 0) {
-                pulse('warning');  // Warning color from theme
-            }
-            if (typeof activityScope !== 'undefined' && activityScope) {
-                activityScope.injectNoise(0.8, 40);
-            }
-        }
-
-        // Update tracking
-        _lastTaskId = currentTaskId;
-        _lastFailures = failures;
-    }
-
-    /**
-     * Process activity event - respond to tool calls, writes, errors during tasks
+     * Process an activity-tail event and trigger light / oscilloscope effects.
+     *
+     * Two families flow through here from /api/activity/tail:
+     *   - Event-bus lifecycle events (task.* / workflow.*), which replace the
+     *     old /api/state diffing: a task moving to in-progress / done / failed,
+     *     or a workflow run completing / failing.
+     *   - Harness tool activity (write / edit / bash / error / rate_limit / text).
+     *
+     * Oscilloscope effects work regardless of light connection.
      */
     function processActivity(event) {
         const type = (event.type || '').toLowerCase();
 
-        // Different effects for different activity types
+        // ── Task & workflow lifecycle (event bus) ──
+        if (type === 'task.status_changed' || type === 'workflow.run_completed' ||
+            type === 'workflow.run_failed' || type === 'workflow.run_cancelled') {
+            const to = (event.to || '').toLowerCase();
+
+            // Task moved into execution → START.
+            if (type === 'task.status_changed' && to === 'in-progress') {
+                _stats.starts++;
+                _lastEvent = { type: 'START', time: new Date(), taskId: event.task_id };
+                updateStatsUI();
+                if (_linked && _selectedNodes.length > 0) {
+                    celebrateColors();  // Dramatic cycle through all theme colors
+                }
+                if (typeof activityScope !== 'undefined' && activityScope) {
+                    activityScope.injectPulse(1.5, 40);
+                }
+                return;
+            }
+
+            // Task done, or a workflow run completed → COMPLETE.
+            if ((type === 'task.status_changed' && to === 'done') || type === 'workflow.run_completed') {
+                _stats.completes++;
+                _lastEvent = { type: 'COMPLETE', time: new Date(), taskId: event.task_id };
+                updateStatsUI();
+                if (_linked && _selectedNodes.length > 0) {
+                    celebrateColors();
+                }
+                if (typeof activityScope !== 'undefined' && activityScope) {
+                    activityScope.injectSweep(1.0);
+                }
+                return;
+            }
+
+            // Task failed, or a workflow run failed → ERROR.
+            if ((type === 'task.status_changed' && to === 'failed') || type === 'workflow.run_failed') {
+                _stats.errors++;
+                _lastEvent = { type: 'ERROR', time: new Date(), taskId: event.task_id };
+                updateStatsUI();
+                if (_linked && _selectedNodes.length > 0) {
+                    pulse('warning');  // Warning color from theme
+                }
+                if (typeof activityScope !== 'undefined' && activityScope) {
+                    activityScope.injectNoise(0.8, 40);
+                }
+                return;
+            }
+
+            // Other transitions (todo, needs-input, run_cancelled) → no effect.
+            return;
+        }
+
+        // ── Harness tool activity ──
         switch (type) {
             case 'write':
             case 'edit':
@@ -909,7 +905,6 @@ const Aether = (function() {
         startBonding,
         stopBonding,
         loadNodes,
-        processState,
         processActivity,
         pulse,
         pulseQuick,

--- a/src/ui/static/modules/polling.js
+++ b/src/ui/static/modules/polling.js
@@ -33,10 +33,8 @@ async function pollState() {
         setConnectionStatus('connected');
         updateUI(state);
 
-        // Aether ambient feedback
-        if (typeof Aether !== 'undefined') {
-            Aether.processState(state);
-        }
+        // Aether ambient feedback is driven from the event bus via the activity
+        // tail (see Aether.processActivity in pollActivity), not from /api/state.
 
         // Update Overview side panel every poll (no extra fetch — uses state already in hand)
         updateOverviewWorkflowPanel(state);

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -138,6 +138,7 @@ if (1 -in $layersToRun) {
     $worktreeCode         = Invoke-TestFile -Layer '1' -FileName 'Test-Worktree.ps1'
     $executorCode         = Invoke-TestFile -Layer '1' -FileName 'Test-Executor.ps1'
     $hooksCode            = Invoke-TestFile -Layer '1' -FileName 'Test-Hooks.ps1'
+    $eventsCode           = Invoke-TestFile -Layer '1' -FileName 'Test-Events.ps1'
     $mdRefsCode          = Invoke-TestFile -Layer '1' -FileName 'Test-MdRefs.ps1'
     $legacyVocabularyCode = Invoke-TestFile -Layer '1' -FileName 'Test-NoLegacyVocabulary.ps1'
     $backslashPathsCode   = Invoke-TestFile -Layer '1' -FileName 'Test-NoBackslashPaths.ps1'
@@ -147,7 +148,7 @@ if (1 -in $layersToRun) {
     $pathSanitizerCode   = Invoke-TestFile -Layer '1' -FileName 'Test-PathSanitizer.ps1'
     $mcpSurfaceCode      = Invoke-TestFile -Layer '1' -FileName 'Test-McpSurface.ps1'
 
-    $exitCode = if ($structureCode -ne 0 -or $compilationCode -ne 0 -or $workflowManifestCode -ne 0 -or $dataModelCode -ne 0 -or $runtimeCode -ne 0 -or $worktreeCode -ne 0 -or $executorCode -ne 0 -or $hooksCode -ne 0 -or $mdRefsCode -ne 0 -or $legacyVocabularyCode -ne 0 -or $backslashPathsCode -ne 0 -or $clarificationCode -ne 0 -or $activityLogCode -ne 0 -or $privacyScanCode -ne 0 -or $pathSanitizerCode -ne 0 -or $mcpSurfaceCode -ne 0) { 1 } else { 0 }
+    $exitCode = if ($structureCode -ne 0 -or $compilationCode -ne 0 -or $workflowManifestCode -ne 0 -or $dataModelCode -ne 0 -or $runtimeCode -ne 0 -or $worktreeCode -ne 0 -or $executorCode -ne 0 -or $hooksCode -ne 0 -or $eventsCode -ne 0 -or $mdRefsCode -ne 0 -or $legacyVocabularyCode -ne 0 -or $backslashPathsCode -ne 0 -or $clarificationCode -ne 0 -or $activityLogCode -ne 0 -or $privacyScanCode -ne 0 -or $pathSanitizerCode -ne 0 -or $mcpSurfaceCode -ne 0) { 1 } else { 0 }
     $layerResults["1"] = ($exitCode -eq 0)
     if ($exitCode -ne 0) { $overallFailed = $true }
 }

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -139,6 +139,7 @@ if (1 -in $layersToRun) {
     $executorCode         = Invoke-TestFile -Layer '1' -FileName 'Test-Executor.ps1'
     $hooksCode            = Invoke-TestFile -Layer '1' -FileName 'Test-Hooks.ps1'
     $eventsCode           = Invoke-TestFile -Layer '1' -FileName 'Test-Events.ps1'
+    $aetherCode           = Invoke-TestFile -Layer '1' -FileName 'Test-Aether.ps1'
     $mdRefsCode          = Invoke-TestFile -Layer '1' -FileName 'Test-MdRefs.ps1'
     $legacyVocabularyCode = Invoke-TestFile -Layer '1' -FileName 'Test-NoLegacyVocabulary.ps1'
     $backslashPathsCode   = Invoke-TestFile -Layer '1' -FileName 'Test-NoBackslashPaths.ps1'
@@ -148,7 +149,7 @@ if (1 -in $layersToRun) {
     $pathSanitizerCode   = Invoke-TestFile -Layer '1' -FileName 'Test-PathSanitizer.ps1'
     $mcpSurfaceCode      = Invoke-TestFile -Layer '1' -FileName 'Test-McpSurface.ps1'
 
-    $exitCode = if ($structureCode -ne 0 -or $compilationCode -ne 0 -or $workflowManifestCode -ne 0 -or $dataModelCode -ne 0 -or $runtimeCode -ne 0 -or $worktreeCode -ne 0 -or $executorCode -ne 0 -or $hooksCode -ne 0 -or $eventsCode -ne 0 -or $mdRefsCode -ne 0 -or $legacyVocabularyCode -ne 0 -or $backslashPathsCode -ne 0 -or $clarificationCode -ne 0 -or $activityLogCode -ne 0 -or $privacyScanCode -ne 0 -or $pathSanitizerCode -ne 0 -or $mcpSurfaceCode -ne 0) { 1 } else { 0 }
+    $exitCode = if ($structureCode -ne 0 -or $compilationCode -ne 0 -or $workflowManifestCode -ne 0 -or $dataModelCode -ne 0 -or $runtimeCode -ne 0 -or $worktreeCode -ne 0 -or $executorCode -ne 0 -or $hooksCode -ne 0 -or $eventsCode -ne 0 -or $aetherCode -ne 0 -or $mdRefsCode -ne 0 -or $legacyVocabularyCode -ne 0 -or $backslashPathsCode -ne 0 -or $clarificationCode -ne 0 -or $activityLogCode -ne 0 -or $privacyScanCode -ne 0 -or $pathSanitizerCode -ne 0 -or $mcpSurfaceCode -ne 0) { 1 } else { 0 }
     $layerResults["1"] = ($exitCode -eq 0)
     if ($exitCode -ne 0) { $overallFailed = $true }
 }

--- a/tests/Test-Aether.ps1
+++ b/tests/Test-Aether.ps1
@@ -1,0 +1,63 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Layer 1: Aether client-side event-bus wiring (PRD-031 AC#8 / AC#9).
+.DESCRIPTION
+    Source-level assertions that the browser Aether module drives its
+    lights/oscilloscope from task.* / workflow.* events on the activity tail,
+    with the old /api/state diffing removed — and that the activity tail poll
+    itself is untouched.
+
+    The frontend has no JS unit harness in this suite, so these are static
+    source checks (same approach as the other UI/source assertions).
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+Import-Module "$PSScriptRoot\Test-Helpers.psm1" -Force
+
+$repoRoot = Get-RepoRoot
+
+Write-Host ""
+Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Blue
+Write-Host "  Aether event-bus wiring" -ForegroundColor Blue
+Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Blue
+Write-Host ""
+
+Reset-TestResults
+
+$aetherPath  = Join-Path $repoRoot 'src/ui/static/modules/aether.js'
+$pollingPath = Join-Path $repoRoot 'src/ui/static/modules/polling.js'
+Assert-PathExists -Name "aether.js exists"  -Path $aetherPath
+Assert-PathExists -Name "polling.js exists" -Path $pollingPath
+
+$aether  = Get-Content -LiteralPath $aetherPath  -Raw
+$polling = Get-Content -LiteralPath $pollingPath -Raw
+
+# ── AC#8: /api/state diffing removed ──
+Assert-True -Name "aether.js no longer defines processState (diffing removed)" `
+    -Condition (-not ($aether -match 'function\s+processState'))
+Assert-True -Name "aether.js no longer references processState at all" `
+    -Condition (-not ($aether -match 'processState'))
+Assert-True -Name "polling.js no longer calls Aether.processState" `
+    -Condition (-not ($polling -match 'Aether\.processState'))
+
+# ── AC#8: Aether drives from task.* / workflow.* events ──
+Assert-True -Name "aether.js handles task.status_changed"     -Condition ($aether -match 'task\.status_changed')
+Assert-True -Name "aether.js handles workflow.run_completed"  -Condition ($aether -match 'workflow\.run_completed')
+Assert-True -Name "aether.js handles workflow.run_failed"     -Condition ($aether -match 'workflow\.run_failed')
+Assert-True -Name "aether.js reacts to the 'in-progress' task transition" -Condition ($aether -match "in-progress")
+
+# ── AC#9: the activity-tail poll is still wired (oscilloscope/tail untouched) ──
+Assert-True -Name "aether.js still exports processActivity"     -Condition ($aether -match '(?m)^\s*processActivity,')
+Assert-True -Name "polling.js still feeds Aether.processActivity from the tail" -Condition ($polling -match 'Aether\.processActivity')
+Assert-True -Name "polling.js still polls /api/activity/tail"   -Condition ($polling -match '/api/activity/tail')
+
+$allPassed = Write-TestSummary -LayerName "Layer 1: Aether event-bus wiring"
+
+if (-not $allPassed) {
+    exit 1
+}

--- a/tests/Test-Events.ps1
+++ b/tests/Test-Events.ps1
@@ -93,7 +93,7 @@ function New-SinkFixture {
         $body = if ($PSBoundParameters.ContainsKey('ScriptBody')) {
             $ScriptBody
         } else {
-            "function Invoke-Sink { param(`$Event) }`nExport-ModuleMember -Function Invoke-Sink"
+            "function Invoke-Sink { param(`$Event, `$Context) }`nExport-ModuleMember -Function Invoke-Sink"
         }
         Set-Content -LiteralPath $scriptPath -Value $body -Encoding utf8NoBOM
     }
@@ -218,7 +218,7 @@ try {
     # the sink runspace (type + nested data round-trip).
     $markerBody = @'
 function Invoke-Sink {
-    param($Event)
+    param($Event, $Context)
     Set-Content -LiteralPath $Event.data.marker -Value $Event.type -Encoding utf8NoBOM
 }
 Export-ModuleMember -Function Invoke-Sink
@@ -235,14 +235,14 @@ Export-ModuleMember -Function Invoke-Sink
     Assert-Equal -Name "sink received the event payload (type via data.marker)" -Expected 'task.created' -Actual (Get-Content -LiteralPath $markerFile -Raw).Trim()
 
     # A sink that throws → captured as failure, never rethrown.
-    $throwSink = New-SinkFixture -Root $disp -Name 'boom' -Metadata @{ name = 'boom'; subscribed_events = @('task.*'); max_duration = 10 } -ScriptBody "function Invoke-Sink { param(`$Event) throw 'kaboom' }`nExport-ModuleMember -Function Invoke-Sink"
+    $throwSink = New-SinkFixture -Root $disp -Name 'boom' -Metadata @{ name = 'boom'; subscribed_events = @('task.*'); max_duration = 10 } -ScriptBody "function Invoke-Sink { param(`$Event, `$Context) throw 'kaboom' }`nExport-ModuleMember -Function Invoke-Sink"
     $throwRec  = Read-SinkMetadata -SinkDir $throwSink
     $throwRes  = Invoke-SingleSink -Sink $throwRec -Event $evt
     Assert-True -Name "throwing sink reports failure (not rethrown)" -Condition (-not [bool]$throwRes.success)
     Assert-True -Name "throwing sink message carries the error"      -Condition ($throwRes.message -match 'kaboom')
 
     # A slow sink → forcibly stopped at max_duration, marked timed_out.
-    $slowSink = New-SinkFixture -Root $disp -Name 'slow' -Metadata @{ name = 'slow'; subscribed_events = @('task.*'); max_duration = 1 } -ScriptBody "function Invoke-Sink { param(`$Event) Start-Sleep -Seconds 5 }`nExport-ModuleMember -Function Invoke-Sink"
+    $slowSink = New-SinkFixture -Root $disp -Name 'slow' -Metadata @{ name = 'slow'; subscribed_events = @('task.*'); max_duration = 1 } -ScriptBody "function Invoke-Sink { param(`$Event, `$Context) Start-Sleep -Seconds 5 }`nExport-ModuleMember -Function Invoke-Sink"
     $slowRec  = Read-SinkMetadata -SinkDir $slowSink
     $slowRes  = Invoke-SingleSink -Sink $slowRec -Event $evt
     Assert-True -Name "slow sink is marked timed_out"     -Condition ([bool]$slowRes.timed_out)
@@ -257,10 +257,10 @@ Export-ModuleMember -Function Invoke-Sink
 # marker. If dispatch aborted on failure, the marker would never appear.
 $fan = New-SinksRoot
 try {
-    New-SinkFixture -Root $fan -Name 'aaa-boom' -Metadata @{ name = 'aaa-boom'; subscribed_events = @('task.*'); max_duration = 10 } -ScriptBody "function Invoke-Sink { param(`$Event) throw 'first sink fails' }`nExport-ModuleMember -Function Invoke-Sink" | Out-Null
+    New-SinkFixture -Root $fan -Name 'aaa-boom' -Metadata @{ name = 'aaa-boom'; subscribed_events = @('task.*'); max_duration = 10 } -ScriptBody "function Invoke-Sink { param(`$Event, `$Context) throw 'first sink fails' }`nExport-ModuleMember -Function Invoke-Sink" | Out-Null
     $goodBody = @'
 function Invoke-Sink {
-    param($Event)
+    param($Event, $Context)
     Set-Content -LiteralPath $Event.data.marker -Value 'ran' -Encoding utf8NoBOM
 }
 Export-ModuleMember -Function Invoke-Sink
@@ -302,7 +302,7 @@ try {
     # of deliveries (lets us prove at-least-once / no-drop precisely).
     $markerBody = @'
 function Invoke-Sink {
-    param($Event)
+    param($Event, $Context)
     Add-Content -LiteralPath $Event.data.marker -Value $Event.id -Encoding utf8NoBOM
 }
 Export-ModuleMember -Function Invoke-Sink
@@ -369,7 +369,7 @@ try {
         Set-Content -LiteralPath (Join-Path $rsinkDir 'metadata.json') -Encoding utf8NoBOM
     Set-Content -LiteralPath (Join-Path $rsinkDir 'script.ps1') -Encoding utf8NoBOM -Value @'
 function Invoke-Sink {
-    param($Event)
+    param($Event, $Context)
     Add-Content -LiteralPath $Event.data.marker -Value $Event.id -Encoding utf8NoBOM
 }
 Export-ModuleMember -Function Invoke-Sink
@@ -398,10 +398,78 @@ Export-ModuleMember -Function Invoke-Sink
 }
 
 # ═══════════════════════════════════════════════════════════════════════════
+# webhooks sink (HTTPS-only + HMAC + SSRF guard + per-endpoint filter)
+# ═══════════════════════════════════════════════════════════════════════════
+
+Write-Host ""
+Write-Host "  webhooks sink" -ForegroundColor Cyan
+Write-Host "  ──────────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$whScript = Join-Path $repoRoot 'src/runtime/Plugins/Events/Sinks/webhooks/script.ps1'
+Assert-True -Name "webhooks sink ships script.ps1"     -Condition (Test-Path -LiteralPath $whScript)
+Assert-True -Name "webhooks sink ships metadata.json"  -Condition (Test-Path -LiteralPath (Join-Path $repoRoot 'src/runtime/Plugins/Events/Sinks/webhooks/metadata.json'))
+
+# The shipped sink must pass the very discovery/validation it will face at runtime.
+$whRec = Read-SinkMetadata -SinkDir (Join-Path $repoRoot 'src/runtime/Plugins/Events/Sinks/webhooks')
+Assert-Equal -Name "webhooks metadata name is 'webhooks'" -Expected 'webhooks' -Actual $whRec.name
+
+$whMod = New-Module -Name 'DotbotWebhooksTest' -ScriptBlock ([ScriptBlock]::Create((Get-Content -LiteralPath $whScript -Raw)))
+
+# ── URL validation: HTTPS-only + SSRF (IP literals → no DNS needed) ──
+$pubIp = '93.184.216.34'
+Assert-True  -Name "https public IP is allowed"            -Condition (& $whMod Test-WebhookUrlAllowed -Url "https://$pubIp/hook").allowed
+Assert-Equal -Name "http scheme is rejected"               -Expected 'not_https'        -Actual (& $whMod Test-WebhookUrlAllowed -Url "http://$pubIp/hook").reason
+Assert-Equal -Name "loopback 127.0.0.1 is rejected"        -Expected 'blocked_ip_range' -Actual (& $whMod Test-WebhookUrlAllowed -Url 'https://127.0.0.1/x').reason
+Assert-Equal -Name "private 10/8 is rejected"              -Expected 'blocked_ip_range' -Actual (& $whMod Test-WebhookUrlAllowed -Url 'https://10.1.2.3/x').reason
+Assert-Equal -Name "private 192.168/16 is rejected"        -Expected 'blocked_ip_range' -Actual (& $whMod Test-WebhookUrlAllowed -Url 'https://192.168.0.1/x').reason
+Assert-Equal -Name "cloud metadata 169.254.169.254 blocked" -Expected 'blocked_ip_range' -Actual (& $whMod Test-WebhookUrlAllowed -Url 'https://169.254.169.254/latest').reason
+Assert-Equal -Name "IPv6 loopback [::1] is rejected"       -Expected 'blocked_ip_range' -Actual (& $whMod Test-WebhookUrlAllowed -Url 'https://[::1]/x').reason
+Assert-Equal -Name "localhost hostname is rejected"        -Expected 'internal_hostname' -Actual (& $whMod Test-WebhookUrlAllowed -Url 'https://localhost/x').reason
+Assert-True  -Name "172.32/x (outside 172.16/12) allowed"  -Condition (& $whMod Test-WebhookUrlAllowed -Url 'https://172.32.0.1/x').allowed
+
+# ── HMAC signature ──
+$sigA = & $whMod New-WebhookSignature -Body '{"a":1}' -Secret 'shh'
+$sigB = & $whMod New-WebhookSignature -Body '{"a":1}' -Secret 'shh'
+$sigC = & $whMod New-WebhookSignature -Body '{"a":1}' -Secret 'different'
+Assert-True  -Name "HMAC signature is well-formed (sha256=<64 hex>)" -Condition ($sigA -match '^sha256=[0-9a-f]{64}$')
+Assert-Equal -Name "HMAC is deterministic for same body+secret"      -Expected $sigA -Actual $sigB
+Assert-True  -Name "HMAC differs when the secret differs"            -Condition ($sigA -ne $sigC)
+
+# ── Delivery plan: per-endpoint filter + SSRF pruning ──
+$cfg = [pscustomobject]@{
+    enabled   = $true
+    endpoints = @(
+        [pscustomobject]@{ url = "https://$pubIp/tasks";     events = @('task.*');     secret = 's1' }
+        [pscustomobject]@{ url = 'https://127.0.0.1/blocked'; events = @('task.*');     secret = 's2' }  # SSRF → pruned
+        [pscustomobject]@{ url = "https://$pubIp/wf";        events = @('workflow.*'); secret = 's3' }
+    )
+}
+$planTask = @(& $whMod Get-WebhookDeliveryPlan -Event @{ type = 'task.created' } -Config $cfg)
+Assert-Equal -Name "plan honours filter + SSRF: task.created → 1 endpoint" -Expected 1 -Actual $planTask.Count
+Assert-Equal -Name "plan keeps the public task endpoint"                    -Expected "https://$pubIp/tasks" -Actual $planTask[0].url
+
+$planWf = @(& $whMod Get-WebhookDeliveryPlan -Event @{ type = 'workflow.run_completed' } -Config $cfg)
+Assert-Equal -Name "plan honours filter: workflow event → workflow endpoint only" -Expected 1 -Actual $planWf.Count
+Assert-Equal -Name "plan keeps the workflow endpoint"                             -Expected "https://$pubIp/wf" -Actual $planWf[0].url
+
+$planNone = @(& $whMod Get-WebhookDeliveryPlan -Event @{ type = 'decision.created' } -Config $cfg)
+Assert-Equal -Name "plan is empty when no endpoint filter matches" -Expected 0 -Actual $planNone.Count
+
+# ── Invoke-Sink gating (no network) ──
+$disabledCtx = @{ BotRoot = 'x'; Events = [pscustomobject]@{ webhooks = [pscustomobject]@{ enabled = $false; endpoints = @() } } }
+$rDisabled = & $whMod Invoke-Sink -Event @{ type = 'task.created' } -Context $disabledCtx
+Assert-True  -Name "Invoke-Sink no-ops when webhooks disabled" -Condition ([bool]$rDisabled.Success)
+Assert-True  -Name "disabled message says disabled"           -Condition ($rDisabled.Message -match 'disabled')
+
+$noCfgCtx = @{ BotRoot = 'x'; Events = $null }
+$rNoCfg = & $whMod Invoke-Sink -Event @{ type = 'task.created' } -Context $noCfgCtx
+Assert-True -Name "Invoke-Sink no-ops when there is no events config" -Condition ([bool]$rNoCfg.Success)
+
+# ═══════════════════════════════════════════════════════════════════════════
 # SUMMARY
 # ═══════════════════════════════════════════════════════════════════════════
 
-$allPassed = Write-TestSummary -LayerName "Layer 1: Dotbot.Events Sink Discovery + Dispatch + Consumer"
+$allPassed = Write-TestSummary -LayerName "Layer 1: Dotbot.Events Sink Discovery + Dispatch + Consumer + webhooks"
 
 if (-not $allPassed) {
     exit 1

--- a/tests/Test-Events.ps1
+++ b/tests/Test-Events.ps1
@@ -100,6 +100,20 @@ function New-SinkFixture {
     return $sinkDir
 }
 
+function Add-EventLine {
+    # Append one activity.jsonl event line (hand-written so this test needn't
+    # import Dotbot.Runtime/Dotbot.Task). data.marker points a sink at its
+    # output file.
+    param(
+        [Parameter(Mandatory)] [string]$LogPath,
+        [Parameter(Mandatory)] [string]$Id,
+        [Parameter(Mandatory)] [string]$Type,
+        [string]$Marker
+    )
+    $line = @{ id = $Id; type = $Type; source = 'runtime'; data = @{ marker = $Marker } } | ConvertTo-Json -Compress
+    Add-Content -LiteralPath $LogPath -Value $line -Encoding utf8NoBOM
+}
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Happy-path discovery
 # ═══════════════════════════════════════════════════════════════════════════
@@ -273,10 +287,121 @@ Export-ModuleMember -Function Invoke-Sink
 }
 
 # ═══════════════════════════════════════════════════════════════════════════
+# Consumer (byte cursor, at-least-once, replay)
+# ═══════════════════════════════════════════════════════════════════════════
+
+Write-Host ""
+Write-Host "  Consumer" -ForegroundColor Cyan
+Write-Host "  ──────────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$cbot = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-consumer-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+New-Item -ItemType Directory -Path (Join-Path $cbot '.control') -Force | Out-Null
+$csinks = New-SinksRoot
+try {
+    # A sink that APPENDS each received event id to a file → line count = number
+    # of deliveries (lets us prove at-least-once / no-drop precisely).
+    $markerBody = @'
+function Invoke-Sink {
+    param($Event)
+    Add-Content -LiteralPath $Event.data.marker -Value $Event.id -Encoding utf8NoBOM
+}
+Export-ModuleMember -Function Invoke-Sink
+'@
+    New-SinkFixture -Root $csinks -Name 'recorder' -Metadata @{ name = 'recorder'; subscribed_events = @('task.*'); max_duration = 10 } -ScriptBody $markerBody | Out-Null
+    $reg = @(Get-SinkRegistry -SinksDir $csinks)
+
+    $log    = Join-Path $cbot '.control/activity.jsonl'
+    $marker = Join-Path $cbot 'deliveries.out'
+
+    # ── Cursor round-trip ──
+    Save-EventCursor -BotRoot $cbot -Offset 42
+    Assert-Equal -Name "cursor round-trips through disk" -Expected 42 -Actual (Read-EventCursor -BotRoot $cbot)
+
+    # ── Read-EventBatch by offset ──
+    Add-EventLine -LogPath $log -Id 'evt_1' -Type 'task.created'         -Marker $marker
+    Add-EventLine -LogPath $log -Id 'evt_2' -Type 'task.updated'         -Marker $marker
+    Add-EventLine -LogPath $log -Id 'evt_3' -Type 'workflow.run_started' -Marker $marker
+
+    $b0 = Read-EventBatch -LogPath $log -Offset 0
+    Assert-Equal -Name "batch from 0 reads all 3 lines" -Expected 3 -Actual (@($b0.events).Count)
+    Assert-True  -Name "batch position advances to EOF" -Condition ($b0.position -gt 0)
+
+    $b1 = Read-EventBatch -LogPath $log -Offset $b0.position
+    Assert-Equal -Name "batch from EOF reads nothing" -Expected 0 -Actual (@($b1.events).Count)
+    Assert-Equal -Name "batch from EOF keeps position" -Expected $b0.position -Actual $b1.position
+
+    # ── Tick: dispatch task.* only, advance cursor ──
+    Save-EventCursor -BotRoot $cbot -Offset 0
+    $t1 = Invoke-EventConsumerTick -BotRoot $cbot -Registry $reg -LogPath $log
+    Assert-Equal -Name "tick processes every event in the batch" -Expected 3 -Actual $t1.processed
+    Assert-Equal -Name "tick dispatches only the 2 task.* events"  -Expected 2 -Actual $t1.dispatched
+    Assert-Equal -Name "recorder delivered 2 events"               -Expected 2 -Actual (@(Get-Content -LiteralPath $marker)).Count
+    Assert-Equal -Name "cursor advanced to batch position"         -Expected $t1.position -Actual (Read-EventCursor -BotRoot $cbot)
+
+    # ── Second tick with nothing new → no-op ──
+    $t2 = Invoke-EventConsumerTick -BotRoot $cbot -Registry $reg -LogPath $log
+    Assert-Equal -Name "idle tick processes nothing"    -Expected 0 -Actual $t2.processed
+    Assert-Equal -Name "idle tick delivers nothing new" -Expected 2 -Actual (@(Get-Content -LiteralPath $marker)).Count
+
+    # ── Resume from persisted cursor: a new event is delivered, old ones aren't ──
+    Add-EventLine -LogPath $log -Id 'evt_4' -Type 'task.status_changed' -Marker $marker
+    $t3 = Invoke-EventConsumerTick -BotRoot $cbot -Registry $reg -LogPath $log
+    Assert-Equal -Name "resume tick processes only the new event"  -Expected 1 -Actual $t3.processed
+    Assert-Equal -Name "resume tick delivers only the new task.* event" -Expected 3 -Actual (@(Get-Content -LiteralPath $marker)).Count
+
+    # ── At-least-once / replay: rewinding the cursor re-delivers ──
+    Save-EventCursor -BotRoot $cbot -Offset 0
+    $t4 = Invoke-EventConsumerTick -BotRoot $cbot -Registry $reg -LogPath $log
+    Assert-Equal -Name "replay tick re-reads all 4 events"                 -Expected 4 -Actual $t4.processed
+    Assert-Equal -Name "replay re-delivers the 3 task.* events (3+3=6)"    -Expected 6 -Actual (@(Get-Content -LiteralPath $marker)).Count
+} finally {
+    Remove-Item -Recurse -Force $cbot -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force $csinks -ErrorAction SilentlyContinue
+}
+
+# ── Runspace lifecycle: Start-EventConsumer delivers, Stop tears down ──
+$rbot = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-consumer-rs-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+$rsinkDir = Join-Path $rbot 'src/runtime/Plugins/Events/Sinks/recorder'
+New-Item -ItemType Directory -Path (Join-Path $rbot '.control') -Force | Out-Null
+New-Item -ItemType Directory -Path $rsinkDir -Force | Out-Null
+try {
+    @{ name = 'recorder'; subscribed_events = @('task.*'); max_duration = 10 } | ConvertTo-Json -Depth 6 |
+        Set-Content -LiteralPath (Join-Path $rsinkDir 'metadata.json') -Encoding utf8NoBOM
+    Set-Content -LiteralPath (Join-Path $rsinkDir 'script.ps1') -Encoding utf8NoBOM -Value @'
+function Invoke-Sink {
+    param($Event)
+    Add-Content -LiteralPath $Event.data.marker -Value $Event.id -Encoding utf8NoBOM
+}
+Export-ModuleMember -Function Invoke-Sink
+'@
+
+    $rlog    = Join-Path $rbot '.control/activity.jsonl'
+    $rmarker = Join-Path $rbot 'deliveries.out'
+
+    $consumer = Start-EventConsumer -BotRoot $rbot -IntervalSeconds 0.5
+    Assert-True -Name "Start-EventConsumer returns a running handle" -Condition ($null -ne $consumer -and $consumer.enabled)
+
+    # Append AFTER start (cursor was seeded to EOF), so the consumer must tail it.
+    Add-EventLine -LogPath $rlog -Id 'evt_rs1' -Type 'task.created' -Marker $rmarker
+
+    $delivered = $false
+    for ($i = 0; $i -lt 60; $i++) {
+        if (Test-Path -LiteralPath $rmarker) { $delivered = $true; break }
+        Start-Sleep -Milliseconds 100
+    }
+    Assert-True -Name "background consumer tails and delivers an appended event" -Condition $delivered
+
+    Stop-EventConsumer -Consumer $consumer
+    Assert-True -Name "Stop-EventConsumer signals the stop flag" -Condition ([bool]$consumer.stop_flag[0])
+} finally {
+    Remove-Item -Recurse -Force $rbot -ErrorAction SilentlyContinue
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
 # SUMMARY
 # ═══════════════════════════════════════════════════════════════════════════
 
-$allPassed = Write-TestSummary -LayerName "Layer 1: Dotbot.Events Sink Discovery + Dispatch"
+$allPassed = Write-TestSummary -LayerName "Layer 1: Dotbot.Events Sink Discovery + Dispatch + Consumer"
 
 if (-not $allPassed) {
     exit 1

--- a/tests/Test-Events.ps1
+++ b/tests/Test-Events.ps1
@@ -456,20 +456,65 @@ $planNone = @(& $whMod Get-WebhookDeliveryPlan -Event @{ type = 'decision.create
 Assert-Equal -Name "plan is empty when no endpoint filter matches" -Expected 0 -Actual $planNone.Count
 
 # ── Invoke-Sink gating (no network) ──
-$disabledCtx = @{ BotRoot = 'x'; Events = [pscustomobject]@{ webhooks = [pscustomobject]@{ enabled = $false; endpoints = @() } } }
+$disabledCtx = @{ BotRoot = 'x'; Settings = [pscustomobject]@{ events = [pscustomobject]@{ webhooks = [pscustomobject]@{ enabled = $false; endpoints = @() } } } }
 $rDisabled = & $whMod Invoke-Sink -Event @{ type = 'task.created' } -Context $disabledCtx
 Assert-True  -Name "Invoke-Sink no-ops when webhooks disabled" -Condition ([bool]$rDisabled.Success)
 Assert-True  -Name "disabled message says disabled"           -Condition ($rDisabled.Message -match 'disabled')
 
-$noCfgCtx = @{ BotRoot = 'x'; Events = $null }
+$noCfgCtx = @{ BotRoot = 'x'; Settings = $null }
 $rNoCfg = & $whMod Invoke-Sink -Event @{ type = 'task.created' } -Context $noCfgCtx
 Assert-True -Name "Invoke-Sink no-ops when there is no events config" -Condition ([bool]$rNoCfg.Success)
+
+# ═══════════════════════════════════════════════════════════════════════════
+# mothership sink (gated no-op until the fleet events endpoint exists)
+# ═══════════════════════════════════════════════════════════════════════════
+
+Write-Host ""
+Write-Host "  mothership sink" -ForegroundColor Cyan
+Write-Host "  ──────────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$msDir = Join-Path $repoRoot 'src/runtime/Plugins/Events/Sinks/mothership'
+Assert-True  -Name "mothership sink ships script.ps1"    -Condition (Test-Path -LiteralPath (Join-Path $msDir 'script.ps1'))
+$msRec = Read-SinkMetadata -SinkDir $msDir
+Assert-Equal -Name "mothership metadata name is 'mothership'" -Expected 'mothership' -Actual $msRec.name
+
+$msMod = New-Module -Name 'DotbotMothershipTest' -ScriptBlock ([ScriptBlock]::Create((Get-Content -LiteralPath (Join-Path $msDir 'script.ps1') -Raw)))
+
+function New-MsSettings {
+    param([bool]$MsEnabled, [bool]$SinkEnabled, [string]$ServerUrl = 'https://mothership.example', $Sync = @('task.*'))
+    return [pscustomobject]@{
+        mothership = [pscustomobject]@{ enabled = $MsEnabled; server_url = $ServerUrl; sync_events = $Sync }
+        events     = [pscustomobject]@{ mothership = [pscustomobject]@{ enabled = $SinkEnabled } }
+    }
+}
+
+$evt = @{ type = 'task.created' }
+Assert-Equal -Name "gate: mothership disabled → no forward" -Expected 'mothership_disabled' `
+    -Actual (& $msMod Test-MothershipShouldForward -Event $evt -Settings (New-MsSettings -MsEnabled $false -SinkEnabled $true)).reason
+Assert-Equal -Name "gate: sink disabled → no forward" -Expected 'sink_disabled' `
+    -Actual (& $msMod Test-MothershipShouldForward -Event $evt -Settings (New-MsSettings -MsEnabled $true -SinkEnabled $false)).reason
+Assert-Equal -Name "gate: missing server_url → no forward" -Expected 'no_server_url' `
+    -Actual (& $msMod Test-MothershipShouldForward -Event $evt -Settings (New-MsSettings -MsEnabled $true -SinkEnabled $true -ServerUrl '')).reason
+Assert-Equal -Name "gate: event not in sync_events → no forward" -Expected 'not_in_sync_events' `
+    -Actual (& $msMod Test-MothershipShouldForward -Event @{ type = 'workflow.run_started' } -Settings (New-MsSettings -MsEnabled $true -SinkEnabled $true -Sync @('task.*'))).reason
+Assert-True  -Name "all gates pass → forward=true" `
+    -Condition (& $msMod Test-MothershipShouldForward -Event $evt -Settings (New-MsSettings -MsEnabled $true -SinkEnabled $true -Sync @('task.*'))).forward
+
+# Invoke-Sink is a gated no-op: never throws, always Success, never POSTs.
+$rSkip = & $msMod Invoke-Sink -Event $evt -Context @{ BotRoot = 'x'; Settings = (New-MsSettings -MsEnabled $false -SinkEnabled $false) }
+Assert-True -Name "Invoke-Sink no-ops (skipped) when disabled" -Condition ([bool]$rSkip.Success -and $rSkip.Message -match 'skipped')
+
+$rFwd = & $msMod Invoke-Sink -Event $evt -Context @{ BotRoot = 'x'; Settings = (New-MsSettings -MsEnabled $true -SinkEnabled $true -Sync @('task.*')) }
+Assert-True -Name "Invoke-Sink is a gated no-op even when all gates pass" -Condition ([bool]$rFwd.Success -and $rFwd.Message -match 'would forward')
+
+$rNoSettings = & $msMod Invoke-Sink -Event $evt -Context @{ BotRoot = 'x'; Settings = $null }
+Assert-True -Name "Invoke-Sink no-ops when there are no settings" -Condition ([bool]$rNoSettings.Success)
 
 # ═══════════════════════════════════════════════════════════════════════════
 # SUMMARY
 # ═══════════════════════════════════════════════════════════════════════════
 
-$allPassed = Write-TestSummary -LayerName "Layer 1: Dotbot.Events Sink Discovery + Dispatch + Consumer + webhooks"
+$allPassed = Write-TestSummary -LayerName "Layer 1: Dotbot.Events Discovery + Dispatch + Consumer + webhooks + mothership"
 
 if (-not $allPassed) {
     exit 1

--- a/tests/Test-Events.ps1
+++ b/tests/Test-Events.ps1
@@ -74,7 +74,8 @@ function New-SinkFixture {
         [object]$Metadata,          # hashtable to serialize, or a raw string for malformed-JSON cases
         [switch]$NoMetadata,
         [switch]$NoScript,
-        [string]$RawMetadata
+        [string]$RawMetadata,
+        [string]$ScriptBody         # override the default Invoke-Sink body
     )
     $sinkDir = Join-Path $Root $Name
     New-Item -ItemType Directory -Path $sinkDir -Force | Out-Null
@@ -89,10 +90,12 @@ function New-SinkFixture {
     }
     if (-not $NoScript) {
         $scriptPath = Join-Path $sinkDir 'script.ps1'
-        Set-Content -LiteralPath $scriptPath -Encoding utf8NoBOM -Value @'
-function Invoke-Sink { param($Event) }
-Export-ModuleMember -Function Invoke-Sink
-'@
+        $body = if ($PSBoundParameters.ContainsKey('ScriptBody')) {
+            $ScriptBody
+        } else {
+            "function Invoke-Sink { param(`$Event) }`nExport-ModuleMember -Function Invoke-Sink"
+        }
+        Set-Content -LiteralPath $scriptPath -Value $body -Encoding utf8NoBOM
     }
     return $sinkDir
 }
@@ -188,10 +191,92 @@ try {
 }
 
 # ═══════════════════════════════════════════════════════════════════════════
+# Dispatch (time-boxed child runspace, non-aborting)
+# ═══════════════════════════════════════════════════════════════════════════
+
+Write-Host ""
+Write-Host "  Dispatch" -ForegroundColor Cyan
+Write-Host "  ──────────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$disp = New-SinksRoot
+try {
+    # A sink that records the event it received, to prove the payload reaches
+    # the sink runspace (type + nested data round-trip).
+    $markerBody = @'
+function Invoke-Sink {
+    param($Event)
+    Set-Content -LiteralPath $Event.data.marker -Value $Event.type -Encoding utf8NoBOM
+}
+Export-ModuleMember -Function Invoke-Sink
+'@
+    $markerSink = New-SinkFixture -Root $disp -Name 'marker' -Metadata @{ name = 'marker'; subscribed_events = @('task.*'); max_duration = 10 } -ScriptBody $markerBody
+    $markerRec  = Read-SinkMetadata -SinkDir $markerSink
+
+    $markerFile = Join-Path $disp 'marker.out'
+    $evt = @{ type = 'task.created'; data = @{ marker = $markerFile } }
+    $res = Invoke-SingleSink -Sink $markerRec -Event $evt
+    Assert-True  -Name "successful sink reports success"        -Condition ([bool]$res.success)
+    Assert-True  -Name "successful sink is not timed_out"        -Condition (-not $res.timed_out)
+    Assert-True  -Name "sink actually ran (marker file written)" -Condition (Test-Path -LiteralPath $markerFile)
+    Assert-Equal -Name "sink received the event payload (type via data.marker)" -Expected 'task.created' -Actual (Get-Content -LiteralPath $markerFile -Raw).Trim()
+
+    # A sink that throws → captured as failure, never rethrown.
+    $throwSink = New-SinkFixture -Root $disp -Name 'boom' -Metadata @{ name = 'boom'; subscribed_events = @('task.*'); max_duration = 10 } -ScriptBody "function Invoke-Sink { param(`$Event) throw 'kaboom' }`nExport-ModuleMember -Function Invoke-Sink"
+    $throwRec  = Read-SinkMetadata -SinkDir $throwSink
+    $throwRes  = Invoke-SingleSink -Sink $throwRec -Event $evt
+    Assert-True -Name "throwing sink reports failure (not rethrown)" -Condition (-not [bool]$throwRes.success)
+    Assert-True -Name "throwing sink message carries the error"      -Condition ($throwRes.message -match 'kaboom')
+
+    # A slow sink → forcibly stopped at max_duration, marked timed_out.
+    $slowSink = New-SinkFixture -Root $disp -Name 'slow' -Metadata @{ name = 'slow'; subscribed_events = @('task.*'); max_duration = 1 } -ScriptBody "function Invoke-Sink { param(`$Event) Start-Sleep -Seconds 5 }`nExport-ModuleMember -Function Invoke-Sink"
+    $slowRec  = Read-SinkMetadata -SinkDir $slowSink
+    $slowRes  = Invoke-SingleSink -Sink $slowRec -Event $evt
+    Assert-True -Name "slow sink is marked timed_out"     -Condition ([bool]$slowRes.timed_out)
+    Assert-True -Name "slow sink reports failure"          -Condition (-not [bool]$slowRes.success)
+    Assert-True -Name "slow sink stopped near max_duration (< 4s)" -Condition ($slowRes.duration.TotalSeconds -lt 4)
+} finally {
+    Remove-Item -Recurse -Force $disp -ErrorAction SilentlyContinue
+}
+
+# ── Non-aborting fan-out: a failing sink must not stop the others ──
+# 'aaa-boom' sorts first and throws; 'bbb-good' sorts second and writes a
+# marker. If dispatch aborted on failure, the marker would never appear.
+$fan = New-SinksRoot
+try {
+    New-SinkFixture -Root $fan -Name 'aaa-boom' -Metadata @{ name = 'aaa-boom'; subscribed_events = @('task.*'); max_duration = 10 } -ScriptBody "function Invoke-Sink { param(`$Event) throw 'first sink fails' }`nExport-ModuleMember -Function Invoke-Sink" | Out-Null
+    $goodBody = @'
+function Invoke-Sink {
+    param($Event)
+    Set-Content -LiteralPath $Event.data.marker -Value 'ran' -Encoding utf8NoBOM
+}
+Export-ModuleMember -Function Invoke-Sink
+'@
+    New-SinkFixture -Root $fan -Name 'bbb-good' -Metadata @{ name = 'bbb-good'; subscribed_events = @('task.*'); max_duration = 10 } -ScriptBody $goodBody | Out-Null
+
+    $registry = @(Get-SinkRegistry -SinksDir $fan)
+    $fanMarker = Join-Path $fan 'good.out'
+    $dispatch = Invoke-EventSinks -Event @{ type = 'task.created'; data = @{ marker = $fanMarker } } -Registry $registry
+
+    Assert-Equal -Name "Invoke-EventSinks dispatched to both matching sinks" -Expected 2 -Actual $dispatch.dispatched
+    Assert-Equal -Name "Invoke-EventSinks reports event_type" -Expected 'task.created' -Actual $dispatch.event_type
+    Assert-True  -Name "non-aborting: good sink ran despite the earlier sink failing" -Condition (Test-Path -LiteralPath $fanMarker)
+    $boomResult = @($dispatch.results | Where-Object { $_.name -eq 'aaa-boom' })[0]
+    $goodResult = @($dispatch.results | Where-Object { $_.name -eq 'bbb-good' })[0]
+    Assert-True -Name "failing sink recorded as failure in results"  -Condition (-not [bool]$boomResult.success)
+    Assert-True -Name "good sink recorded as success in results"     -Condition ([bool]$goodResult.success)
+
+    # Routing: an event no sink subscribes to dispatches to nothing (no error).
+    $none = Invoke-EventSinks -Event @{ type = 'decision.created'; data = @{} } -Registry $registry
+    Assert-Equal -Name "unsubscribed event dispatches to zero sinks" -Expected 0 -Actual $none.dispatched
+} finally {
+    Remove-Item -Recurse -Force $fan -ErrorAction SilentlyContinue
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
 # SUMMARY
 # ═══════════════════════════════════════════════════════════════════════════
 
-$allPassed = Write-TestSummary -LayerName "Layer 1: Dotbot.Events Sink Discovery"
+$allPassed = Write-TestSummary -LayerName "Layer 1: Dotbot.Events Sink Discovery + Dispatch"
 
 if (-not $allPassed) {
     exit 1

--- a/tests/Test-Events.ps1
+++ b/tests/Test-Events.ps1
@@ -1,0 +1,198 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Layer 1: Dotbot.Events sink-discovery tests.
+.DESCRIPTION
+    Covers the discovery surface of Dotbot.Events (parity with the Dotbot.Hook
+    engine):
+
+      - Folder-per-sink discovery: metadata.json + script.ps1, sorted by folder
+        name, records carry the expected shape.
+      - Event routing: Get-SinksForEvent matches a concrete dotted event type
+        against each sink's subscribed_events glob patterns.
+      - Fail-loud validation: malformed sink metadata throws rather than being
+        silently skipped, so one bad sink among valid ones fails the whole
+        registry scan at startup.
+
+    No installed dotbot needed (module is imported directly from src/).
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+Import-Module "$PSScriptRoot\Test-Helpers.psm1" -Force
+
+$repoRoot = Get-RepoRoot
+
+Write-Host ""
+Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Blue
+Write-Host "  Dotbot.Events — Sink Discovery" -ForegroundColor Blue
+Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Blue
+Write-Host ""
+
+Reset-TestResults
+
+Import-Module (Join-Path $repoRoot "src/runtime/Modules/Dotbot.Events/Dotbot.Events.psd1") -Force -DisableNameChecking -Global
+
+# Small helper: assert a scriptblock throws and (optionally) message matches a pattern.
+function Assert-Throws {
+    param(
+        [Parameter(Mandatory)] [string]$Name,
+        [Parameter(Mandatory)] [scriptblock]$Action,
+        [string]$Pattern
+    )
+    $threw = $false
+    $msg = ''
+    try { & $Action } catch { $threw = $true; $msg = $_.Exception.Message }
+    if (-not $threw) {
+        Write-TestResult -Name $Name -Status Fail -Message "Expected an exception, got none."
+        return
+    }
+    if ($Pattern -and ($msg -notmatch $Pattern)) {
+        Write-TestResult -Name $Name -Status Fail -Message "Exception '$msg' did not match pattern '$Pattern'."
+        return
+    }
+    Write-TestResult -Name $Name -Status Pass
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# Fixture helpers
+# ───────────────────────────────────────────────────────────────────────────
+
+function New-SinksRoot {
+    $dir = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-sinks-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    return $dir
+}
+
+function New-SinkFixture {
+    param(
+        [Parameter(Mandatory)] [string]$Root,
+        [Parameter(Mandatory)] [string]$Name,
+        [object]$Metadata,          # hashtable to serialize, or a raw string for malformed-JSON cases
+        [switch]$NoMetadata,
+        [switch]$NoScript,
+        [string]$RawMetadata
+    )
+    $sinkDir = Join-Path $Root $Name
+    New-Item -ItemType Directory -Path $sinkDir -Force | Out-Null
+
+    if (-not $NoMetadata) {
+        $metaPath = Join-Path $sinkDir 'metadata.json'
+        if ($PSBoundParameters.ContainsKey('RawMetadata')) {
+            Set-Content -LiteralPath $metaPath -Value $RawMetadata -Encoding utf8NoBOM
+        } else {
+            ($Metadata | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $metaPath -Encoding utf8NoBOM
+        }
+    }
+    if (-not $NoScript) {
+        $scriptPath = Join-Path $sinkDir 'script.ps1'
+        Set-Content -LiteralPath $scriptPath -Encoding utf8NoBOM -Value @'
+function Invoke-Sink { param($Event) }
+Export-ModuleMember -Function Invoke-Sink
+'@
+    }
+    return $sinkDir
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Happy-path discovery
+# ═══════════════════════════════════════════════════════════════════════════
+
+Write-Host "  Discovery" -ForegroundColor Cyan
+Write-Host "  ──────────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$root = New-SinksRoot
+try {
+    New-SinkFixture -Root $root -Name 'alpha' -Metadata @{ name = 'alpha'; description = 'A sink'; subscribed_events = @('task.*'); max_duration = 10 } | Out-Null
+    New-SinkFixture -Root $root -Name 'zeta'  -Metadata @{ name = 'zeta';  subscribed_events = @('workflow.run_completed', 'task.created'); max_duration = 5 } | Out-Null
+
+    $registry = @(Get-SinkRegistry -SinksDir $root)
+    Assert-Equal -Name "registry discovers both sinks" -Expected 2 -Actual $registry.Count
+    Assert-Equal -Name "registry is sorted by folder name (alpha first)" -Expected 'alpha' -Actual $registry[0].name
+    Assert-Equal -Name "registry is sorted by folder name (zeta second)" -Expected 'zeta'  -Actual $registry[1].name
+
+    $alpha = $registry[0]
+    Assert-Equal -Name "alpha carries description"           -Expected 'A sink' -Actual $alpha.description
+    Assert-Equal -Name "alpha carries max_duration as int"   -Expected 10       -Actual $alpha.max_duration
+    Assert-True  -Name "alpha subscribed_events has task.*"   -Condition ($alpha.subscribed_events -contains 'task.*')
+    Assert-True  -Name "alpha record points at its script.ps1" -Condition (Test-Path -LiteralPath $alpha.script_path)
+    Assert-True  -Name "alpha record points at its metadata.json" -Condition (Test-Path -LiteralPath $alpha.metadata_path)
+
+    # ── Event routing (glob match) ──
+    $forTaskCreated = @(Get-SinksForEvent -Registry $registry -EventType 'task.created')
+    Assert-Equal -Name "task.created routes to both (alpha via task.*, zeta via exact)" -Expected 2 -Actual $forTaskCreated.Count
+
+    $forTaskUpdated = @(Get-SinksForEvent -Registry $registry -EventType 'task.updated')
+    Assert-Equal -Name "task.updated routes to alpha only (task.* glob)" -Expected 1 -Actual $forTaskUpdated.Count
+    Assert-Equal -Name "task.updated matched sink is alpha" -Expected 'alpha' -Actual $forTaskUpdated[0].name
+
+    $forRunCompleted = @(Get-SinksForEvent -Registry $registry -EventType 'workflow.run_completed')
+    Assert-Equal -Name "workflow.run_completed routes to zeta only" -Expected 1 -Actual $forRunCompleted.Count
+    Assert-Equal -Name "workflow.run_completed matched sink is zeta" -Expected 'zeta' -Actual $forRunCompleted[0].name
+
+    $forDecision = @(Get-SinksForEvent -Registry $registry -EventType 'decision.created')
+    Assert-Equal -Name "unsubscribed event routes to no sinks" -Expected 0 -Actual $forDecision.Count
+} finally {
+    Remove-Item -Recurse -Force $root -ErrorAction SilentlyContinue
+}
+
+# ── Empty / missing sinks dir is not an error ──
+$missing = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-sinks-none-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+Assert-Equal -Name "missing sinks dir yields empty registry (no throw)" -Expected 0 -Actual (@(Get-SinkRegistry -SinksDir $missing)).Count
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fail-loud validation
+# ═══════════════════════════════════════════════════════════════════════════
+
+Write-Host ""
+Write-Host "  Fail-loud validation" -ForegroundColor Cyan
+Write-Host "  ──────────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$bad = New-SinksRoot
+try {
+    $d = New-SinkFixture -Root $bad -Name 'no-meta' -NoMetadata
+    Assert-Throws -Name "missing metadata.json throws" -Action { Read-SinkMetadata -SinkDir $d } -Pattern 'missing metadata.json'
+
+    $d = New-SinkFixture -Root $bad -Name 'no-script' -Metadata @{ name = 'x'; subscribed_events = @('task.*'); max_duration = 5 } -NoScript
+    Assert-Throws -Name "missing script.ps1 throws" -Action { Read-SinkMetadata -SinkDir $d } -Pattern 'missing script.ps1'
+
+    $d = New-SinkFixture -Root $bad -Name 'bad-json' -RawMetadata '{ not valid json ]'
+    Assert-Throws -Name "invalid JSON throws" -Action { Read-SinkMetadata -SinkDir $d } -Pattern 'Invalid metadata.json'
+
+    $d = New-SinkFixture -Root $bad -Name 'no-max' -Metadata @{ name = 'x'; subscribed_events = @('task.*') }
+    Assert-Throws -Name "missing required field throws" -Action { Read-SinkMetadata -SinkDir $d } -Pattern "missing required field 'max_duration'"
+
+    $d = New-SinkFixture -Root $bad -Name 'empty-events' -Metadata @{ name = 'x'; subscribed_events = @(); max_duration = 5 }
+    Assert-Throws -Name "empty subscribed_events throws" -Action { Read-SinkMetadata -SinkDir $d } -Pattern 'empty subscribed_events'
+
+    $d = New-SinkFixture -Root $bad -Name 'blank-event' -Metadata @{ name = 'x'; subscribed_events = @('task.*', ''); max_duration = 5 }
+    Assert-Throws -Name "blank subscribed_events entry throws" -Action { Read-SinkMetadata -SinkDir $d } -Pattern 'blank entry in subscribed_events'
+
+    $d = New-SinkFixture -Root $bad -Name 'zero-dur' -Metadata @{ name = 'x'; subscribed_events = @('task.*'); max_duration = 0 }
+    Assert-Throws -Name "non-positive max_duration throws" -Action { Read-SinkMetadata -SinkDir $d } -Pattern 'non-positive max_duration'
+} finally {
+    Remove-Item -Recurse -Force $bad -ErrorAction SilentlyContinue
+}
+
+# ── One malformed sink among valid ones fails the whole registry scan ──
+$mixed = New-SinksRoot
+try {
+    New-SinkFixture -Root $mixed -Name 'good' -Metadata @{ name = 'good'; subscribed_events = @('task.*'); max_duration = 5 } | Out-Null
+    New-SinkFixture -Root $mixed -Name 'broken' -Metadata @{ name = 'broken'; subscribed_events = @('task.*') } | Out-Null  # missing max_duration
+    Assert-Throws -Name "Get-SinkRegistry fails loudly when any sink is malformed" -Action { Get-SinkRegistry -SinksDir $mixed } -Pattern "missing required field"
+} finally {
+    Remove-Item -Recurse -Force $mixed -ErrorAction SilentlyContinue
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+# SUMMARY
+# ═══════════════════════════════════════════════════════════════════════════
+
+$allPassed = Write-TestSummary -LayerName "Layer 1: Dotbot.Events Sink Discovery"
+
+if (-not $allPassed) {
+    exit 1
+}

--- a/tests/Test-Hooks.ps1
+++ b/tests/Test-Hooks.ps1
@@ -378,10 +378,10 @@ try {
     Get-Content -LiteralPath $logPath | ForEach-Object {
         try {
             $obj = $_ | ConvertFrom-Json -ErrorAction Stop
-            if ($obj.type -eq 'hook_failed' -and $obj.task_id -eq $tid) { $hookFailedLines++ }
+            if ($obj.type -eq 'hook.failed' -and $obj.task_id -eq $tid) { $hookFailedLines++ }
         } catch { }
     }
-    Assert-True -Name "activity.jsonl contains hook_failed for the task" -Condition ($hookFailedLines -ge 1)
+    Assert-True -Name "activity.jsonl contains hook.failed for the task" -Condition ($hookFailedLines -ge 1)
 
     # Replace the aborter with an advisory hook; transition should now succeed.
     Remove-Item -LiteralPath (Join-Path $projectHookDir 'enter-done') -Recurse -Force

--- a/tests/Test-ProcessDispatch.ps1
+++ b/tests/Test-ProcessDispatch.ps1
@@ -192,6 +192,24 @@ Assert-True -Name "Task-runner finalizes WorkflowRun live status" `
     -Condition ($workflowProcessContent -match 'Set-WorkflowRunLiveStatus' -and $workflowProcessContent -match 'New-WorkflowRunStatus') `
     -Message "Workflow runner should update .control/workflow-runs/<run>.json when it exits"
 
+Assert-True -Name "Task-runner emits workflow.run terminal events on the bus" `
+    -Condition ($workflowProcessContent -match 'Write-ActivityEvent' -and $workflowProcessContent -match 'workflow\.run_\$runStatus') `
+    -Message "Invoke-WorkflowProcess should emit workflow.run_<terminal> via Write-ActivityEvent when a run ends"
+
+Assert-True -Name "Task-runner guards the terminal-event emit to terminal states" `
+    -Condition ($workflowProcessContent -match "@\('completed',\s*'failed',\s*'cancelled'\)") `
+    -Message "The workflow.run_* emit must only fire for terminal run statuses, not 'running'"
+
+$uiServerFile = Join-Path $dotbotDir "src/ui/server.ps1"
+if (Test-Path $uiServerFile) {
+    $uiServerContent = Get-Content $uiServerFile -Raw
+    Assert-True -Name "UI orphan-fail path emits workflow.run_failed on the bus" `
+        -Condition ($uiServerContent -match 'Write-ActivityEvent' -and $uiServerContent -match "workflow\.run_failed") `
+        -Message "ui/server.ps1 should emit workflow.run_failed when a run fails to launch before the runner starts"
+} else {
+    Write-TestResult -Name "UI orphan-fail path emits workflow.run_failed on the bus" -Status Skip -Message "ui/server.ps1 not found at $uiServerFile"
+}
+
 Assert-True -Name "Task-runner uses legal executor status transitions" `
     -Condition ($workflowProcessContent -match 'Set-TaskInProgressForExecutorDispatch' -and $workflowProcessContent -match 'Set-TaskTerminalFailureForExecutorDispatch') `
     -Message "Executor tasks must move through in-progress before terminal states"

--- a/tests/Test-Runtime.ps1
+++ b/tests/Test-Runtime.ps1
@@ -538,15 +538,15 @@ try {
     $hasCreated  = $false; $hasUpdated = $false; $hasStatus = $false; $hasRunStarted = $false
     foreach ($l in $lines) {
         $obj = $l | ConvertFrom-Json
-        if ($obj.type -eq 'task_created')           { $hasCreated = $true }
-        if ($obj.type -eq 'task_updated')           { $hasUpdated = $true }
-        if ($obj.type -eq 'task_status_changed')    { $hasStatus  = $true }
-        if ($obj.type -eq 'workflow_run_started')   { $hasRunStarted = $true }
+        if ($obj.type -eq 'task.created')           { $hasCreated = $true }
+        if ($obj.type -eq 'task.updated')           { $hasUpdated = $true }
+        if ($obj.type -eq 'task.status_changed')    { $hasStatus  = $true }
+        if ($obj.type -eq 'workflow.run_started')   { $hasRunStarted = $true }
     }
-    Assert-True -Name "activity.jsonl contains task_created"        -Condition $hasCreated
-    Assert-True -Name "activity.jsonl contains task_updated"        -Condition $hasUpdated
-    Assert-True -Name "activity.jsonl contains task_status_changed" -Condition $hasStatus
-    Assert-True -Name "activity.jsonl contains workflow_run_started" -Condition $hasRunStarted
+    Assert-True -Name "activity.jsonl contains task.created"        -Condition $hasCreated
+    Assert-True -Name "activity.jsonl contains task.updated"        -Condition $hasUpdated
+    Assert-True -Name "activity.jsonl contains task.status_changed" -Condition $hasStatus
+    Assert-True -Name "activity.jsonl contains workflow.run_started" -Condition $hasRunStarted
 
     # ───── Invoke-RuntimeRequest (client helper) ─────
     $oldUrl   = $env:DOTBOT_RUNTIME_URL
@@ -633,10 +633,10 @@ try {
     Get-Content -LiteralPath $logPath | ForEach-Object {
         try {
             $obj = $_ | ConvertFrom-Json -ErrorAction Stop
-            if ($obj.type -eq 'task_updated' -and $obj.task_id -eq $tid) { $updatedLines++ }
+            if ($obj.type -eq 'task.updated' -and $obj.task_id -eq $tid) { $updatedLines++ }
         } catch { }
     }
-    Assert-Equal -Name "Activity log contains exactly 10 task_updated lines for the target task" -Expected 10 -Actual $updatedLines
+    Assert-Equal -Name "Activity log contains exactly 10 task.updated lines for the target task" -Expected 10 -Actual $updatedLines
 
 } finally {
     if ($start) { Stop-DotbotRuntime -BotRoot $bot -Listener $start.listener -ErrorAction SilentlyContinue }

--- a/tests/Test-Runtime.ps1
+++ b/tests/Test-Runtime.ps1
@@ -689,7 +689,7 @@ $emarker = Join-Path $ebot 'delivered.out'
 # Sink writes each matching event's type to a fixed marker path (baked literal).
 Set-Content -LiteralPath (Join-Path $esinkDir 'script.ps1') -Encoding utf8NoBOM -Value @"
 function Invoke-Sink {
-    param(`$Event)
+    param(`$Event, `$Context)
     Add-Content -LiteralPath '$emarker' -Value `$Event.type -Encoding utf8NoBOM
 }
 Export-ModuleMember -Function Invoke-Sink

--- a/tests/Test-Runtime.ps1
+++ b/tests/Test-Runtime.ps1
@@ -270,7 +270,7 @@ try {
         Assert-Equal -Name "Second Start-DotbotRuntime reuses the URL" -Expected $startResult.url -Actual $second.url
         Assert-Equal -Name "Second Start-DotbotRuntime reuses the token" -Expected $startResult.token -Actual $second.token
     } finally {
-        Stop-DotbotRuntime -BotRoot $bot -Listener $startResult.listener -ErrorAction SilentlyContinue
+        Stop-DotbotRuntime -BotRoot $bot -Listener $startResult.listener -ControlPlaneRegistration $startResult.control_plane -EventConsumer $startResult.events_consumer -ErrorAction SilentlyContinue
     }
 
     Assert-True -Name "Stop-DotbotRuntime removes runtime.json" -Condition (-not (Test-Path (Get-RuntimeConnectionFilePath -BotRoot $bot)))
@@ -597,7 +597,7 @@ try {
     }
 
 } finally {
-    if ($start) { Stop-DotbotRuntime -BotRoot $bot -Listener $start.listener -ErrorAction SilentlyContinue }
+    if ($start) { Stop-DotbotRuntime -BotRoot $bot -Listener $start.listener -ControlPlaneRegistration $start.control_plane -EventConsumer $start.events_consumer -ErrorAction SilentlyContinue }
     Remove-TestBotRoot -BotRoot $bot
 }
 
@@ -668,9 +668,55 @@ try {
     Assert-Equal -Name "Activity log contains exactly 10 task.updated lines for the target task" -Expected 10 -Actual $updatedLines
 
 } finally {
-    if ($start) { Stop-DotbotRuntime -BotRoot $bot -Listener $start.listener -ErrorAction SilentlyContinue }
+    if ($start) { Stop-DotbotRuntime -BotRoot $bot -Listener $start.listener -ControlPlaneRegistration $start.control_plane -EventConsumer $start.events_consumer -ErrorAction SilentlyContinue }
     Remove-TestBotRoot -BotRoot $bot
 }
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Event-bus consumer hosted by the runtime (Step 7 / AC#6)
+# ═══════════════════════════════════════════════════════════════════════════
+
+Write-Host ""
+Write-Host "  Event-bus consumer hosted by the runtime" -ForegroundColor Cyan
+Write-Host "  ──────────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$ebot = New-TestBotRoot
+$esinkDir = Join-Path $ebot 'src/runtime/Plugins/Events/Sinks/recorder'
+New-Item -ItemType Directory -Path $esinkDir -Force | Out-Null
+$emarker = Join-Path $ebot 'delivered.out'
+@{ name = 'recorder'; subscribed_events = @('task.*'); max_duration = 10 } | ConvertTo-Json -Depth 6 |
+    Set-Content -LiteralPath (Join-Path $esinkDir 'metadata.json') -Encoding utf8NoBOM
+# Sink writes each matching event's type to a fixed marker path (baked literal).
+Set-Content -LiteralPath (Join-Path $esinkDir 'script.ps1') -Encoding utf8NoBOM -Value @"
+function Invoke-Sink {
+    param(`$Event)
+    Add-Content -LiteralPath '$emarker' -Value `$Event.type -Encoding utf8NoBOM
+}
+Export-ModuleMember -Function Invoke-Sink
+"@
+
+$estart = Start-DotbotRuntime -BotRoot $ebot
+try {
+    Assert-True -Name "Start-DotbotRuntime hosts the event consumer" `
+        -Condition ($null -ne $estart.events_consumer -and [bool]$estart.events_consumer.enabled)
+
+    # A producer appends a bus event after the runtime is up (the cursor was
+    # seeded to EOF at start, so this must be tailed and delivered).
+    $eLog = Join-Path $ebot '.control/activity.jsonl'
+    (@{ id = 'evt_rt1'; type = 'task.created'; source = 'runtime'; data = @{} } | ConvertTo-Json -Compress) |
+        Add-Content -LiteralPath $eLog -Encoding utf8NoBOM
+
+    $delivered = $false
+    for ($i = 0; $i -lt 60; $i++) {
+        if (Test-Path -LiteralPath $emarker) { $delivered = $true; break }
+        Start-Sleep -Milliseconds 100
+    }
+    Assert-True -Name "runtime-hosted consumer tails and delivers a bus event to a sink" -Condition $delivered
+} finally {
+    Stop-DotbotRuntime -BotRoot $ebot -Listener $estart.listener -ControlPlaneRegistration $estart.control_plane -EventConsumer $estart.events_consumer -ErrorAction SilentlyContinue
+}
+Assert-True -Name "Stop-DotbotRuntime tears down the event consumer" -Condition ([bool]$estart.events_consumer.stop_flag[0])
+Remove-TestBotRoot -BotRoot $ebot
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Mutex: deterministic acquire order for multi-task ops

--- a/tests/Test-Runtime.ps1
+++ b/tests/Test-Runtime.ps1
@@ -548,6 +548,35 @@ try {
     Assert-True -Name "activity.jsonl contains task.status_changed" -Condition $hasStatus
     Assert-True -Name "activity.jsonl contains workflow.run_started" -Condition $hasRunStarted
 
+    $termBot = Join-Path ([System.IO.Path]::GetTempPath()) ("rt-term-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+    New-Item -ItemType Directory -Path (Join-Path $termBot '.control') -Force | Out-Null
+    try {
+        $knownTypes = Get-ActivityLogEventTypes
+        foreach ($t in @('workflow.run_completed','workflow.run_failed','workflow.run_cancelled')) {
+            Assert-True -Name "vocabulary includes $t" -Condition ($knownTypes -contains $t)
+        }
+
+        $terminalMap = @{ completed = 'workflow.run_completed'; failed = 'workflow.run_failed'; cancelled = 'workflow.run_cancelled' }
+        foreach ($runStatus in $terminalMap.Keys) {
+            $rid = 'wr_' + (New-DotbotNanoId)
+            Write-ActivityEvent -BotRoot $termBot -Type "workflow.run_$runStatus" -RunId $rid -From 'running' -To $runStatus -Actor 'system'
+        }
+
+        $termLines = Get-Content -LiteralPath (Get-ActivityLogPath -BotRoot $termBot) | ForEach-Object { $_ | ConvertFrom-Json }
+        foreach ($runStatus in $terminalMap.Keys) {
+            $expectedType = $terminalMap[$runStatus]
+            $evt = $termLines | Where-Object { $_.type -eq $expectedType } | Select-Object -First 1
+            Assert-True  -Name "activity.jsonl contains $expectedType"                 -Condition ($null -ne $evt)
+            Assert-Equal -Name "$expectedType carries source=runtime"                  -Expected 'runtime'   -Actual $evt.source
+            Assert-Equal -Name "$expectedType carries to=$runStatus"                   -Expected $runStatus  -Actual $evt.to
+            Assert-Equal -Name "$expectedType carries from=running"                    -Expected 'running'   -Actual $evt.from
+            Assert-True  -Name "$expectedType has a well-formed event id"              -Condition ($evt.id -match '^evt_[A-Za-z0-9]{8}$')
+            Assert-True  -Name "$expectedType matches the workflow.* sink glob"        -Condition ($evt.type -like 'workflow.*')
+        }
+    } finally {
+        Remove-Item -Recurse -Force $termBot -ErrorAction SilentlyContinue
+    }
+
     # ───── Invoke-RuntimeRequest (client helper) ─────
     $oldUrl   = $env:DOTBOT_RUNTIME_URL
     $oldToken = $env:DOTBOT_RUNTIME_TOKEN


### PR DESCRIPTION
## Linked issue

Closes #93

## Summary of changes

Adds a lightweight, in-process event bus for the outpost: producers publish typed
events to the durable activity log, a runtime-hosted background consumer tails that
log by byte cursor, and folder-discovered sinks react to the events they subscribe to.
It builds on the existing activity log, the `Dotbot.Hook` plugin-engine pattern, and
the `/api/activity/tail` polling transport, so there is one event stream end to end.

**What's included**

- **Publish** — `Publish-DotBotEvent -Type -Source -Data` stamps a well-formed envelope
  (`id`, `type`, `timestamp`, `source`, `data`, `project_id`, `actor`) and appends it to
  `.control/activity.jsonl`, reusing the existing writer lock. The `type` is validated
  against an **extensible registry**; an unregistered type is logged and still delivered.
  (`Dotbot.Runtime/Private/ActivityLog.psm1`)
- **Task & workflow lifecycle on the bus** — lifecycle transitions are surfaced as dotted
  `task.*` / `workflow.*` events at the single `Write-ActivityEvent` choke point:
  `task.created`, `task.updated`, `task.status_changed`, `workflow.run_started`,
  `hook.failed`, and the run-terminal events `workflow.run_completed` /
  `workflow.run_failed` / `workflow.run_cancelled`.
- **Subscribe (sinks)** — new `Dotbot.Events` runtime module structured like `Dotbot.Hook`:
  folder-per-plugin under `src/runtime/Plugins/Events/Sinks/<name>/` (`metadata.json`
  declaring `subscribed_events` globs + `script.ps1` exporting `Invoke-Sink`). Discovery
  fails loudly on malformed metadata. Dispatch runs each sink in a time-boxed child
  runspace and is **non-aborting** (a sink failure/timeout is logged, never rolls back a
  task) and **out-of-band** (dispatched only after the event is durably logged).
- **Deliver** — a background consumer tails `activity.jsonl` by persisted byte cursor
  (`.control/events-cursor.json`), so delivery is **at-least-once** and resumes after a
  restart. It is **hosted by the runtime server process** (`Start-DotbotRuntime` starts it,
  `Stop-DotbotRuntime` tears it down, on a dedicated runspace). Because both `dotbot go`
  and `dotbot serve` launch the runtime (attach-if-alive via `runtime.json`), there is
  exactly one consumer per project; the UI server never hosts it. Events appended while no
  runtime is running are delivered from the persisted cursor on the next start.
- **Sinks shipped**
  - **webhooks** (net-new) — POSTs matching events to configured **HTTPS-only** endpoints,
    signed with a per-endpoint **HMAC-SHA256**, honouring each endpoint's `events` filter,
    with **SSRF URL validation** (rejects loopback/private/link-local/metadata/etc.).
  - **mothership** — forwards selected events to the mothership, gated on the mothership
    settings + `mothership.sync_events`. Ships as a **gated no-op** until the server-side
    fleet events endpoint exists.
  - **aether** — consumed **client-side** in `aether.js`: it now drives the Hue lights from
    `task.*` / `workflow.*` events on the activity tail, and the old `/api/state` diffing is
    removed. No server-side aether sink.
- **Settings** — new `events` section in `content/settings/settings.default.json` with
  per-sink enable flags and the webhook endpoint list (`url`, `events`, `secret`), following
  the `file_listener` / `mothership` shape. Sinks are opt-in (disabled by default).

## Screenshots / recordings

No visual UI changes

## Testing notes

**Automated tests** (`pwsh tests/Run-Tests.ps1`):

- New `tests/Test-Events.ps1` (Layer 1, 89 assertions) — discovery + fail-loud validation,
  time-boxed non-aborting dispatch, consumer at-least-once + cursor resume/replay, and the
  webhooks + mothership sinks (URL/SSRF, HMAC, per-endpoint filter, gating).
- New `tests/Test-Aether.ps1` (Layer 1) — `/api/state` diffing removed; aether driven from
  `task.*` / `workflow.*`; the tail poll is untouched.
- Extended `tests/Test-Runtime.ps1` — dotted lifecycle events on the bus, run-terminal
  event shape, and the runtime hosting/tearing-down the consumer end-to-end.
- Extended `tests/Test-ProcessDispatch.ps1` — task-runner + UI orphan-fail emit the
  run-terminal events.

**end-to-end**: `dotbot init` a fresh project, launched
`dotbot serve` / `dotbot go`, drove the runtime API to create/transition a task and start a
workflow run, and confirmed: the dotted events land in `activity.jsonl`; the runtime-hosted
consumer delivers them to a sink; the cursor advances; and the dashboard fetches
`/api/activity/tail` and receives the bus events with zero JS console errors.

## Checklist

- [x] Tests added or updated
- [x] Docs updated (if behaviour changed) — new `events` settings section; in-code docs for the event vocabulary, the mothership gated no-op, and the sink `Context` contract
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
