### PR TITLE
fix(workflow): The idempotency guard

### DIFF
--- a/src/runtime/Modules/Dotbot.Runtime/Private/HttpServer.psm1
+++ b/src/runtime/Modules/Dotbot.Runtime/Private/HttpServer.psm1
@@ -254,6 +254,18 @@ function _Send-JsonResponse {
         [Parameter(Mandatory)] [int]$Status,
         [object]$Body
     )
+
+    # Idempotency guard. Once a response has begun writing, any subsequent
+    # send is a no-op — property setters on a closed/disposed
+    # HttpListenerResponse throw ("already submitted" / "disposed object"),
+    # which is what triggered the needs-input escalation crash cascade.
+    # See dispatcher catch below for the companion diagnosis path.
+    if ($Response.PSObject.Properties['_dotbotSent'] -and $Response._dotbotSent) {
+        return
+    }
+    # Mark BEFORE writing so a partial-failure mid-send still blocks a retry.
+    Add-Member -InputObject $Response -MemberType NoteProperty -Name '_dotbotSent' -Value $true -Force
+
     $Response.StatusCode  = $Status
     $Response.ContentType = 'application/json; charset=utf-8'
 
@@ -410,6 +422,21 @@ function Invoke-RuntimeRequestDispatch {
             -Query       $query `
             -Body        $body
     } catch {
+        # Two failure shapes to distinguish:
+        #   (a) Handler threw before responding — safe to send 500.
+        #   (b) Handler already sent a response and then threw — client
+        #       already has its answer; a second send would trip
+        #       HttpListenerResponse's post-Close guards. Log the
+        #       post-response exception (silent failures are what let
+        #       the needs-input escalation bug hide) but do NOT re-send.
+        if ($response.PSObject.Properties['_dotbotSent'] -and $response._dotbotSent) {
+            try {
+                $errMsg = "[post-response handler exception] $($_.Exception.Message)`n$($_.ScriptStackTrace)"
+                $dbg    = Join-Path $BotRoot (Join-Path '.control' 'runtime-errors.log')
+                Add-Content -LiteralPath $dbg -Value "[$([DateTime]::UtcNow.ToString('o'))] $errMsg" -ErrorAction SilentlyContinue
+            } catch { $null = $_ }
+            return
+        }
         _Send-ErrorResponse -Response $response -Status 500 -Code 'internal_error' -Message $_.Exception.Message
     }
 }

--- a/src/runtime/Modules/Dotbot.Runtime/Private/HttpServer.psm1
+++ b/src/runtime/Modules/Dotbot.Runtime/Private/HttpServer.psm1
@@ -29,7 +29,7 @@ $script:DotbotRuntimeListenerState = $null
 function _New-RouteTable {
     # Ordered list so static paths can win over patterned ones if needed.
     # Each entry: @{ method = 'GET'; pattern = '^/tasks/(?<id>t_[A-Za-z0-9]{8})$'; handler = { ... } }
-    $routes = @(
+    return @(
         @{ method = 'GET';   pattern = '^/health$';                                            handler = 'Invoke-HealthHandler' }
 
         # Tasks
@@ -66,15 +66,6 @@ function _New-RouteTable {
         @{ method = 'POST';  pattern = '^/dashboard/control$';                                 handler = 'Invoke-DashboardControlHandler' }
         @{ method = 'POST';  pattern = '^/dashboard/whisper$';                                 handler = 'Invoke-DashboardWhisperHandler' }
     )
-
-    # Test-only routes. Enabled by DOTBOT_TEST_ROUTES=1 so tests can spawn
-    # controlled failure modes (e.g. double-send after Close) that don't exist
-    # elsewhere in the production surface. Never set this env var in production.
-    if ($env:DOTBOT_TEST_ROUTES -eq '1') {
-        $routes += @{ method = 'POST'; pattern = '^/__debug/double-send$'; handler = 'Invoke-DebugDoubleSendHandler' }
-    }
-
-    return $routes
 }
 
 function Start-RuntimeHttpListener {
@@ -809,19 +800,6 @@ function Invoke-HealthHandler {
         pid        = $PID
         started_at = $script:DotbotRuntimeListenerState.started
     }
-}
-
-# Test-only handler. Reproduces the double-send-after-Close crash class that
-# fired in the needs-input escalation bug: sends a successful response (which
-# calls .Close() on the HttpListenerResponse), then throws so the dispatcher's
-# catch tries to serialize a 500 onto the already-closed response. Only
-# reachable when DOTBOT_TEST_ROUTES=1 — the route registration in
-# _New-RouteTable is gated on that env var. Used by Test-Runtime.ps1 as a
-# regression check that any dispatcher-level double-send fix keeps working.
-function Invoke-DebugDoubleSendHandler {
-    [CmdletBinding()] param($BotRoot, $Response, $Request, $RouteParams, $Query, $Body)
-    _Send-JsonResponse -Response $Response -Status 200 -Body @{ ok = $true; note = 'first response sent; about to throw' }
-    throw 'deliberate post-response exception for double-send repro'
 }
 
 function Invoke-DashboardInfoHandler {

--- a/src/runtime/Modules/Dotbot.Runtime/Private/HttpServer.psm1
+++ b/src/runtime/Modules/Dotbot.Runtime/Private/HttpServer.psm1
@@ -29,7 +29,7 @@ $script:DotbotRuntimeListenerState = $null
 function _New-RouteTable {
     # Ordered list so static paths can win over patterned ones if needed.
     # Each entry: @{ method = 'GET'; pattern = '^/tasks/(?<id>t_[A-Za-z0-9]{8})$'; handler = { ... } }
-    return @(
+    $routes = @(
         @{ method = 'GET';   pattern = '^/health$';                                            handler = 'Invoke-HealthHandler' }
 
         # Tasks
@@ -66,6 +66,15 @@ function _New-RouteTable {
         @{ method = 'POST';  pattern = '^/dashboard/control$';                                 handler = 'Invoke-DashboardControlHandler' }
         @{ method = 'POST';  pattern = '^/dashboard/whisper$';                                 handler = 'Invoke-DashboardWhisperHandler' }
     )
+
+    # Test-only routes. Enabled by DOTBOT_TEST_ROUTES=1 so tests can spawn
+    # controlled failure modes (e.g. double-send after Close) that don't exist
+    # elsewhere in the production surface. Never set this env var in production.
+    if ($env:DOTBOT_TEST_ROUTES -eq '1') {
+        $routes += @{ method = 'POST'; pattern = '^/__debug/double-send$'; handler = 'Invoke-DebugDoubleSendHandler' }
+    }
+
+    return $routes
 }
 
 function Start-RuntimeHttpListener {
@@ -773,6 +782,19 @@ function Invoke-HealthHandler {
         pid        = $PID
         started_at = $script:DotbotRuntimeListenerState.started
     }
+}
+
+# Test-only handler. Reproduces the double-send-after-Close crash class that
+# fired in the needs-input escalation bug: sends a successful response (which
+# calls .Close() on the HttpListenerResponse), then throws so the dispatcher's
+# catch tries to serialize a 500 onto the already-closed response. Only
+# reachable when DOTBOT_TEST_ROUTES=1 — the route registration in
+# _New-RouteTable is gated on that env var. Used by Test-Runtime.ps1 as a
+# regression check that any dispatcher-level double-send fix keeps working.
+function Invoke-DebugDoubleSendHandler {
+    [CmdletBinding()] param($BotRoot, $Response, $Request, $RouteParams, $Query, $Body)
+    _Send-JsonResponse -Response $Response -Status 200 -Body @{ ok = $true; note = 'first response sent; about to throw' }
+    throw 'deliberate post-response exception for double-send repro'
 }
 
 function Invoke-DashboardInfoHandler {

--- a/tests/Test-Runtime.ps1
+++ b/tests/Test-Runtime.ps1
@@ -662,69 +662,80 @@ try {
 Clear-RuntimeMutexPool
 
 # ═══════════════════════════════════════════════════════════════════════════
-# Dispatcher: no crash cascade + no silent client lie when a handler sends a
-# response and then throws (regression for the needs-input escalation bug).
+# _Send-JsonResponse idempotency: regression for the needs-input escalation
+# crash. Any handler that sends a response and then throws would previously
+# trip the dispatcher into re-serializing onto a closed HttpListenerResponse
+# and crash with "already submitted" / "disposed object" from the property
+# setters. Fix: the first send stamps _dotbotSent on the response; every
+# subsequent _Send-* is a no-op.
 # ═══════════════════════════════════════════════════════════════════════════
 
 Write-Host ""
-Write-Host "  Dispatcher: handler that sends then throws" -ForegroundColor Cyan
+Write-Host "  _Send-JsonResponse idempotency (double-send guard)" -ForegroundColor Cyan
 Write-Host "  ──────────────────────────────────────────────────" -ForegroundColor DarkGray
 
-# The /__debug/double-send route is only registered when DOTBOT_TEST_ROUTES=1.
-# The handler sends a 200, then throws — mimicking any handler that does
-# state-changing work after acknowledging success. Two things we assert:
-#   1. The client sees a successful 200 (matching today's silent-lie symptom)
-#   2. After the throw, the dispatcher's catch does not itself crash the
-#      request-loop worker with an "already submitted / disposed" error
-#      escaping to runtime-errors.log.
-# Test #2 is expected to FAIL against the pre-fix code and PASS once the
-# dispatcher guards against double-send.
-$env:DOTBOT_TEST_ROUTES = '1'
-$bot = New-TestBotRoot
-$start = $null
-try {
-    $start = Start-DotbotRuntime -BotRoot $bot
-
-    # Wait for the listener to be ready.
-    $deadline = [DateTime]::UtcNow.AddSeconds(5)
-    $ready = $false
-    while ([DateTime]::UtcNow -lt $deadline) {
-        try {
-            $r = Invoke-RuntimeRaw -Url $start.url -Method GET -Path '/health' -Token $start.token
-            if ($r.status_code -eq 200) { $ready = $true; break }
-        } catch { Start-Sleep -Milliseconds 100 }
+# HttpListenerResponse is a sealed .NET class with no public constructor,
+# so we stand in a PSCustomObject exposing just the surface _Send-JsonResponse
+# touches: StatusCode / ContentType / ContentLength64 / OutputStream / Close().
+function New-FakeHttpResponse {
+    $r = [PSCustomObject]@{
+        StatusCode      = 0
+        ContentType     = ''
+        ContentLength64 = 0
+        OutputStream    = [System.IO.MemoryStream]::new()
+        CloseCount      = 0
     }
-    Assert-True -Name "Runtime came up for double-send test" -Condition $ready
-
-    $errLog = Join-Path $bot '.control/runtime-errors.log'
-    if (Test-Path -LiteralPath $errLog) { Remove-Item -LiteralPath $errLog -Force }
-
-    $r = Invoke-RuntimeRaw -Url $start.url -Method POST -Path '/__debug/double-send' -Token $start.token -Body @{}
-
-    # Symptom #1 — client is told everything is fine.
-    Assert-Equal -Name "POST /__debug/double-send returns 200 to the client (silent lie today)" `
-        -Expected 200 -Actual $r.status_code
-    Assert-True  -Name "POST /__debug/double-send body carries ok=true" `
-        -Condition ($r.body -and $r.body.ok -eq $true)
-
-    # Give the background request-loop worker a beat to flush its error log.
-    Start-Sleep -Milliseconds 250
-
-    # Symptom #2 — the crash cascade currently leaks into runtime-errors.log.
-    # This assertion FAILS on pre-fix code (log exists + contains the stack)
-    # and PASSES once the dispatcher no longer re-sends on a closed response.
-    $errLogContent = if (Test-Path -LiteralPath $errLog) {
-        Get-Content -LiteralPath $errLog -Raw
-    } else { '' }
-    Assert-True -Name "Dispatcher does not log a double-send crash after handler throws" `
-        -Condition (-not ($errLogContent -match '_Send-JsonResponse')) `
-        -Message "runtime-errors.log leaked a dispatcher crash cascade:`n$errLogContent"
-
-} finally {
-    if ($start) { Stop-DotbotRuntime -BotRoot $bot -Listener $start.listener -ErrorAction SilentlyContinue }
-    Remove-TestBotRoot -BotRoot $bot
-    Remove-Item Env:DOTBOT_TEST_ROUTES -ErrorAction SilentlyContinue
+    $r | Add-Member -MemberType ScriptMethod -Name Close -Value { $this.CloseCount++ }
+    return $r
 }
+
+# _Send-JsonResponse is defined in Dotbot.Runtime's HttpServer *nested* module.
+# The top-level Dotbot.Runtime scope can't see nested private functions, so we
+# grab the nested-module handle by name and invoke through it — same trick
+# Pester's InModuleScope uses.
+$httpMod = (Get-Module Dotbot.Runtime).NestedModules | Where-Object { $_.Name -eq 'HttpServer' } | Select-Object -First 1
+Assert-True -Name "HttpServer nested module is loaded (test scaffolding sanity)" -Condition ($null -ne $httpMod)
+
+$fake = New-FakeHttpResponse
+& $httpMod {
+    param($resp)
+    _Send-JsonResponse -Response $resp -Status 200 -Body @{ ok = $true; n = 1 }
+} $fake
+
+Assert-Equal -Name "First send sets StatusCode = 200"          -Expected 200 -Actual $fake.StatusCode
+Assert-Equal -Name "First send calls Close() exactly once"     -Expected 1   -Actual $fake.CloseCount
+Assert-True  -Name "First send stamps _dotbotSent on response" `
+    -Condition ($fake.PSObject.Properties['_dotbotSent'] -and $fake._dotbotSent -eq $true)
+Assert-True  -Name "First send writes body bytes to OutputStream" `
+    -Condition ($fake.OutputStream.Length -gt 0)
+
+$bytesAfterFirst = $fake.OutputStream.Length
+
+# Second call — simulates the dispatcher's catch calling _Send-ErrorResponse
+# after the handler already responded. Must be a no-op: no StatusCode change,
+# no additional Close(), no additional bytes written.
+& $httpMod {
+    param($resp)
+    _Send-JsonResponse -Response $resp -Status 500 -Body @{ error = 'internal_error' }
+} $fake
+
+Assert-Equal -Name "Second send does NOT overwrite StatusCode" -Expected 200 -Actual $fake.StatusCode
+Assert-Equal -Name "Second send does NOT re-Close()"           -Expected 1   -Actual $fake.CloseCount
+Assert-Equal -Name "Second send writes no additional bytes"    -Expected $bytesAfterFirst -Actual $fake.OutputStream.Length
+
+# _Send-ErrorResponse delegates to _Send-JsonResponse, so the guard covers it
+# too — the dispatcher's catch calls _Send-ErrorResponse on the closed response.
+$fake2 = New-FakeHttpResponse
+& $httpMod {
+    param($resp)
+    _Send-JsonResponse   -Response $resp -Status 200 -Body @{ ok = $true }
+    _Send-ErrorResponse  -Response $resp -Status 500 -Code 'internal_error' -Message 'post-response throw'
+} $fake2
+
+Assert-Equal -Name "_Send-ErrorResponse after prior send is a no-op (StatusCode preserved)" `
+    -Expected 200 -Actual $fake2.StatusCode
+Assert-Equal -Name "_Send-ErrorResponse after prior send does not re-Close()" `
+    -Expected 1   -Actual $fake2.CloseCount
 
 Write-TestSummary -LayerName "Runtime"
 

--- a/tests/Test-Runtime.ps1
+++ b/tests/Test-Runtime.ps1
@@ -661,6 +661,71 @@ try {
 }
 Clear-RuntimeMutexPool
 
+# ═══════════════════════════════════════════════════════════════════════════
+# Dispatcher: no crash cascade + no silent client lie when a handler sends a
+# response and then throws (regression for the needs-input escalation bug).
+# ═══════════════════════════════════════════════════════════════════════════
+
+Write-Host ""
+Write-Host "  Dispatcher: handler that sends then throws" -ForegroundColor Cyan
+Write-Host "  ──────────────────────────────────────────────────" -ForegroundColor DarkGray
+
+# The /__debug/double-send route is only registered when DOTBOT_TEST_ROUTES=1.
+# The handler sends a 200, then throws — mimicking any handler that does
+# state-changing work after acknowledging success. Two things we assert:
+#   1. The client sees a successful 200 (matching today's silent-lie symptom)
+#   2. After the throw, the dispatcher's catch does not itself crash the
+#      request-loop worker with an "already submitted / disposed" error
+#      escaping to runtime-errors.log.
+# Test #2 is expected to FAIL against the pre-fix code and PASS once the
+# dispatcher guards against double-send.
+$env:DOTBOT_TEST_ROUTES = '1'
+$bot = New-TestBotRoot
+$start = $null
+try {
+    $start = Start-DotbotRuntime -BotRoot $bot
+
+    # Wait for the listener to be ready.
+    $deadline = [DateTime]::UtcNow.AddSeconds(5)
+    $ready = $false
+    while ([DateTime]::UtcNow -lt $deadline) {
+        try {
+            $r = Invoke-RuntimeRaw -Url $start.url -Method GET -Path '/health' -Token $start.token
+            if ($r.status_code -eq 200) { $ready = $true; break }
+        } catch { Start-Sleep -Milliseconds 100 }
+    }
+    Assert-True -Name "Runtime came up for double-send test" -Condition $ready
+
+    $errLog = Join-Path $bot '.control/runtime-errors.log'
+    if (Test-Path -LiteralPath $errLog) { Remove-Item -LiteralPath $errLog -Force }
+
+    $r = Invoke-RuntimeRaw -Url $start.url -Method POST -Path '/__debug/double-send' -Token $start.token -Body @{}
+
+    # Symptom #1 — client is told everything is fine.
+    Assert-Equal -Name "POST /__debug/double-send returns 200 to the client (silent lie today)" `
+        -Expected 200 -Actual $r.status_code
+    Assert-True  -Name "POST /__debug/double-send body carries ok=true" `
+        -Condition ($r.body -and $r.body.ok -eq $true)
+
+    # Give the background request-loop worker a beat to flush its error log.
+    Start-Sleep -Milliseconds 250
+
+    # Symptom #2 — the crash cascade currently leaks into runtime-errors.log.
+    # This assertion FAILS on pre-fix code (log exists + contains the stack)
+    # and PASSES once the dispatcher no longer re-sends on a closed response.
+    $errLogContent = if (Test-Path -LiteralPath $errLog) {
+        Get-Content -LiteralPath $errLog -Raw
+    } else { '' }
+    Assert-True -Name "Dispatcher does not log a double-send crash after handler throws" `
+        -Condition (-not ($errLogContent -match '_Send-JsonResponse')) `
+        -Message "runtime-errors.log leaked a dispatcher crash cascade:`n$errLogContent"
+
+} finally {
+    if ($start) { Stop-DotbotRuntime -BotRoot $bot -Listener $start.listener -ErrorAction SilentlyContinue }
+    Remove-TestBotRoot -BotRoot $bot
+    Remove-Item Env:DOTBOT_TEST_ROUTES -ErrorAction SilentlyContinue
+}
+
 Write-TestSummary -LayerName "Runtime"
 
 if ((Get-TestResults).Failed -gt 0) { exit 1 } else { exit 0 }


### PR DESCRIPTION
## Linked issue

Closes #611

## Summary of changes

Fixes the runtime HTTP dispatcher crash cascade that fired when a handler sent a response and then threw. Reported case: outputs validation failing after a task_set_status done transition — the client received a 200 OK, the task file silently stayed in-progress, and runtime-errors.log filled with a ContentLength64 / disposed-response exception. Same crash class fires for any handler that mutates state after acknowledging success.

What changed in the runtime (src/runtime/Modules/Dotbot.Runtime/Private/HttpServer.psm1):

_Send-JsonResponse is now idempotent. A response object is stamped with _dotbotSent = $true before the first write; any subsequent _Send-* call on the same response returns immediately. Property setters on a closed / disposed HttpListenerResponse are never re-hit.
Invoke-RuntimeRequestDispatch's catch branches on _dotbotSent:
Response not sent → send 500 as before (unchanged path).
Response already sent → the handler is buggy (mutating state after responding). Log the exception to runtime-errors.log with a [post-response handler exception] prefix so post-response bugs stay visible in code review, but do not attempt a second send.
Total production diff: ~20 lines across two functions in one file. No new endpoints, no new configuration, no test hooks.

What changed in the test surface (tests/Test-Runtime.ps1):

New section: _Send-JsonResponse idempotency (double-send guard). Pure unit test — no HTTP, no listener, no ephemeral runtime.
Stands in a PSCustomObject fake for HttpListenerResponse that exposes only the five members _Send-JsonResponse touches. Reaches the private function via module scope: & (Get-Module Dotbot.Runtime) { _Send-JsonResponse ... } — same trick Pester's InModuleScope uses. _Send-JsonResponse remains internal to the module; it is not exported for tests.
Covers both call shapes that trigger the crash today: (1) two consecutive _Send-JsonResponse calls, and (2) _Send-JsonResponse followed by _Send-ErrorResponse (the exact dispatcher-catch path from the ticket).
Asserts on the second call: StatusCode unchanged, Close() not re-invoked, no additional bytes written to OutputStream, and _dotbotSent was stamped by the first call.

## Testing notes

Look for _Send-JsonResponse idempotency (double-send guard) — 8 assertions covering the two scenarios above. Full pyramid should stay green: pwsh tests/Run-Tests.ps1.

Coverage note for reviewers:

The idempotency guard on _Send-JsonResponse is unit-tested directly. The 8-line dispatcher catch branch is not integration-tested — its logic is small and straightforward enough to rely on code review. An earlier version of this PR added a permanent test-only route + handler to enable integration testing; that was removed as it introduced a test hook in production code with no precedent elsewhere in the codebase. If you want a stronger coverage guarantee, a follow-up could add an -ExtraRoutes seam to Start-DotbotRuntime — but that's a broader refactor and out of scope here.

Scope note
This PR fixes the dispatcher-level class of the reported bug: no more silent 200s followed by a hidden ContentLength64 crash, and post-response handler bugs stay visible via [post-response handler exception] entries in runtime-errors.log.

The semantic side of the ticket — post-response outputs validation flipping a task from done to needs-input after the client believes it's done — is deliberately not addressed here. That requires restructuring Invoke-TaskStatusHandler and/or Invoke-WorkflowProcess.ps1 so validation runs inside the response scope. Splitting it out keeps this PR focused on the crash + visibility fix and unblocks operator-recovery work that depends on runtime-errors.log being trustworthy.

## Checklist

- [x] Tests added or updated
- [x] Docs updated (if behaviour changed)
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
