### PR TITLE
Bugfix/623 rate limit poisons dependency graph

### DIFF
--- a/content/settings/settings.default.json
+++ b/content/settings/settings.default.json
@@ -51,7 +51,10 @@
     "model": "best",
     "max_concurrent": 1,
     "provider_completion_grace_seconds": 10,
-    "provider_stop_check_interval_seconds": 2
+    "provider_stop_check_interval_seconds": 2,
+    "max_retries_per_task": 2,
+    "rate_limit_max_wait_minutes": 240,
+    "rate_limit_max_deferrals": 3
   },
   "git": {
     "base_branch": null

--- a/content/settings/settings.default.json
+++ b/content/settings/settings.default.json
@@ -54,7 +54,8 @@
     "provider_stop_check_interval_seconds": 2,
     "max_retries_per_task": 2,
     "rate_limit_max_wait_minutes": 240,
-    "rate_limit_max_deferrals": 3
+    "rate_limit_max_deferrals": 3,
+    "rate_limit_no_reset_backoff_seconds": 60
   },
   "git": {
     "base_branch": null

--- a/src/runtime/Modules/Dotbot.Harness/Dotbot.Harness.psd1
+++ b/src/runtime/Modules/Dotbot.Harness/Dotbot.Harness.psd1
@@ -28,6 +28,7 @@
         # Cross-cutting utilities
         'Write-ActivityLog'
         'Get-FailureReason'
+        'Get-RateLimitResetTime'
     )
 
     CmdletsToExport   = @()

--- a/src/runtime/Modules/Dotbot.Harness/Dotbot.Harness.psm1
+++ b/src/runtime/Modules/Dotbot.Harness/Dotbot.Harness.psm1
@@ -177,4 +177,5 @@ Export-ModuleMember -Function @(
     'Get-RegisteredHarnessAdapters'
     'Write-ActivityLog'
     'Get-FailureReason'
+    'Get-RateLimitResetTime'
 )

--- a/src/runtime/Modules/Dotbot.Harness/Private/Failure.ps1
+++ b/src/runtime/Modules/Dotbot.Harness/Private/Failure.ps1
@@ -16,6 +16,33 @@ task is retryable.
 # string array of substrings (matched case-insensitively) or a regex pattern.
 $script:HarnessFailureRules = @(
     @{
+        # First: rate-limit texts sometimes mention accounts/plans and must not
+        # leak into AuthError (#623). dotbot can drive several harnesses
+        # (ClaudeCodeAdapter, CodexAdapter, AntigravityAdapter, ...), each with
+        # its own provider's wording — grouped below by source so a phrase can
+        # be traced back to where it was verified.
+        Type             = 'RateLimitError'
+        Description      = 'Provider usage/rate limit reached'
+        Recoverable      = $true
+        SuggestedAction  = 'Wait for the limit to reset, then retry'
+        Substrings       = @(
+            # Cross-provider (generic HTTP 429 wording)
+            'rate limit', 'rate-limit', 'rate_limit', 'too many requests',
+            # Claude (Anthropic) CLI — verbatim from the reported bug's log
+            'hit your limit', 'usage limit', 'overloaded_error',
+            # Codex (OpenAI) CLI — openai/codex issues #690, #6792, #30041;
+            # OpenAI API error-code docs
+            'rate_limit_exceeded', 'insufficient_quota', 'quota exceeded',
+            # Antigravity (Gemini) CLI — Gemini API error-code-429 reference;
+            # 'resource_exhausted' is the gRPC/API status enum, the other two
+            # are the human-readable message wording Google's docs quote
+            'resource_exhausted', 'resource exhausted', 'resource has been exhausted'
+        )
+        # 429 only with HTTP-ish context — a bare \b429\b would false-positive
+        # on ordinary numbers ("returned 429 items").
+        Regex            = '(?:http|status|error|code)\s*:?\s*429\b|\b429\s+too\s+many'
+    },
+    @{
         Type             = 'AuthError'
         Description      = 'Authentication error detected'
         Recoverable      = $true
@@ -106,4 +133,66 @@ function Get-FailureReason {
         recoverable      = $true
         suggested_action = 'Review output and retry'
     }
+}
+
+function Get-RateLimitResetTime {
+    <#
+    .SYNOPSIS
+    Best-effort parse of a provider rate-limit reset hint out of error text.
+
+    .DESCRIPTION
+    Recognises the common phrasings provider CLIs emit alongside a usage/rate
+    limit — Claude's "resets 3:30pm" / "resets at 15:30", and the relative
+    "try again in 45 seconds" / "retry after 2 minutes" / OpenAI's abbreviated
+    "please try again in 3s" — and converts them to an absolute local DateTime
+    with a small safety margin added. A clock time already in the past is
+    interpreted as tomorrow.
+
+    The message format is NOT a provider contract — callers must treat the
+    result as a hint and keep a fallback path for $null (no parseable hint).
+    #>
+    [CmdletBinding()]
+    param([string]$ErrorText)
+
+    if ([string]::IsNullOrWhiteSpace($ErrorText)) { return $null }
+
+    $safetyMargin = [TimeSpan]::FromSeconds(120)
+    $now = Get-Date
+
+    # "try again in N seconds/minutes/hours" / "retry after N ..." — accepts
+    # both spelled-out units and OpenAI's abbreviated form ("try again in 3s").
+    if ($ErrorText -match '(?:try\s+again|retry)\s+(?:in|after)\s+(\d+)\s*(s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)\b') {
+        $n = [int]$Matches[1]
+        $unit = $Matches[2].ToLowerInvariant()
+        $span = if ($unit.StartsWith('s')) { [TimeSpan]::FromSeconds($n) }
+                elseif ($unit.StartsWith('m')) { [TimeSpan]::FromMinutes($n) }
+                else { [TimeSpan]::FromHours($n) }
+        return $now.Add($span).Add($safetyMargin)
+    }
+
+    # "resets 3:30pm" / "resets at 15:30" / "resets 4pm" — interpreted in the
+    # machine's local time zone. The CLI does not state one explicitly, but
+    # since the harness CLI (claude.exe / codex / antigravity) runs as a
+    # *child process on this same machine*, it necessarily renders the reset
+    # clock time using that machine's own local clock — there is no separate
+    # server timezone to reconcile with. The deferral cap in the caller
+    # (rate_limit_max_deferrals) is still kept as defense-in-depth in case a
+    # future CLI version formats this differently (e.g. an explicit UTC
+    # offset) in a way this parser does not yet understand.
+    if ($ErrorText -match 'resets?\s*(?:at\s*)?(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\b') {
+        $hour = [int]$Matches[1]
+        $minute = if ($Matches[2]) { [int]$Matches[2] } else { 0 }
+        $meridiem = if ($Matches[3]) { $Matches[3].ToLowerInvariant() } else { $null }
+        # A bare hour with no minutes and no am/pm ("resets 2026") is too
+        # ambiguous to act on — refuse rather than sleep to a random time.
+        if (-not $Matches[2] -and -not $meridiem) { return $null }
+        if ($meridiem -eq 'pm' -and $hour -lt 12) { $hour += 12 }
+        if ($meridiem -eq 'am' -and $hour -eq 12) { $hour = 0 }
+        if ($hour -gt 23 -or $minute -gt 59) { return $null }
+        $candidate = $now.Date.AddHours($hour).AddMinutes($minute)
+        if ($candidate -le $now) { $candidate = $candidate.AddDays(1) }
+        return $candidate.Add($safetyMargin)
+    }
+
+    return $null
 }

--- a/src/runtime/Modules/Dotbot.Harness/Private/Failure.ps1
+++ b/src/runtime/Modules/Dotbot.Harness/Private/Failure.ps1
@@ -162,12 +162,19 @@ function Get-RateLimitResetTime {
     # "try again in N seconds/minutes/hours" / "retry after N ..." — accepts
     # both spelled-out units and OpenAI's abbreviated form ("try again in 3s").
     if ($ErrorText -match '(?:try\s+again|retry)\s+(?:in|after)\s+(\d+)\s*(s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)\b') {
-        $n = [int]$Matches[1]
+        # A pathologically large count ("try again in 99999999999 hours") would
+        # overflow the numeric cast or the TimeSpan/DateTime arithmetic. This is
+        # a best-effort parser with a documented $null contract, and the caller
+        # invokes it without a try/catch, so treat any such overflow as "no
+        # parseable hint" rather than letting the exception crash the workflow.
+        try { $n = [long]$Matches[1] } catch { return $null }
         $unit = $Matches[2].ToLowerInvariant()
-        $span = if ($unit.StartsWith('s')) { [TimeSpan]::FromSeconds($n) }
-                elseif ($unit.StartsWith('m')) { [TimeSpan]::FromMinutes($n) }
-                else { [TimeSpan]::FromHours($n) }
-        return $now.Add($span).Add($safetyMargin)
+        try {
+            $span = if ($unit.StartsWith('s')) { [TimeSpan]::FromSeconds($n) }
+                    elseif ($unit.StartsWith('m')) { [TimeSpan]::FromMinutes($n) }
+                    else { [TimeSpan]::FromHours($n) }
+            return $now.Add($span).Add($safetyMargin)
+        } catch { return $null }
     }
 
     # "resets 3:30pm" / "resets at 15:30" / "resets 4pm" — interpreted in the

--- a/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
+++ b/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
@@ -705,6 +705,18 @@ function Get-NextWorkflowTask {
     # claiming. Answered human-input tasks are requeued as todo with
     # resume_context attached.
     $blockedCount = 0
+    # Names of tasks blocked on an unmet dependency specifically (#623) — a
+    # framework-error skip (e.g. max-retries) never joins doneSet, so a
+    # dependent can stay in this state forever with no indication of which
+    # task or why. Scoped to the dependency-gate below only; the barrier and
+    # condition-mark-failure blocked-paths are unrelated to that failure mode
+    # and already have their own Write-BotLog diagnostics.
+    $blockedNames = [System.Collections.Generic.List[string]]::new()
+    function _NoteBlocked { param($TaskContent)
+        $label = Get-DotbotTaskProp -Object $TaskContent -Name 'name'
+        if (-not $label) { $label = Get-DotbotTaskProp -Object $TaskContent -Name 'id' }
+        if ($label) { $blockedNames.Add([string]$label) }
+    }
     $candidates = @($allTasks | Where-Object { [string]$_.Content.status -eq 'todo' })
     $eligible = @()
     foreach ($cand in $candidates) {
@@ -718,7 +730,7 @@ function Get-NextWorkflowTask {
         # dependents). Checking deps first keeps such a task 'todo' (blocked); the
         # condition is re-evaluated on a later selection pass once the producer has
         # completed (Get-NextWorkflowTask reloads task state from disk each call).
-        if (-not (_AreDepsMet -Task $c -Set $doneSet)) { $blockedCount++; continue }
+        if (-not (_AreDepsMet -Task $c -Set $doneSet)) { $blockedCount++; _NoteBlocked -TaskContent $c; continue }
         if (-not (_IsManifestConditionMet -Task $c)) {
             # Deps are satisfied but the condition is genuinely unmet, so the
             # producing task has already had its turn — a real condition-skip.
@@ -757,7 +769,15 @@ function Get-NextWorkflowTask {
     }
 
     $msg = "No pending tasks available in $scopeLabel."
-    if ($blockedCount -gt 0) { $msg += " $blockedCount task(s) blocked by unmet dependencies." }
+    if ($blockedCount -gt 0) {
+        $msg += " $blockedCount task(s) blocked by unmet dependencies"
+        if ($blockedNames.Count -gt 0) {
+            $preview = @($blockedNames | Select-Object -First 3) -join "', '"
+            $overflow = if ($blockedNames.Count -gt 3) { ", +$($blockedNames.Count - 3) more" } else { "" }
+            $msg += ": '$preview'$overflow"
+        }
+        $msg += "."
+    }
     return @{ success = $true; task = $null; message = $msg }
 }
 

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -40,6 +40,17 @@ $providerStopCheckIntervalSeconds = 2
 if ($settings.execution -and $settings.execution.PSObject.Properties['provider_stop_check_interval_seconds']) {
     try { $providerStopCheckIntervalSeconds = [Math]::Max(1, [int]$settings.execution.provider_stop_check_interval_seconds) } catch { $providerStopCheckIntervalSeconds = 2 }
 }
+# Rate-limit handling (#623): how long a slot may sleep waiting for an
+# advertised usage-limit reset (0 = never sleep, always park), and how many
+# such deferrals a single task gets before it is parked to needs-input.
+$rateLimitMaxWaitMinutes = 240
+if ($settings.execution -and $settings.execution.PSObject.Properties['rate_limit_max_wait_minutes']) {
+    try { $rateLimitMaxWaitMinutes = [Math]::Max(0, [int]$settings.execution.rate_limit_max_wait_minutes) } catch { $rateLimitMaxWaitMinutes = 240 }
+}
+$rateLimitMaxDeferrals = 3
+if ($settings.execution -and $settings.execution.PSObject.Properties['rate_limit_max_deferrals']) {
+    try { $rateLimitMaxDeferrals = [Math]::Max(0, [int]$settings.execution.rate_limit_max_deferrals) } catch { $rateLimitMaxDeferrals = 3 }
+}
 
 $tasksBaseDir = Join-Path (Join-Path $botRoot "workspace") "tasks"
 $WorkflowName = if ($processData -is [hashtable] -and $processData['workflow_name']) { [string]$processData['workflow_name'] } else { $null }
@@ -1222,6 +1233,9 @@ try {
 
 $tasksProcessed = 0
 $maxRetriesPerTask = 2
+if ($settings.execution -and $settings.execution.PSObject.Properties['max_retries_per_task']) {
+    try { $maxRetriesPerTask = [Math]::Max(0, [int]$settings.execution.max_retries_per_task) } catch { $maxRetriesPerTask = 2 }
+}
 $consecutiveFailureThreshold = 3
 
 # Workflows require a git repo. Repositories with no commits are valid:
@@ -1392,6 +1406,11 @@ try {
                 }
             } else {
                 Write-Status "No tasks available" -Type Info
+                # Distinguish "queue drained" from "queue starved by a
+                # framework-error skip" before exiting silently (#623).
+                if ($RunId) {
+                    try { Test-DependencyDeadlock -ProcessId $procId -BotRoot $botRoot -RunId $RunId | Out-Null } catch { Write-BotLog -Level Debug -Message "Deadlock check failed" -Exception $_ }
+                }
                 Write-Diag "EXIT: No tasks and Continue not set"
                 break
             }
@@ -1960,6 +1979,11 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
         # so escalation messaging accurately names the failure source.
         $postScriptFailureSource = 'post_script'
         $attemptNumber = 0
+        # Rate-limit deferrals granted to this task (#623). Tracked separately
+        # from attemptNumber: a transient provider limit must not consume the
+        # retry budget, but still needs its own cap so a never-clearing limit
+        # cannot spin this loop forever.
+        $rateLimitDeferrals = 0
 
         if ($worktreePath) { Push-Location $worktreePath }
         try {
@@ -2110,6 +2134,62 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
             $harnessErrText = @($streamResult.ErrorText, $execErrorText | Where-Object { $_ }) -join "`n"
             $failureReason = Get-FailureReason -ExitCode $exitCode -Stdout $harnessErrText -Stderr $harnessErrText -TimedOut $false
 
+            # Usage/rate limit mid-run (#623): a transient provider condition is
+            # not the task's fault — never charge the retry budget for it, and
+            # never let it decay into a max-retries skip that poisons the
+            # dependency graph. If the provider advertised a reset time within
+            # the configured wait budget, sleep until it (heartbeating, honoring
+            # stop signals) and retry in the same worktree. Otherwise park the
+            # task to needs-input (same pattern as AuthError below): dependents
+            # stay pending-but-recoverable instead of permanently starved.
+            if ($failureReason.type -eq 'RateLimitError') {
+                $attemptNumber--   # this attempt does not count against the budget
+                $rateLimitDeferrals++
+                $resetAt = Get-RateLimitResetTime -ErrorText $harnessErrText
+                $withinWaitBudget = $resetAt -and (($resetAt - (Get-Date)) -le [TimeSpan]::FromMinutes($rateLimitMaxWaitMinutes))
+                if ($withinWaitBudget -and $rateLimitDeferrals -le $rateLimitMaxDeferrals) {
+                    $resumeLabel = $resetAt.ToString('HH:mm')
+                    Write-Status "Usage limit reached — waiting until $resumeLabel, then retrying (deferral $rateLimitDeferrals of $rateLimitMaxDeferrals): $($task.name)" -Type Warn
+                    Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task '$($task.name)' rate-limited — waiting until $resumeLabel before retrying (deferral $rateLimitDeferrals/$rateLimitMaxDeferrals)"
+                    $processData.heartbeat_status = "Rate limited - resumes at $resumeLabel"
+                    Write-ProcessFile -Id $procId -Data $processData
+                    $stoppedWhileWaiting = $false
+                    while ((Get-Date) -lt $resetAt) {
+                        Start-Sleep -Seconds 15
+                        if (Test-ProcessStopSignal -Id $procId -BotRoot $botRoot) { $stoppedWhileWaiting = $true; break }
+                        $processData.last_heartbeat = (Get-Date).ToUniversalTime().ToString("o")
+                        Write-ProcessFile -Id $procId -Data $processData
+                    }
+                    if ($stoppedWhileWaiting) {
+                        $processData.status = 'stopped'
+                        $processData.failed_at = (Get-Date).ToUniversalTime().ToString("o")
+                        Write-ProcessFile -Id $procId -Data $processData
+                        break
+                    }
+                    Write-Status "Usage limit window elapsed — retrying: $($task.name)" -Type Info
+                    Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Rate-limit wait elapsed — retrying task '$($task.name)'"
+                    continue
+                }
+
+                $parkCause = if (-not $resetAt) {
+                    "no parseable reset time in the provider error"
+                } elseif (-not $withinWaitBudget) {
+                    "reset is beyond the ${rateLimitMaxWaitMinutes}-minute wait budget"
+                } else {
+                    "deferral budget exhausted ($rateLimitMaxDeferrals)"
+                }
+                $limitDetail = if ($harnessErrText.Length -gt 1000) { $harnessErrText.Substring(0, 1000) + " … [truncated, showing 1000 of $($harnessErrText.Length) chars]" } else { $harnessErrText }
+                $limitContext = "$($failureReason.description) — $parkCause. The task was parked instead of skipped so dependent tasks stay blocked-but-recoverable. Wait for the limit to reset, then choose 'Investigate logs and retry'. Detail: $limitDetail"
+                Write-Status "Usage limit reached ($parkCause) — parking for operator: $($task.name)" -Type Warn
+                Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task '$($task.name)' parked (needs-input): provider usage limit — $parkCause"
+                Set-WorkflowTaskNeedsInput -Task $task -RunDir $runDir `
+                    -QuestionId "rate-limit-$($task.id)" `
+                    -Question "Provider usage limit reached for task '$($task.name)'" `
+                    -Context $limitContext | Out-Null
+                $taskParked = $true
+                break
+            }
+
             # Auth expiry mid-run: park to needs-input (worktree retained, no
             # merge, retry budget not consumed) and prompt the operator to
             # re-authenticate, instead of burning retries against the same wall.
@@ -2140,6 +2220,11 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
                 try {
                     Invoke-TaskMarkSkipped -Arguments @{ task_id = $task.id; skip_reason = 'max-retries'; skip_detail = "Retry budget exhausted after $attemptNumber attempt(s)" } | Out-Null
                 } catch { Write-BotLog -Level Warn -Message "Task operation failed" -Exception $_ }
+                # A max-retries skip can strand dependents (#623) — surface the
+                # deadlock at the moment it is created, not only at queue drain.
+                if ($RunId) {
+                    try { Test-DependencyDeadlock -ProcessId $procId -BotRoot $botRoot -RunId $RunId | Out-Null } catch { Write-BotLog -Level Debug -Message "Deadlock check failed" -Exception $_ }
+                }
                 break
             }
         }

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -2177,8 +2177,12 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
                     $processData.heartbeat_status = "Rate limited - resumes at $resumeLabel"
                     Write-ProcessFile -Id $procId -Data $processData -BotRoot $botRoot
                     $stoppedWhileWaiting = $false
-                    while ((Get-Date) -lt $resumeAt) {
-                        Start-Sleep -Seconds 15
+                    while ($true) {
+                        $now = Get-Date
+                        if ($now -ge $resumeAt) { break }
+                        $remainingSeconds = [Math]::Ceiling(($resumeAt - $now).TotalSeconds)
+                        $sleepSeconds = [Math]::Max(1, [Math]::Min(5, [int]$remainingSeconds))
+                        Start-Sleep -Seconds $sleepSeconds
                         if (Test-ProcessStopSignal -Id $procId -BotRoot $botRoot) { $stoppedWhileWaiting = $true; break }
                         $processData.last_heartbeat = (Get-Date).ToUniversalTime().ToString("o")
                         Write-ProcessFile -Id $procId -Data $processData -BotRoot $botRoot

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -2191,6 +2191,14 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
                     }
                     Write-Status "Usage limit window elapsed — retrying: $($task.name)" -Type Info
                     Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Rate-limit wait elapsed — retrying task '$($task.name)'"
+                    # Clear the "Rate limited" heartbeat before re-entering the
+                    # retry loop. The "Executing" status is set once above the
+                    # loop (not per-attempt), so a bare continue would leave the
+                    # stale rate-limit label on the dashboard through the whole
+                    # re-execution. Pin -BotRoot for the same reason the waits do.
+                    $processData.heartbeat_status = "Executing: $($task.name)"
+                    $processData.last_heartbeat = (Get-Date).ToUniversalTime().ToString("o")
+                    Write-ProcessFile -Id $procId -Data $processData -BotRoot $botRoot
                     continue
                 }
 

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -41,8 +41,9 @@ if ($settings.execution -and $settings.execution.PSObject.Properties['provider_s
     try { $providerStopCheckIntervalSeconds = [Math]::Max(1, [int]$settings.execution.provider_stop_check_interval_seconds) } catch { $providerStopCheckIntervalSeconds = 2 }
 }
 # Rate-limit handling (#623): how long a slot may sleep waiting for an
-# advertised usage-limit reset (0 = never sleep, always park), and how many
-# such deferrals a single task gets before it is parked to needs-input.
+# advertised usage-limit reset (0 = never wait for an advertised reset; a
+# no-reset transient limit is still subject to the backoff configured below),
+# and how many such deferrals a single task gets before it is parked.
 $rateLimitMaxWaitMinutes = 240
 if ($settings.execution -and $settings.execution.PSObject.Properties['rate_limit_max_wait_minutes']) {
     try { $rateLimitMaxWaitMinutes = [Math]::Max(0, [int]$settings.execution.rate_limit_max_wait_minutes) } catch { $rateLimitMaxWaitMinutes = 240 }
@@ -1406,7 +1407,10 @@ try {
                         break
                     }
 
-                    if ($RunId -and (Test-DependencyDeadlock -ProcessId $procId -BotRoot $botRoot -RunId $RunId)) { break }
+                    if ($RunId) {
+                        try { if (Test-DependencyDeadlock -ProcessId $procId -BotRoot $botRoot -RunId $RunId) { break } }
+                        catch { Write-BotLog -Level Debug -Message "Deadlock check failed" -Exception $_ }
+                    }
                 }
                 if (-not $foundTask) {
                     Write-Diag "EXIT: No task found after wait loop (foundTask=$foundTask)"
@@ -2157,11 +2161,14 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
                 $attemptNumber--   # this attempt does not count against the budget
                 $rateLimitDeferrals++
                 $resetAt = Get-RateLimitResetTime -ErrorText $harnessErrText
-                $withinWaitBudget = $resetAt -and (($resetAt - (Get-Date)) -le [TimeSpan]::FromMinutes($rateLimitMaxWaitMinutes))
                 # A hard quota/billing exhaustion will not clear on its own — it
                 # needs an operator to add credit or upgrade — so it must never
-                # spend a short-backoff retry; it goes straight to park.
+                # wait, on an advertised reset OR a short backoff; it goes
+                # straight to park. Compute it before the wait decision and fold
+                # it into $withinWaitBudget so a billing error that happens to
+                # also carry a reset hint still parks immediately.
                 $looksLikeBilling = [bool]($harnessErrText -match '(?i)insufficient_quota|quota\s+exceeded|billing|upgrade\s+your\s+plan|insufficient\s+(?:funds|credit)')
+                $withinWaitBudget = (-not $looksLikeBilling) -and $resetAt -and (($resetAt - (Get-Date)) -le [TimeSpan]::FromMinutes($rateLimitMaxWaitMinutes))
                 # When to resume: the advertised reset if within budget; else a
                 # short backoff for a transient (non-billing) limit with no
                 # reset hint. $null => nothing safe to wait on, fall through to park.
@@ -2170,18 +2177,27 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
                                 (Get-Date).AddSeconds($rateLimitNoResetBackoffSeconds)
                             } else { $null }
                 if ($resumeAt -and $rateLimitDeferrals -le $rateLimitMaxDeferrals) {
-                    $resumeLabel = $resumeAt.ToString('HH:mm')
+                    # The reset parser maps a clock time already in the past to
+                    # tomorrow, and a custom wait budget can span days — a bare
+                    # HH:mm for a non-today resume would read as a moment
+                    # already gone, so include the day when it isn't today.
+                    $resumeLabel = if ($resumeAt.Date -eq (Get-Date).Date) { $resumeAt.ToString('HH:mm') } else { $resumeAt.ToString('ddd HH:mm') }
                     $waitKind = if ($withinWaitBudget) { "advertised reset" } else { "${rateLimitNoResetBackoffSeconds}s backoff" }
                     Write-Status "Usage limit reached — waiting until $resumeLabel ($waitKind), then retrying (deferral $rateLimitDeferrals of $rateLimitMaxDeferrals): $($task.name)" -Type Warn
                     Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task '$($task.name)' rate-limited — waiting until $resumeLabel before retrying (deferral $rateLimitDeferrals/$rateLimitMaxDeferrals)"
                     $processData.heartbeat_status = "Rate limited - resumes at $resumeLabel"
                     Write-ProcessFile -Id $procId -Data $processData -BotRoot $botRoot
                     $stoppedWhileWaiting = $false
+                    # Poll in short slices (5s, matching the runner's other idle
+                    # wait loops) rather than one long sleep: a fixed 15s sleep
+                    # delays stop-signal response by up to its full interval and
+                    # overshoots a small backoff or an imminent reset. Clamp the
+                    # last slice to the remaining time so we never sleep past
+                    # $resumeAt, and never below 1s.
                     while ($true) {
                         $now = Get-Date
                         if ($now -ge $resumeAt) { break }
-                        $remainingSeconds = [Math]::Ceiling(($resumeAt - $now).TotalSeconds)
-                        $sleepSeconds = [Math]::Max(1, [Math]::Min(5, [int]$remainingSeconds))
+                        $sleepSeconds = [int][Math]::Max(1, [Math]::Min(5, [Math]::Ceiling(($resumeAt - $now).TotalSeconds)))
                         Start-Sleep -Seconds $sleepSeconds
                         if (Test-ProcessStopSignal -Id $procId -BotRoot $botRoot) { $stoppedWhileWaiting = $true; break }
                         $processData.last_heartbeat = (Get-Date).ToUniversalTime().ToString("o")

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -51,6 +51,14 @@ $rateLimitMaxDeferrals = 3
 if ($settings.execution -and $settings.execution.PSObject.Properties['rate_limit_max_deferrals']) {
     try { $rateLimitMaxDeferrals = [Math]::Max(0, [int]$settings.execution.rate_limit_max_deferrals) } catch { $rateLimitMaxDeferrals = 3 }
 }
+# Transient rate/overload errors that advertise no reset time (a plain 429, an
+# Anthropic 529 "overloaded") self-heal in seconds, so give them a short
+# bounded backoff-and-retry before parking to needs-input. 0 = disable the
+# backoff and park at once (restores the earlier always-park behavior).
+$rateLimitNoResetBackoffSeconds = 60
+if ($settings.execution -and $settings.execution.PSObject.Properties['rate_limit_no_reset_backoff_seconds']) {
+    try { $rateLimitNoResetBackoffSeconds = [Math]::Max(0, [int]$settings.execution.rate_limit_no_reset_backoff_seconds) } catch { $rateLimitNoResetBackoffSeconds = 60 }
+}
 
 $tasksBaseDir = Join-Path (Join-Path $botRoot "workspace") "tasks"
 $WorkflowName = if ($processData -is [hashtable] -and $processData['workflow_name']) { [string]$processData['workflow_name'] } else { $null }
@@ -2137,33 +2145,48 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
             # Usage/rate limit mid-run (#623): a transient provider condition is
             # not the task's fault — never charge the retry budget for it, and
             # never let it decay into a max-retries skip that poisons the
-            # dependency graph. If the provider advertised a reset time within
-            # the configured wait budget, sleep until it (heartbeating, honoring
-            # stop signals) and retry in the same worktree. Otherwise park the
-            # task to needs-input (same pattern as AuthError below): dependents
-            # stay pending-but-recoverable instead of permanently starved.
+            # dependency graph. Resume strategy, in order: (1) if the provider
+            # advertised a reset time within the wait budget, sleep until it;
+            # (2) else if it is a transient limit with no reset hint, sleep a
+            # short backoff; then retry in the same worktree. All waits
+            # heartbeat and honor stop signals. If nothing is safe to wait on
+            # (hard quota/billing, reset beyond budget, or deferrals exhausted)
+            # park the task to needs-input (same pattern as AuthError below):
+            # dependents stay pending-but-recoverable instead of starved.
             if ($failureReason.type -eq 'RateLimitError') {
                 $attemptNumber--   # this attempt does not count against the budget
                 $rateLimitDeferrals++
                 $resetAt = Get-RateLimitResetTime -ErrorText $harnessErrText
                 $withinWaitBudget = $resetAt -and (($resetAt - (Get-Date)) -le [TimeSpan]::FromMinutes($rateLimitMaxWaitMinutes))
-                if ($withinWaitBudget -and $rateLimitDeferrals -le $rateLimitMaxDeferrals) {
-                    $resumeLabel = $resetAt.ToString('HH:mm')
-                    Write-Status "Usage limit reached — waiting until $resumeLabel, then retrying (deferral $rateLimitDeferrals of $rateLimitMaxDeferrals): $($task.name)" -Type Warn
+                # A hard quota/billing exhaustion will not clear on its own — it
+                # needs an operator to add credit or upgrade — so it must never
+                # spend a short-backoff retry; it goes straight to park.
+                $looksLikeBilling = [bool]($harnessErrText -match '(?i)insufficient_quota|quota\s+exceeded|billing|upgrade\s+your\s+plan|insufficient\s+(?:funds|credit)')
+                # When to resume: the advertised reset if within budget; else a
+                # short backoff for a transient (non-billing) limit with no
+                # reset hint. $null => nothing safe to wait on, fall through to park.
+                $resumeAt = if ($withinWaitBudget) { $resetAt }
+                            elseif ((-not $resetAt) -and (-not $looksLikeBilling) -and ($rateLimitNoResetBackoffSeconds -gt 0)) {
+                                (Get-Date).AddSeconds($rateLimitNoResetBackoffSeconds)
+                            } else { $null }
+                if ($resumeAt -and $rateLimitDeferrals -le $rateLimitMaxDeferrals) {
+                    $resumeLabel = $resumeAt.ToString('HH:mm')
+                    $waitKind = if ($withinWaitBudget) { "advertised reset" } else { "${rateLimitNoResetBackoffSeconds}s backoff" }
+                    Write-Status "Usage limit reached — waiting until $resumeLabel ($waitKind), then retrying (deferral $rateLimitDeferrals of $rateLimitMaxDeferrals): $($task.name)" -Type Warn
                     Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Task '$($task.name)' rate-limited — waiting until $resumeLabel before retrying (deferral $rateLimitDeferrals/$rateLimitMaxDeferrals)"
                     $processData.heartbeat_status = "Rate limited - resumes at $resumeLabel"
-                    Write-ProcessFile -Id $procId -Data $processData
+                    Write-ProcessFile -Id $procId -Data $processData -BotRoot $botRoot
                     $stoppedWhileWaiting = $false
-                    while ((Get-Date) -lt $resetAt) {
+                    while ((Get-Date) -lt $resumeAt) {
                         Start-Sleep -Seconds 15
                         if (Test-ProcessStopSignal -Id $procId -BotRoot $botRoot) { $stoppedWhileWaiting = $true; break }
                         $processData.last_heartbeat = (Get-Date).ToUniversalTime().ToString("o")
-                        Write-ProcessFile -Id $procId -Data $processData
+                        Write-ProcessFile -Id $procId -Data $processData -BotRoot $botRoot
                     }
                     if ($stoppedWhileWaiting) {
                         $processData.status = 'stopped'
                         $processData.failed_at = (Get-Date).ToUniversalTime().ToString("o")
-                        Write-ProcessFile -Id $procId -Data $processData
+                        Write-ProcessFile -Id $procId -Data $processData -BotRoot $botRoot
                         break
                     }
                     Write-Status "Usage limit window elapsed — retrying: $($task.name)" -Type Info
@@ -2171,12 +2194,14 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
                     continue
                 }
 
-                $parkCause = if (-not $resetAt) {
-                    "no parseable reset time in the provider error"
-                } elseif (-not $withinWaitBudget) {
+                $parkCause = if ($looksLikeBilling -and -not $withinWaitBudget) {
+                    "provider reports a quota/billing limit that will not reset automatically"
+                } elseif ($resetAt -and -not $withinWaitBudget) {
                     "reset is beyond the ${rateLimitMaxWaitMinutes}-minute wait budget"
+                } elseif ($rateLimitDeferrals -gt $rateLimitMaxDeferrals) {
+                    "retry/deferral budget exhausted ($rateLimitMaxDeferrals)"
                 } else {
-                    "deferral budget exhausted ($rateLimitMaxDeferrals)"
+                    "no parseable reset time in the provider error"
                 }
                 $limitDetail = if ($harnessErrText.Length -gt 1000) { $harnessErrText.Substring(0, 1000) + " … [truncated, showing 1000 of $($harnessErrText.Length) chars]" } else { $harnessErrText }
                 $limitContext = "$($failureReason.description) — $parkCause. The task was parked instead of skipped so dependent tasks stay blocked-but-recoverable. Wait for the limit to reset, then choose 'Investigate logs and retry'. Detail: $limitDetail"

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -1834,6 +1834,67 @@ if ($harnessLoaded) {
         -Condition ($timeoutReason.type -eq 'Timeout') `
         -Message "Expected Timeout, got '$($timeoutReason.type)'"
 
+    # Failure classifier (#623): usage/rate-limit text must classify as
+    # RateLimitError so the consumer defers or parks instead of burning the
+    # retry budget against a limit that will not clear for hours.
+    $usageLimitReason = Get-FailureReason -ExitCode 1 -Stdout "You've hit your limit $([char]0xB7) resets 3:30pm" -Stderr '' -TimedOut $false
+    Assert-True -Name "Get-FailureReason classifies usage-limit text as RateLimitError (#623)" `
+        -Condition ($usageLimitReason.type -eq 'RateLimitError') `
+        -Message "Expected RateLimitError, got '$($usageLimitReason.type)'"
+
+    $http429Reason = Get-FailureReason -ExitCode 1 -Stdout 'Request failed: HTTP 429 Too Many Requests' -Stderr '' -TimedOut $false
+    Assert-True -Name "Get-FailureReason classifies HTTP 429 as RateLimitError" `
+        -Condition ($http429Reason.type -eq 'RateLimitError') `
+        -Message "Expected RateLimitError, got '$($http429Reason.type)'"
+
+    $not429Reason = Get-FailureReason -ExitCode 1 -Stdout 'request returned 429 items from the index' -Stderr '' -TimedOut $false
+    Assert-True -Name "Get-FailureReason does not treat a bare 429 count as rate limit" `
+        -Condition ($not429Reason.type -ne 'RateLimitError') `
+        -Message "Expected non-RateLimitError, got '$($not429Reason.type)'"
+
+    # Provider-specific wording (#623) — Codex (OpenAI) and Antigravity
+    # (Gemini) phrase their rate/quota limits differently from Claude.
+    $codexReason = Get-FailureReason -ExitCode 1 -Stdout 'Rate limit reached for gpt-5.5 on tokens per min. Please try again in 3s.' -Stderr '' -TimedOut $false
+    Assert-True -Name "Get-FailureReason classifies Codex 'Rate limit reached...' as RateLimitError" `
+        -Condition ($codexReason.type -eq 'RateLimitError') `
+        -Message "Expected RateLimitError, got '$($codexReason.type)'"
+
+    $codexQuotaReason = Get-FailureReason -ExitCode 1 -Stdout 'Quota exceeded. Check your plan and billing details.' -Stderr '' -TimedOut $false
+    Assert-True -Name "Get-FailureReason classifies Codex 'Quota exceeded' as RateLimitError" `
+        -Condition ($codexQuotaReason.type -eq 'RateLimitError') `
+        -Message "Expected RateLimitError, got '$($codexQuotaReason.type)'"
+
+    $geminiReason = Get-FailureReason -ExitCode 1 -Stdout 'Resource exhausted. Please try again later. Please refer to https://cloud.google.com/vertex-ai/generative-ai/docs/error-code-429 for more details.' -Stderr '' -TimedOut $false
+    Assert-True -Name "Get-FailureReason classifies Antigravity/Gemini 'Resource exhausted' as RateLimitError" `
+        -Condition ($geminiReason.type -eq 'RateLimitError') `
+        -Message "Expected RateLimitError, got '$($geminiReason.type)'"
+
+    # Get-RateLimitResetTime (#623): best-effort reset-hint parser.
+    $resetPm = Get-RateLimitResetTime -ErrorText "You've hit your limit $([char]0xB7) resets 3:30pm"
+    Assert-True -Name "Get-RateLimitResetTime parses 'resets 3:30pm' to future 15:32 local (+2min margin)" `
+        -Condition ($null -ne $resetPm -and $resetPm.Hour -eq 15 -and $resetPm.Minute -eq 32 -and $resetPm -gt (Get-Date)) `
+        -Message "Expected future 15:32 (15:30 + 120s margin), got '$resetPm'"
+
+    $resetIn = Get-RateLimitResetTime -ErrorText 'Rate limited. Try again in 45 seconds.'
+    Assert-True -Name "Get-RateLimitResetTime parses 'try again in 45 seconds'" `
+        -Condition ($null -ne $resetIn -and ($resetIn - (Get-Date)).TotalSeconds -gt 150 -and ($resetIn - (Get-Date)).TotalSeconds -lt 180) `
+        -Message "Expected ~165s from now, got '$resetIn'"
+
+    $resetCodexAbbrev = Get-RateLimitResetTime -ErrorText 'Rate limit reached for gpt-5.5 on tokens per min. Please try again in 3s.'
+    Assert-True -Name "Get-RateLimitResetTime parses Codex's abbreviated 'try again in 3s'" `
+        -Condition ($null -ne $resetCodexAbbrev -and ($resetCodexAbbrev - (Get-Date)).TotalSeconds -gt 118 -and ($resetCodexAbbrev - (Get-Date)).TotalSeconds -lt 125) `
+        -Message "Expected ~123s from now (3s + 120s margin), got '$resetCodexAbbrev'"
+
+    $resetNone = Get-RateLimitResetTime -ErrorText 'quota exceeded, please upgrade your plan'
+    Assert-True -Name "Get-RateLimitResetTime returns null with no parseable hint" `
+        -Condition ($null -eq $resetNone) `
+        -Message "Expected null, got '$resetNone'"
+
+    $resetAmbiguous = Get-RateLimitResetTime -ErrorText 'limit resets 2026'
+    Assert-True -Name "Get-RateLimitResetTime refuses bare-hour ambiguity ('resets 2026')" `
+        -Condition ($null -eq $resetAmbiguous) `
+        -Message "Expected null, got '$resetAmbiguous'"
+
     # Test Get-HarnessConfig for Claude (default)
     $claudeConfig = $null
     try { $claudeConfig = Get-HarnessConfig -Name "claude" } catch { Write-Verbose "Settings operation failed: $_" }

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -1875,15 +1875,22 @@ if ($harnessLoaded) {
         -Condition ($null -ne $resetPm -and $resetPm.Hour -eq 15 -and $resetPm.Minute -eq 32 -and $resetPm -gt (Get-Date)) `
         -Message "Expected future 15:32 (15:30 + 120s margin), got '$resetPm'"
 
+    # Capture a single baseline immediately before the call and measure the
+    # delta against it once — calling Get-Date twice inside the condition (and
+    # after the parse) makes these assertions drift on a loaded CI runner.
+    $resetInStart = Get-Date
     $resetIn = Get-RateLimitResetTime -ErrorText 'Rate limited. Try again in 45 seconds.'
+    $resetInDeltaSeconds = ($resetIn - $resetInStart).TotalSeconds
     Assert-True -Name "Get-RateLimitResetTime parses 'try again in 45 seconds'" `
-        -Condition ($null -ne $resetIn -and ($resetIn - (Get-Date)).TotalSeconds -gt 150 -and ($resetIn - (Get-Date)).TotalSeconds -lt 180) `
-        -Message "Expected ~165s from now, got '$resetIn'"
+        -Condition ($null -ne $resetIn -and $resetInDeltaSeconds -gt 140 -and $resetInDeltaSeconds -lt 190) `
+        -Message "Expected ~165s from call time (45s + 120s margin), got '$resetIn'"
 
+    $resetCodexStart = Get-Date
     $resetCodexAbbrev = Get-RateLimitResetTime -ErrorText 'Rate limit reached for gpt-5.5 on tokens per min. Please try again in 3s.'
+    $resetCodexDeltaSeconds = ($resetCodexAbbrev - $resetCodexStart).TotalSeconds
     Assert-True -Name "Get-RateLimitResetTime parses Codex's abbreviated 'try again in 3s'" `
-        -Condition ($null -ne $resetCodexAbbrev -and ($resetCodexAbbrev - (Get-Date)).TotalSeconds -gt 118 -and ($resetCodexAbbrev - (Get-Date)).TotalSeconds -lt 125) `
-        -Message "Expected ~123s from now (3s + 120s margin), got '$resetCodexAbbrev'"
+        -Condition ($null -ne $resetCodexAbbrev -and $resetCodexDeltaSeconds -gt 110 -and $resetCodexDeltaSeconds -lt 140) `
+        -Message "Expected ~123s from call time (3s + 120s margin), got '$resetCodexAbbrev'"
 
     $resetNone = Get-RateLimitResetTime -ErrorText 'quota exceeded, please upgrade your plan'
     Assert-True -Name "Get-RateLimitResetTime returns null with no parseable hint" `

--- a/tests/Test-TaskActions.ps1
+++ b/tests/Test-TaskActions.ps1
@@ -1795,6 +1795,73 @@ finally {
     if ($testProject569) { Remove-TestProject -Path $testProject569 }
 }
 
+# ─── Deadlock visibility on framework-error skips (issue #623) ───────────────
+# A task skipped with max-retries must not silently starve its dependents:
+# the scheduler's no-task message must name the blocked task, and
+# Test-DependencyDeadlock must detect the poisoned subtree in the run scope.
+
+$testProject623 = $null
+$savedDotbotProjectRoot623 = $global:DotbotProjectRoot
+try {
+    $testProject623 = New-SourceBackedTestProject -RepoRoot $repoRoot
+    Push-Location $testProject623
+    $botDir623 = Join-Path $testProject623 ".bot"
+    # Dir name must end in -<short> where short = first 4 chars of the run id
+    # body, and run.json must echo the id (Find-WorkflowRunDir contract).
+    $runId623  = "wr_dl623abc"
+    $runDir623 = Join-Path $botDir623 "workspace\tasks\workflow-runs\run-dl62"
+    New-Item -ItemType Directory -Path $runDir623 -Force | Out-Null
+    $global:DotbotProjectRoot = $testProject623
+
+    Import-Module (Join-Path $botDir623 "src/runtime/Modules/Dotbot.Task/Dotbot.Task.psd1")     -Force -DisableNameChecking
+    Import-Module (Join-Path $botDir623 "src/runtime/Modules/Dotbot.Workflow/Dotbot.Workflow.psd1") -Force -DisableNameChecking
+    Import-Module (Join-Path $botDir623 "src/runtime/Modules/Dotbot.Process/Dotbot.Process.psd1")  -Force -DisableNameChecking
+
+    [ordered]@{ run_id = $runId623; workflow = 'sched623'; status = 'running' } |
+        ConvertTo-Json -Depth 5 | Set-Content -Path (Join-Path $runDir623 "run.json") -Encoding UTF8
+
+    function New-DeadlockFixture623 {
+        param([string]$TaskId,[string]$Status,[string[]]$Dependencies=@(),[string]$SkipReason)
+        $task = [ordered]@{
+            id=$TaskId; name="Fixture $TaskId"; description="deadlock fixture"; status=$Status; type='prompt'
+            priority=50; dependencies=@($Dependencies)
+            provenance=[ordered]@{ workflow='sched623'; run_id=$runId623 }; updated_at="2026-01-01T00:00:00Z"
+        }
+        if ($SkipReason) { $task['extensions'] = [ordered]@{ runner = [ordered]@{ skip_reason = $SkipReason; skip_detail = 'fixture' } } }
+        $task | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $runDir623 "$TaskId.json") -Encoding UTF8
+    }
+
+    New-DeadlockFixture623 -TaskId "blocker-623"   -Status "skipped" -SkipReason "max-retries"
+    New-DeadlockFixture623 -TaskId "dependent-623" -Status "todo"    -Dependencies @("blocker-623")
+
+    # Scheduler: dependent must not be selected, and the message must name it.
+    $nx = Get-NextWorkflowTask -BotRoot $botDir623 -RunId $runId623
+    Assert-True -Name "#623: max-retries skip does not satisfy dependents (no task selected)" `
+        -Condition ($nx.success -and $null -eq $nx.task) `
+        -Message "Expected no eligible task, got: $($nx | ConvertTo-Json -Compress)"
+    Assert-True -Name "#623: blocked-task message names the starved task" `
+        -Condition ($nx.message -like "*Fixture dependent-623*") `
+        -Message "Expected message to name 'Fixture dependent-623', got: '$($nx.message)'"
+
+    # Deadlock detector: poisoned subtree must be detected in the run scope.
+    $dl = Test-DependencyDeadlock -ProcessId "test-proc-623" -BotRoot $botDir623 -RunId $runId623
+    Assert-True -Name "#623: Test-DependencyDeadlock detects framework-error-skip starvation" `
+        -Condition ($dl -eq $true) `
+        -Message "Expected deadlock=true, got '$dl'"
+
+    # Control: an INTENTIONAL skip must satisfy dependents — no deadlock.
+    New-DeadlockFixture623 -TaskId "blocker-623" -Status "skipped" -SkipReason "not-applicable"
+    $dl2 = Test-DependencyDeadlock -ProcessId "test-proc-623" -BotRoot $botDir623 -RunId $runId623
+    Assert-True -Name "#623: intentional skip does not register as deadlock" `
+        -Condition ($dl2 -eq $false) `
+        -Message "Expected deadlock=false, got '$dl2'"
+}
+finally {
+    $global:DotbotProjectRoot = $savedDotbotProjectRoot623
+    Pop-Location -ErrorAction SilentlyContinue
+    if ($testProject623) { Remove-TestProject -Path $testProject623 }
+}
+
 # ─── task-get-next runtime condition evaluation ──────────────────────────────
 # task-get-next is a thin HTTP wrapper around GET /tasks/next. Condition
 # evaluation is covered by handler-level runtime tests.


### PR DESCRIPTION
## Linked issue

Closes #623

## Summary of changes

Rate-limiting mid-task no longer burns the retry budget or poisons the
dependency graph.

**Classification & backoff**
- New `RateLimitError` failure class (evaluated before `AuthError`) matching
  Claude/Codex/Gemini/generic-429 wording, with a guarded 429 regex that
  ignores bare numbers ("returned 429 items").
- `Get-RateLimitResetTime` best-effort parses a reset hint ("resets 3:30pm",
  "try again in 45s", "retry after 2 minutes") into an absolute local time.
- Runner resume strategy for a rate limit: sleep until the advertised reset if
  within `rate_limit_max_wait_minutes`; else, for a transient limit with no
  reset hint, a short `rate_limit_no_reset_backoff_seconds` (default 60s)
  backoff-and-retry; else park to needs-input. Hard quota/billing exhaustion
  always parks immediately. Rate-limit waits never consume the retry budget
  and are capped by `rate_limit_max_deferrals`.

**Dependency-graph visibility**
- A framework-error skip (max-retries / non-recoverable) never satisfies
  dependents. The scheduler's "no tasks" message now names the starved
  task(s), and `Test-DependencyDeadlock` is wired in at the two points a
  poisoned subtree becomes observable (right after a max-retries skip, and at
  queue drain / wait).

**Process-state correctness**
- All process-registry writes in the rate-limit wait loop pin `-BotRoot` to the
  canonical root, so they don't resolve through the worktree `.control`
  junction (guards the #637 race in the new wait path).

New `execution` settings: `max_retries_per_task`, `rate_limit_max_wait_minutes`,
`rate_limit_max_deferrals`, `rate_limit_no_reset_backoff_seconds`.

## Screenshots / recordings

N/A — no UI changes.

## Testing notes

- `pwsh tests/Test-Components.ps1` - 856/856
- `pwsh tests/Test-TaskActions.ps1` - 190/190, incl. the four #623
  scheduler/deadlock cases.
- Standalone harness exercising the shipped classifier, reset parser, the
  resume/park decision matrix (with the billing regex lifted verbatim from the
  runner), the deadlock/scheduler path, and the `-BotRoot` invariant: 37/37.

## Checklist

- [x] Tests added or updated (classifier, reset parser, #623 scheduler/deadlock;
      runner rate-limit branch covered by a standalone validation harness)
- [x] Linked issue exists
- [x] Follows the contribution guide