### PR TITLE
docs: add release notes for v4.0.2

### DIFF
--- a/docs/release-notes/v4.0.2.md
+++ b/docs/release-notes/v4.0.2.md
@@ -1,0 +1,82 @@
+# dotbot v4.0.2 — Release Notes
+
+**Released:** July 10, 2026
+**Previous version:** v4.0.1 (July 3, 2026)
+**Type:** Patch release
+
+> 6 bugs fixed · 2 enhancements · 1 CI fix · 13 issues closed
+
+---
+
+## Highlights
+
+**Post-task pipeline and repo-clone hardened** — [#566](https://github.com/andresharpe/dotbot/issues/566) [#568](https://github.com/andresharpe/dotbot/issues/568) [#569](https://github.com/andresharpe/dotbot/issues/569) [#570](https://github.com/andresharpe/dotbot/issues/570) [#571](https://github.com/andresharpe/dotbot/issues/571)
+Five of the eight bugs tracked in the [#557](https://github.com/andresharpe/dotbot/issues/557) omnibus are resolved. ADO PAT no longer leaks in clone URLs. Recipe links and output paths resolve correctly. Condition-skip cascades and parallel barriers behave as designed. Orphan worktrees with unborn master no longer break squash-merge. Privacy scan no longer mislabels successful tasks as skipped.
+
+**Priority sort fixed** — [#613](https://github.com/andresharpe/dotbot/issues/613) [#614](https://github.com/andresharpe/dotbot/issues/614)
+`Get-NextWorkflowTask` was sorting eligible tasks in reverse priority order — higher priority numbers were winning instead of lower. Tasks now execute in the intended order.
+
+**Registry remove command** — [#550](https://github.com/andresharpe/dotbot/issues/550)
+`dotbot registry remove <name>` removes a registered stack or workflow. RegistryManager now auto-updates the registry on `init` and `run`, keeping registrations in sync without a manual step.
+
+**Linked issues auto-close on release branch merge** — [#617](https://github.com/andresharpe/dotbot/issues/617)
+CI now processes `Closes #NNN` keywords when a PR merges into a `release/*` or `releases/*` branch and closes the linked issues automatically. Previously this only worked for PRs targeting `main`.
+
+---
+
+## Stabilization — 6 bugs fixed
+
+### Post-task pipeline & repo-clone
+
+| Issue | PR | Fix |
+|---|---|---|
+| [#566](https://github.com/andresharpe/dotbot/issues/566) | [#565](https://github.com/andresharpe/dotbot/pull/565) | ADO PAT leaked into the clone URL logged to the activity log; Jira-key parser rejected all clone paths that included a period in the project key |
+| [#568](https://github.com/andresharpe/dotbot/issues/568) | [#572](https://github.com/andresharpe/dotbot/pull/572) | `Invoke-WorkflowProcess` recipe resolver produced a broken link; output path join double-nested the outputs directory |
+| [#569](https://github.com/andresharpe/dotbot/issues/569) | [#573](https://github.com/andresharpe/dotbot/pull/573) | Condition-skip on a dep-gated step propagated a false skip through all downstream steps; parallel barriers did not wait for all spawned children before advancing |
+| [#570](https://github.com/andresharpe/dotbot/issues/570) | [#578](https://github.com/andresharpe/dotbot/pull/578) | Orphan worktrees cloned from repos with no commits (`unborn master`) failed squash-merge with an unrelated-history error and were not cleaned up |
+| [#571](https://github.com/andresharpe/dotbot/issues/571) | [#579](https://github.com/andresharpe/dotbot/pull/579) | Privacy scan hook returned `done` when it should have escalated to `needs-input`; the verify-hook-blocked path now correctly escalates |
+
+### Task scheduling
+
+| Issue | PR | Fix |
+|---|---|---|
+| [#613](https://github.com/andresharpe/dotbot/issues/613) / [#614](https://github.com/andresharpe/dotbot/issues/614) | [#616](https://github.com/andresharpe/dotbot/pull/616) | `Get-NextWorkflowTask` negated the priority integer (`-[int]$priority`) before sorting ascending — inverting the order so higher numbers won. Negation removed; priority-less tasks now sort last via `[int]::MaxValue` sentinel |
+
+---
+
+## Enhancements — 2 items
+
+| Issue | PR | Enhancement |
+|---|---|---|
+| [#550](https://github.com/andresharpe/dotbot/issues/550) | [#564](https://github.com/andresharpe/dotbot/pull/564) | **Registry remove command** — `dotbot registry remove <name>` removes a stack or workflow registration. New `RegistryManager` module; namespace:stack resolution; auto-update on `init` and `run` |
+| [#617](https://github.com/andresharpe/dotbot/issues/617) | [#621](https://github.com/andresharpe/dotbot/pull/621) | **CI auto-close on release branch** — `Closes #NNN` keywords in PR bodies now trigger issue close when the PR merges into any `release/*` or `releases/*` branch, not only `main` |
+
+---
+
+## CI & release pipeline fix
+
+| PR | Fix |
+|---|---|
+| [#567](https://github.com/andresharpe/dotbot/pull/567) | Bump-release workflow was failing after the v4 restructure. Switched to a PR-based flow; repaired the `dotbot.psd1` path; confirmed end-to-end on v4.0.1 |
+
+---
+
+## Get this release
+
+```bash
+# Homebrew (macOS / Linux)
+brew upgrade dotbot
+
+# Scoop (Windows)
+scoop update dotbot
+
+# From source
+git pull && pwsh bootstrap.ps1
+```
+
+Run `dotbot status` after updating to confirm you're on v4.0.2.
+
+---
+
+*Next patch release: ~July 17, 2026*
+*Release notes: [`docs/release-notes/`](../release-notes/)*


### PR DESCRIPTION
## Summary

- Adds `docs/release-notes/v4.0.2.md` following the v4.0.1 template
- Covers all issues and PRs merged to main between v4.0.1 and v4.0.2
- 6 bugs fixed · 2 enhancements · 1 CI fix · 13 issues closed

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)