### PR TITLE
feat(ui): navigation shell CSS, review harness & shared-CSS serving (#604)

### DIFF
--- a/.github/workflows/studio-ui.yml
+++ b/.github/workflows/studio-ui.yml
@@ -2,13 +2,15 @@ name: Studio UI Build & Validate
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'releases/**']
     paths:
       - 'src/studio-ui/**'
+      - 'src/shared/css/**'
   pull_request:
-    branches: [main]
+    branches: [main, 'releases/**']
     paths:
       - 'src/studio-ui/**'
+      - 'src/shared/css/**'
   workflow_dispatch:
 
 jobs:

--- a/src/server-dotnet/src/Dotbot.Server/Dotbot.Server.csproj
+++ b/src/server-dotnet/src/Dotbot.Server/Dotbot.Server.csproj
@@ -30,4 +30,13 @@
     <InternalsVisibleTo Include="Dotbot.Server.Tests" />
   </ItemGroup>
 
+  <!-- Shared design tokens/shell CSS: copy into wwwroot for build/publish output
+       (dev serving uses a PhysicalFileProvider straight at src/shared/css). -->
+  <ItemGroup>
+    <Content Include="..\..\..\shared\css\*.css"
+             Link="wwwroot\shared\css\%(Filename)%(Extension)"
+             CopyToOutputDirectory="PreserveNewest"
+             CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/src/server-dotnet/src/Dotbot.Server/Pages/Shared/_Layout.cshtml
+++ b/src/server-dotnet/src/Dotbot.Server/Pages/Shared/_Layout.cshtml
@@ -7,43 +7,11 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+    @* Design tokens now come from the shared stylesheet (single source of truth,
+       #551/#604). Values are identical to the inline block this replaces; the
+       remaining inline component styles below move to the shared shell in #605. *@
+    <link rel="stylesheet" href="/shared/css/dotbot-tokens.css" />
     <style>
-        /* === Custom Properties — Amber Classic palette === */
-        :root {
-            --color-primary: #E8A030;
-            --color-primary-dim: #B87820;
-            --color-secondary: #5FB3B3;
-            --color-success: #00FF88;
-            --color-error: #D16969;
-            --color-muted: #888899;
-            --color-bezel: #3A3B48;
-
-            --bg-deep: #050508;
-            --bg-panel: #0A0B0F;
-            --bg-module: #0D0E14;
-            --bg-screen: #070A08;
-
-            --primary-05: rgba(232, 160, 48, 0.05);
-            --primary-08: rgba(232, 160, 48, 0.08);
-            --primary-10: rgba(232, 160, 48, 0.10);
-            --primary-15: rgba(232, 160, 48, 0.15);
-            --primary-20: rgba(232, 160, 48, 0.20);
-            --primary-30: rgba(232, 160, 48, 0.30);
-            --primary-50: rgba(232, 160, 48, 0.50);
-
-            --secondary-12: rgba(95, 179, 179, 0.12);
-            --secondary-20: rgba(95, 179, 179, 0.20);
-            --secondary-30: rgba(95, 179, 179, 0.30);
-
-            --success-15: rgba(0, 255, 136, 0.15);
-
-            --grid-color: var(--primary-05);
-            --grid-color-strong: rgba(232, 160, 48, 0.075);
-
-            --font-mono: 'JetBrains Mono', 'Consolas', monospace;
-            --font-ui: 'Inter', -apple-system, sans-serif;
-        }
-
         /* === Reset === */
         * { box-sizing: border-box; margin: 0; padding: 0; }
         html, body { height: 100%; }

--- a/src/server-dotnet/src/Dotbot.Server/Program.cs
+++ b/src/server-dotnet/src/Dotbot.Server/Program.cs
@@ -195,6 +195,28 @@ try
     app.UseMiddleware<MagicLinkAuthMiddleware>();
 
     app.UseStaticFiles();
+
+    // Shared design tokens/shell CSS (src/shared/css) — in Development the repo
+    // checkout is present, so serve straight from it; published output instead
+    // carries a copy under wwwroot/shared/css via the csproj Content link.
+    if (app.Environment.IsDevelopment())
+    {
+        var sharedCss = Path.GetFullPath(Path.Combine(app.Environment.ContentRootPath, "..", "..", "..", "shared", "css"));
+        if (Directory.Exists(sharedCss))
+        {
+            // .css only — the directory also holds the dev-only harness.html,
+            // which must never be served.
+            var cssOnly = new Microsoft.AspNetCore.StaticFiles.FileExtensionContentTypeProvider(
+                new Dictionary<string, string> { [".css"] = "text/css" });
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                FileProvider = new Microsoft.Extensions.FileProviders.PhysicalFileProvider(sharedCss),
+                RequestPath = "/shared/css",
+                ContentTypeProvider = cssOnly
+            });
+        }
+    }
+
     app.UseRouting();
 
     // Auth middleware pipeline

--- a/src/shared/css/dotbot-shell.css
+++ b/src/shared/css/dotbot-shell.css
@@ -1,0 +1,333 @@
+/* DOTBOT Shared Navigation Shell
+ * One shell, many rooms: the v4 navigation frame shared by Mothership and Outpost.
+ * Spec: docs/DOTBOT-v4-DESIGN-IDEAS.md §7 — 44px top bar · 56px icon rail (pinnable
+ * to 200px labelled mode) · 28px dispatch ticker · content capped at 1280px.
+ *
+ * Consumption order: dotbot-tokens.css → dotbot-crt.css → dotbot-shell.css
+ * Shell chrome only — no page-content components live here.
+ * Pure token consumer: zero raw colors, so all theme presets work via the
+ * runtime --color-*-rgb injection (src/ui/static/modules/theme.js).
+ *
+ * Deferred hooks:
+ *   Ticker scroll animation + pause/expand behaviour  → #607
+ *   Command palette overlay                           → #553
+ *   Persona type split (data-persona)                 → #607
+ *   Responsive/mobile pass below 1200px               → #552 (content cap goes
+ *   fluid via minmax below; rail/topbar geometry intentionally unchanged)
+ */
+
+/* === Shell frame ======================================================= */
+
+.shell {
+    /* Geometry knobs — override per app or per test, never hardcode below */
+    --shell-topbar-h: 44px;
+    --shell-rail-w: 56px;
+    --shell-rail-w-pinned: 200px;
+    --shell-ticker-h: 28px;
+    --shell-content-max: 1280px;
+    /* Scanline intensity: 6% on chrome, 0% on content (spec §11) */
+    --shell-scanline-alpha: 0.06;
+
+    display: grid;
+    grid-template:
+        "topbar topbar" var(--shell-topbar-h)
+        "rail   content" 1fr
+        "ticker ticker" var(--shell-ticker-h)
+        / var(--shell-rail-w) 1fr;
+    height: 100vh;
+    overflow: hidden;
+    background: var(--bg-deep);
+    color: var(--color-primary);
+    font-family: var(--font-mono);
+}
+
+.shell[data-rail="pinned"] {
+    grid-template-columns: var(--shell-rail-w-pinned) 1fr;
+}
+
+/* The shell owns its own chrome texture; suppress the global crt.css overlay
+ * so content panels stay at 0% (spec §11). No-op until .shell markup exists. */
+body:has(.shell)::after {
+    content: none;
+}
+
+/* Chrome scanline overlay — applied per region, never on content */
+.shell-topbar::after,
+.shell-rail::after,
+.shell-ticker::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: repeating-linear-gradient(
+        0deg,
+        transparent 0 2px,
+        rgb(0 0 0 / var(--shell-scanline-alpha)) 2px 4px
+    );
+}
+
+/* === Top bar (44px) ==================================================== */
+
+.shell-topbar {
+    grid-area: topbar;
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 0 16px;
+    background: var(--bg-panel);
+    border-bottom: 1px solid var(--bezel-edge);
+}
+
+.shell-logo {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-primary);
+    text-shadow: 0 0 8px var(--primary-glow);
+    white-space: nowrap;
+}
+
+.shell-context {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    font-size: 11px;
+    color: var(--color-muted);
+    background: var(--primary-05);
+    border: 1px solid var(--primary-10);
+    border-radius: 4px;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.shell-context:hover {
+    border-color: var(--primary-20);
+    color: var(--color-primary);
+}
+
+/* Search pill — the visible palette affordance. Behaviour lands with #553. */
+.shell-search {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-left: auto;
+    padding: 5px 12px;
+    min-width: 220px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-muted);
+    background: var(--primary-05);
+    border: 1px solid var(--primary-20);
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.shell-search:hover,
+.shell-search:focus-visible {
+    border-color: var(--primary-30);
+    color: var(--color-primary);
+    outline: none;
+}
+
+.shell-search-kbd {
+    margin-left: auto;
+    padding: 1px 6px;
+    font-size: 10px;
+    color: var(--color-muted);
+    background: var(--bg-module);
+    border: 1px solid var(--bezel-edge);
+    border-radius: 3px;
+}
+
+/* LEDs — system state via [data-type] (success/warning/error/info).
+ * [data-status] is reserved for task lifecycle; do not use it here. */
+.shell-leds {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.shell-led {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--type-color, var(--color-muted));
+    box-shadow: 0 0 6px var(--type-glow, transparent);
+}
+
+/* === Icon rail (56px / 200px pinned) =================================== */
+
+.shell-rail {
+    grid-area: rail;
+    position: relative;
+    overflow: visible; /* tooltip flyouts escape the rail */
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 2px;
+    padding: 8px 0;
+    background: var(--bg-panel);
+    border-right: 1px solid var(--bezel-edge);
+    z-index: 10;
+}
+
+.shell-rail-item {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 0 8px;
+    padding: 9px 11px;
+    color: var(--color-muted);
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    text-decoration: none;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.shell-rail-item:hover {
+    color: var(--color-primary);
+    background: var(--primary-08);
+}
+
+.shell-rail-item[aria-current="page"] {
+    color: var(--color-primary);
+    background: var(--primary-10);
+    border-color: var(--primary-20);
+    text-shadow: 0 0 6px var(--primary-glow);
+}
+
+.shell-rail-icon {
+    flex: 0 0 auto;
+    width: 16px;
+    text-align: center;
+    font-size: 14px;
+    line-height: 1;
+}
+
+/* Label: tooltip flyout when unpinned, inline text when pinned */
+.shell-rail-label {
+    font-size: 10px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.shell:not([data-rail="pinned"]) .shell-rail-label {
+    position: absolute;
+    left: calc(100% + 10px);
+    top: 50%;
+    translate: 0 -50%;
+    padding: 4px 10px;
+    color: var(--color-primary);
+    background: var(--bg-module);
+    border: 1px solid var(--bezel-edge);
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgb(var(--color-bg-deep-rgb) / 0.8);
+    opacity: 0;
+    visibility: hidden;
+    z-index: 20;
+}
+
+.shell:not([data-rail="pinned"]) .shell-rail-item:hover .shell-rail-label,
+.shell:not([data-rail="pinned"]) .shell-rail-item:focus-visible .shell-rail-label {
+    opacity: 1;
+    visibility: visible;
+}
+
+.shell-rail-divider {
+    height: 1px;
+    margin: 8px 12px;
+    background: var(--bezel-edge);
+    box-shadow: 0 1px 0 var(--bezel-dark);
+}
+
+/* Pin toggle sits at the rail foot */
+.shell-rail-pin {
+    margin-top: auto;
+}
+
+/* === Content =========================================================== */
+
+.shell-content {
+    grid-area: content;
+    overflow-y: auto;
+    background:
+        linear-gradient(var(--grid-color) 1px, transparent 1px),
+        linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
+    background-size: 24px 24px;
+    background-color: var(--bg-deep);
+}
+
+.shell-content-inner {
+    max-width: var(--shell-content-max);
+    margin: 0 auto;
+    padding: 32px;
+}
+
+/* === Dispatch ticker (28px) ============================================
+ * Geometry + typography only. Scroll animation, pause-on-hover, collapse
+ * behaviour and event wiring land with #607. */
+
+.shell-ticker {
+    grid-area: ticker;
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 0 16px;
+    background: var(--bg-panel);
+    border-top: 1px solid var(--bezel-edge);
+    font-size: 11px;
+    letter-spacing: 0.05em;
+    color: var(--color-muted);
+}
+
+.shell-ticker-line {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.shell-ticker-byline {
+    margin-left: auto;
+    flex: 0 0 auto;
+    color: var(--primary-50);
+}
+
+/* === Reduced motion ====================================================
+ * First prefers-reduced-motion implementation in the codebase (#551
+ * Decision #7): keep color and shape, drop the movement. */
+
+@media (prefers-reduced-motion: reduce) {
+    .shell *,
+    .shell *::before,
+    .shell *::after {
+        transition: none !important;
+        animation: none !important;
+    }
+}
+
+/* === Responsive ========================================================
+ * Below the content cap the inner column goes fluid; rail and topbar
+ * geometry stay fixed. Full mobile pass is #552 scope. */
+
+@media (max-width: 1200px) {
+    .shell-content-inner {
+        padding: 20px;
+    }
+    .shell-search {
+        min-width: 140px;
+    }
+}

--- a/src/shared/css/harness.html
+++ b/src/shared/css/harness.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<!--
+  DOTBOT Shell Harness — dev-only visual test bench for dotbot-shell.css.
+  Never served by any app: the Outpost /shared/css route allowlists .css,
+  the Mothership csproj glob copies *.css only, and Studio imports modules.
+  Open directly via file:// — no server needed. Google Fonts load needs
+  network; JetBrains Mono / Inter fall back to Consolas / system sans.
+
+  Preset RGB values are copied from src/ui/static/theme-config.json
+  (source of truth). Applied via the same mechanism as
+  src/ui/static/modules/theme.js: only the base - -color-*-rgb triplets are
+  set; every derived variant in dotbot-tokens.css recomputes from them.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>dotbot shell harness</title>
+<link rel="stylesheet" href="./dotbot-tokens.css">
+<link rel="stylesheet" href="./dotbot-crt.css">
+<link rel="stylesheet" href="./dotbot-shell.css">
+<style>
+    /* Harness chrome — deliberately un-dotbot so it can't be mistaken for shell */
+    .hx-strip {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        padding: 8px 12px;
+        background: #1d2430;
+        color: #c8d2e0;
+        font: 12px/1.4 system-ui, sans-serif;
+        border-bottom: 2px solid #35405a;
+    }
+    .hx-strip label { display: flex; align-items: center; gap: 6px; }
+    .hx-strip select, .hx-strip button {
+        font: inherit;
+        padding: 2px 8px;
+        background: #2a3346;
+        color: inherit;
+        border: 1px solid #43507a;
+        border-radius: 3px;
+        cursor: pointer;
+    }
+    .hx-note { margin-left: auto; opacity: 0.7; font-size: 11px; }
+    .hx-frame { height: calc(100vh - 38px); }
+    .hx-frame .shell { height: 100%; }
+
+    /* Mock content bits — stand-ins for real app panels, harness-local */
+    .hx-panel {
+        margin-top: 20px;
+        border: 1px solid var(--bezel-edge);
+        border-radius: 6px;
+        background: var(--bg-module);
+        overflow: hidden;
+    }
+    .hx-panel-header {
+        padding: 8px 14px;
+        font-size: 10px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-muted);
+        background: var(--bg-panel);
+        border-bottom: 1px solid var(--bezel-edge);
+    }
+    .hx-panel-body { padding: 24px; font-size: 13px; }
+    .hx-stat {
+        font-size: 28px;
+        font-weight: 700;
+        color: var(--color-primary);
+        text-shadow: 0 0 10px var(--primary-glow);
+    }
+    .hx-stat-label {
+        margin-top: 4px;
+        font-size: 10px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-muted);
+    }
+</style>
+</head>
+<body>
+
+<div class="hx-strip">
+    <label>variant
+        <select id="hx-variant">
+            <option value="mothership">Mothership</option>
+            <option value="outpost">Outpost</option>
+        </select>
+    </label>
+    <label><input type="checkbox" id="hx-pin"> pin rail (200px)</label>
+    <label>theme
+        <select id="hx-theme">
+            <option value="">Default (tokens.css)</option>
+            <option value="amber">Amber Classic</option>
+            <option value="green">Green</option>
+            <option value="cyan">Cyan</option>
+            <option value="blue">Blue</option>
+            <option value="purple">Purple</option>
+            <option value="white">White</option>
+        </select>
+    </label>
+    <span class="hx-note">reduced motion: toggle via OS / devtools emulation — transitions must stop</span>
+</div>
+
+<div class="hx-frame">
+<div class="shell" id="hx-shell">
+
+    <header class="shell-topbar">
+        <div class="shell-logo">◈ DOTBOT</div>
+        <button class="shell-context" type="button">project/easy-bookmarks ▾</button>
+        <button class="shell-search" type="button">
+            <span>search…</span>
+            <span class="shell-search-kbd">⌘K</span>
+        </button>
+        <div class="shell-leds">
+            <span class="shell-led" data-type="success" title="Connection: online"></span>
+            <span class="shell-led" data-type="warning" title="Running: 2 processes"></span>
+            <span class="shell-led" data-type="info" title="Signal: nominal"></span>
+        </div>
+    </header>
+
+    <nav class="shell-rail" id="hx-rail"></nav>
+
+    <main class="shell-content">
+        <div class="shell-content-inner">
+            <h1 style="font-size:18px; letter-spacing:0.05em;">SHELL HARNESS</h1>
+            <p style="color: var(--color-muted); font-size: 13px; margin-top: 8px;">
+                Content area. Grid texture at token opacity, no scanlines here —
+                chrome regions (top bar, rail, ticker) carry them instead.
+            </p>
+            <div class="hx-panel">
+                <div class="hx-panel-header">Mock module panel</div>
+                <div class="hx-panel-body">
+                    <div class="hx-stat">42</div>
+                    <div class="hx-stat-label">Phosphor-glow stat — check glow follows preset</div>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <footer class="shell-ticker">
+        <span class="shell-ticker-line">DISPATCH · 03 · task T-042 moved to analysed · process P-09 started · all systems nominal</span>
+        <span class="shell-ticker-byline">— M</span>
+    </footer>
+
+</div>
+</div>
+
+<script>
+    // Rail item sets per app variant (glyphs from the design spec §7/§8/§9)
+    var RAILS = {
+        mothership: [
+            { icon: '□', label: 'Fleet' },
+            { icon: '▣', label: 'Decisions', current: true },
+            { icon: '○', label: 'People' },
+            { divider: true },
+            { icon: '◇', label: 'Studio' },
+            { icon: '⚙', label: 'Settings' }
+        ],
+        outpost: [
+            { icon: '□', label: 'Overview', current: true },
+            { icon: '▣', label: 'Tasks' },
+            { icon: '◆', label: 'Product' },
+            { icon: '◇', label: 'Decisions' },
+            { icon: '○', label: 'Workflow' },
+            { divider: true },
+            { icon: '⚙', label: 'Settings' }
+        ]
+    };
+
+    // Preset RGB values copied from src/ui/static/theme-config.json (source of
+    // truth). Keys map to --color-{key}-rgb, same as modules/theme.js does.
+    var PRESETS = {
+        amber:  {"primary":[232,160,48],"primary-dim":[184,120,32],"secondary":[156,112,40],"tertiary":[156,112,40],"success":[0,255,136],"success-dim":[0,170,92],"error":[232,160,48],"warning":[232,160,48],"info":[156,112,40],"muted":[112,104,92],"bezel":[56,52,44],"bg-deep":[5,5,8],"bg-panel":[10,11,15],"bg-module":[13,14,20],"bg-screen":[7,10,8]},
+        green:  {"primary":[0,255,136],"primary-dim":[0,170,92],"secondary":[0,136,72],"tertiary":[0,136,72],"success":[0,255,136],"success-dim":[0,170,92],"error":[0,255,136],"warning":[0,255,136],"info":[0,136,72],"muted":[88,112,96],"bezel":[40,56,46],"bg-deep":[3,8,5],"bg-panel":[6,15,10],"bg-module":[8,20,13],"bg-screen":[4,12,7]},
+        cyan:   {"primary":[95,179,179],"primary-dim":[70,140,140],"secondary":[56,112,112],"tertiary":[56,112,112],"success":[0,255,136],"success-dim":[0,170,92],"error":[95,179,179],"warning":[95,179,179],"info":[56,112,112],"muted":[92,108,108],"bezel":[42,54,54],"bg-deep":[4,7,7],"bg-panel":[8,14,14],"bg-module":[10,18,18],"bg-screen":[5,11,10]},
+        blue:   {"primary":[68,136,255],"primary-dim":[48,100,200],"secondary":[40,80,160],"tertiary":[40,80,160],"success":[0,255,136],"success-dim":[0,170,92],"error":[68,136,255],"warning":[68,136,255],"info":[40,80,160],"muted":[96,100,116],"bezel":[44,48,58],"bg-deep":[4,5,10],"bg-panel":[8,10,18],"bg-module":[10,13,24],"bg-screen":[5,7,14]},
+        purple: {"primary":[170,136,255],"primary-dim":[130,100,200],"secondary":[104,84,160],"tertiary":[104,84,160],"success":[232,160,48],"success-dim":[184,120,32],"error":[170,136,255],"warning":[170,136,255],"info":[104,84,160],"muted":[104,96,116],"bezel":[50,46,58],"bg-deep":[6,4,10],"bg-panel":[12,8,18],"bg-module":[16,11,24],"bg-screen":[9,6,14]},
+        white:  {"primary":[220,220,230],"primary-dim":[170,170,180],"secondary":[100,160,180],"tertiary":[100,160,180],"success":[0,200,255],"success-dim":[0,150,200],"error":[220,220,230],"warning":[220,220,230],"info":[100,160,180],"muted":[108,108,112],"bezel":[52,52,56],"bg-deep":[6,6,8],"bg-panel":[12,12,16],"bg-module":[16,16,22],"bg-screen":[10,10,12]}
+    };
+    var PRESET_KEYS = Object.keys(PRESETS.amber);
+
+    var shell = document.getElementById('hx-shell');
+    var rail = document.getElementById('hx-rail');
+
+    function buildRail(variant) {
+        rail.innerHTML = '';
+        RAILS[variant].forEach(function (item) {
+            if (item.divider) {
+                var d = document.createElement('div');
+                d.className = 'shell-rail-divider';
+                rail.appendChild(d);
+                return;
+            }
+            var a = document.createElement('a');
+            a.className = 'shell-rail-item';
+            a.href = '#';
+            if (item.current) a.setAttribute('aria-current', 'page');
+            a.innerHTML = '<span class="shell-rail-icon">' + item.icon +
+                '</span><span class="shell-rail-label">' + item.label + '</span>';
+            rail.appendChild(a);
+        });
+    }
+
+    function applyPreset(name) {
+        var root = document.documentElement;
+        PRESET_KEYS.forEach(function (key) {
+            var prop = '--color-' + key + '-rgb';
+            if (!name) {
+                root.style.removeProperty(prop);
+            } else {
+                root.style.setProperty(prop, PRESETS[name][key].join(' '));
+            }
+        });
+    }
+
+    document.getElementById('hx-variant').addEventListener('change', function (e) {
+        buildRail(e.target.value);
+    });
+    document.getElementById('hx-pin').addEventListener('change', function (e) {
+        if (e.target.checked) { shell.dataset.rail = 'pinned'; }
+        else { delete shell.dataset.rail; }
+    });
+    document.getElementById('hx-theme').addEventListener('change', function (e) {
+        applyPreset(e.target.value);
+    });
+
+    buildRail('mothership');
+</script>
+
+</body>
+</html>

--- a/src/studio-ui/src/client/styles/globals.css
+++ b/src/studio-ui/src/client/styles/globals.css
@@ -4,6 +4,9 @@
 
 @import '@shared/css/dotbot-tokens.css';
 @import '@shared/css/dotbot-crt.css';
+/* v4 navigation shell (#551/#604) — no .shell markup in Studio yet; importing
+ * keeps the stylesheet build-checked and ready for the R2 consolidation. */
+@import '@shared/css/dotbot-shell.css';
 
 /* === App Layout === */
 #root {

--- a/src/ui/server.ps1
+++ b/src/ui/server.ps1
@@ -2827,6 +2827,26 @@ $docContext
                     break
                 }
 
+                # Shared shell/token stylesheets live outside the static root (src/shared/css).
+                # Explicit route with a traversal guard; .css only — nothing else in that
+                # directory is servable (e.g. harness.html is dev-only).
+                { $_ -like '/shared/css/*' } {
+                    $sharedCssRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..' 'shared' 'css'))
+                    $requested = $url.Substring('/shared/css/'.Length)
+                    $candidate = [System.IO.Path]::GetFullPath((Join-Path $sharedCssRoot $requested))
+                    $rootWithSep = $sharedCssRoot.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+                    if ($candidate.StartsWith($rootWithSep, [System.StringComparison]::OrdinalIgnoreCase) -and
+                        [System.IO.Path]::GetExtension($candidate) -eq '.css' -and
+                        (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+                        $contentType = 'text/css; charset=utf-8'
+                        $content = Get-Content -LiteralPath $candidate -Raw
+                    } else {
+                        $statusCode = 404
+                        $content = "Not found: $url"
+                    }
+                    break
+                }
+
                 default {
                     # Serve static files
                     $filePath = Join-Path $staticRoot $url.TrimStart('/')


### PR DESCRIPTION
## Linked issue

Closes #604

## Summary of changes

Part 1 of 4 of the #551 navigation-shell rollout (R1, v4.1).

- **`src/shared/css/dotbot-shell.css`** (new) — v4 shell chrome: 44px top bar, 56px icon rail (pinnable to 200px labelled mode), 28px ticker slot, 1280px content cap. Pure token consumer — all 6 theme presets work via existing runtime injection. First `prefers-reduced-motion` usage in the codebase. Ticker behaviour/persona split deferred to #607, palette to #553.
- **`src/shared/css/harness.html`** (new) — dev-only `file://` review bench: both app rail variants, pin toggle, all 6 presets + tokens.css baseline. Never served by either app.
- **Outpost** — `/shared/css/*` route in `server.ps1` (path-traversal guard, `.css` allowlist).
- **Mothership** — dev `PhysicalFileProvider` (css-only content types) + csproj Content link so publish output carries `wwwroot/shared/css`. `_Layout.cshtml` `:root` token block replaced with a link to the shared `dotbot-tokens.css` — same names, identical values. Note: tokens.css `@import`s the same Google Fonts URL the layout already links (intentional, single cached fetch); `wwwroot/css/dashboard.css` still re-defines tokens as hex — flagged as #605 debt.
- **Studio** — one-line `@import` of the shell stylesheet (no `.shell` markup yet; makes the Vite build syntax-check it).
- **CI** — `studio-ui.yml` now watches `src/shared/css/**` and fires on `releases/**` branches (was main-only, so R1 PRs ran zero checks).

No visual change to any app. Shell markup lands in #605.

## Screenshots / recordings

### Harness (new shell, reviewable without running dotbot)

| Default (Mothership rail) | Pinned rail (200px) |
|---|---|
| <img width="1440" height="900" alt="1-default-mothership" src="https://github.com/user-attachments/assets/5e00215e-1b8a-4b35-b351-44d34226ee4b" /> | <img width="1440" height="900" alt="2-pinned" src="https://github.com/user-attachments/assets/e0735f9b-f601-4059-bcc8-aeb780547d80"> |

<details>
<summary>More: Outpost variant · cyan preset · green preset · tooltip hover</summary>

<img width="1440" height="900" alt="3-outpost" src="https://github.com/user-attachments/assets/28af71dd-f677-4cf6-90e5-731855626665" />
<img width="1440" height="900" alt="4-outpost-cyan" src="https://github.com/user-attachments/assets/bd05d54b-ec18-4d85-95fa-379dcdf30213" />
<img width="1440" height="900" alt="5-outpost-green" src="https://github.com/user-attachments/assets/1888024e-9625-4fdd-9f54-6b57358c7e47" />
<img width="1440" height="900" alt="6-tooltip-hover" src="https://github.com/user-attachments/assets/8f398123-871b-4136-9485-0be2ced7ebc8" />

</details>

### Mothership regression proof (_Layout token swap)

Pixel diff: **98 / 1,296,000 px (0.008%)** — antialiasing jitter on dynamic timestamps only, no palette shift.

| Before | After |
|---|---|
| <img width="1440" height="900" alt="mship-before" src="https://github.com/user-attachments/assets/a78fd48c-55ae-4277-a801-568dcd6d233e" /> | <img width="1440" height="900" alt="mship-after" src="https://github.com/user-attachments/assets/3e8ae2da-f945-4d07-97ec-90d4d91accd2" /> |

<details>
<summary>/Respond stakeholder page (eyeball check)</summary>

<img width="1077" height="853" alt="Screenshot 2026-07-08 141512" src="https://github.com/user-attachments/assets/9798bea0-d4ba-4134-9228-ac0effd9840a" />

</details>

## Testing notes

- Harness: open `src/shared/css/harness.html` via `file://` — geometry (44/56/28/1280), scanlines on chrome only, presets recolor everything, tooltips on hover, pin toggle.
- Outpost: `curl /shared/css/dotbot-shell.css` → 200 `text/css`; `harness.html` → 404; traversal probe → 404; `/css/theme.css`, `/` unchanged.
- Mothership dev: same curls pass; dashboard/Respond render pixel-identical (screenshots).
- `dotnet publish -c Release` → `publish/wwwroot/shared/css/*.css` present.
- Studio `npm run build` green.

## Checklist

- [ ] Tests added or updated — N/A: CSS + serving plumbing; verified by harness + curl + pixel-diff
- [x] Docs updated (if behaviour changed) — no behaviour change
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
