### PR TITLE
fix(mcp): exit on stdin EOF instead of busy-looping

### DIFF
--- a/src/mcp/dotbot-mcp.ps1
+++ b/src/mcp/dotbot-mcp.ps1
@@ -313,9 +313,16 @@ function Start-McpServerLoop {
     
     while ($true) {
         try {
+            $id = $null
             $line = [Console]::ReadLine()
-            
-            if ([string]::IsNullOrEmpty($line)) {
+
+            # $null means stdin EOF (parent closed the pipe) - shut down cleanly
+            if ($null -eq $line) {
+                [Console]::Error.WriteLine("stdin closed (EOF) - shutting down")
+                return
+            }
+
+            if ([string]::IsNullOrWhiteSpace($line)) {
                 continue
             }
             


### PR DESCRIPTION
## Linked issue

Closes #646

## Summary of changes

The MCP server's main loop treated stdin EOF (`[Console]::ReadLine()` returning `$null`) the same as an empty line and `continue`d. Since `ReadLine()` never blocks again after EOF, an orphaned server (parent process dead, stdin closed) spun at full CPU forever.

- `Start-McpServerLoop` now distinguishes `$null` (EOF → log to stderr and shut down cleanly with exit code 0) from blank lines (skip, now via `IsNullOrWhiteSpace`).
- `$id` is reset at the top of each iteration so the `catch` block can no longer emit an error response carrying a stale request id from the previous message.

## Testing notes

Manual verification (server needs `DOTBOT_RUNTIME_URL` + `DOTBOT_RUNTIME_TOKEN` set, values can be fake for this test):

1. **EOF exit:** `'not-json' | pwsh -File src/mcp/dotbot-mcp.ps1` — piped stdin ends after one line. Before: process hangs spinning forever. After: logs `stdin closed (EOF) - shutting down`, exits with code 0.
2. **Regression:** pipe `initialize`, a blank line, and `tools/list` requests — both requests get correct JSON-RPC responses, blank line is skipped, then EOF exits cleanly.
3. Reproduced the original symptom per the issue: kill the parent process of a running server and watch CPU climb; with this fix the server exits as soon as the stdin pipe closes.

## Checklist

- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
