### PR TITLE
fix(process): pin process-state writes to canonical BotRoot, not worktree

### DIFF
--- a/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
+++ b/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
@@ -106,6 +106,9 @@ function Write-ProcessFile {
         [string]$BotRoot
     )
     $processesDir = Get-ProcessesDir -BotRoot $BotRoot
+    if (-not (Test-Path $processesDir)) {
+        New-Item -Path $processesDir -ItemType Directory -Force | Out-Null
+    }
     $filePath = Join-Path $processesDir "$Id.json"
     $tempFile = "$filePath.tmp"
     $retry = Get-ProcessRetryConfig -BotRoot $BotRoot

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -837,7 +837,12 @@ function Invoke-TaskClarificationLoopIfPresent {
         [string]$ModelName,
         [bool]$ShowDebug,
         [bool]$ShowVerbose,
-        [string]$PermissionMode
+        [string]$PermissionMode,
+        # Canonical project .bot root for process-registry writes (proc-*.json).
+        # Distinct from $BotRoot above, which is worktree-scoped (used for the
+        # answers-file path) — process state must never resolve through the
+        # worktree's transient .control junction (#612).
+        [string]$ProcessBotRoot
     )
     $questionsPath = Join-Path $ProductDir "clarification-questions.json"
     if (-not (Test-Path $questionsPath)) { return $null }
@@ -858,7 +863,7 @@ function Invoke-TaskClarificationLoopIfPresent {
         $PD.status = 'running'
         $PD.pending_questions = $null
         $PD.heartbeat_status = "Running task: $TaskName"
-        Write-ProcessFile -Id $Id -Data $PD
+        Write-ProcessFile -Id $Id -Data $PD -BotRoot $ProcessBotRoot
     }
 
     $questionsData = $null
@@ -899,14 +904,14 @@ function Invoke-TaskClarificationLoopIfPresent {
     $ProcessData.product_dir = $ProductDir
     $ProcessData.answers_path = $answersPath
     $ProcessData.heartbeat_status = "Waiting for answers (task: $($Task.name))"
-    Write-ProcessFile -Id $ProcId -Data $ProcessData
+    Write-ProcessFile -Id $ProcId -Data $ProcessData -BotRoot $ProcessBotRoot
 
     while (-not (Test-Path $answersPath)) {
-        if (Test-ProcessStopSignal -Id $ProcId) {
+        if (Test-ProcessStopSignal -Id $ProcId -BotRoot $ProcessBotRoot) {
             $ProcessData.status = 'stopped'
             $ProcessData.failed_at = (Get-Date).ToUniversalTime().ToString("o")
             $ProcessData.pending_questions = $null
-            Write-ProcessFile -Id $ProcId -Data $ProcessData
+            Write-ProcessFile -Id $ProcId -Data $ProcessData -BotRoot $ProcessBotRoot
             return "Process stopped by user during clarification wait"
         }
         Start-Sleep -Seconds 2
@@ -1963,10 +1968,10 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
             if ($attemptNumber -gt 1) {
                 Write-Status "Retry attempt $attemptNumber of $maxRetriesPerTask" -Type Warn
             }
-            if (Test-ProcessStopSignal -Id $procId) {
+            if (Test-ProcessStopSignal -Id $procId -BotRoot $botRoot) {
                 $processData.status = 'stopped'
                 $processData.failed_at = (Get-Date).ToUniversalTime().ToString("o")
-                Write-ProcessFile -Id $procId -Data $processData
+                Write-ProcessFile -Id $procId -Data $processData -BotRoot $botRoot
                 break
             }
 
@@ -2015,7 +2020,7 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
 
             # Update heartbeat
             $processData.last_heartbeat = (Get-Date).ToUniversalTime().ToString("o")
-            Write-ProcessFile -Id $procId -Data $processData
+            Write-ProcessFile -Id $procId -Data $processData -BotRoot $botRoot
 
             # Check completion
             $completionCheck = Test-TaskCompletion -TaskId $task.id
@@ -2170,7 +2175,8 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
                 -ProductDir $executionProductDir -ProcessData $processData -ProcId $procId `
                 -ProjectRoot $worktreePath `
                 -ModelName $modelTier -ShowDebug $ShowDebug `
-                -ShowVerbose $ShowVerbose -PermissionMode $permissionMode
+                -ShowVerbose $ShowVerbose -PermissionMode $permissionMode `
+                -ProcessBotRoot $botRoot
             if ($clarErr) {
                 $taskSuccess = $false
                 $postScriptFailed = $true


### PR DESCRIPTION
## Linked issue

Closes #612

## Summary of changes

`Write-ProcessFile` and `Test-ProcessStopSignal` resolve `BotRoot` via `$PWD`
whenever no `-BotRoot` is passed. During task execution,
`Invoke-WorkflowProcess.ps1` `Push-Location`s into the task's worktree, whose
`.bot/.control` is a junction back to the canonical `.control` dir. Worktree
teardown (`Complete-TaskWorktree`, `Reset-TaskWorktree`, `Remove-OrphanWorktrees`)
removes that junction before removing the worktree itself, so a heartbeat write
racing the teardown resolves to a path that no longer exists and silently drops
after exhausting retries (`Could not find a part of the path '…\worktrees\1\task-…\.bot\.control\processes\proc-….json.tmp'`).

Changes:

- **Pin every process-registry write inside the worktree-scoped execution window**
  to `$botRoot` — the canonical root captured once at process start and never
  reassigned. Covers all `Write-ProcessFile` / `Test-ProcessStopSignal` calls
  between the worktree `Push-Location` and its `Pop-Location`.
- **Thread the same canonical root through `Invoke-TaskClarificationLoopIfPresent`**
  via a new `-ProcessBotRoot` parameter, kept deliberately separate from its
  existing worktree-scoped `-BotRoot` (which is still used for the answers-file
  path).
- **Add a `processes/` directory guard to `Write-ProcessFile`**, mirroring
  `Write-ProcessActivity`, so a missing directory self-heals instead of failing
  outright.

Process writes outside the worktree window (CWD = project root) are intentionally
left unpinned — they already resolve to the canonical root. Sibling runners
(`Invoke-PromptProcess.ps1`, `Invoke-DotbotProcess.ps1`) never `Push-Location`
into a worktree, so they are unaffected. Activity-log writes go through
`Write-BotLog`, which is init-pinned to the canonical control dir at startup, so
they were never vulnerable to this race.

## Testing notes

- `pwsh` parse check on both changed files — clean.
- `tests/Test-ProcessRegistry.ps1` — 20/20 pass.
- `tests/Test-Compilation.ps1` — 372 pass, 0 fail.
- Reproduced the exact #612 scenario in a sandbox with a real `.control` junction:
  a `BotRoot`-pinned write reaches the canonical `processes/` dir and survives
  junction teardown, the directory guard recreates a deleted `processes/`, while
  an unpinned write (the old behaviour) resolves to the now-orphaned worktree path
  and never reaches canonical — confirming both the bug and the fix.

## Checklist
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)