### PR TITLE
feat(ui): render v4 navigation shell in Outpost and Mothership dashboard (#605)

### DIFF
--- a/src/server-dotnet/src/Dotbot.Server/Pages/Index.cshtml
+++ b/src/server-dotnet/src/Dotbot.Server/Pages/Index.cshtml
@@ -1,42 +1,20 @@
 @page
 @model Dotbot.Server.Pages.IndexModel
 @{
-    Layout = null;
+    Layout = "_LayoutDashboard";
+    ViewData["Title"] = "Dashboard";
+    ViewData["UserName"] = Model.UserName;
 }
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Dotbot Dashboard</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
-    <link rel="stylesheet" href="/css/dashboard.css" />
-</head>
-<body>
-    <div class="control-panel">
-        <!-- Header -->
-        <div class="header-bar">
-            <div class="header-left">
-                <span class="logo">DOTBOT</span>
-                <span class="logo-sub">DASHBOARD</span>
-            </div>
-            <div class="header-right">
-                <span class="user-info">@Model.UserName</span>
-                <a href="/api/dashboard/signout" class="ctrl-btn-sm">SIGN OUT</a>
-            </div>
-        </div>
 
-        <!-- Tab Bar -->
-        <div class="tab-bar-container">
-            <button class="tab active" data-tab="overview">Overview</button>
-            <button class="tab" data-tab="by-person">By Person</button>
-            <button class="tab" data-tab="by-project">By Project</button>
-        </div>
+<!-- Tab Bar (in-page filters; become filter chips in #606) -->
+<div class="tab-bar-container">
+    <button class="tab active" data-tab="overview">Overview</button>
+    <button class="tab" data-tab="by-person">By Person</button>
+    <button class="tab" data-tab="by-project">By Project</button>
+</div>
 
-        <!-- Main Content -->
-        <div class="main-content">
+<!-- Main Content -->
+<div class="main-content">
             <!-- Overview Tab -->
             <div class="tab-pane active" id="tab-overview">
                 <div class="stats-row">
@@ -140,13 +118,6 @@
             </div>
         </div>
 
-        <!-- Footer -->
-        <div class="footer-bar">
-            <span id="last-refresh">Loading...</span>
-            <span class="footer-version">Dotbot Dashboard v1.0</span>
-        </div>
-    </div>
-
+@section Scripts {
     <script src="/js/dashboard.js"></script>
-</body>
-</html>
+}

--- a/src/server-dotnet/src/Dotbot.Server/Pages/Shared/_LayoutDashboard.cshtml
+++ b/src/server-dotnet/src/Dotbot.Server/Pages/Shared/_LayoutDashboard.cshtml
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+@* Dashboard layout with the v4 navigation shell (#551/#605). Used by admin
+   surfaces (Index today; Fleet #547 / People #601 add rail items here as
+   their pages land). Stakeholder magic-link pages (Respond/Confirmation)
+   stay on the plain _Layout — no shell. *@
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - Dotbot</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/shared/css/dotbot-tokens.css" />
+    <link rel="stylesheet" href="/css/dashboard.css" />
+    <link rel="stylesheet" href="/shared/css/dotbot-shell.css" />
+</head>
+<body>
+    <div class="shell">
+        <header class="shell-topbar">
+            <div class="shell-logo">◈ DOTBOT <span class="logo-sub">DASHBOARD</span></div>
+            <button class="shell-search" type="button" disabled title="Command palette — coming with #553">
+                <span>search…</span>
+                <span class="shell-search-kbd">Ctrl+K</span>
+            </button>
+            <span class="user-info">@ViewData["UserName"]</span>
+            <a href="/api/dashboard/signout" class="ctrl-btn-sm">SIGN OUT</a>
+        </header>
+
+        @* Rail shows only destinations that exist; Fleet (#547), People (#601)
+           and Settings slots are added as their pages land — Q5 pattern. *@
+        <nav class="shell-rail" aria-label="Primary">
+            <a class="shell-rail-item" href="/" aria-current="page"><span class="shell-rail-icon">▣</span><span class="shell-rail-label">Decisions</span></a>
+            <div class="shell-rail-divider"></div>
+        </nav>
+
+        <main class="shell-content">
+            <div class="shell-content-inner">
+                @RenderBody()
+            </div>
+        </main>
+
+        <footer class="shell-ticker">
+            <span class="shell-ticker-line" id="last-refresh">Loading...</span>
+            <span class="shell-ticker-byline">Dotbot Dashboard v1.0</span>
+        </footer>
+    </div>
+
+    @await RenderSectionAsync("Scripts", required: false)
+</body>
+</html>

--- a/src/server-dotnet/src/Dotbot.Server/wwwroot/css/dashboard.css
+++ b/src/server-dotnet/src/Dotbot.Server/wwwroot/css/dashboard.css
@@ -2,7 +2,12 @@
    DOTBOT DASHBOARD — Retro Terminal Design System
    ============================================================ */
 
-/* === CSS Variables — Amber Classic Palette === */
+/* === CSS Variables — Amber Classic Palette ===
+ * #606 migration debt: these values intentionally DIVERGE from the shared
+ * /shared/css/dotbot-tokens.css for secondary (#5FB3B3 cyan vs amber-brown),
+ * error (#D16969 red vs amber) and muted. This block loads after tokens.css
+ * and wins; dropping it without reconciling would recolor dashboard content.
+ * Reconcile when the dashboard content is restructured in #606. */
 :root {
     --color-primary: #E8A030;
     --color-primary-dim: #B87820;
@@ -65,53 +70,10 @@ body {
     background-size: 10px 10px, 10px 10px, 50px 50px, 50px 50px;
 }
 
-/* === Scanlines overlay === */
-body::after {
-    content: '';
-    position: fixed;
-    top: 0; left: 0; right: 0; bottom: 0;
-    pointer-events: none;
-    z-index: 9999;
-    background: repeating-linear-gradient(
-        0deg,
-        transparent,
-        transparent 2px,
-        rgba(0, 0, 0, 0.03) 2px,
-        rgba(0, 0, 0, 0.03) 4px
-    );
-}
-
-/* === Control Panel — full-height flex column === */
-.control-panel {
-    display: flex;
-    flex-direction: column;
-    height: 100vh;
-}
-
-/* === Header Bar === */
-.header-bar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 10px 20px;
-    background: var(--bezel-dark);
-    border-bottom: 1px solid var(--bezel-edge);
-    flex-shrink: 0;
-}
-.header-left {
-    display: flex;
-    align-items: baseline;
-    gap: 8px;
-}
-.logo {
-    font-family: var(--font-mono);
-    font-size: 18px;
-    font-weight: 700;
-    letter-spacing: 0.15em;
-    text-transform: uppercase;
-    color: var(--color-primary);
-    text-shadow: 0 0 15px var(--primary-50);
-}
+/* Page chrome (topbar/rail/ticker + its scanlines) comes from
+ * /shared/css/dotbot-shell.css since #605. The old header/footer/scanline
+ * blocks were removed; .logo-sub and .user-info stay — they render inside
+ * the shell topbar now. */
 .logo-sub {
     font-family: var(--font-ui);
     font-size: 10px;
@@ -120,15 +82,11 @@ body::after {
     text-transform: uppercase;
     color: var(--color-muted);
 }
-.header-right {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-}
 .user-info {
     font-family: var(--font-ui);
     font-size: 12px;
     color: var(--color-muted);
+    margin-left: auto;
 }
 
 /* === Tab Bar === */
@@ -164,39 +122,18 @@ body::after {
     text-shadow: 0 0 8px var(--primary-30);
 }
 
-/* === Main Content === */
+/* === Main Content ===
+ * Inside .shell-content the page flows as a document; the shell owns
+ * scrolling. Panes no longer self-scroll. */
 .main-content {
-    flex: 1;
-    overflow: hidden;
     position: relative;
 }
 .tab-pane {
     display: none;
-    height: 100%;
-    overflow-y: auto;
-    padding: 16px 20px;
+    padding: 16px 0;
 }
 .tab-pane.active {
     display: block;
-}
-
-/* === Footer Bar === */
-.footer-bar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 8px 20px;
-    background: var(--bezel-dark);
-    border-top: 1px solid var(--bezel-edge);
-    font-family: var(--font-ui);
-    font-size: 10px;
-    color: var(--color-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    flex-shrink: 0;
-}
-.footer-version {
-    color: var(--color-bezel);
 }
 
 /* === Stats Row — polished with grid backgrounds === */
@@ -289,7 +226,7 @@ body::after {
         linear-gradient(var(--grid-color-strong) 1px, transparent 1px),
         linear-gradient(90deg, var(--grid-color-strong) 1px, transparent 1px);
     background-size: 10px 10px, 10px 10px, 50px 50px, 50px 50px;
-    max-height: calc(100vh - 380px);
+    max-height: calc(100vh - 420px); /* retuned for shell chrome (#605): 44px topbar + 28px ticker + inner padding */
     overflow-y: auto;
 }
 
@@ -642,7 +579,7 @@ select.filter-input option {
 .split-view {
     display: grid;
     grid-template-columns: 300px 1fr;
-    height: calc(100vh - 150px);
+    height: calc(100vh - 210px); /* retuned for shell chrome (#605) */
     gap: 0;
     background: var(--bg-panel);
     border: 1px solid var(--bezel-edge);

--- a/src/ui/static/app.js
+++ b/src/ui/static/app.js
@@ -30,6 +30,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Initialize UI components
     initTabs();
+    initShell();
     initLogoClick();
     initHamburgerMenu();
     initSidebarCollapse();

--- a/src/ui/static/css/layout.css
+++ b/src/ui/static/css/layout.css
@@ -1,33 +1,27 @@
 /* DOTBOT Control Panel - Layout
  * Page structure: control panel, header, footer, main content area
  */
-/* ========== LAYOUT ========== */
-.control-panel {
-    display: flex;
-    flex-direction: column;
-    height: 100vh;
-    background: var(--bg-deep);
+/* ========== LAYOUT ==========
+ * Page chrome (topbar/rail/ticker) comes from /shared/css/dotbot-shell.css
+ * (#551/#605). This file keeps app-side pieces that live inside the shell:
+ * context group, badges, pickers, LEDs, editor button, main-layout/sidebar. */
+
+/* Glue: the cockpit layout fills the shell content area without the 1280px
+ * reading cap — resizable sidebar + pipeline columns need full width. */
+.shell-content > .main-layout {
+    height: 100%;
 }
 
-/* ========== HEADER ========== */
-.header {
+/* App-side topbar group: project badge + runtime picker + workflow badges */
+.shell-context-group {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    padding: 12px 20px;
-    background: var(--bezel-dark);
-    border-bottom: 1px solid var(--bezel-edge);
-    flex-shrink: 0;
-}
-
-.system-id {
-    display: flex;
-    align-items: center;
-    gap: 16px;
+    gap: 12px;
+    min-width: 0;
 }
 
 .logo {
-    font-size: 16px;
+    font-size: 14px;
     font-weight: 700;
     letter-spacing: 0.15em;
     color: var(--color-primary);
@@ -229,11 +223,6 @@
     100% { transform: scale(1); }
 }
 
-.header-signals {
-    display: flex;
-    gap: 24px;
-}
-
 .signal {
     display: flex;
     align-items: center;
@@ -269,7 +258,7 @@
     50% { opacity: 0.4; }
 }
 
-/* Framework banner (DOTBOT_HOME / git state) — lives in .header-signals so
+/* Framework banner (DOTBOT_HOME / git state) — lives in the shell topbar so
    the active checkout is the first thing a dev sees on every page paint.
    Default state stays muted; --warn pops to the warning palette when the
    framework tree is dirty or off main/master. */
@@ -359,82 +348,8 @@
     overflow: hidden;
 }
 
-/* Tab Bar Container (Full Width) */
-.tab-bar-container {
-    background: var(--bezel-dark);
-    border-bottom: 1px solid var(--bezel-edge);
-    flex-shrink: 0;
-}
-
-/* Tab Bar */
-.tab-bar {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background: var(--bezel-dark);
-    flex-shrink: 0;
-    padding-right: 12px;
-}
-
-.tab-group-main {
-    display: flex;
-}
-
-.tab {
-    padding: 10px 18px;
-    background: none;
-    border: none;
-    border-bottom: 2px solid transparent;
-    font-family: var(--font-ui);
-    font-size: 10px;
-    font-weight: 500;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--label-color);
-    cursor: pointer;
-    transition: all 0.2s ease;
-}
-
-.tab:hover {
-    color: var(--color-primary-dim);
-    background: var(--primary-05);
-}
-
-.tab.active {
-    color: var(--color-primary);
-    border-bottom-color: var(--color-primary);
-    background: var(--primary-08);
-}
-
-/* Tab Action Button (Whisper) */
-.tab-action {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    background: transparent;
-    border: 1px solid var(--color-secondary-dim);
-    color: var(--color-secondary);
-    padding: 6px 12px;
-    font-family: var(--font-ui);
-    font-size: 10px;
-    font-weight: 600;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    border-radius: 3px;
-    cursor: pointer;
-    transition: all 0.2s ease;
-}
-
-.tab-action:hover {
-    background: var(--secondary-15);
-    border-color: var(--color-secondary);
-    box-shadow: 0 0 8px var(--secondary-glow);
-}
-
-.tab-action svg {
-    width: 14px;
-    height: 14px;
-}
+/* Tab bar chrome removed in #605 — navigation lives in the shell rail
+ * (/shared/css/dotbot-shell.css). Panes below are still driven by tabs.js. */
 
 /* Tab Content */
 .tab-content {
@@ -453,46 +368,41 @@
     display: block;
 }
 
-/* ========== FOOTER ========== */
-.footer {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 8px 20px;
-    background: var(--bezel-dark);
-    border-top: 1px solid var(--bezel-edge);
-    font-size: 10px;
+/* Footer chrome removed in #605 — replaced by the shell ticker slot
+ * (/shared/css/dotbot-shell.css); scroll behaviour lands with #607. */
+
+/* Topbar density: nothing wraps in the 44px bar. Priority under pressure:
+ * identity values (project, workflow, DOTBOT_HOME SHA) keep full text; the
+ * inert search pill compresses first; workflow pills ellipsize last — the
+ * full list lives on the Workflows tab. */
+.shell-topbar .workflow-pills {
+    flex-wrap: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+}
+
+.shell-topbar .project-badge,
+.shell-topbar .workflow-badge,
+.shell-topbar .framework-banner {
+    white-space: nowrap;
     flex-shrink: 0;
 }
 
-.footer-left,
-.footer-right {
-    display: flex;
-    align-items: center;
-    gap: 8px;
+.shell-topbar .framework-banner__value {
+    white-space: nowrap;
 }
 
-.footer-center {
-    flex: 1;
-    text-align: center;
+.shell-topbar .shell-search {
+    min-width: 120px;
+    flex-shrink: 1;
+    overflow: hidden;
 }
 
-.footer-label {
-    color: var(--label-color);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-
-.footer-value {
-    color: var(--type-color, var(--color-primary-dim));
-    font-weight: 500;
-}
-
-.footer-sep {
-    color: var(--bezel-edge);
-}
-
-.footer-mission {
-    color: var(--label-color);
-    font-style: italic;
+@media (max-width: 1200px) {
+    .shell-topbar .shell-search,
+    .shell-topbar .workflow-pills {
+        display: none;
+    }
 }

--- a/src/ui/static/css/responsive.css
+++ b/src/ui/static/css/responsive.css
@@ -64,7 +64,9 @@
         display: flex;
     }
 
-    .system-id {
+    .shell-context-group,
+    .shell-search,
+    #framework-banner {
         display: none;
     }
 
@@ -133,11 +135,7 @@
         padding-left: 16px;
     }
 
-    /* Header signals: compact */
-    .header-signals {
-        gap: 12px;
-    }
-
+    /* Topbar signals: LEDs only, no text labels */
     .signal span:not(.led) {
         display: none;
     }
@@ -180,15 +178,5 @@
 
     .stat-card {
         padding: 10px 12px;
-    }
-
-    /* Tab bar: scrollable */
-    .tab-bar {
-        overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
-    }
-
-    .tab-group-main {
-        flex-wrap: nowrap;
     }
 }

--- a/src/ui/static/index.html
+++ b/src/ui/static/index.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="css/crt.css">
     <link rel="stylesheet" href="css/processes.css">
     <link rel="stylesheet" href="css/responsive.css">
+    <link rel="stylesheet" href="/shared/css/dotbot-shell.css">
     <style>
         /* Hide body until theme is loaded to prevent flash */
         body { opacity: 0; transition: opacity 0.15s ease-in; }
@@ -23,14 +24,16 @@
 </head>
 <body>
     <div class="mobile-overlay" id="mobile-overlay"></div>
-    <div class="control-panel">
-        <!-- Header (v2 style) -->
-        <header class="header">
+    <div class="shell" id="shell">
+        <!-- Top bar (v4 shell, #551/#605) -->
+        <header class="shell-topbar">
             <button class="hamburger-menu" id="hamburger-menu" aria-label="Toggle menu">
                 <!-- Menu icon loaded dynamically -->
             </button>
-            <div class="system-id">
+            <div class="shell-logo">
                 <span class="logo">◈ DOTBOT</span>
+            </div>
+            <div class="shell-context-group">
                 <span class="project-badge" id="project-name">autonomous</span>
                 <label class="runtime-picker-wrap" title="Registered runtime">
                     <span class="runtime-picker-count" id="runtime-picker-status">0</span>
@@ -41,11 +44,19 @@
                 <span class="workflow-badge" id="workflow-badge"></span>
                 <span class="workflow-pills" id="workflow-pills"></span>
             </div>
-            <div class="header-signals">
-                <div class="framework-banner" id="framework-banner" title="DOTBOT_HOME / framework status">
-                    <span class="framework-banner__label">DOTBOT_HOME</span>
-                    <span class="framework-banner__value" id="framework-banner-value">…</span>
-                </div>
+            <button class="shell-search" type="button" disabled title="Command palette — coming with #553">
+                <span>search…</span>
+                <span class="shell-search-kbd">Ctrl+K</span>
+            </button>
+            <div class="framework-banner" id="framework-banner" title="DOTBOT_HOME / framework status">
+                <span class="framework-banner__label">DOTBOT_HOME</span>
+                <span class="framework-banner__value" id="framework-banner-value">…</span>
+            </div>
+            <button class="editor-btn dimmed" id="editor-btn" title="Configure editor" aria-label="Configure editor">
+                <span class="editor-btn-icon" id="editor-btn-icon"></span>
+                <span class="editor-btn-label" id="editor-btn-label"></span>
+            </button>
+            <div class="shell-leds">
                 <div class="signal">
                     <span class="led" id="connection-led"></span>
                     <span id="connection-status">CONNECTING</span>
@@ -61,26 +72,23 @@
             </div>
         </header>
 
-        <!-- Tab Bar (Full Width) -->
-        <div class="tab-bar-container">
-            <div class="tab-bar">
-                <div class="tab-group-main">
-                    <button class="tab active" data-tab="overview">Overview</button>
-                    <button class="tab" data-tab="product">Product</button>
-                    <button class="tab" data-tab="pipeline">Roadmap</button>
-                    <button class="tab" data-tab="processes">Processes</button>
-                    <button class="tab" data-tab="decisions">Decisions</button>
-                    <button class="tab" data-tab="workflow">Workflows</button>
-                    <button class="tab" data-tab="settings">Settings</button>
-                </div>
-                <button class="editor-btn dimmed" id="editor-btn" title="Configure editor" aria-label="Configure editor">
-                    <span class="editor-btn-icon" id="editor-btn-icon"></span>
-                    <span class="editor-btn-label" id="editor-btn-label"></span>
-                </button>
-            </div>
-        </div>
+        <!-- Icon rail (replaces tab bar; destinations mirror pre-shell tabs 1:1 — restructure in #606) -->
+        <nav class="shell-rail" id="shell-rail" aria-label="Primary">
+            <a class="shell-rail-item" href="#" data-tab="overview" aria-current="page"><span class="shell-rail-icon">□</span><span class="shell-rail-label">Overview</span></a>
+            <a class="shell-rail-item" href="#" data-tab="product"><span class="shell-rail-icon">◆</span><span class="shell-rail-label">Product</span></a>
+            <a class="shell-rail-item" href="#" data-tab="pipeline"><span class="shell-rail-icon">▣</span><span class="shell-rail-label">Roadmap</span></a>
+            <a class="shell-rail-item" href="#" data-tab="processes"><span class="shell-rail-icon">◎</span><span class="shell-rail-label">Processes</span></a>
+            <a class="shell-rail-item" href="#" data-tab="decisions"><span class="shell-rail-icon">◇</span><span class="shell-rail-label">Decisions</span></a>
+            <a class="shell-rail-item" href="#" data-tab="workflow"><span class="shell-rail-icon">○</span><span class="shell-rail-label">Workflows</span></a>
+            <div class="shell-rail-divider"></div>
+            <a class="shell-rail-item" href="#" data-tab="settings"><span class="shell-rail-icon">⚙</span><span class="shell-rail-label">Settings</span></a>
+            <button class="shell-rail-item shell-rail-pin" id="shell-rail-pin" type="button" title="Pin rail open">
+                <span class="shell-rail-icon">⇥</span><span class="shell-rail-label">Pin rail</span>
+            </button>
+        </nav>
 
-        <!-- Main Layout -->
+        <!-- Content -->
+        <div class="shell-content">
         <div class="main-layout" id="main-layout">
             <!-- Left Sidebar (Context-Aware) -->
             <aside class="sidebar-left">
@@ -1239,26 +1247,12 @@
             </main>
         </div>
 
-        <footer class="footer">
-            <div class="footer-left">
-                <span class="footer-label">INSTANCE ID:</span>
-                <span class="footer-value" id="instance-id">--</span>
-                <span class="footer-sep">|</span>
-                <span class="footer-label">LAST UPDATE:</span>
-                <span class="footer-value" id="last-update">--:--:--</span>
-                <span class="footer-sep">|</span>
-                <span class="footer-label">REFRESH:</span>
-                <span class="footer-value" data-type="primary">5s</span>
-                <span class="footer-sep">|</span>
-                <span class="footer-label">CACHE:</span>
-                <span class="footer-value" id="cache-status">--</span>
-            </div>
-            <div class="footer-center">
-                <span class="footer-mission" id="footer-mission">◈ .bot autonomous development system</span>
-            </div>
-            <div class="footer-right">
-                <span class="footer-label">v4.0.0</span>
-            </div>
+        </div><!-- /shell-content -->
+
+        <!-- Dispatch ticker slot (static line; scroll behaviour lands with #607) -->
+        <footer class="shell-ticker">
+            <span class="shell-ticker-line">INSTANCE <span id="instance-id">--</span> · LAST UPDATE <span id="last-update">--:--:--</span> · <span id="footer-mission">◈ .bot autonomous development system</span></span>
+            <span class="shell-ticker-byline">v4.0.0</span>
         </footer>
     </div>
 
@@ -1592,6 +1586,7 @@
     <script src="modules/theme.js"></script>
     <script src="modules/markdown.js"></script>
     <script src="modules/tabs.js"></script>
+    <script src="modules/shell.js"></script>
     <script src="modules/sidebar.js"></script>
     <script src="modules/workflow.js"></script>
     <script src="modules/runs.js"></script>

--- a/src/ui/static/modules/shell.js
+++ b/src/ui/static/modules/shell.js
@@ -1,0 +1,55 @@
+// Shell chrome behaviour (v4 navigation shell, #551/#605).
+// Rail items delegate to switchToTab() so all tab side effects (polling
+// start/stop, decision reloads, settings init) keep working unchanged.
+
+const RAIL_PIN_KEY = 'dotbot:shell:railPinned';
+
+function initShell() {
+    const shell = document.getElementById('shell');
+    if (!shell) return;
+
+    document.querySelectorAll('.shell-rail-item[data-tab]').forEach(item => {
+        item.addEventListener('click', (e) => {
+            e.preventDefault();
+            switchToTab(item.dataset.tab);
+        });
+    });
+
+    const pinBtn = document.getElementById('shell-rail-pin');
+    if (pinBtn) {
+        if (layoutGet(RAIL_PIN_KEY) === '1') {
+            shell.dataset.rail = 'pinned';
+        }
+        updatePinButton(shell, pinBtn);
+        pinBtn.addEventListener('click', () => {
+            const pinned = shell.dataset.rail === 'pinned';
+            if (pinned) {
+                delete shell.dataset.rail;
+                layoutRemove(RAIL_PIN_KEY);
+            } else {
+                shell.dataset.rail = 'pinned';
+                layoutSet(RAIL_PIN_KEY, '1');
+            }
+            updatePinButton(shell, pinBtn);
+        });
+    }
+}
+
+function updatePinButton(shell, pinBtn) {
+    const pinned = shell.dataset.rail === 'pinned';
+    pinBtn.querySelector('.shell-rail-icon').textContent = pinned ? '⇤' : '⇥';
+    pinBtn.querySelector('.shell-rail-label').textContent = pinned ? 'Unpin rail' : 'Pin rail';
+    pinBtn.title = pinned ? 'Collapse rail to icons' : 'Pin rail open';
+}
+
+// Called from switchToTab() so rail state follows every tab change,
+// whatever triggered it (rail click, logo click, editor.js jump).
+function syncRailActive(tabId) {
+    document.querySelectorAll('.shell-rail-item[data-tab]').forEach(item => {
+        if (item.dataset.tab === tabId) {
+            item.setAttribute('aria-current', 'page');
+        } else {
+            item.removeAttribute('aria-current');
+        }
+    });
+}

--- a/src/ui/static/modules/tabs.js
+++ b/src/ui/static/modules/tabs.js
@@ -34,6 +34,9 @@ function switchToTab(targetId) {
     const targetPane = document.getElementById(`tab-${targetId}`);
     if (targetPane) targetPane.classList.add('active');
 
+    // Keep the shell rail's active marker in sync (modules/shell.js)
+    syncRailActive(targetId);
+
     // Switch context panel in left sidebar
     switchContextPanel(targetId);
 }

--- a/tests/e2e/specs/controls.spec.ts
+++ b/tests/e2e/specs/controls.spec.ts
@@ -10,9 +10,9 @@ test.describe("Control buttons emit correct backend requests", () => {
     page,
   }) => {
     await page.goto("/");
-    await expect(page.locator('.tab[data-tab="overview"]')).toHaveClass(
-      /active/,
-    );
+    await expect(
+      page.locator('.shell-rail-item[data-tab="overview"]'),
+    ).toHaveAttribute("aria-current", "page");
 
     // app.js's DOMContentLoaded handler awaits initSidebar() before calling
     // initControlButtons(), so the panic-reset listener isn't attached at

--- a/tests/e2e/specs/error-handling.spec.ts
+++ b/tests/e2e/specs/error-handling.spec.ts
@@ -35,9 +35,9 @@ test.describe("UI degrades gracefully on server errors", () => {
       `Uncaught page errors:\n${pageErrors.join("\n")}`,
     ).toEqual([]);
 
-    await page.locator('.tab[data-tab="settings"]').click();
+    await page.locator('.shell-rail-item[data-tab="settings"]').click();
     await expect(page.locator("#tab-settings")).toHaveClass(/active/);
-    await page.locator('.tab[data-tab="overview"]').click();
+    await page.locator('.shell-rail-item[data-tab="overview"]').click();
     await expect(page.locator("#tab-overview")).toHaveClass(/active/);
 
     // Confirm the error path ran rather than passing silently.

--- a/tests/e2e/specs/lists.spec.ts
+++ b/tests/e2e/specs/lists.spec.ts
@@ -35,7 +35,7 @@ test.describe("Task list rendering (Roadmap tab)", () => {
       timeout: 10_000,
     });
 
-    await page.locator('.tab[data-tab="pipeline"]').click();
+    await page.locator('.shell-rail-item[data-tab="pipeline"]').click();
     await expect(page.locator("#tab-pipeline")).toHaveClass(/active/);
 
     const rows = page.locator("#upcoming-tasks .task-list-item");
@@ -54,7 +54,7 @@ test.describe("Task list rendering (Roadmap tab)", () => {
     await expect(page.locator("#todo-count")).toHaveText("0", {
       timeout: 10_000,
     });
-    await page.locator('.tab[data-tab="pipeline"]').click();
+    await page.locator('.shell-rail-item[data-tab="pipeline"]').click();
     await expect(page.locator("#upcoming-tasks .task-list-item")).toHaveCount(
       0,
     );
@@ -89,7 +89,7 @@ test.describe("Process list rendering (Processes tab)", () => {
     // Cannot use overview-active as a guard because index.html hardcodes
     // `class="tab active"` on the overview button.
     await expect(page.locator("body")).toHaveAttribute("data-app-ready", "1");
-    await page.locator('.tab[data-tab="processes"]').click();
+    await page.locator('.shell-rail-item[data-tab="processes"]').click();
     await expect(page.locator("#tab-processes")).toHaveClass(/active/);
 
     const row = page.locator(
@@ -102,7 +102,7 @@ test.describe("Process list rendering (Processes tab)", () => {
   test("renders empty state when no process JSONs exist", async ({ page }) => {
     await page.goto("/");
     await expect(page.locator("body")).toHaveAttribute("data-app-ready", "1");
-    await page.locator('.tab[data-tab="processes"]').click();
+    await page.locator('.shell-rail-item[data-tab="processes"]').click();
     await expect(page.locator("#tab-processes")).toHaveClass(/active/);
 
     await expect(page.locator("#process-list .empty-state")).toBeVisible({

--- a/tests/e2e/specs/polling.spec.ts
+++ b/tests/e2e/specs/polling.spec.ts
@@ -11,9 +11,9 @@ test.describe("State polling reflects backend state in the DOM", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
-    await expect(page.locator('.tab[data-tab="overview"]')).toHaveClass(
-      /active/,
-    );
+    await expect(
+      page.locator('.shell-rail-item[data-tab="overview"]'),
+    ).toHaveAttribute("aria-current", "page");
   });
 
   test.afterEach(async () => {

--- a/tests/e2e/specs/settings.spec.ts
+++ b/tests/e2e/specs/settings.spec.ts
@@ -36,7 +36,7 @@ test.describe("Settings persistence via real /api/settings", () => {
     // initSettingsToggles() binds change handlers after several awaited
     // fetches inside the DOMContentLoaded handler.
     await page.waitForLoadState("networkidle");
-    await page.locator('.tab[data-tab="settings"]').click();
+    await page.locator('.shell-rail-item[data-tab="settings"]').click();
     await expect(page.locator("#tab-settings")).toHaveClass(/active/);
 
     // show-debug lives in #settings-execution, which starts hidden until
@@ -72,7 +72,7 @@ test.describe("Settings persistence via real /api/settings", () => {
     // Reload exercises the GET round-trip: stored value → /api/settings → UI.
     await page.reload();
     await page.waitForLoadState("networkidle");
-    await page.locator('.tab[data-tab="settings"]').click();
+    await page.locator('.shell-rail-item[data-tab="settings"]').click();
     await page
       .locator('.settings-nav-item[data-settings-section="execution"]')
       .click();

--- a/tests/e2e/specs/tabs.spec.ts
+++ b/tests/e2e/specs/tabs.spec.ts
@@ -20,20 +20,29 @@ test.describe("Tab navigation", () => {
     (page as Page & { __pageErrors: string[] }).__pageErrors = pageErrors;
 
     await page.goto("/");
-    await expect(page.locator('.tab[data-tab="overview"]')).toHaveClass(
-      /active/,
-    );
+    // Rail click handlers attach late in app.js's async init chain; wait for
+    // the real init-complete signal (see app.js data-app-ready) instead of
+    // racing it. aria-current="page" on Overview is hardcoded in index.html,
+    // so it is not a safe readiness indicator.
+    // 15s: first navigation of a run pays server cold-start + full module
+    // bootstrapping; the default 5s expect timeout is too tight for it.
+    await expect(page.locator("body")).toHaveAttribute("data-app-ready", "1", {
+      timeout: 15_000,
+    });
+    await expect(
+      page.locator('.shell-rail-item[data-tab="overview"]'),
+    ).toHaveAttribute("aria-current", "page");
   });
 
   for (const id of TABS) {
     test(`switches to "${id}" tab and shows matching pane`, async ({
       page,
     }) => {
-      await page.locator(`.tab[data-tab="${id}"]`).click();
+      await page.locator(`.shell-rail-item[data-tab="${id}"]`).click();
 
-      await expect(page.locator(`.tab[data-tab="${id}"]`)).toHaveClass(
-        /active/,
-      );
+      await expect(
+        page.locator(`.shell-rail-item[data-tab="${id}"]`),
+      ).toHaveAttribute("aria-current", "page");
       await expect(page.locator(`#tab-${id}`)).toHaveClass(/active/);
 
       const errors = (page as Page & { __pageErrors: string[] }).__pageErrors;
@@ -47,7 +56,7 @@ test.describe("Tab navigation", () => {
   test("activating one tab deactivates the previously active pane", async ({
     page,
   }) => {
-    await page.locator('.tab[data-tab="settings"]').click();
+    await page.locator('.shell-rail-item[data-tab="settings"]').click();
     await expect(page.locator("#tab-settings")).toHaveClass(/active/);
     await expect(page.locator("#tab-overview")).not.toHaveClass(/active/);
   });


### PR DESCRIPTION
## Linked issue

Closes #605

## Summary of changes

Part 2 of 4 of the #551 navigation-shell rollout (R1, v4.1). The shell CSS shipped in #604 now renders in both apps — first visible change of the rollout.

- **Outpost** — 60px header + tab row + 36px footer replaced by the shared 44px topbar / 56px icon rail (pinnable to 200px, persisted via `dotbot:shell:railPinned`) / 28px ticker slot. Rail mirrors today's 7 tabs 1:1 (restructure to 6 = #606); all tab side effects preserved by delegating to `switchToTab()`. Sidebar untouched (re-homes in #606). New `modules/shell.js` (~60 lines); net −150 lines of chrome CSS.
- **Mothership** — dashboard renders inside the shell via new `_LayoutDashboard.cshtml` (reusable: #547 Fleet / #601 People add rail items there). Rail shows only real destinations (Decisions) per the Q5 pattern — slots appear as pages land. In-page tabs (Overview/By Person/By Project) stay as content until #606. Viewport height math retuned for the new chrome.
- **Respond/Confirmation untouched** — zero diff to stakeholder magic-link pages (`git diff` proof).
- **e2e specs** — selectors updated for the rail (`.tab[data-tab]` → `.shell-rail-item[data-tab]`, `.active` → `aria-current`); `tabs.spec` adopts the same `data-app-ready` readiness wait `lists.spec` already uses.

Notes for reviewers:
- **Topbar density**: identity values (project badge, workflow badge, DOTBOT_HOME SHA) never truncate; the inert search pill compresses first; workflow pills ellipsize last (full list on the Workflows tab). The v4 spec's topbar doesn't include pills at all — question raised on #606 whether they stay.
- **E2E suite health**: the suite does not pass on clean `releases/4.1.0` (baseline run: 14 passed / 8 failed — pre-existing init race). This branch: 19 passed / 2 flaky (`controls` stop-button, `error-handling` todo-count recovery — both in files this PR doesn't touch). Flagging rather than fixing here.
- Sidebar removal deliberately NOT in this PR — completes with #606 per PRD 5.3/5.4 split.

## Screenshots / recordings

<!-- drag-drop from C:\tmp\605-shots\ — suggested layout: -->

### Outpost

| Before | After |
|---|---|
| <img width="1440" height="900" alt="outpost-before-overview" src="https://github.com/user-attachments/assets/896b747a-abc4-441b-9bb3-4553989e5386" /> | <img width="1440" height="900" alt="outpost-after-overview" src="https://github.com/user-attachments/assets/8b34bfc6-a511-4d66-9f19-fdb23ac9f8dd" /> |
| <img width="1440" height="900" alt="outpost-before-processes" src="https://github.com/user-attachments/assets/ff525fca-3e37-4295-84aa-a690f6328444" /> | <img width="1440" height="900" alt="outpost-after-processes" src="https://github.com/user-attachments/assets/f56a75fd-7ecb-4789-b289-023c825f1570" /> |

<details>
<summary>Pinned rail (200px) · cyan preset · mobile drawer · topbar detail · rail tooltip</summary>
<img width="1440" height="900" alt="outpost-after-pinned" src="https://github.com/user-attachments/assets/73f722f3-2472-4705-b15a-167149b51dbf" /> 
<img width="1440" height="900" alt="outpost-after-cyan" src="https://github.com/user-attachments/assets/89740606-1a0f-472f-a532-cdc0b5ca9c45" />
<img width="800" height="800" alt="outpost-mobile-drawer" src="https://github.com/user-attachments/assets/965a5bae-1760-4fe1-98ca-e314ccf63484" />
<img width="1440" height="60" alt="outpost-topbar-fixed" src="https://github.com/user-attachments/assets/1609c8ad-6ef4-4631-bfac-6c882e3f8ca4" />
<img width="500" height="500" alt="outpost-rail-tooltip" src="https://github.com/user-attachments/assets/3a35d335-e792-45b3-a8d2-e41ae8f8d1be" />
</details>

### Mothership

| Before | After |
|---|---|
| <img width="1440" height="900" alt="mship-before" src="https://github.com/user-attachments/assets/16bd770b-1dc6-41e0-8c4d-c15a9c393da3" /> | <img width="1440" height="900" alt="mship-after" src="https://github.com/user-attachments/assets/ba6bf811-f960-4768-8dcc-e9de3b7deb5e" /> |

<details>
<summary>Instance modal in shell · By Person split-view</summary>
<img width="1440" height="900" alt="mship-modal-in-shell" src="https://github.com/user-attachments/assets/fafa3b47-8869-442a-9d33-5527cfa3e3a2" /> <img width="1440" height="900" alt="mship-after-byperson" src="https://github.com/user-attachments/assets/62ee20b0-4b64-416b-a3ba-30175aa92de1" />
</details>

## Testing notes

- Outpost (fixture project): all 7 rail items switch panes + side effects; logo→Overview; editor.js settings jump; pin persists across reload; sidebar splitter drags; hamburger drawer <900px; no topbar clipping at 1000/1200px; all presets recolor (cyan shown); ticker updates live; zero page errors.
- Mothership dev: in-page tabs, sort/filter, instance modal (overlays shell correctly), nudge, live ticker; heights sane at 1440/1200; `dotnet build` 0 warnings.
- E2E: 19 passed; 2 pre-existing flaky (see notes); baseline comparison run attached in notes.

## Checklist

- [x] Tests added or updated — e2e specs updated for the rail
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
