### PR TITLE
feat(ci): auto-close linked issues on release-branch merge

### DIFF
--- a/.github/workflows/release-autoclose.yml
+++ b/.github/workflows/release-autoclose.yml
@@ -1,0 +1,62 @@
+name: "Auto-close linked issues (release branches)"
+
+on:
+  # pull_request_target: token can close issues from fork PRs; no checkout.
+  pull_request_target:
+    types: [closed]
+    branches:
+      - 'releases/**'
+
+permissions:
+  issues: write
+
+jobs:
+  close-linked:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close linked issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const base = pr.base.ref;
+            const body = pr.body || '';
+
+            // Same keywords as pr-link-check.yml; bare same-repo #N only.
+            const re = /(?:closes|fixes|resolves):?\s+#(\d+)/gi;
+            const numbers = [...new Set([...body.matchAll(re)].map(m => Number(m[1])))];
+
+            if (numbers.length === 0) {
+              core.info('No linked issues found in PR body.');
+              return;
+            }
+
+            for (const issue_number of numbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                });
+                if (issue.pull_request) { core.info(`#${issue_number} is a PR, skipping.`); continue; }
+                if (issue.state === 'closed') { core.info(`#${issue_number} already closed, skipping.`); continue; }
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  body: `Closed via #${pr.number} (merged to \`${base}\`).`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+                core.info(`Closed #${issue_number}.`);
+              } catch (err) {
+                core.warning(`Failed to close #${issue_number}: ${err.message}`);
+              }
+            }


### PR DESCRIPTION
## Linked issue

Closes #617

## Summary of changes

GitHub's `Closes #N` auto-close fires only when a PR merges into the **default branch**, so PRs merged into `releases/**` during a release cycle leave their linked issues open. Milestone/board progress under-reports until someone closes them by hand.

Adds `.github/workflows/release-autoclose.yml` — a sibling of `pr-link-check.yml` (same `pull_request_target` + `github-script` pattern, no checkout):

- Trigger: `pull_request_target: types: [closed]` with `branches: ['releases/**']`, guarded by `github.event.pull_request.merged == true`.
- Parses `closes|fixes|resolves #N` from the PR body (same keywords `pr-link-check.yml` enforces), dedups, same-repo bare `#N` only.
- Per issue: skips PRs and already-closed issues, posts an audit comment (`Closed via #PR (merged to \`releases/x.y.z\`)`), then closes with `state_reason: completed`. Per-issue try/catch so one bad ref can't abort the rest.

> **Note:** must land on `main` to take effect — GitHub reads `pull_request_target` workflows from the default branch.

## Testing notes

- Static: `@action-validator/cli` schema check (pass), embedded `github-script` parsed as valid JS, regex/dedup/skip logic unit-tested (8/8) plus a mocked full-loop simulation of the #615→`releases/4.1.0` case.
- Live end-to-end in a throwaway sandbox repo: workflow on default branch, PR with `Closes #N` merged into a `releases/**` branch → run succeeded, issue closed with reason `completed` and the audit comment posted. Covers trigger + `issues: write` token + default-branch read.

## Checklist

- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)