### PR TITLE
fix(ui): preserve other pending answers on needs-input submit

### DIFF
--- a/src/ui/static/modules/actions.js
+++ b/src/ui/static/modules/actions.js
@@ -8,6 +8,13 @@ let actionItems = [];
 let selectedAnswers = {};    // { taskId: [selectedKeys] }
 let answerAttachments = {};          // { taskId: [{ name, size, content (base64) }] }
 let workflowLaunchAttachments = {};       // { "processId:questionId": [{ name, size, content }] }
+// Un-submitted selections for task-level batch questions (the "task-questions"
+// action item). Keyed { taskId: { questionId: { key, customText } } }. Selections
+// for a batch of pending_questions otherwise live only in the DOM's `.selected`
+// class, so submitting one question — which triggers a full panel re-render —
+// wipes the choices lined up on the sibling questions (issue #622). This store
+// survives re-renders; renderTaskQuestionsItem re-applies it on every paint.
+let taskQuestionDrafts = {};
 let actionWidgetSuppressUntil = 0;
 
 const ANSWER_ALLOWED_EXTENSIONS = ['.md', '.docx', '.xlsx', '.pdf', '.txt'];
@@ -400,14 +407,19 @@ function renderTaskQuestionsItem(item) {
                 <span class="action-item-task">${escapeHtml(item.task_name)}</span>
             </div>
             <div class="action-item-body">
-                ${questions.map((q, idx) => `
+                ${questions.map((q, idx) => {
+                    // Restore any un-submitted selection for this question so a
+                    // re-render (e.g. after a sibling question is submitted)
+                    // does not wipe it — see taskQuestionDrafts (issue #622).
+                    const draft = (taskQuestionDrafts[taskId] || {})[q.id] || {};
+                    return `
                     ${idx > 0 ? '<div class="question-divider"></div>' : ''}
                     <div class="task-question-block" data-question-id="${escapeAttr(q.id)}" data-task-id="${escapeAttr(taskId)}" data-question-type="${escapeAttr(q.type || 'singleChoice')}">
                         <div class="action-question-text"><span class="question-number">Q${idx + 1}.</span> ${escapeHtml(q.question)}</div>
                         ${q.context ? `<div class="action-question-context">${escapeHtml(q.context)}</div>` : ''}
                         <div class="answer-options" data-multi-select="false">
                             ${(q.options || []).map(opt => `
-                                <div class="answer-option"
+                                <div class="answer-option${draft.key != null && draft.key === opt.key ? ' selected' : ''}"
                                      data-key="${escapeAttr(opt.key)}"
                                      data-label="${escapeAttr(opt.label)}"
                                      data-question-key="${escapeAttr(q.id)}">
@@ -420,16 +432,43 @@ function renderTaskQuestionsItem(item) {
                             `).join('')}
                         </div>
                         <div class="workflow-launch-question-freetext">
-                            <textarea class="workflow-launch-freetext-input" placeholder="Or type a custom answer..."></textarea>
+                            <textarea class="workflow-launch-freetext-input" placeholder="Or type a custom answer...">${escapeHtml(draft.customText || '')}</textarea>
                         </div>
                         <div class="interview-question-submit">
                             <button class="ctrl-btn-sm primary submit-task-question" data-task-id="${escapeAttr(taskId)}" data-question-id="${escapeAttr(q.id)}">Submit Q${idx + 1}</button>
                         </div>
                     </div>
-                `).join('')}
+                `;
+                }).join('')}
             </div>
         </div>
     `;
+}
+
+/**
+ * Record an un-submitted selection for a batch (task-questions) question block
+ * so it survives a panel re-render. See taskQuestionDrafts / issue #622.
+ * @param {HTMLElement} questionBlock - The .task-question-block element
+ * @param {{key: string|null, customText: string}} draft - Chosen option key or free text
+ */
+function setTaskQuestionDraft(questionBlock, draft) {
+    const taskId = questionBlock?.dataset.taskId;
+    const questionId = questionBlock?.dataset.questionId;
+    if (!taskId || !questionId) return;
+    if (!taskQuestionDrafts[taskId]) taskQuestionDrafts[taskId] = {};
+    taskQuestionDrafts[taskId][questionId] = draft;
+}
+
+/**
+ * Drop the stored draft for a batch question block — once it is answered or its
+ * inputs are cleared, there is nothing to restore. See taskQuestionDrafts / #622.
+ * @param {HTMLElement} questionBlock - The .task-question-block element
+ */
+function clearTaskQuestionDraft(questionBlock) {
+    const taskId = questionBlock?.dataset.taskId;
+    const questionId = questionBlock?.dataset.questionId;
+    if (!taskId || !questionId) return;
+    if (taskQuestionDrafts[taskId]) delete taskQuestionDrafts[taskId][questionId];
 }
 
 /**
@@ -479,6 +518,10 @@ async function submitTaskQuestion(taskId, questionId) {
         const result = await response.json();
 
         if (result.success) {
+            // This question is resolved server-side now; drop its draft so the
+            // re-render below does not restore a stale selection (issue #622).
+            clearTaskQuestionDraft(questionBlock);
+
             // Mark this question block as answered
             questionBlock.classList.add('answered');
             questionBlock.innerHTML = `<div class="interview-answered-notice">Q answered ✓ — ${result.questions_remaining_count > 0 ? result.questions_remaining_count + ' question(s) still pending' : 'all done, task resuming...'}</div>`;
@@ -877,6 +920,8 @@ function attachActionHandlers(container) {
             option.classList.add('selected');
             const freetext = questionBlock.querySelector('.workflow-launch-freetext-input');
             if (freetext) freetext.value = '';
+            // Persist the choice so it survives a re-render (issue #622).
+            setTaskQuestionDraft(questionBlock, { key: option.dataset.key, customText: '' });
         });
     });
 
@@ -887,6 +932,11 @@ function attachActionHandlers(container) {
             if (questionBlock?.classList.contains('answered')) return;
             if (textarea.value.trim()) {
                 questionBlock?.querySelectorAll('.answer-option').forEach(opt => opt.classList.remove('selected'));
+                // Persist the free-text draft so it survives a re-render (issue #622).
+                setTaskQuestionDraft(questionBlock, { key: null, customText: textarea.value });
+            } else {
+                // Emptied with no option selected — drop the draft.
+                clearTaskQuestionDraft(questionBlock);
             }
         });
     });

--- a/src/ui/static/modules/actions.js
+++ b/src/ui/static/modules/actions.js
@@ -468,7 +468,16 @@ function clearTaskQuestionDraft(questionBlock) {
     const taskId = questionBlock?.dataset.taskId;
     const questionId = questionBlock?.dataset.questionId;
     if (!taskId || !questionId) return;
-    if (taskQuestionDrafts[taskId]) delete taskQuestionDrafts[taskId][questionId];
+
+    const taskDrafts = taskQuestionDrafts[taskId];
+    if (!taskDrafts) return;
+
+    delete taskDrafts[questionId];
+
+    // Avoid accumulating empty per-task draft maps.
+    if (Object.keys(taskDrafts).length === 0) {
+        delete taskQuestionDrafts[taskId];
+    }
 }
 
 /**

--- a/src/ui/static/modules/actions.js
+++ b/src/ui/static/modules/actions.js
@@ -467,6 +467,38 @@ function setTaskQuestionDraft(questionBlock, draft) {
 }
 
 /**
+ * Point the stored draft at whatever a batch question block currently holds.
+ *
+ * The draft only restores a selection correctly if it never disagrees with the
+ * DOM, so derive it from the block instead of having each input handler decide
+ * for itself — a handler that stored the wrong thing (or nothing) for its own
+ * edge case would silently make the selection non-durable across a re-render.
+ * See taskQuestionDrafts / issue #622.
+ *
+ * @param {HTMLElement} questionBlock - The .task-question-block element
+ */
+function syncTaskQuestionDraft(questionBlock) {
+    if (!questionBlock) return;
+
+    const selected = questionBlock.querySelector('.answer-option.selected');
+    if (selected) {
+        // An option and free text are mutually exclusive: selecting one clears
+        // the other, so a live selection means there is no text to keep.
+        setTaskQuestionDraft(questionBlock, { key: selected.dataset.key, customText: '' });
+        return;
+    }
+
+    const textarea = questionBlock.querySelector('.workflow-launch-freetext-input');
+    if (textarea?.value.trim()) {
+        setTaskQuestionDraft(questionBlock, { key: null, customText: textarea.value });
+        return;
+    }
+
+    // Nothing selected and no meaningful text — there is nothing to restore.
+    clearTaskQuestionDraft(questionBlock);
+}
+
+/**
  * Drop the stored draft for a batch question block — once it is answered or its
  * inputs are cleared, there is nothing to restore. See taskQuestionDrafts / #622.
  * @param {HTMLElement} questionBlock - The .task-question-block element
@@ -711,9 +743,16 @@ function renderWorkflowLaunchQuestionsItem(item) {
  * @param {HTMLElement} container - Container element
  */
 function attachActionHandlers(container) {
-    // Answer option selection
+    // Answer option selection for single-question items.
+    // Batch (task-questions) blocks carry data-task-id too, so without this guard
+    // they get handled twice: once here and once by the task-question handler
+    // below. That wrote selectedAnswers entries which nothing reads for a batch
+    // task (submitTaskQuestion reads the DOM) and nothing ever cleans up, and it
+    // left draft correctness depending on the two listeners' attachment order.
+    // Workflow-launch questions are already excluded by the !taskId bail below.
     container.querySelectorAll('.answer-option').forEach(option => {
         option.addEventListener('click', (e) => {
+            if (option.closest('.task-question-block')) return;
             const optionsContainer = option.closest('.answer-options');
             const isMultiSelect = optionsContainer?.dataset.multiSelect === 'true';
             const taskId = option.closest('.action-item')?.dataset.taskId;
@@ -980,7 +1019,7 @@ function attachActionHandlers(container) {
             const freetext = questionBlock.querySelector('.workflow-launch-freetext-input');
             if (freetext) freetext.value = '';
             // Persist the choice so it survives a re-render (issue #622).
-            setTaskQuestionDraft(questionBlock, { key: option.dataset.key, customText: '' });
+            syncTaskQuestionDraft(questionBlock);
         });
     });
 
@@ -989,14 +1028,13 @@ function attachActionHandlers(container) {
         textarea.addEventListener('input', () => {
             const questionBlock = textarea.closest('.task-question-block');
             if (questionBlock?.classList.contains('answered')) return;
+            // Real text wins over a chosen option; whitespace alone is not an
+            // answer, so it leaves any existing selection standing.
             if (textarea.value.trim()) {
                 questionBlock?.querySelectorAll('.answer-option').forEach(opt => opt.classList.remove('selected'));
-                // Persist the free-text draft so it survives a re-render (issue #622).
-                setTaskQuestionDraft(questionBlock, { key: null, customText: textarea.value });
-            } else {
-                // Emptied with no option selected — drop the draft.
-                clearTaskQuestionDraft(questionBlock);
             }
+            // Persist whatever the block now holds so it survives a re-render (#622).
+            syncTaskQuestionDraft(questionBlock);
         });
     });
 

--- a/src/ui/static/modules/actions.js
+++ b/src/ui/static/modules/actions.js
@@ -263,6 +263,9 @@ async function fetchAndRenderActionItems() {
         } else {
             content.innerHTML = '<div class="empty-state">No pending actions</div>';
             actionItems = [];
+            // Nothing is pending server-side, so no stored draft can still belong
+            // to a live question — drop them all (issue #622).
+            pruneTaskQuestionDrafts([]);
         }
     } catch (error) {
         console.error('Failed to fetch action items:', error);
@@ -276,6 +279,10 @@ async function fetchAndRenderActionItems() {
  * @param {Array} items - Action items to render
  */
 function renderActionItems(container, items) {
+    // The payload is the source of truth for what is still pending; discard any
+    // draft it no longer covers before repainting (issue #622).
+    pruneTaskQuestionDrafts(items);
+
     container.innerHTML = items.map(item => {
         if (item.type === 'question') {
             return renderQuestionItem(item);
@@ -411,7 +418,7 @@ function renderTaskQuestionsItem(item) {
                     // Restore any un-submitted selection for this question so a
                     // re-render (e.g. after a sibling question is submitted)
                     // does not wipe it — see taskQuestionDrafts (issue #622).
-                    const draft = (taskQuestionDrafts[taskId] || {})[q.id] || {};
+                    const draft = taskQuestionDrafts[taskId]?.[q.id] || {};
                     return `
                     ${idx > 0 ? '<div class="question-divider"></div>' : ''}
                     <div class="task-question-block" data-question-id="${escapeAttr(q.id)}" data-task-id="${escapeAttr(taskId)}" data-question-type="${escapeAttr(q.type || 'singleChoice')}">
@@ -478,6 +485,49 @@ function clearTaskQuestionDraft(questionBlock) {
     if (Object.keys(taskDrafts).length === 0) {
         delete taskQuestionDrafts[taskId];
     }
+}
+
+/**
+ * Discard drafts that no longer match a pending question in the server payload.
+ *
+ * Question ids are only unique within a batch — Ensure-TaskInputPendingQuestionIds
+ * assigns `q1`, `q2`, … per batch — so a task that re-enters needs-input reuses the
+ * same ids for entirely different questions. A draft abandoned by an earlier batch
+ * (question answered from the CLI or another session, task resumed, new batch
+ * raised) would otherwise be re-applied to an unrelated question, and drafts for
+ * tasks that left needs-input would linger for the lifetime of the page.
+ * See taskQuestionDrafts / issue #622.
+ *
+ * @param {Array} items - Action items the panel is about to render
+ */
+function pruneTaskQuestionDrafts(items) {
+    const liveQuestionIds = {};   // { taskId: Set<questionId> }
+
+    (items || []).forEach(item => {
+        if (item?.type !== 'task-questions' || item.task_id == null) return;
+        const taskId = String(item.task_id);
+        if (!liveQuestionIds[taskId]) liveQuestionIds[taskId] = new Set();
+        (item.questions || []).forEach(q => {
+            if (q?.id != null) liveQuestionIds[taskId].add(String(q.id));
+        });
+    });
+
+    Object.keys(taskQuestionDrafts).forEach(taskId => {
+        const liveIds = liveQuestionIds[taskId];
+        if (!liveIds) {
+            delete taskQuestionDrafts[taskId];
+            return;
+        }
+
+        const taskDrafts = taskQuestionDrafts[taskId];
+        Object.keys(taskDrafts).forEach(questionId => {
+            if (!liveIds.has(questionId)) delete taskDrafts[questionId];
+        });
+
+        if (Object.keys(taskDrafts).length === 0) {
+            delete taskQuestionDrafts[taskId];
+        }
+    });
 }
 
 /**


### PR DESCRIPTION
## Linked issue

Closes #622

## Summary of changes

`renderActionItems` fully rebuilds the action-required panel's DOM after any
question submit (`container.innerHTML = ...`), so submitting one question in
a `pending_questions` batch wiped the `.selected` state and free-text drafts
on sibling, un-submitted questions — the only place that state lived.

Added a small client-side draft store (`taskQuestionDrafts`) in
`src/ui/static/modules/actions.js` that records each un-submitted
selection/free-text as the user makes it, and re-applies it whenever
`renderTaskQuestionsItem` repaints. The draft for a question is cleared once
the server confirms it's answered. No API or backend changes — this keeps
the existing per-question submit/resume contract documented in
PRD-029 (`pending_questions[]`: "mark answered per question; move when all
done"), rather than moving to a single "Submit all" action.

## Screenshots / recordings
Before/after recording: on main, submitting one question in the 4-question batch wipes the in-progress selections on the other pending questions; on this branch, sibling selections/drafts are preserved across submits until each question is answered.

https://github.com/user-attachments/assets/cb46733d-5586-49db-a77b-40f3afe1ee0a

https://github.com/user-attachments/assets/8d185d55-96a0-424c-bd6e-2c0d0b8278d2

## Testing notes

Repro'd with a seeded `needs-input` task carrying 4 `pending_questions`
(`extensions.runner.pending_questions`) against a local `dotbot serve`
instance:

1. Open the action-required panel — 4 questions shown.
2. Select an option on Q2 and Q3 (don't submit).
3. Click "Submit Q1".
4. After the panel re-renders (~1.5s), Q2/Q3 selections are preserved —
   previously they were wiped.
5. Continue submitting Q2 → Q3 → Q4; panel correctly resolves to
   "No pending actions" once the last question is answered.


## Checklist

- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)