### PR TITLE
fix(hooks): resolve verify chain cwd to task worktree/project (#628)

### DIFF
--- a/src/runtime/Plugins/Hooks/Transitions/enter-done/script.ps1
+++ b/src/runtime/Plugins/Hooks/Transitions/enter-done/script.ps1
@@ -32,6 +32,11 @@ function Invoke-Hook {
         $hasHookChain    = [bool](Get-Command Get-DotbotHookChain -ErrorAction SilentlyContinue)
         $hasWorktreeInfo = [bool](Get-Command Get-TaskWorktreeInfo -ErrorAction SilentlyContinue)
 
+        # frameworkRoot is only resolved lazily, on demand — it's mandatory for
+        # the content resolver (Get-DotbotHookChain drives the verify chain
+        # itself) but merely best-effort for the worktree lookup (a resolution
+        # failure there just means the cwd falls through to working_directory
+        # / BotRoot). Don't hard-fail the whole hook over the optional path.
         $frameworkRoot = $null
         if (-not $hasHookChain -or -not $hasWorktreeInfo) {
             $frameworkRoot = if ($env:DOTBOT_HOME) {
@@ -41,6 +46,9 @@ function Invoke-Hook {
             } else {
                 $null
             }
+        }
+
+        if (-not $hasHookChain) {
             if (-not $frameworkRoot) {
                 $sw.Stop()
                 return @{
@@ -49,9 +57,6 @@ function Invoke-Hook {
                     Duration = $sw.Elapsed
                 }
             }
-        }
-
-        if (-not $hasHookChain) {
             $contentResolverModule = Join-Path $frameworkRoot "src/runtime/Modules/Dotbot.Content/Dotbot.Content.psm1"
             Import-Module $contentResolverModule -DisableNameChecking -Global
         }
@@ -59,8 +64,10 @@ function Invoke-Hook {
         # This hook's runspace is a fresh child runspace (see Dispatch.psm1) and
         # doesn't inherit modules loaded by the parent process, so the worktree
         # lookup below needs its own explicit import — same reasoning as the
-        # Dotbot.Content import above.
-        if (-not $hasWorktreeInfo) {
+        # Dotbot.Content import above. Best-effort: if frameworkRoot couldn't be
+        # resolved, just skip it — Get-TaskWorktreeInfo simply won't be found
+        # below and cwd resolution falls through to working_directory / BotRoot.
+        if (-not $hasWorktreeInfo -and $frameworkRoot) {
             $worktreeModule = Join-Path $frameworkRoot "src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1"
             if (Test-Path -LiteralPath $worktreeModule) {
                 Import-Module $worktreeModule -DisableNameChecking -Global
@@ -101,8 +108,17 @@ function Invoke-Hook {
             $verifyCwd = $Task['working_directory']
         }
 
-        if (-not $verifyCwd) {
+        if (-not $verifyCwd -and (Test-Path -LiteralPath $botRoot -PathType Container)) {
             $verifyCwd = $botRoot
+        }
+
+        if (-not $verifyCwd) {
+            $sw.Stop()
+            return @{
+                Success  = $false
+                Message  = "enter-done: no valid working directory could be resolved (worktree, working_directory, and BotRoot '$botRoot' are all invalid or missing)."
+                Duration = $sw.Elapsed
+            }
         }
 
         # Merged verify chain: project hooks at <BotRoot>/hooks/verify/ win

--- a/src/runtime/Plugins/Hooks/Transitions/enter-done/script.ps1
+++ b/src/runtime/Plugins/Hooks/Transitions/enter-done/script.ps1
@@ -29,7 +29,11 @@ function Invoke-Hook {
             }
         }
 
-        if (-not (Get-Command Get-DotbotHookChain -ErrorAction SilentlyContinue)) {
+        $hasHookChain    = [bool](Get-Command Get-DotbotHookChain -ErrorAction SilentlyContinue)
+        $hasWorktreeInfo = [bool](Get-Command Get-TaskWorktreeInfo -ErrorAction SilentlyContinue)
+
+        $frameworkRoot = $null
+        if (-not $hasHookChain -or -not $hasWorktreeInfo) {
             $frameworkRoot = if ($env:DOTBOT_HOME) {
                 $env:DOTBOT_HOME
             } elseif (Get-Command Get-DotbotInstallPath -ErrorAction SilentlyContinue) {
@@ -45,8 +49,60 @@ function Invoke-Hook {
                     Duration = $sw.Elapsed
                 }
             }
+        }
+
+        if (-not $hasHookChain) {
             $contentResolverModule = Join-Path $frameworkRoot "src/runtime/Modules/Dotbot.Content/Dotbot.Content.psm1"
             Import-Module $contentResolverModule -DisableNameChecking -Global
+        }
+
+        # This hook's runspace is a fresh child runspace (see Dispatch.psm1) and
+        # doesn't inherit modules loaded by the parent process, so the worktree
+        # lookup below needs its own explicit import — same reasoning as the
+        # Dotbot.Content import above.
+        if (-not $hasWorktreeInfo) {
+            $worktreeModule = Join-Path $frameworkRoot "src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1"
+            if (Test-Path -LiteralPath $worktreeModule) {
+                Import-Module $worktreeModule -DisableNameChecking -Global
+            }
+        }
+
+        # Resolve where the verify chain should actually run: the task's
+        # project, not wherever the runtime process happened to be launched
+        # from (issue #628). Preference order:
+        #   1. Worktree registry (tasks owned by a WorkflowRun) - the checkout
+        #      the agent actually edited, which can differ from $botRoot.
+        #   2. $Task['working_directory'], if the executor set one.
+        #   3. $botRoot, as a last resort - keeps old behaviour only when
+        #      nothing more specific is known (standalone tasks live in the
+        #      project checkout directly).
+        $verifyCwd = $null
+
+        $runId = $null
+        if ($Task.ContainsKey('provenance') -and $Task['provenance']) {
+            $prov = $Task['provenance']
+            if ($prov -is [hashtable] -and $prov.ContainsKey('run_id')) {
+                $runId = $prov['run_id']
+            } elseif ($prov.PSObject.Properties['run_id']) {
+                $runId = $prov.run_id
+            }
+        }
+
+        if ($runId -and (Get-Command -Name Get-TaskWorktreeInfo -ErrorAction SilentlyContinue)) {
+            $worktreeInfo = Get-TaskWorktreeInfo -TaskId $Task['id'] -BotRoot $botRoot -ErrorAction SilentlyContinue
+            if ($worktreeInfo -and $worktreeInfo.worktree_path -and
+                (Test-Path -LiteralPath $worktreeInfo.worktree_path -PathType Container)) {
+                $verifyCwd = $worktreeInfo.worktree_path
+            }
+        }
+
+        if (-not $verifyCwd -and $Task.ContainsKey('working_directory') -and $Task['working_directory'] -and
+            (Test-Path -LiteralPath $Task['working_directory'] -PathType Container)) {
+            $verifyCwd = $Task['working_directory']
+        }
+
+        if (-not $verifyCwd) {
+            $verifyCwd = $botRoot
         }
 
         # Merged verify chain: project hooks at <BotRoot>/hooks/verify/ win
@@ -56,27 +112,34 @@ function Invoke-Hook {
         # determining execution order.
         $scripts = Get-DotbotHookChain -BotRoot $botRoot -Phase verify
         $failedScript = $null
-        foreach ($s in $scripts) {
-            try {
-                $raw = & pwsh -NoProfile -File $s.Path -TaskId $Task['id'] -Category ([string]$Task['category']) 2>$null
-                if ($LASTEXITCODE -ne 0) {
-                    $failedScript = @{ name = $s.Name; reason = "exit code $LASTEXITCODE" }
-                    break
-                }
-                if ($raw) {
-                    $parsed = $null
-                    try { $parsed = $raw | ConvertFrom-Json -ErrorAction Stop } catch { $parsed = $null }
-                    if ($parsed -and ($parsed.PSObject.Properties['success']) -and (-not [bool]$parsed.success)) {
-                        $msg = if ($parsed.PSObject.Properties['message']) { [string]$parsed.message } else { 'unknown' }
-                        $failedScript = @{ name = $s.Name; reason = $msg }
+
+        Push-Location -LiteralPath $verifyCwd
+        try {
+            foreach ($s in $scripts) {
+                try {
+                    $raw = & pwsh -NoProfile -File $s.Path -TaskId $Task['id'] -Category ([string]$Task['category']) 2>$null
+                    if ($LASTEXITCODE -ne 0) {
+                        $failedScript = @{ name = $s.Name; reason = "exit code $LASTEXITCODE" }
                         break
                     }
+                    if ($raw) {
+                        $parsed = $null
+                        try { $parsed = $raw | ConvertFrom-Json -ErrorAction Stop } catch { $parsed = $null }
+                        if ($parsed -and ($parsed.PSObject.Properties['success']) -and (-not [bool]$parsed.success)) {
+                            $msg = if ($parsed.PSObject.Properties['message']) { [string]$parsed.message } else { 'unknown' }
+                            $failedScript = @{ name = $s.Name; reason = $msg }
+                            break
+                        }
+                    }
+                } catch {
+                    $failedScript = @{ name = $s.Name; reason = $_.Exception.Message }
+                    break
                 }
-            } catch {
-                $failedScript = @{ name = $s.Name; reason = $_.Exception.Message }
-                break
             }
+        } finally {
+            Pop-Location
         }
+
         if ($failedScript) {
             $sw.Stop()
             return @{

--- a/src/runtime/Plugins/Hooks/Transitions/enter-done/script.ps1
+++ b/src/runtime/Plugins/Hooks/Transitions/enter-done/script.ps1
@@ -68,9 +68,16 @@ function Invoke-Hook {
         # resolved, just skip it — Get-TaskWorktreeInfo simply won't be found
         # below and cwd resolution falls through to working_directory / BotRoot.
         if (-not $hasWorktreeInfo -and $frameworkRoot) {
-            $worktreeModule = Join-Path $frameworkRoot "src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1"
-            if (Test-Path -LiteralPath $worktreeModule) {
-                Import-Module $worktreeModule -DisableNameChecking -Global
+            # Import via the .psd1 manifest, not the bare .psm1 — matches the
+            # established pattern elsewhere (Invoke-DotbotProcess.ps1,
+            # Dotbot.TaskInput.psm1). The manifest's ScriptsToProcess pulls in
+            # Dotbot.Core / Dotbot.TaskFile first, which Dotbot.Worktree's
+            # functions depend on (e.g. Write-BotLog); importing the .psm1
+            # directly skips that and risks a confusing secondary failure the
+            # first time one of those dependencies is actually needed.
+            $worktreeManifest = Join-Path $frameworkRoot "src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psd1"
+            if (Test-Path -LiteralPath $worktreeManifest) {
+                Import-Module $worktreeManifest -DisableNameChecking -Global
             }
         }
 

--- a/tests/Test-Hooks.ps1
+++ b/tests/Test-Hooks.ps1
@@ -308,6 +308,19 @@ Write-Host "  ──────────────────────
 
 $enterDoneScript = Join-Path $repoRoot "src/runtime/Plugins/Hooks/Transitions/enter-done/script.ps1"
 
+function ConvertTo-PSSingleQuoteLiteral {
+    # Escapes a value for safe embedding inside a single-quoted PowerShell
+    # string literal in generated source (the stub bodies and out-of-process
+    # runner scripts below build .ps1 source as text). PowerShell's escape
+    # for a literal ' inside '...' is '' — without this, any temp/worktree
+    # path containing an apostrophe (rare but valid on Windows/macOS/Linux,
+    # e.g. a user profile folder) would terminate the string early and make
+    # the generated script syntactically invalid, failing the test for
+    # reasons unrelated to cwd resolution.
+    param([Parameter(Mandatory)] [AllowEmptyString()] [string]$Value)
+    return $Value.Replace("'", "''")
+}
+
 function New-Issue628FixtureDir {
     $dir = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-628-" + [guid]::NewGuid().ToString('N').Substring(0,8))
     New-Item -ItemType Directory -Path $dir -Force | Out-Null
@@ -333,7 +346,7 @@ function New-VerifyCwdStubBotRoot {
 param([string]$TaskId, [string]$Category)
 Add-Content -LiteralPath '__MARKER__' -Value (Get-Location).Path
 @{ success = $true; script = 'stub'; message = 'stub ok' } | ConvertTo-Json
-'@.Replace('__MARKER__', $MarkerFile)
+'@.Replace('__MARKER__', (ConvertTo-PSSingleQuoteLiteral $MarkerFile))
 
     foreach ($name in @('00-privacy-scan.ps1','01-git-clean.ps1','02-git-pushed.ps1','03-check-md-refs.ps1','04-framework-integrity.ps1')) {
         Set-Content -LiteralPath (Join-Path $hooksVerifyDir $name) -Value $stubBody -Encoding utf8NoBOM
@@ -385,13 +398,18 @@ function Invoke-EnterDoneOutOfProcess {
         [string]$LaunchCwd = ([System.IO.Path]::GetTempPath())
     )
 
-    $runIdLiteral   = if ($RunId)            { "'$RunId'" }            else { '$null' }
-    $workDirLiteral = if ($WorkingDirectory) { "'$WorkingDirectory'" } else { '$null' }
+    $runIdLiteral   = if ($RunId)            { "'$(ConvertTo-PSSingleQuoteLiteral $RunId)'" }            else { '$null' }
+    $workDirLiteral = if ($WorkingDirectory) { "'$(ConvertTo-PSSingleQuoteLiteral $WorkingDirectory)'" } else { '$null' }
     $provenanceLiteral = if ($ProvenanceAsPSObject) {
         "[pscustomobject]@{ run_id = $runIdLiteral }"
     } else {
         "@{ run_id = $runIdLiteral }"
     }
+
+    $repoRootLiteral       = ConvertTo-PSSingleQuoteLiteral $repoRoot
+    $enterDoneScriptLiteral = ConvertTo-PSSingleQuoteLiteral $enterDoneScript
+    $taskIdLiteral         = ConvertTo-PSSingleQuoteLiteral $TaskId
+    $botRootDirLiteral     = ConvertTo-PSSingleQuoteLiteral $BotRootDir
 
     # Load script.ps1 the same way Dispatch.psm1's Invoke-SingleTransitionHook
     # actually does in production — build a dynamic module from a scriptblock
@@ -400,17 +418,17 @@ function Invoke-EnterDoneOutOfProcess {
     # both throw "can only be called from inside a module" as a non-terminating
     # error that would otherwise need to be swallowed with 2>$null).
     $runner = @"
-`$env:DOTBOT_HOME = '$repoRoot'
-`$content = Get-Content -LiteralPath '$enterDoneScript' -Raw
+`$env:DOTBOT_HOME = '$repoRootLiteral'
+`$content = Get-Content -LiteralPath '$enterDoneScriptLiteral' -Raw
 `$sb = [ScriptBlock]::Create(`$content)
 `$mod = New-Module -Name 'EnterDoneUnderTest' -ScriptBlock `$sb
 `$task = @{
-    id                = '$TaskId'
+    id                = '$taskIdLiteral'
     category          = 'test'
     provenance        = $provenanceLiteral
     working_directory = $workDirLiteral
 }
-`$runContext = @{ BotRoot = '$BotRootDir' }
+`$runContext = @{ BotRoot = '$botRootDirLiteral' }
 `$result = & `$mod Invoke-Hook -Task `$task -RunContext `$runContext -FromStatus 'in-progress' -ToStatus 'done'
 `$result | ConvertTo-Json -Depth 5 -Compress
 "@

--- a/tests/Test-Hooks.ps1
+++ b/tests/Test-Hooks.ps1
@@ -434,7 +434,7 @@ function Invoke-EnterDoneOutOfProcess {
 "@
     Set-Content -LiteralPath $RunnerPath -Value $runner -Encoding utf8NoBOM
 
-    Push-Location $LaunchCwd
+    Push-Location -LiteralPath $LaunchCwd
     try {
         $out = & pwsh -NoProfile -File $RunnerPath
     } finally {
@@ -565,7 +565,7 @@ function New-RuntimeTestBot {
     New-Item -ItemType Directory -Path $bot | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $bot '.control') | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $bot 'workspace/tasks') -Force | Out-Null
-    Push-Location $base
+    Push-Location -LiteralPath $base
     try {
         & git init -q | Out-Null
         & git config user.email "t@example.com" | Out-Null

--- a/tests/Test-Hooks.ps1
+++ b/tests/Test-Hooks.ps1
@@ -393,9 +393,17 @@ function Invoke-EnterDoneOutOfProcess {
         "@{ run_id = $runIdLiteral }"
     }
 
+    # Load script.ps1 the same way Dispatch.psm1's Invoke-SingleTransitionHook
+    # actually does in production — build a dynamic module from a scriptblock
+    # of the file's content — rather than dot-sourcing or Import-Module on a
+    # bare .ps1 (neither gives Export-ModuleMember a real module scope, so
+    # both throw "can only be called from inside a module" as a non-terminating
+    # error that would otherwise need to be swallowed with 2>$null).
     $runner = @"
 `$env:DOTBOT_HOME = '$repoRoot'
-. '$enterDoneScript'
+`$content = Get-Content -LiteralPath '$enterDoneScript' -Raw
+`$sb = [ScriptBlock]::Create(`$content)
+`$mod = New-Module -Name 'EnterDoneUnderTest' -ScriptBlock `$sb
 `$task = @{
     id                = '$TaskId'
     category          = 'test'
@@ -403,14 +411,14 @@ function Invoke-EnterDoneOutOfProcess {
     working_directory = $workDirLiteral
 }
 `$runContext = @{ BotRoot = '$BotRootDir' }
-`$result = Invoke-Hook -Task `$task -RunContext `$runContext -FromStatus 'in-progress' -ToStatus 'done'
+`$result = & `$mod Invoke-Hook -Task `$task -RunContext `$runContext -FromStatus 'in-progress' -ToStatus 'done'
 `$result | ConvertTo-Json -Depth 5 -Compress
 "@
     Set-Content -LiteralPath $RunnerPath -Value $runner -Encoding utf8NoBOM
 
     Push-Location $LaunchCwd
     try {
-        $out = & pwsh -NoProfile -File $RunnerPath 2>$null
+        $out = & pwsh -NoProfile -File $RunnerPath
     } finally {
         Pop-Location
     }

--- a/tests/Test-Hooks.ps1
+++ b/tests/Test-Hooks.ps1
@@ -288,6 +288,244 @@ $skipResult = $r.hook_results | Where-Object { $_.name -eq 'enter-skipped' } | S
 Assert-True -Name "enter-skipped smoke: hook reports success"   -Condition ([bool]$skipResult.success)
 
 # ═══════════════════════════════════════════════════════════════════════════
+# #628: enter-done resolves the verify chain's cwd, not the launch cwd
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# 01-git-clean.ps1 (and the rest of the verify chain) run `git status`
+# relative to the process's current directory. Before the #628 fix,
+# `pwsh -File` inherited whatever directory the runtime happened to be
+# launched from — wrong whenever that isn't the task's project. These
+# tests drive enter-done's actual script.ps1 (not a fixture stand-in) as a
+# fresh, unimported pwsh child process — same isolation the real dispatcher
+# runspace has (Dispatch.psm1 creates one PowerShell instance per hook with
+# no shared module state) — so the lazy Import-Module branches for
+# Dotbot.Content / Dotbot.Worktree are genuinely exercised, not bypassed by
+# modules this test file already imported above.
+
+Write-Host ""
+Write-Host "  #628: verify chain cwd resolution (worktree / working_directory / botRoot)" -ForegroundColor Cyan
+Write-Host "  ──────────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$enterDoneScript = Join-Path $repoRoot "src/runtime/Plugins/Hooks/Transitions/enter-done/script.ps1"
+
+function New-Issue628FixtureDir {
+    $dir = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-628-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    return $dir
+}
+
+function New-VerifyCwdStubBotRoot {
+    # Overrides every real framework verify script name with a stub that just
+    # records (Get-Location).Path to $MarkerFile and reports success. Project
+    # hooks win over framework ones for the same filename (Get-DotbotHookChain),
+    # so this fully isolates the test from real verify logic (gitleaks, git
+    # state, md refs, ...) and gives an unambiguous signal of which directory
+    # Push-Location actually targeted.
+    param(
+        [Parameter(Mandatory)] [string]$FixtureRoot,
+        [Parameter(Mandatory)] [string]$MarkerFile
+    )
+    $botRootDir     = Join-Path $FixtureRoot 'botroot'
+    $hooksVerifyDir = Join-Path $botRootDir 'hooks/verify'
+    New-Item -ItemType Directory -Force -Path $hooksVerifyDir, (Join-Path $botRootDir '.control') | Out-Null
+
+    $stubBody = @'
+param([string]$TaskId, [string]$Category)
+Add-Content -LiteralPath '__MARKER__' -Value (Get-Location).Path
+@{ success = $true; script = 'stub'; message = 'stub ok' } | ConvertTo-Json
+'@.Replace('__MARKER__', $MarkerFile)
+
+    foreach ($name in @('00-privacy-scan.ps1','01-git-clean.ps1','02-git-pushed.ps1','03-check-md-refs.ps1','04-framework-integrity.ps1')) {
+        Set-Content -LiteralPath (Join-Path $hooksVerifyDir $name) -Value $stubBody -Encoding utf8NoBOM
+    }
+    return $botRootDir
+}
+
+function Set-Issue628WorktreeMapEntry {
+    # Hand-writes <BotRoot>/.control/worktree-map.json — the format
+    # Read-WorktreeMap expects (a JSON object keyed by TaskId) — without
+    # needing Dotbot.Worktree imported in this test process.
+    param(
+        [Parameter(Mandatory)] [string]$BotRootDir,
+        [Parameter(Mandatory)] [string]$TaskId,
+        [Parameter(Mandatory)] [string]$WorktreePath
+    )
+    $map = @{
+        $TaskId = @{
+            worktree_path = $WorktreePath
+            branch_name   = "task/$TaskId"
+            task_name     = "fixture task"
+            created_at    = "2026-07-13T00:00:00Z"
+        }
+    }
+    $map | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath (Join-Path $BotRootDir '.control/worktree-map.json') -Encoding utf8NoBOM
+}
+
+function Invoke-EnterDoneOutOfProcess {
+    # Runs enter-done's real Invoke-Hook in a brand-new pwsh process (no
+    # preloaded modules), launched from an arbitrary directory — reproducing
+    # both halves of the #628 bug scenario (wrong launch cwd; fresh runspace
+    # module state) in one call.
+    #
+    # -ProvenanceAsPSObject builds $Task.provenance as [pscustomobject] instead
+    # of [hashtable] to exercise the `$prov.PSObject.Properties['run_id']`
+    # fallback branch. Today's only production caller (HttpServer.psm1's
+    # Invoke-TaskStatusHandler) reads tasks via ConvertFrom-Json -AsHashtable,
+    # so provenance always arrives as a nested hashtable in practice — this
+    # covers the defensive branch in case another caller ever constructs
+    # $Task differently (it mirrors the same dual-branch check already shipped
+    # in enter-in-progress/script.ps1).
+    param(
+        [Parameter(Mandatory)] [string]$RunnerPath,
+        [Parameter(Mandatory)] [string]$TaskId,
+        [string]$RunId,
+        [string]$WorkingDirectory,
+        [Parameter(Mandatory)] [string]$BotRootDir,
+        [switch]$ProvenanceAsPSObject,
+        [string]$LaunchCwd = ([System.IO.Path]::GetTempPath())
+    )
+
+    $runIdLiteral   = if ($RunId)            { "'$RunId'" }            else { '$null' }
+    $workDirLiteral = if ($WorkingDirectory) { "'$WorkingDirectory'" } else { '$null' }
+    $provenanceLiteral = if ($ProvenanceAsPSObject) {
+        "[pscustomobject]@{ run_id = $runIdLiteral }"
+    } else {
+        "@{ run_id = $runIdLiteral }"
+    }
+
+    $runner = @"
+`$env:DOTBOT_HOME = '$repoRoot'
+. '$enterDoneScript'
+`$task = @{
+    id                = '$TaskId'
+    category          = 'test'
+    provenance        = $provenanceLiteral
+    working_directory = $workDirLiteral
+}
+`$runContext = @{ BotRoot = '$BotRootDir' }
+`$result = Invoke-Hook -Task `$task -RunContext `$runContext -FromStatus 'in-progress' -ToStatus 'done'
+`$result | ConvertTo-Json -Depth 5 -Compress
+"@
+    Set-Content -LiteralPath $RunnerPath -Value $runner -Encoding utf8NoBOM
+
+    Push-Location $LaunchCwd
+    try {
+        $out = & pwsh -NoProfile -File $RunnerPath 2>$null
+    } finally {
+        Pop-Location
+    }
+    try { return ($out -join "`n") | ConvertFrom-Json -ErrorAction Stop } catch { return $null }
+}
+
+function Assert-VerifyCwdMarker {
+    # Asserts the whole verify chain (all 5 stubs) ran in exactly $ExpectedDir.
+    param(
+        [Parameter(Mandatory)] [string]$Name,
+        [Parameter(Mandatory)] [string]$MarkerFile,
+        [Parameter(Mandatory)] [string]$ExpectedDir
+    )
+    $lines = if (Test-Path -LiteralPath $MarkerFile) { @(Get-Content -LiteralPath $MarkerFile) } else { @() }
+    Assert-Equal -Name "$Name`: verify chain ran (5 stub hooks recorded cwd)" -Expected 5 -Actual $lines.Count
+    Assert-Equal -Name "$Name`: verify chain cwd" -Expected $ExpectedDir -Actual ($lines | Select-Object -First 1) `
+        -Message "Expected every stub to run in '$ExpectedDir', got: $($lines -join ', ')"
+    Assert-True -Name "$Name`: cwd consistent across the whole chain" `
+        -Condition (@($lines | Select-Object -Unique).Count -eq 1)
+}
+
+# --- Scenario 1: worktree registry entry exists and is valid → worktree_path wins
+$fx = New-Issue628FixtureDir
+try {
+    $marker      = Join-Path $fx 'marker.txt'
+    $worktreeDir = Join-Path $fx 'worktree'
+    $workingDir  = Join-Path $fx 'workingdir'
+    New-Item -ItemType Directory -Force -Path $worktreeDir, $workingDir | Out-Null
+    $botRootDir = New-VerifyCwdStubBotRoot -FixtureRoot $fx -MarkerFile $marker
+    Set-Issue628WorktreeMapEntry -BotRootDir $botRootDir -TaskId 't_628scn1' -WorktreePath $worktreeDir
+
+    $r = Invoke-EnterDoneOutOfProcess -RunnerPath (Join-Path $fx 'runner.ps1') `
+        -TaskId 't_628scn1' -RunId 'wr_628scn1' -WorkingDirectory $workingDir -BotRootDir $botRootDir
+    Assert-True -Name "Scenario 1 (valid worktree): Invoke-Hook succeeds" -Condition ([bool]$r.Success)
+    Assert-VerifyCwdMarker -Name "Scenario 1 (valid worktree)" -MarkerFile $marker -ExpectedDir $worktreeDir
+} finally {
+    Remove-Item -LiteralPath $fx -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# --- Scenario 1b: same as Scenario 1, but provenance arrives as a PSCustomObject
+#     (e.g. plain ConvertFrom-Json without -AsHashtable) instead of a hashtable
+$fx = New-Issue628FixtureDir
+try {
+    $marker      = Join-Path $fx 'marker.txt'
+    $worktreeDir = Join-Path $fx 'worktree'
+    $workingDir  = Join-Path $fx 'workingdir'
+    New-Item -ItemType Directory -Force -Path $worktreeDir, $workingDir | Out-Null
+    $botRootDir = New-VerifyCwdStubBotRoot -FixtureRoot $fx -MarkerFile $marker
+    Set-Issue628WorktreeMapEntry -BotRootDir $botRootDir -TaskId 't_628scn1b' -WorktreePath $worktreeDir
+
+    $r = Invoke-EnterDoneOutOfProcess -RunnerPath (Join-Path $fx 'runner.ps1') `
+        -TaskId 't_628scn1b' -RunId 'wr_628scn1b' -WorkingDirectory $workingDir -BotRootDir $botRootDir `
+        -ProvenanceAsPSObject
+    Assert-True -Name "Scenario 1b (PSCustomObject provenance): Invoke-Hook succeeds" -Condition ([bool]$r.Success)
+    Assert-VerifyCwdMarker -Name "Scenario 1b (PSCustomObject provenance, valid worktree)" -MarkerFile $marker -ExpectedDir $worktreeDir
+} finally {
+    Remove-Item -LiteralPath $fx -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# --- Scenario 2: worktree registry entry exists but worktree_path is gone from
+#     disk (Test-Path guard) → falls back to working_directory
+$fx = New-Issue628FixtureDir
+try {
+    $marker      = Join-Path $fx 'marker.txt'
+    $missingWorktreeDir = Join-Path $fx 'worktree-deleted'
+    $workingDir  = Join-Path $fx 'workingdir'
+    New-Item -ItemType Directory -Force -Path $workingDir | Out-Null
+    # Deliberately never create $missingWorktreeDir — registry points at a
+    # worktree that's already been discarded (e.g. Reset-TaskWorktree ran).
+    $botRootDir = New-VerifyCwdStubBotRoot -FixtureRoot $fx -MarkerFile $marker
+    Set-Issue628WorktreeMapEntry -BotRootDir $botRootDir -TaskId 't_628scn2' -WorktreePath $missingWorktreeDir
+
+    $r = Invoke-EnterDoneOutOfProcess -RunnerPath (Join-Path $fx 'runner.ps1') `
+        -TaskId 't_628scn2' -RunId 'wr_628scn2' -WorkingDirectory $workingDir -BotRootDir $botRootDir
+    Assert-True -Name "Scenario 2 (stale worktree entry): Invoke-Hook succeeds" -Condition ([bool]$r.Success)
+    Assert-VerifyCwdMarker -Name "Scenario 2 (stale worktree entry falls back)" -MarkerFile $marker -ExpectedDir $workingDir
+} finally {
+    Remove-Item -LiteralPath $fx -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# --- Scenario 3: no provenance/run_id (standalone task) → working_directory,
+#     worktree registry never consulted
+$fx = New-Issue628FixtureDir
+try {
+    $marker     = Join-Path $fx 'marker.txt'
+    $workingDir = Join-Path $fx 'workingdir'
+    New-Item -ItemType Directory -Force -Path $workingDir | Out-Null
+    $botRootDir = New-VerifyCwdStubBotRoot -FixtureRoot $fx -MarkerFile $marker
+    # No worktree-map.json entry at all — a standalone task has nothing to look up.
+
+    $r = Invoke-EnterDoneOutOfProcess -RunnerPath (Join-Path $fx 'runner.ps1') `
+        -TaskId 't_628scn3' -RunId $null -WorkingDirectory $workingDir -BotRootDir $botRootDir
+    Assert-True -Name "Scenario 3 (no run_id): Invoke-Hook succeeds" -Condition ([bool]$r.Success)
+    Assert-VerifyCwdMarker -Name "Scenario 3 (no run_id uses working_directory)" -MarkerFile $marker -ExpectedDir $workingDir
+} finally {
+    Remove-Item -LiteralPath $fx -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# --- Scenario 4: no run_id AND working_directory doesn't exist on disk → botRoot
+$fx = New-Issue628FixtureDir
+try {
+    $marker           = Join-Path $fx 'marker.txt'
+    $missingWorkingDir = Join-Path $fx 'workingdir-does-not-exist'
+    $botRootDir = New-VerifyCwdStubBotRoot -FixtureRoot $fx -MarkerFile $marker
+    # Deliberately never create $missingWorkingDir.
+
+    $r = Invoke-EnterDoneOutOfProcess -RunnerPath (Join-Path $fx 'runner.ps1') `
+        -TaskId 't_628scn4' -RunId $null -WorkingDirectory $missingWorkingDir -BotRootDir $botRootDir
+    Assert-True -Name "Scenario 4 (nothing valid): Invoke-Hook succeeds" -Condition ([bool]$r.Success)
+    Assert-VerifyCwdMarker -Name "Scenario 4 (falls all the way back to botRoot)" -MarkerFile $marker -ExpectedDir $botRootDir
+} finally {
+    Remove-Item -LiteralPath $fx -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
 # End-to-end: HTTP /tasks/<id>/status with aborting hook reverts on disk
 # ═══════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Linked issue

Closes #628

## Summary of changes

`enter-done`'s verify hook chain (e.g. `01-git-clean.ps1`) ran `git status` relative to whatever directory the runtime process was launched from, instead of the task's actual project/worktree. This meant the check's outcome depended on the launch folder, not the task - a dirty launch folder wrongly failed the task, and a non-repo launch folder wrongly passed it without checking anything.

Resolves the verify chain's working directory before running it, in this order: task's worktree (via the worktree registry, for WorkflowRun tasks) -> `Task.working_directory` -> `BotRoot` as a last resort. Each candidate is validated with `Test-Path` before use, so a stale/deleted worktree registry entry falls through to the next option instead of erroring.

## Screenshots / recordings

N/A - backend/runtime fix, no UI changes.

## Testing notes

Added 5 new regression scenarios to `tests/Test-Hooks.ps1` (20 assertions total), each driving the real `enter-done/script.ps1` as a fresh, unimported `pwsh` child process launched from an arbitrary directory - reproducing the actual bug conditions (wrong launch cwd + fresh runspace with no preloaded modules):

1. Valid worktree registry entry -> uses