### PR TITLE
fix(process): correct inverted priority sort in Get-NextWorkflowTask

### DIFF
--- a/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
+++ b/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
@@ -743,7 +743,7 @@ function Get-NextWorkflowTask {
     }
     if ($eligible.Count -gt 0) {
         $next = $eligible | Sort-Object @(
-            @{ Expression = { if ($_.Content.priority -is [int] -or $_.Content.priority -is [long]) { -[int]$_.Content.priority } else { 0 } }; Ascending = $true }
+            @{ Expression = { if ($_.Content.priority -is [int] -or $_.Content.priority -is [long]) { [int]$_.Content.priority } else { [int]::MaxValue } }; Ascending = $true }
             @{ Expression = { [string]$_.Content.created_at }; Ascending = $true }
         ) | Select-Object -First 1
         return @{


### PR DESCRIPTION
## Linked issue

Closes #613

## Summary of changes

`Get-NextWorkflowTask` negated priority before ascending sort, so highest-numbered (lowest-urgency) tasks ran first. Priority-less tasks fell back to `0`, sorting above `priority=1`.

Fix: remove negation, use `[int]::MaxValue` fallback so priority-less tasks sort last. Aligns with the pattern in `Dotbot.TaskIndex` and the documented convention (1-100, lower = higher urgency).

Normally masked by dependency serialization; surfaces when multiple tasks become eligible simultaneously.

## Testing notes

Load `Dotbot.Process` module, create two independent eligible tasks (`priority=1` and `priority=10`), call `Get-NextWorkflowTask` — confirm `priority=1` is selected. Existing `Test-WorkflowManifest.ps1` suite passes (covers `Get-NextWorkflowTask` priority and condition ordering).

## Checklist

- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)