### PR TITLE
feat(server): Team registry: core workspace structure + team CRUD #630

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ dotbot workflow list           # List active + available workflows
 dotbot registry add <n> <src>  # Add an enterprise extension registry
 dotbot registry update [name]  # Update registry (all or named)
 dotbot registry list           # List registries and available content
+dotbot team add <name> <email> [role]   # Register a team member (role: developer|lead|reviewer|qa)
+dotbot team list               # List all team members
+dotbot team get <name>         # Show a single team member record
 dotbot doctor                  # Run project health checks
 dotbot go                      # Launch runtime + dashboard for an initialized project
 dotbot serve                   # Launch only the low-level runtime

--- a/bin/dotbot.ps1
+++ b/bin/dotbot.ps1
@@ -136,6 +136,9 @@ function Show-Help {
     Write-DotbotLabel "    registry add      " "Add an enterprise extension registry"
     Write-DotbotLabel "    registry list     " "List registered extension registries"
     Write-DotbotLabel "    registry remove   " "Remove an extension registry"
+    Write-DotbotLabel "    team add          " "Register a team member (name email [role])"
+    Write-DotbotLabel "    team list         " "List all team members"
+    Write-DotbotLabel "    team get          " "Show a single team member record"
     Write-DotbotLabel "    update            " "Update global installation"
     Write-DotbotLabel "    studio            " "Launch visual configuration studio"
     Write-DotbotLabel "    doctor            " "Scan project for health issues"
@@ -423,6 +426,69 @@ function Invoke-Registry {
     }
 }
 
+function Invoke-Team {
+    # Parse: team add <name> <email> [--role <role>] | team list | team get <name>
+    $teamSubCmd = if ($SubArgs.Count -gt 0) { $SubArgs[0] } else { '' }
+    # [array] cast is load-bearing: without it, a single-element range slice
+    # like $SubArgs[1..1] returned from an `if` expression inside a function
+    # unwraps to the scalar element (e.g. the string 'ana'), and later
+    # indexing into it (`$teamRest[0]`) yields the first character instead
+    # of the whole argument.
+    [array]$teamRest = if ($SubArgs.Count -gt 1) { $SubArgs[1..($SubArgs.Count-1)] } else { @() }
+
+    $teamScript = switch ($teamSubCmd) {
+        'add'  { Join-Path $ScriptsDir 'team-add.ps1' }
+        'list' { Join-Path $ScriptsDir 'team-list.ps1' }
+        'get'  { Join-Path $ScriptsDir 'team-get.ps1' }
+        default { $null }
+    }
+
+    if ($teamScript -and (Test-Path $teamScript)) {
+        $teamSplat = @{}
+        [array]$positional = @()
+        $ti = 0
+        while ($ti -lt $teamRest.Count) {
+            if ($teamRest[$ti] -match '^--?(.+)$') {
+                $pname = $Matches[1]
+                if (($ti + 1) -lt $teamRest.Count -and $teamRest[$ti + 1] -notmatch '^--?') {
+                    $teamSplat[$pname] = $teamRest[$ti + 1]
+                    $ti += 2
+                } else {
+                    $teamSplat[$pname] = $true
+                    $ti++
+                }
+            } else {
+                $positional += $teamRest[$ti]
+                $ti++
+            }
+        }
+
+        # Positional mapping:
+        #   team add  <name> [<email>] [<role>]
+        #   team get  <name>
+        # Named --email / --role flags always win over their positional slot.
+        if ($teamSubCmd -eq 'add') {
+            if ($positional.Count -ge 1) { $teamSplat['Name'] = $positional[0] }
+            if ($positional.Count -ge 2 -and -not $teamSplat.Contains('email') -and -not $teamSplat.Contains('Email')) {
+                $teamSplat['Email'] = $positional[1]
+            }
+            if ($positional.Count -ge 3 -and -not $teamSplat.Contains('role') -and -not $teamSplat.Contains('Role')) {
+                $teamSplat['Role'] = $positional[2]
+            }
+        } elseif ($teamSubCmd -eq 'get') {
+            if ($positional.Count -ge 1) { $teamSplat['Name'] = $positional[0] }
+        }
+
+        & $teamScript @teamSplat
+    } else {
+        Write-DotbotWarning "Usage: dotbot team [add|list|get] ..."
+        Write-DotbotCommand "  add   <name> <email> [role] | add <name> --email <email> [--role <role>]"
+        Write-DotbotCommand "  list"
+        Write-DotbotCommand "  get   <name>"
+        Write-DotbotCommand "  Roles: developer | lead | reviewer | qa"
+    }
+}
+
 function Invoke-Install {
     $installSubCmd = ''
     $contentSplat = @{}
@@ -666,6 +732,7 @@ switch ($Command) {
     "init" { Invoke-Init }
     "workflow" { Invoke-Workflow }
     "registry" { Invoke-Registry }
+    "team"     { Invoke-Team }
     "install" { Invoke-Install }
     "run" { Invoke-Run }
     "tasks" { Invoke-Tasks }

--- a/src/cli/team-add.ps1
+++ b/src/cli/team-add.ps1
@@ -1,24 +1,32 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-    Add a team member to the project's workspace team registry.
+    Add a team member to the project's team registry.
 
 .DESCRIPTION
-    Persists a new entry to .bot/workspace/team-registry.json. Names must be
-    unique (case-insensitive) — a follow-up ticket adds team update / remove.
+    Persists a new entry to .bot/team-registry.json. Names must be unique
+    (case-insensitive). Email is required — it's the contact address the
+    downstream Q&A routing (#632/#600/#609) delivers questions to.
+    A follow-up ticket (#631) adds team update / remove.
 
 .PARAMETER Name
     Case-preserving unique identifier for the member.
 
+.PARAMETER Email
+    Contact address. Required. Basic 'user@domain.tld' shape enforced.
+
 .PARAMETER Role
-    Optional role string (e.g. developer, reviewer, product).
+    Optional role. Must be one of: developer, lead, reviewer, qa.
 
 .EXAMPLE
-    dotbot team add ana-smith --role developer
+    dotbot team add ana-smith ana@example.com --role developer
+    dotbot team add ana-smith --email ana@example.com --role developer
 #>
 param(
     [Parameter(Position = 0)]
     [string]$Name,
+
+    [string]$Email,
 
     [string]$Role
 )
@@ -38,18 +46,19 @@ if (-not (Test-Path $BotDir)) {
     exit 1
 }
 
-if (-not $Name) {
-    Write-DotbotWarning "Usage: dotbot team add <name> [--role <role>]"
-    Write-DotbotCommand "Example: dotbot team add ana-smith --role developer"
+if (-not $Name -or -not $Email) {
+    Write-DotbotWarning "Usage: dotbot team add <name> <email> [--role <role>]"
+    Write-DotbotCommand "Example: dotbot team add ana-smith ana@example.com --role developer"
+    Write-DotbotCommand "Roles:   developer | lead | reviewer | qa"
     exit 1
 }
 
 try {
-    $member = Add-DotbotTeamMember -BotRoot $BotDir -Name $Name -Role $Role
+    $member = Add-DotbotTeamMember -BotRoot $BotDir -Name $Name -Email $Email -Role $Role
 } catch {
     Write-DotbotError $_.Exception.Message
     exit 1
 }
 
 $roleDisplay = if ([string]::IsNullOrWhiteSpace($member.role)) { '<none>' } else { $member.role }
-Write-Success "Added $($member.name) ($($member.id)) — role: $roleDisplay"
+Write-Success "Added $($member.name) <$($member.email)> ($($member.id)) — role: $roleDisplay"

--- a/src/cli/team-add.ps1
+++ b/src/cli/team-add.ps1
@@ -1,0 +1,55 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Add a team member to the project's workspace team registry.
+
+.DESCRIPTION
+    Persists a new entry to .bot/workspace/team-registry.json. Names must be
+    unique (case-insensitive) — a follow-up ticket adds team update / remove.
+
+.PARAMETER Name
+    Case-preserving unique identifier for the member.
+
+.PARAMETER Role
+    Optional role string (e.g. developer, reviewer, product).
+
+.EXAMPLE
+    dotbot team add ana-smith --role developer
+#>
+param(
+    [Parameter(Position = 0)]
+    [string]$Name,
+
+    [string]$Role
+)
+
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot ".." "runtime" "Modules" "Dotbot.Core" "Dotbot.Core.psm1") -Force -DisableNameChecking
+$DotbotBase = Get-DotbotInstallPath
+$BotDir     = Get-DotbotProjectBotPath
+
+Import-Module (Join-Path $DotbotBase "src/cli/Platform-Functions.psm1") -Force
+Import-Module (Join-Path $DotbotBase "src/runtime/Modules/Dotbot.Theme/Dotbot.Theme.psd1") -Force -DisableNameChecking
+Import-Module (Join-Path $DotbotBase "src/runtime/Modules/Dotbot.TeamRegistry/Dotbot.TeamRegistry.psd1") -Force -DisableNameChecking
+
+if (-not (Test-Path $BotDir)) {
+    Write-DotbotError "No .bot directory found. Run 'dotbot init' first."
+    exit 1
+}
+
+if (-not $Name) {
+    Write-DotbotWarning "Usage: dotbot team add <name> [--role <role>]"
+    Write-DotbotCommand "Example: dotbot team add ana-smith --role developer"
+    exit 1
+}
+
+try {
+    $member = Add-DotbotTeamMember -BotRoot $BotDir -Name $Name -Role $Role
+} catch {
+    Write-DotbotError $_.Exception.Message
+    exit 1
+}
+
+$roleDisplay = if ([string]::IsNullOrWhiteSpace($member.role)) { '<none>' } else { $member.role }
+Write-Success "Added $($member.name) ($($member.id)) — role: $roleDisplay"

--- a/src/cli/team-get.ps1
+++ b/src/cli/team-get.ps1
@@ -1,0 +1,61 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Show a single team member record by name (case-insensitive).
+
+.PARAMETER Name
+    The member's name.
+#>
+param(
+    [Parameter(Position = 0)]
+    [string]$Name
+)
+
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot ".." "runtime" "Modules" "Dotbot.Core" "Dotbot.Core.psm1") -Force -DisableNameChecking
+$DotbotBase = Get-DotbotInstallPath
+$BotDir     = Get-DotbotProjectBotPath
+
+Import-Module (Join-Path $DotbotBase "src/cli/Platform-Functions.psm1") -Force
+Import-Module (Join-Path $DotbotBase "src/runtime/Modules/Dotbot.Theme/Dotbot.Theme.psd1") -Force -DisableNameChecking
+Import-Module (Join-Path $DotbotBase "src/runtime/Modules/Dotbot.TeamRegistry/Dotbot.TeamRegistry.psd1") -Force -DisableNameChecking
+
+if (-not (Test-Path $BotDir)) {
+    Write-DotbotError "No .bot directory found. Run 'dotbot init' first."
+    exit 1
+}
+
+if (-not $Name) {
+    Write-DotbotWarning "Usage: dotbot team get <name>"
+    exit 1
+}
+
+try {
+    $member = Get-DotbotTeamMember -BotRoot $BotDir -Name $Name
+} catch {
+    Write-DotbotError $_.Exception.Message
+    exit 1
+}
+
+if (-not $member) {
+    Write-DotbotError "No team member named '$Name'."
+    exit 1
+}
+
+Write-BlankLine
+Write-DotbotSection -Title "TEAM MEMBER"
+Write-DotbotLabel -Label 'name       ' -Value ([string]$member.name) -ValueType Success
+Write-DotbotLabel -Label 'id         ' -Value ([string]$member.id)
+$role = if ([string]::IsNullOrWhiteSpace($member.role)) { '<none>' } else { [string]$member.role }
+Write-DotbotLabel -Label 'role       ' -Value $role
+# ConvertFrom-Json -AsHashtable auto-parses ISO strings to [DateTime].
+# Render back as UTC ISO so the CLI matches the on-disk format.
+$createdAt = if ($member.created_at -is [DateTime]) {
+    $member.created_at.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
+} else {
+    [string]$member.created_at
+}
+Write-DotbotLabel -Label 'created_at ' -Value $createdAt
+Write-DotbotLabel -Label 'created_by ' -Value ([string]$member.created_by)
+Write-BlankLine

--- a/src/cli/team-get.ps1
+++ b/src/cli/team-get.ps1
@@ -47,6 +47,7 @@ Write-BlankLine
 Write-DotbotSection -Title "TEAM MEMBER"
 Write-DotbotLabel -Label 'name       ' -Value ([string]$member.name) -ValueType Success
 Write-DotbotLabel -Label 'id         ' -Value ([string]$member.id)
+Write-DotbotLabel -Label 'email      ' -Value ([string]$member.email)
 $role = if ([string]::IsNullOrWhiteSpace($member.role)) { '<none>' } else { [string]$member.role }
 Write-DotbotLabel -Label 'role       ' -Value $role
 # ConvertFrom-Json -AsHashtable auto-parses ISO strings to [DateTime].

--- a/src/cli/team-list.ps1
+++ b/src/cli/team-list.ps1
@@ -1,0 +1,52 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    List every member in the project's workspace team registry.
+#>
+param()
+
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot ".." "runtime" "Modules" "Dotbot.Core" "Dotbot.Core.psm1") -Force -DisableNameChecking
+$DotbotBase = Get-DotbotInstallPath
+$BotDir     = Get-DotbotProjectBotPath
+
+Import-Module (Join-Path $DotbotBase "src/cli/Platform-Functions.psm1") -Force
+Import-Module (Join-Path $DotbotBase "src/runtime/Modules/Dotbot.Theme/Dotbot.Theme.psd1") -Force -DisableNameChecking
+Import-Module (Join-Path $DotbotBase "src/runtime/Modules/Dotbot.TeamRegistry/Dotbot.TeamRegistry.psd1") -Force -DisableNameChecking
+
+if (-not (Test-Path $BotDir)) {
+    Write-DotbotError "No .bot directory found. Run 'dotbot init' first."
+    exit 1
+}
+
+try {
+    $members = Get-DotbotTeamMembers -BotRoot $BotDir
+} catch {
+    Write-DotbotError $_.Exception.Message
+    exit 1
+}
+
+Write-BlankLine
+Write-DotbotSection -Title "TEAM MEMBERS"
+
+if (-not $members -or $members.Count -eq 0) {
+    Write-DotbotCommand "(none)"
+    Write-BlankLine
+    return
+}
+
+foreach ($m in $members) {
+    $role = if ([string]::IsNullOrWhiteSpace($m.role)) { '<none>' } else { [string]$m.role }
+    # ConvertFrom-Json -AsHashtable auto-parses ISO strings to [DateTime].
+    # Render back as UTC ISO so the CLI matches the on-disk format.
+    $addedAt = if ($m.created_at -is [DateTime]) {
+        $m.created_at.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
+    } else {
+        [string]$m.created_at
+    }
+    Write-DotbotLabel -Label $([string]$m.name).PadRight(24) -Value $role -ValueType Info
+    Write-DotbotCommand "$(' ' * 24)id: $($m.id) · added: $addedAt"
+}
+
+Write-BlankLine

--- a/src/cli/team-list.ps1
+++ b/src/cli/team-list.ps1
@@ -46,6 +46,7 @@ foreach ($m in $members) {
         [string]$m.created_at
     }
     Write-DotbotLabel -Label $([string]$m.name).PadRight(24) -Value $role -ValueType Info
+    Write-DotbotCommand "$(' ' * 24)$([string]$m.email)"
     Write-DotbotCommand "$(' ' * 24)id: $($m.id) · added: $addedAt"
 }
 

--- a/src/runtime/Modules/Dotbot.TeamRegistry/Dotbot.TeamRegistry.psd1
+++ b/src/runtime/Modules/Dotbot.TeamRegistry/Dotbot.TeamRegistry.psd1
@@ -1,0 +1,21 @@
+@{
+    RootModule        = 'Dotbot.TeamRegistry.psm1'
+    ModuleVersion     = '1.0.0'
+    GUID              = '7c9e4a2f-3d5b-4e8c-b1a6-9f2d8e0a7b12'
+    Author            = 'dotbot contributors'
+    Description       = 'Sole writer of the workspace team registry (.bot/workspace/team-registry.json). Provides read/add/get + schema validation for team members.'
+    PowerShellVersion = '7.0'
+
+    FunctionsToExport = @(
+        'Get-DotbotTeamRegistryPath'
+        'Read-DotbotTeamRegistry'
+        'Assert-DotbotTeamMember'
+        'Add-DotbotTeamMember'
+        'Get-DotbotTeamMembers'
+        'Get-DotbotTeamMember'
+    )
+
+    CmdletsToExport   = @()
+    VariablesToExport = @()
+    AliasesToExport   = @()
+}

--- a/src/runtime/Modules/Dotbot.TeamRegistry/Dotbot.TeamRegistry.psm1
+++ b/src/runtime/Modules/Dotbot.TeamRegistry/Dotbot.TeamRegistry.psm1
@@ -1,0 +1,250 @@
+<#
+.SYNOPSIS
+Dotbot team registry — sole writer of .bot/workspace/team-registry.json.
+
+Registry shape (schema_version = 1):
+    {
+      "schema_version": 1,
+      "members": [
+        { "id": "tm_XXXXXXXX", "name": "...", "role": "...",
+          "created_at": "RFC3339-Z", "created_by": "cli|api|..." }
+      ]
+    }
+
+Writers use atomic temp-file rename so concurrent readers never see a
+half-written file. All CLI + future MCP surfaces should go through this
+module rather than touching the JSON directly.
+#>
+
+$script:SCHEMA_VERSION = 1
+$script:NAME_REGEX     = '^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$'
+$script:ID_ALPHABET    = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+$script:ID_LENGTH      = 8
+$script:ID_PREFIX      = 'tm_'
+
+function Get-DotbotTeamRegistryPath {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$BotRoot)
+    return (Join-Path (Join-Path $BotRoot 'workspace') 'team-registry.json')
+}
+
+function _New-TeamMemberId {
+    # CSRNG rejection sampling over a 62-char alphabet for uniform distribution.
+    # Threshold = floor(256 / 62) * 62 = 248. Bytes >= 248 are discarded.
+    $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+    try {
+        $sb  = [System.Text.StringBuilder]::new($script:ID_LENGTH)
+        $buf = [byte[]]::new(1)
+        while ($sb.Length -lt $script:ID_LENGTH) {
+            $rng.GetBytes($buf)
+            if ($buf[0] -lt 248) {
+                [void]$sb.Append($script:ID_ALPHABET[$buf[0] % $script:ID_ALPHABET.Length])
+            }
+        }
+        return "$($script:ID_PREFIX)$($sb.ToString())"
+    } finally {
+        $rng.Dispose()
+    }
+}
+
+function _Write-TeamRegistryJsonAtomic {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)]$Object
+    )
+    $dir = Split-Path -Parent $Path
+    if ($dir -and -not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    $tmp = "$Path.tmp"
+    $Object | ConvertTo-Json -Depth 10 | Set-Content -Path $tmp -Encoding utf8NoBOM
+    Move-Item -LiteralPath $tmp -Destination $Path -Force
+}
+
+function _New-EmptyRegistry {
+    return [ordered]@{
+        schema_version = $script:SCHEMA_VERSION
+        members        = @()
+    }
+}
+
+function Read-DotbotTeamRegistry {
+    <#
+    .SYNOPSIS
+    Read the team registry. Returns an empty envelope if the file is missing.
+
+    .PARAMETER BotRoot
+    Path to the project's .bot directory.
+
+    .OUTPUTS
+    Hashtable: @{ schema_version = <int>; members = <array of hashtables> }
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$BotRoot)
+
+    $path = Get-DotbotTeamRegistryPath -BotRoot $BotRoot
+    if (-not (Test-Path -LiteralPath $path)) {
+        return _New-EmptyRegistry
+    }
+
+    try {
+        $raw = Get-Content -LiteralPath $path -Raw -ErrorAction Stop
+    } catch {
+        throw "Team registry at '$path' could not be read: $($_.Exception.Message)"
+    }
+
+    try {
+        $parsed = $raw | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+    } catch {
+        throw "Team registry at '$path' is not valid JSON: $($_.Exception.Message)"
+    }
+
+    if ($null -eq $parsed) { return _New-EmptyRegistry }
+
+    if (-not $parsed.Contains('schema_version')) {
+        throw "Team registry at '$path' is missing schema_version."
+    }
+    if ($parsed.schema_version -ne $script:SCHEMA_VERSION) {
+        throw "Team registry at '$path' has schema_version=$($parsed.schema_version); this build understands only version $($script:SCHEMA_VERSION)."
+    }
+    if (-not $parsed.Contains('members') -or $null -eq $parsed.members) {
+        $parsed.members = @()
+    }
+
+    return $parsed
+}
+
+function Assert-DotbotTeamMember {
+    <#
+    .SYNOPSIS
+    Validate a member instance. Throws with an actionable message on failure.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)]$Member)
+
+    foreach ($required in @('id', 'name', 'created_at', 'created_by')) {
+        if (-not $Member.Contains($required) -or [string]::IsNullOrWhiteSpace([string]$Member[$required])) {
+            throw "Team member is missing required field '$required'."
+        }
+    }
+
+    if ([string]$Member.name -notmatch $script:NAME_REGEX) {
+        throw "Team member name '$($Member.name)' is invalid. Names must match: $($script:NAME_REGEX) (start with alphanumeric; 1-64 chars; letters, digits, dot, dash, underscore)."
+    }
+
+    if ($Member.Contains('role') -and $null -ne $Member.role -and $Member.role -isnot [string]) {
+        throw "Team member 'role' must be a string or null; got: $($Member.role.GetType().Name)."
+    }
+}
+
+function _Find-TeamMemberIndex {
+    param(
+        [Parameter(Mandatory)]$Registry,
+        [Parameter(Mandatory)][string]$Name
+    )
+    $needle = $Name.ToLowerInvariant()
+    for ($i = 0; $i -lt $Registry.members.Count; $i++) {
+        $m = $Registry.members[$i]
+        if ([string]$m.name -and ([string]$m.name).ToLowerInvariant() -eq $needle) {
+            return $i
+        }
+    }
+    return -1
+}
+
+function Add-DotbotTeamMember {
+    <#
+    .SYNOPSIS
+    Persist a new team member to the workspace registry.
+
+    .DESCRIPTION
+    Reads the registry, rejects duplicate names (case-insensitive),
+    validates the new member, and writes atomically. Returns the newly
+    created member on success.
+
+    .PARAMETER BotRoot
+    Path to the project's .bot directory.
+
+    .PARAMETER Name
+    Case-preserving unique identifier for the member.
+
+    .PARAMETER Role
+    Optional role string.
+
+    .PARAMETER CreatedBy
+    Origin of the request. Defaults to 'cli'.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$BotRoot,
+        [Parameter(Mandatory)][string]$Name,
+        [string]$Role,
+        [string]$CreatedBy = 'cli'
+    )
+
+    if ($Name -notmatch $script:NAME_REGEX) {
+        throw "Invalid name '$Name'. Names must match: $($script:NAME_REGEX) (start with alphanumeric; 1-64 chars; letters, digits, dot, dash, underscore)."
+    }
+
+    $registry = Read-DotbotTeamRegistry -BotRoot $BotRoot
+    $existingIdx = _Find-TeamMemberIndex -Registry $registry -Name $Name
+    if ($existingIdx -ge 0) {
+        $existing = $registry.members[$existingIdx]
+        throw "Team member '$Name' already exists (id: $($existing.id)). Names are case-insensitive; a follow-up ticket will add 'dotbot team update'."
+    }
+
+    $member = [ordered]@{
+        id         = _New-TeamMemberId
+        name       = $Name
+        role       = if ([string]::IsNullOrWhiteSpace($Role)) { $null } else { $Role }
+        created_at = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
+        created_by = $CreatedBy
+    }
+
+    Assert-DotbotTeamMember -Member $member
+
+    $registry.members = @($registry.members) + @($member)
+
+    $path = Get-DotbotTeamRegistryPath -BotRoot $BotRoot
+    _Write-TeamRegistryJsonAtomic -Path $path -Object $registry
+
+    return $member
+}
+
+function Get-DotbotTeamMembers {
+    <#
+    .SYNOPSIS
+    Return all team members as an array (possibly empty).
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$BotRoot)
+
+    $registry = Read-DotbotTeamRegistry -BotRoot $BotRoot
+    return @($registry.members)
+}
+
+function Get-DotbotTeamMember {
+    <#
+    .SYNOPSIS
+    Return a single team member by name (case-insensitive) or $null.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$BotRoot,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    $registry = Read-DotbotTeamRegistry -BotRoot $BotRoot
+    $idx = _Find-TeamMemberIndex -Registry $registry -Name $Name
+    if ($idx -lt 0) { return $null }
+    return $registry.members[$idx]
+}
+
+Export-ModuleMember -Function @(
+    'Get-DotbotTeamRegistryPath'
+    'Read-DotbotTeamRegistry'
+    'Assert-DotbotTeamMember'
+    'Add-DotbotTeamMember'
+    'Get-DotbotTeamMembers'
+    'Get-DotbotTeamMember'
+)

--- a/src/runtime/Modules/Dotbot.TeamRegistry/Dotbot.TeamRegistry.psm1
+++ b/src/runtime/Modules/Dotbot.TeamRegistry/Dotbot.TeamRegistry.psm1
@@ -1,31 +1,44 @@
 <#
 .SYNOPSIS
-Dotbot team registry — sole writer of .bot/workspace/team-registry.json.
+Dotbot team registry — sole writer of .bot/team-registry.json.
 
 Registry shape (schema_version = 1):
     {
       "schema_version": 1,
       "members": [
-        { "id": "tm_XXXXXXXX", "name": "...", "role": "...",
+        { "id": "tm_XXXXXXXX", "name": "...", "email": "...",
+          "role": "developer|lead|reviewer|qa",
           "created_at": "RFC3339-Z", "created_by": "cli|api|..." }
       ]
     }
 
-Writers use atomic temp-file rename so concurrent readers never see a
-half-written file. All CLI + future MCP surfaces should go through this
-module rather than touching the JSON directly.
+Writers hold a named-mutex lock around the full read-modify-write cycle so
+concurrent `dotbot team add` invocations can't lose each other's writes.
+Atomic temp-file rename on top prevents readers from seeing a torn file.
+
+`id` generation contract: `tm_` + 8 characters uniform-drawn from the
+62-char alphabet [0-9a-zA-Z] via System.Security.Cryptography.RandomNumberGenerator
+with rejection sampling. Collision domain is 62**8 ≈ 2.18e14 — safe for any
+plausible team size. See _New-TeamMemberId + the collision retry in
+Add-DotbotTeamMember for the belt-and-suspenders check.
+
+All CLI + future MCP surfaces should go through this module rather than
+touching the JSON directly.
 #>
 
 $script:SCHEMA_VERSION = 1
 $script:NAME_REGEX     = '^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$'
+$script:EMAIL_REGEX    = '^[^@\s]+@[^@\s]+\.[^@\s]+$'
+$script:VALID_ROLES    = @('developer', 'lead', 'reviewer', 'qa')
 $script:ID_ALPHABET    = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 $script:ID_LENGTH      = 8
 $script:ID_PREFIX      = 'tm_'
+$script:LOCK_TIMEOUT_MS = 5000
 
 function Get-DotbotTeamRegistryPath {
     [CmdletBinding()]
     param([Parameter(Mandatory)][string]$BotRoot)
-    return (Join-Path (Join-Path $BotRoot 'workspace') 'team-registry.json')
+    return (Join-Path $BotRoot 'team-registry.json')
 }
 
 function _New-TeamMemberId {
@@ -66,6 +79,58 @@ function _New-EmptyRegistry {
         schema_version = $script:SCHEMA_VERSION
         members        = @()
     }
+}
+
+function _Acquire-TeamRegistryLock {
+    <#
+    .SYNOPSIS
+    Acquire a cross-process lock keyed on the registry file's absolute path.
+
+    .DESCRIPTION
+    Uses a named System.Threading.Mutex so two concurrent dotbot processes on
+    the same machine serialize their read-modify-write cycles. Returns the
+    mutex; caller must release with _Release-TeamRegistryLock.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$BotRoot,
+        [int]$TimeoutMs = $script:LOCK_TIMEOUT_MS
+    )
+    $path = Get-DotbotTeamRegistryPath -BotRoot $BotRoot
+    try {
+        $abs = [System.IO.Path]::GetFullPath($path)
+    } catch {
+        $abs = $path
+    }
+    # Hash the path so the mutex name is stable, safe (no path chars),
+    # and short enough for Global\ namespace.
+    $hasher = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $hashBytes = $hasher.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($abs.ToLowerInvariant()))
+        $hashHex   = -join ($hashBytes | ForEach-Object { $_.ToString('x2') })
+    } finally {
+        $hasher.Dispose()
+    }
+    $mutexName = "Global\dotbot-team-registry-$($hashHex.Substring(0, 16))"
+
+    $mutex = [System.Threading.Mutex]::new($false, $mutexName)
+    try {
+        if (-not $mutex.WaitOne($TimeoutMs)) {
+            $mutex.Dispose()
+            throw "Timed out waiting for team registry lock ($TimeoutMs ms). Another dotbot process may be adding a member."
+        }
+    } catch [System.Threading.AbandonedMutexException] {
+        # Prior owner crashed without releasing. WaitOne throws but we now
+        # hold the mutex — safe to proceed since we're about to overwrite
+        # the file atomically anyway.
+        $null = $_
+    }
+    return $mutex
+}
+
+function _Release-TeamRegistryLock {
+    param([Parameter(Mandatory)]$Lock)
+    try { $Lock.ReleaseMutex() } catch { $null = $_ }
+    try { $Lock.Dispose() }      catch { $null = $_ }
 }
 
 function Read-DotbotTeamRegistry {
@@ -122,7 +187,7 @@ function Assert-DotbotTeamMember {
     [CmdletBinding()]
     param([Parameter(Mandatory)]$Member)
 
-    foreach ($required in @('id', 'name', 'created_at', 'created_by')) {
+    foreach ($required in @('id', 'name', 'email', 'created_at', 'created_by')) {
         if (-not $Member.Contains($required) -or [string]::IsNullOrWhiteSpace([string]$Member[$required])) {
             throw "Team member is missing required field '$required'."
         }
@@ -132,8 +197,14 @@ function Assert-DotbotTeamMember {
         throw "Team member name '$($Member.name)' is invalid. Names must match: $($script:NAME_REGEX) (start with alphanumeric; 1-64 chars; letters, digits, dot, dash, underscore)."
     }
 
-    if ($Member.Contains('role') -and $null -ne $Member.role -and $Member.role -isnot [string]) {
-        throw "Team member 'role' must be a string or null; got: $($Member.role.GetType().Name)."
+    if ([string]$Member.email -notmatch $script:EMAIL_REGEX) {
+        throw "Team member email '$($Member.email)' is invalid. Expected a basic 'user@domain.tld' shape."
+    }
+
+    if ($Member.Contains('role') -and $null -ne $Member.role -and -not [string]::IsNullOrWhiteSpace([string]$Member.role)) {
+        if ([string]$Member.role -notin $script:VALID_ROLES) {
+            throw "Invalid role '$($Member.role)'. Must be one of: $($script:VALID_ROLES -join ', ')."
+        }
     }
 }
 
@@ -158,9 +229,12 @@ function Add-DotbotTeamMember {
     Persist a new team member to the workspace registry.
 
     .DESCRIPTION
-    Reads the registry, rejects duplicate names (case-insensitive),
-    validates the new member, and writes atomically. Returns the newly
-    created member on success.
+    Read-modify-write is serialized under a named mutex keyed to the registry
+    path so concurrent `dotbot team add` calls can't clobber each other. The
+    write itself is a temp-file rename so readers never see a torn file.
+
+    Rejects duplicate names (case-insensitive) and invalid role / email
+    values. Returns the newly created member on success.
 
     .PARAMETER BotRoot
     Path to the project's .bot directory.
@@ -168,8 +242,11 @@ function Add-DotbotTeamMember {
     .PARAMETER Name
     Case-preserving unique identifier for the member.
 
+    .PARAMETER Email
+    Contact address for downstream Q&A routing (#632/#600/#609). Required.
+
     .PARAMETER Role
-    Optional role string.
+    Optional role — must be one of: developer, lead, reviewer, qa.
 
     .PARAMETER CreatedBy
     Origin of the request. Defaults to 'cli'.
@@ -178,6 +255,7 @@ function Add-DotbotTeamMember {
     param(
         [Parameter(Mandatory)][string]$BotRoot,
         [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Email,
         [string]$Role,
         [string]$CreatedBy = 'cli'
     )
@@ -185,30 +263,48 @@ function Add-DotbotTeamMember {
     if ($Name -notmatch $script:NAME_REGEX) {
         throw "Invalid name '$Name'. Names must match: $($script:NAME_REGEX) (start with alphanumeric; 1-64 chars; letters, digits, dot, dash, underscore)."
     }
-
-    $registry = Read-DotbotTeamRegistry -BotRoot $BotRoot
-    $existingIdx = _Find-TeamMemberIndex -Registry $registry -Name $Name
-    if ($existingIdx -ge 0) {
-        $existing = $registry.members[$existingIdx]
-        throw "Team member '$Name' already exists (id: $($existing.id)). Names are case-insensitive; a follow-up ticket will add 'dotbot team update'."
+    if ($Email -notmatch $script:EMAIL_REGEX) {
+        throw "Invalid email '$Email'. Expected 'user@domain.tld' shape."
+    }
+    if (-not [string]::IsNullOrWhiteSpace($Role) -and $Role -notin $script:VALID_ROLES) {
+        throw "Invalid role '$Role'. Must be one of: $($script:VALID_ROLES -join ', ')."
     }
 
-    $member = [ordered]@{
-        id         = _New-TeamMemberId
-        name       = $Name
-        role       = if ([string]::IsNullOrWhiteSpace($Role)) { $null } else { $Role }
-        created_at = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
-        created_by = $CreatedBy
+    $lock = _Acquire-TeamRegistryLock -BotRoot $BotRoot
+    try {
+        $registry = Read-DotbotTeamRegistry -BotRoot $BotRoot
+        $existingIdx = _Find-TeamMemberIndex -Registry $registry -Name $Name
+        if ($existingIdx -ge 0) {
+            $existing = $registry.members[$existingIdx]
+            throw "Team member '$Name' already exists (id: $($existing.id)). Names are case-insensitive; a follow-up ticket will add 'dotbot team update'."
+        }
+
+        # Belt-and-suspenders: re-draw id on the astronomically unlikely
+        # collision with an existing member. Collision domain is 62^8 ≈ 2e14.
+        $existingIds = @{}
+        foreach ($m in $registry.members) { if ($m.id) { $existingIds[$m.id] = $true } }
+        do { $newId = _New-TeamMemberId } while ($existingIds.Contains($newId))
+
+        $member = [ordered]@{
+            id         = $newId
+            name       = $Name
+            email      = $Email
+            role       = if ([string]::IsNullOrWhiteSpace($Role)) { $null } else { $Role }
+            created_at = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
+            created_by = $CreatedBy
+        }
+
+        Assert-DotbotTeamMember -Member $member
+
+        $registry.members = @($registry.members) + @($member)
+
+        $path = Get-DotbotTeamRegistryPath -BotRoot $BotRoot
+        _Write-TeamRegistryJsonAtomic -Path $path -Object $registry
+
+        return $member
+    } finally {
+        _Release-TeamRegistryLock -Lock $lock
     }
-
-    Assert-DotbotTeamMember -Member $member
-
-    $registry.members = @($registry.members) + @($member)
-
-    $path = Get-DotbotTeamRegistryPath -BotRoot $BotRoot
-    _Write-TeamRegistryJsonAtomic -Path $path -Object $registry
-
-    return $member
 }
 
 function Get-DotbotTeamMembers {

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -165,8 +165,9 @@ if (2 -in $layersToRun) {
     $studioAPICode           = Invoke-TestFile -Layer '2' -FileName 'Test-StudioAPI.ps1'
     $toolLocalCode           = Invoke-TestFile -Layer '2' -FileName 'Test-ToolLocal.ps1'
     $mcpHandshakeCode        = Invoke-TestFile -Layer '2' -FileName 'Test-MCPHandshake.ps1'
+    $teamRegistryCode        = Invoke-TestFile -Layer '2' -FileName 'Test-TeamRegistry.ps1'
 
-    $exitCode = if ($componentsCode -ne 0 -or $taskActionsCode -ne 0 -or $serverStartupCode -ne 0 -or $workflowIntegrationCode -ne 0 -or $processRegistryCode -ne 0 -or $processDispatchCode -ne 0 -or $studioAPICode -ne 0 -or $toolLocalCode -ne 0 -or $mcpHandshakeCode -ne 0) { 1 } else { 0 }
+    $exitCode = if ($componentsCode -ne 0 -or $taskActionsCode -ne 0 -or $serverStartupCode -ne 0 -or $workflowIntegrationCode -ne 0 -or $processRegistryCode -ne 0 -or $processDispatchCode -ne 0 -or $studioAPICode -ne 0 -or $toolLocalCode -ne 0 -or $mcpHandshakeCode -ne 0 -or $teamRegistryCode -ne 0) { 1 } else { 0 }
     $layerResults["2"] = ($exitCode -eq 0)
     if ($exitCode -ne 0) { $overallFailed = $true }
 }

--- a/tests/Test-TeamRegistry.ps1
+++ b/tests/Test-TeamRegistry.ps1
@@ -1,0 +1,201 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Layer 2: Dotbot.TeamRegistry module + CLI smoke coverage.
+.DESCRIPTION
+    Exercises the workspace team registry (.bot/workspace/team-registry.json):
+      - Read on missing file returns an empty envelope
+      - Add creates the file with schema_version=1 and one entry
+      - Add rejects duplicate names case-insensitively
+      - Add rejects invalid names
+      - Get and List round-trip
+      - Schema-version mismatch on read throws
+      - Atomic write leaves no .tmp file behind
+    Plus a CLI smoke pass invoking the three scripts via pwsh to verify wiring.
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3.0
+
+Import-Module "$PSScriptRoot\Test-Helpers.psm1" -Force
+
+$repoRoot = Get-RepoRoot
+
+Write-Host ""
+Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Blue
+Write-Host "  Team Registry" -ForegroundColor Blue
+Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Blue
+Write-Host ""
+
+Reset-TestResults
+
+Import-Module (Join-Path $repoRoot "src/runtime/Modules/Dotbot.TeamRegistry/Dotbot.TeamRegistry.psd1") -Force -DisableNameChecking -Global
+
+# Local test scaffolding — same shape as Test-Runtime.ps1's helper.
+function New-TestBotRoot {
+    $base = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-team-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+    $bot  = Join-Path $base '.bot'
+    New-Item -ItemType Directory -Path $bot | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $bot '.control') | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $bot 'workspace') | Out-Null
+    return $bot
+}
+
+function Remove-TestBotRoot {
+    param([Parameter(Mandatory)][string]$BotRoot)
+    $project = Split-Path -Parent $BotRoot
+    try { Remove-Item -Recurse -Force $project } catch { $null = $_ }
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Module: read path (missing / valid / malformed / schema mismatch)
+# ═══════════════════════════════════════════════════════════════════════════
+
+Write-Host "  Module: read behavior" -ForegroundColor Cyan
+Write-Host "  ──────────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$bot = New-TestBotRoot
+try {
+    $reg = Read-DotbotTeamRegistry -BotRoot $bot
+    Assert-Equal -Name "Missing-file read returns schema_version = 1"      -Expected 1 -Actual $reg.schema_version
+    Assert-Equal -Name "Missing-file read returns an empty members array"  -Expected 0 -Actual @($reg.members).Count
+
+    $path = Get-DotbotTeamRegistryPath -BotRoot $bot
+    Assert-Equal -Name "Registry path lands under workspace/" `
+        -Expected (Join-Path (Join-Path $bot 'workspace') 'team-registry.json') `
+        -Actual   $path
+    Assert-True  -Name "Missing-file read does NOT create the file" -Condition (-not (Test-Path -LiteralPath $path))
+
+    # Malformed JSON should throw
+    New-Item -ItemType Directory -Path (Split-Path -Parent $path) -Force | Out-Null
+    Set-Content -Path $path -Value '{ not json' -Encoding utf8NoBOM
+    $threw = $false
+    try { Read-DotbotTeamRegistry -BotRoot $bot } catch { $threw = $true }
+    Assert-True -Name "Malformed JSON throws from Read-DotbotTeamRegistry" -Condition $threw
+
+    # Schema-version mismatch should throw
+    Set-Content -Path $path -Value '{"schema_version":999,"members":[]}' -Encoding utf8NoBOM
+    $threw = $false
+    try { Read-DotbotTeamRegistry -BotRoot $bot } catch { $threw = $true }
+    Assert-True -Name "Unknown schema_version throws from Read-DotbotTeamRegistry" -Condition $threw
+} finally {
+    Remove-TestBotRoot -BotRoot $bot
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Module: add / list / get happy path
+# ═══════════════════════════════════════════════════════════════════════════
+
+Write-Host ""
+Write-Host "  Module: add / list / get" -ForegroundColor Cyan
+Write-Host "  ──────────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$bot = New-TestBotRoot
+try {
+    $m1 = Add-DotbotTeamMember -BotRoot $bot -Name 'ana-smith' -Role 'developer'
+    Assert-Equal -Name "Add returns member with the requested name"                 -Expected 'ana-smith' -Actual $m1.name
+    Assert-Equal -Name "Add returns member with the requested role"                 -Expected 'developer' -Actual $m1.role
+    Assert-True  -Name "Add returns id with 'tm_' prefix + 8 chars"                 -Condition ($m1.id -match '^tm_[A-Za-z0-9]{8}$')
+    Assert-True  -Name "Add stamps created_at with an RFC3339-Z-ish string"         -Condition ($m1.created_at -match '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$')
+    Assert-Equal -Name "Add stamps created_by = 'cli' by default"                   -Expected 'cli' -Actual $m1.created_by
+
+    $path = Get-DotbotTeamRegistryPath -BotRoot $bot
+    Assert-True -Name "Add writes the registry file"       -Condition (Test-Path -LiteralPath $path)
+    Assert-True -Name "Atomic write leaves no .tmp behind" -Condition (-not (Test-Path -LiteralPath "$path.tmp"))
+
+    # Second add — different name, appends.
+    $m2 = Add-DotbotTeamMember -BotRoot $bot -Name 'ben' -Role 'reviewer'
+    $members = Get-DotbotTeamMembers -BotRoot $bot
+    Assert-Equal -Name "List after two adds returns two members" -Expected 2 -Actual @($members).Count
+    Assert-True  -Name "List preserves insertion order"          -Condition ($members[0].name -eq 'ana-smith' -and $members[1].name -eq 'ben')
+
+    # Get — case-insensitive
+    $lookup = Get-DotbotTeamMember -BotRoot $bot -Name 'ANA-SMITH'
+    Assert-True  -Name "Get is case-insensitive"                            -Condition ($null -ne $lookup)
+    Assert-Equal -Name "Get returns the correct member (case-insensitive)"  -Expected $m1.id -Actual $lookup.id
+
+    Assert-True -Name "Get on missing name returns \$null" -Condition ($null -eq (Get-DotbotTeamMember -BotRoot $bot -Name 'nobody'))
+
+    # Omitted --role → role is $null (not an empty string)
+    $m3 = Add-DotbotTeamMember -BotRoot $bot -Name 'no-role-user'
+    Assert-True -Name "Add without --role stores role as null" -Condition ($null -eq $m3.role)
+} finally {
+    Remove-TestBotRoot -BotRoot $bot
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Module: rejection cases (duplicates + malformed inputs)
+# ═══════════════════════════════════════════════════════════════════════════
+
+Write-Host ""
+Write-Host "  Module: rejection cases" -ForegroundColor Cyan
+Write-Host "  ──────────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$bot = New-TestBotRoot
+try {
+    Add-DotbotTeamMember -BotRoot $bot -Name 'ana' -Role 'developer' | Out-Null
+
+    # Exact-case duplicate
+    $threw = $false; $err = ''
+    try { Add-DotbotTeamMember -BotRoot $bot -Name 'ana' } catch { $threw = $true; $err = $_.Exception.Message }
+    Assert-True -Name "Duplicate name (same case) throws"                              -Condition $threw
+    Assert-True -Name "Duplicate error mentions the offending name"                    -Condition ($err -match 'ana')
+
+    # Case-insensitive duplicate
+    $threw = $false
+    try { Add-DotbotTeamMember -BotRoot $bot -Name 'ANA' } catch { $threw = $true }
+    Assert-True -Name "Duplicate name (different case) throws"                         -Condition $threw
+
+    # Invalid name — starts with dash
+    $threw = $false
+    try { Add-DotbotTeamMember -BotRoot $bot -Name '-invalid' } catch { $threw = $true }
+    Assert-True -Name "Name starting with '-' is rejected"                             -Condition $threw
+
+    # Invalid name — spaces
+    $threw = $false
+    try { Add-DotbotTeamMember -BotRoot $bot -Name 'has space' } catch { $threw = $true }
+    Assert-True -Name "Name containing spaces is rejected"                             -Condition $threw
+
+    # Assert-DotbotTeamMember on incomplete input
+    $threw = $false
+    try {
+        Assert-DotbotTeamMember -Member @{ name = 'x' }  # missing id, created_at, created_by
+    } catch { $threw = $true }
+    Assert-True -Name "Assert-DotbotTeamMember rejects a member missing required fields" -Condition $threw
+} finally {
+    Remove-TestBotRoot -BotRoot $bot
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CLI smoke: syntax check + dispatch (parses each script, no execution)
+# ═══════════════════════════════════════════════════════════════════════════
+
+Write-Host ""
+Write-Host "  CLI: script parses + declares expected params" -ForegroundColor Cyan
+Write-Host "  ──────────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$cliDir  = Join-Path $repoRoot 'src/cli'
+$scripts = @('team-add.ps1', 'team-list.ps1', 'team-get.ps1')
+
+foreach ($s in $scripts) {
+    $path = Join-Path $cliDir $s
+    Assert-True -Name "CLI script exists: $s" -Condition (Test-Path -LiteralPath $path)
+
+    # Parse the script — Layer 1 handles broader syntax, but for these
+    # specific files we want a fast, in-suite check.
+    $tokens = $null; $errors = $null
+    [void][System.Management.Automation.Language.Parser]::ParseFile($path, [ref]$tokens, [ref]$errors)
+    Assert-Equal -Name "CLI script parses without errors: $s" -Expected 0 -Actual @($errors).Count
+}
+
+# Verify the dispatcher branch in bin/dotbot.ps1 references the team scripts.
+$dispatcher = Get-Content -LiteralPath (Join-Path $repoRoot 'bin/dotbot.ps1') -Raw
+Assert-True -Name "Dispatcher registers 'team' command" -Condition ($dispatcher -match '"team"\s*\{\s*Invoke-Team\s*\}')
+Assert-True -Name "Dispatcher defines Invoke-Team"      -Condition ($dispatcher -match 'function\s+Invoke-Team')
+
+Write-TestSummary -LayerName "TeamRegistry"
+
+if ((Get-TestResults).Failed -gt 0) { exit 1 } else { exit 0 }

--- a/tests/Test-TeamRegistry.ps1
+++ b/tests/Test-TeamRegistry.ps1
@@ -3,15 +3,18 @@
 .SYNOPSIS
     Layer 2: Dotbot.TeamRegistry module + CLI smoke coverage.
 .DESCRIPTION
-    Exercises the workspace team registry (.bot/workspace/team-registry.json):
+    Exercises the team registry (.bot/team-registry.json):
       - Read on missing file returns an empty envelope
       - Add creates the file with schema_version=1 and one entry
+      - Email is required; invalid email is rejected
+      - Role is optional; must be one of {developer,lead,reviewer,qa}
       - Add rejects duplicate names case-insensitively
       - Add rejects invalid names
-      - Get and List round-trip
+      - Get and List round-trip; get is case-insensitive
       - Schema-version mismatch on read throws
       - Atomic write leaves no .tmp file behind
-    Plus a CLI smoke pass invoking the three scripts via pwsh to verify wiring.
+      - Concurrent adds are serialized under the file-scoped mutex — no lost writes
+    Plus a CLI smoke pass parsing each script + verifying the dispatcher wiring.
 #>
 
 [CmdletBinding()]
@@ -40,7 +43,6 @@ function New-TestBotRoot {
     $bot  = Join-Path $base '.bot'
     New-Item -ItemType Directory -Path $bot | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $bot '.control') | Out-Null
-    New-Item -ItemType Directory -Path (Join-Path $bot 'workspace') | Out-Null
     return $bot
 }
 
@@ -64,13 +66,12 @@ try {
     Assert-Equal -Name "Missing-file read returns an empty members array"  -Expected 0 -Actual @($reg.members).Count
 
     $path = Get-DotbotTeamRegistryPath -BotRoot $bot
-    Assert-Equal -Name "Registry path lands under workspace/" `
-        -Expected (Join-Path (Join-Path $bot 'workspace') 'team-registry.json') `
+    Assert-Equal -Name "Registry path lands directly under .bot/" `
+        -Expected (Join-Path $bot 'team-registry.json') `
         -Actual   $path
     Assert-True  -Name "Missing-file read does NOT create the file" -Condition (-not (Test-Path -LiteralPath $path))
 
     # Malformed JSON should throw
-    New-Item -ItemType Directory -Path (Split-Path -Parent $path) -Force | Out-Null
     Set-Content -Path $path -Value '{ not json' -Encoding utf8NoBOM
     $threw = $false
     try { Read-DotbotTeamRegistry -BotRoot $bot } catch { $threw = $true }
@@ -95,9 +96,10 @@ Write-Host "  ──────────────────────
 
 $bot = New-TestBotRoot
 try {
-    $m1 = Add-DotbotTeamMember -BotRoot $bot -Name 'ana-smith' -Role 'developer'
-    Assert-Equal -Name "Add returns member with the requested name"                 -Expected 'ana-smith' -Actual $m1.name
-    Assert-Equal -Name "Add returns member with the requested role"                 -Expected 'developer' -Actual $m1.role
+    $m1 = Add-DotbotTeamMember -BotRoot $bot -Name 'ana-smith' -Email 'ana@example.com' -Role 'developer'
+    Assert-Equal -Name "Add returns member with the requested name"                 -Expected 'ana-smith'      -Actual $m1.name
+    Assert-Equal -Name "Add returns member with the requested email"                -Expected 'ana@example.com' -Actual $m1.email
+    Assert-Equal -Name "Add returns member with the requested role"                 -Expected 'developer'      -Actual $m1.role
     Assert-True  -Name "Add returns id with 'tm_' prefix + 8 chars"                 -Condition ($m1.id -match '^tm_[A-Za-z0-9]{8}$')
     Assert-True  -Name "Add stamps created_at with an RFC3339-Z-ish string"         -Condition ($m1.created_at -match '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$')
     Assert-Equal -Name "Add stamps created_by = 'cli' by default"                   -Expected 'cli' -Actual $m1.created_by
@@ -107,7 +109,7 @@ try {
     Assert-True -Name "Atomic write leaves no .tmp behind" -Condition (-not (Test-Path -LiteralPath "$path.tmp"))
 
     # Second add — different name, appends.
-    $m2 = Add-DotbotTeamMember -BotRoot $bot -Name 'ben' -Role 'reviewer'
+    $m2 = Add-DotbotTeamMember -BotRoot $bot -Name 'ben' -Email 'ben@example.com' -Role 'reviewer'
     $members = Get-DotbotTeamMembers -BotRoot $bot
     Assert-Equal -Name "List after two adds returns two members" -Expected 2 -Actual @($members).Count
     Assert-True  -Name "List preserves insertion order"          -Condition ($members[0].name -eq 'ana-smith' -and $members[1].name -eq 'ben')
@@ -120,8 +122,50 @@ try {
     Assert-True -Name "Get on missing name returns \$null" -Condition ($null -eq (Get-DotbotTeamMember -BotRoot $bot -Name 'nobody'))
 
     # Omitted --role → role is $null (not an empty string)
-    $m3 = Add-DotbotTeamMember -BotRoot $bot -Name 'no-role-user'
+    $m3 = Add-DotbotTeamMember -BotRoot $bot -Name 'no-role-user' -Email 'no-role@example.com'
     Assert-True -Name "Add without --role stores role as null" -Condition ($null -eq $m3.role)
+} finally {
+    Remove-TestBotRoot -BotRoot $bot
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Module: email + role validation
+# ═══════════════════════════════════════════════════════════════════════════
+
+Write-Host ""
+Write-Host "  Module: email + role validation" -ForegroundColor Cyan
+Write-Host "  ──────────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$bot = New-TestBotRoot
+try {
+    # Missing email → PowerShell parameter binding rejects with a clear error
+    $threw = $false
+    try { Add-DotbotTeamMember -BotRoot $bot -Name 'ana' } catch { $threw = $true }
+    Assert-True -Name "Add without -Email throws (parameter is mandatory)" -Condition $threw
+
+    # Malformed email — module-level validation
+    foreach ($bad in @('no-at-sign', 'foo@', '@bar', 'foo bar@baz.com')) {
+        $threw = $false
+        try { Add-DotbotTeamMember -BotRoot $bot -Name "user-$([guid]::NewGuid().ToString('N').Substring(0,4))" -Email $bad } catch { $threw = $true }
+        Assert-True -Name "Malformed email is rejected: '$bad'" -Condition $threw
+    }
+
+    # Each valid role accepted
+    $validRoles = @('developer','lead','reviewer','qa')
+    for ($i = 0; $i -lt $validRoles.Count; $i++) {
+        $r = $validRoles[$i]
+        $m = Add-DotbotTeamMember -BotRoot $bot -Name "role-user-$i" -Email "role$i@example.com" -Role $r
+        Assert-Equal -Name "Role '$r' is accepted" -Expected $r -Actual $m.role
+    }
+
+    # Invalid roles rejected
+    foreach ($bad in @('devops', 'admin', 'Developer', 'developer ', '')) {
+        if ([string]::IsNullOrWhiteSpace($bad)) { continue }   # empty role is treated as "not set"; covered above
+        $threw = $false; $err = ''
+        try { Add-DotbotTeamMember -BotRoot $bot -Name "bad-$([guid]::NewGuid().ToString('N').Substring(0,4))" -Email 'x@example.com' -Role $bad } catch { $threw = $true; $err = $_.Exception.Message }
+        Assert-True -Name "Invalid role rejected: '$bad'"                    -Condition $threw
+        Assert-True -Name "Invalid-role error names the allowed roles: '$bad'" -Condition ($err -match 'developer' -and $err -match 'qa')
+    }
 } finally {
     Remove-TestBotRoot -BotRoot $bot
 }
@@ -136,35 +180,92 @@ Write-Host "  ──────────────────────
 
 $bot = New-TestBotRoot
 try {
-    Add-DotbotTeamMember -BotRoot $bot -Name 'ana' -Role 'developer' | Out-Null
+    Add-DotbotTeamMember -BotRoot $bot -Name 'ana' -Email 'ana@example.com' -Role 'developer' | Out-Null
 
     # Exact-case duplicate
     $threw = $false; $err = ''
-    try { Add-DotbotTeamMember -BotRoot $bot -Name 'ana' } catch { $threw = $true; $err = $_.Exception.Message }
+    try { Add-DotbotTeamMember -BotRoot $bot -Name 'ana' -Email 'other@example.com' } catch { $threw = $true; $err = $_.Exception.Message }
     Assert-True -Name "Duplicate name (same case) throws"                              -Condition $threw
     Assert-True -Name "Duplicate error mentions the offending name"                    -Condition ($err -match 'ana')
 
     # Case-insensitive duplicate
     $threw = $false
-    try { Add-DotbotTeamMember -BotRoot $bot -Name 'ANA' } catch { $threw = $true }
+    try { Add-DotbotTeamMember -BotRoot $bot -Name 'ANA' -Email 'other@example.com' } catch { $threw = $true }
     Assert-True -Name "Duplicate name (different case) throws"                         -Condition $threw
 
     # Invalid name — starts with dash
     $threw = $false
-    try { Add-DotbotTeamMember -BotRoot $bot -Name '-invalid' } catch { $threw = $true }
+    try { Add-DotbotTeamMember -BotRoot $bot -Name '-invalid' -Email 'x@example.com' } catch { $threw = $true }
     Assert-True -Name "Name starting with '-' is rejected"                             -Condition $threw
 
     # Invalid name — spaces
     $threw = $false
-    try { Add-DotbotTeamMember -BotRoot $bot -Name 'has space' } catch { $threw = $true }
+    try { Add-DotbotTeamMember -BotRoot $bot -Name 'has space' -Email 'x@example.com' } catch { $threw = $true }
     Assert-True -Name "Name containing spaces is rejected"                             -Condition $threw
 
     # Assert-DotbotTeamMember on incomplete input
     $threw = $false
     try {
-        Assert-DotbotTeamMember -Member @{ name = 'x' }  # missing id, created_at, created_by
+        Assert-DotbotTeamMember -Member @{ name = 'x' }  # missing id, email, created_at, created_by
     } catch { $threw = $true }
     Assert-True -Name "Assert-DotbotTeamMember rejects a member missing required fields" -Condition $threw
+} finally {
+    Remove-TestBotRoot -BotRoot $bot
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Module: concurrent-add serialization (file lock exists and works)
+# ═══════════════════════════════════════════════════════════════════════════
+# Reviewer feedback on #630: atomic temp-file rename prevents corruption but
+# not lost updates. Two concurrent `dotbot team add` calls can both read the
+# registry, both append their entry, and one silently overwrites the other.
+# `Add-DotbotTeamMember` now serializes read-modify-write under a named
+# Mutex. This test spawns two add jobs racing on the same bot root and
+# asserts both entries survive.
+
+Write-Host ""
+Write-Host "  Module: concurrent adds don't lose writes" -ForegroundColor Cyan
+Write-Host "  ──────────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$bot = New-TestBotRoot
+try {
+    # Repeat a few times because a race that never fires under lock could
+    # look like a passing test on a slow machine. 5 rounds keeps the test
+    # under ~2 seconds while catching a broken lock reliably.
+    $rounds       = 5
+    $observedBoth = 0
+    for ($r = 0; $r -lt $rounds; $r++) {
+        # Wipe the registry between rounds so each round starts empty.
+        $regPath = Get-DotbotTeamRegistryPath -BotRoot $bot
+        if (Test-Path -LiteralPath $regPath) { Remove-Item -LiteralPath $regPath -Force }
+
+        $repo = $repoRoot
+        $b    = $bot
+        $suffix = "$r"
+        $job1 = Start-ThreadJob -ScriptBlock {
+            param($repo, $bot, $suffix)
+            Import-Module (Join-Path $repo 'src/runtime/Modules/Dotbot.TeamRegistry/Dotbot.TeamRegistry.psd1') -Force -DisableNameChecking
+            Add-DotbotTeamMember -BotRoot $bot -Name "racer-a-$suffix" -Email "a-$suffix@example.com" -Role 'developer' | Out-Null
+        } -ArgumentList $repo, $b, $suffix
+        $job2 = Start-ThreadJob -ScriptBlock {
+            param($repo, $bot, $suffix)
+            Import-Module (Join-Path $repo 'src/runtime/Modules/Dotbot.TeamRegistry/Dotbot.TeamRegistry.psd1') -Force -DisableNameChecking
+            Add-DotbotTeamMember -BotRoot $bot -Name "racer-b-$suffix" -Email "b-$suffix@example.com" -Role 'reviewer' | Out-Null
+        } -ArgumentList $repo, $b, $suffix
+
+        Wait-Job -Job @($job1, $job2) -Timeout 15 | Out-Null
+        Receive-Job -Job $job1 -ErrorAction SilentlyContinue | Out-Null
+        Receive-Job -Job $job2 -ErrorAction SilentlyContinue | Out-Null
+        Remove-Job  -Job @($job1, $job2) -Force -ErrorAction SilentlyContinue
+
+        $members = Get-DotbotTeamMembers -BotRoot $bot
+        $names   = @($members | ForEach-Object { [string]$_.name })
+        if ($names -contains "racer-a-$suffix" -and $names -contains "racer-b-$suffix") {
+            $observedBoth++
+        }
+    }
+    Assert-Equal -Name "Both racers persist across all rounds (no lost write under file lock)" `
+        -Expected $rounds -Actual $observedBoth
 } finally {
     Remove-TestBotRoot -BotRoot $bot
 }


### PR DESCRIPTION
## Linked issue

<!-- Every PR should close an issue. Replace the number below. -->
<!-- PRs without a linked issue will be sent back unless they're trivial. -->

Closes #630

## Summary of changes

Delivers the minimum team-registry write surface that unblocks the v4.1 human-in-the-loop chain ([#632](https://github.com/tarikcosovic97/dotbot/issues/632), [#600](https://github.com/tarikcosovic97/dotbot/issues/600), [#609](https://github.com/tarikcosovic97/dotbot/issues/609), [#586](https://github.com/tarikcosovic97/dotbot/issues/586), [#587](https://github.com/tarikcosovic97/dotbot/issues/587)). Sole writer of a new tracked file .bot/team-registry.json; three CLI commands (team add / list / get); schema validation + actionable errors. Mothership sync ([#601](https://github.com/tarikcosovic97/dotbot/issues/601)), lifecycle commands (remove/update/set-availability, role-* — [#631](https://github.com/tarikcosovic97/dotbot/issues/631)), and hosting ([#576](https://github.com/tarikcosovic97/dotbot/issues/576)) are all handled elsewhere.

Files touched:

src/runtime/Modules/Dotbot.TeamRegistry/ — new module. Sole writer of the registry file; read/add/get/assert helpers.
src/cli/team-{add,list,get}.ps1 — thin CLI wrappers over the module. Both positional and --flag argument forms supported.
bin/dotbot.ps1 — Invoke-Team dispatcher + team switch branch + help entries.
tests/Test-TeamRegistry.ps1 — Layer 2 test file registered in tests/Run-Tests.ps1.
README.md — three team commands added to the Commands table.
Registry shape (schema_version: 1):

```
{
  "schema_version": 1,
  "members": [
    { "id": "tm_a1b2c3d4",
      "name": "ana-smith",
      "email": "ana@example.com",
      "role": "developer",
      "created_at": "2026-07-17T13:00:00Z",
      "created_by": "cli" }
  ]
}
```

Reviewer feedback applied:

Path corrected to .bot/team-registry.json (directly under .bot/, git-tracked).
email is required — needed by downstream Q&A routing; basic user@domain.tld validation.
role constrained to developer | lead | reviewer | qa; invalid values rejected with a message that names the allowed set.
id generation contract documented: tm_ + 8 chars uniform-drawn from [0-9a-zA-Z] via CSRNG rejection sampling; belt-and-suspenders collision retry.
Add-DotbotTeamMember serializes read-modify-write under a named System.Threading.Mutex keyed on a hash of the registry path. Prevents lost updates from concurrent adds. Atomic temp-file rename on top guards readers from torn files.
Branch cut from releases/4.1.0, not main.
Testing notes
pwsh tests/Test-TeamRegistry.ps1        # focused
pwsh tests/Run-Tests.ps1                # full pyramid (layers 1-3)
Covers the module read/add/get/list paths, email + role validation (including case-sensitivity of role), duplicate rejection (case-insensitive), schema-version mismatch, atomic-write cleanup, and a concurrent-add race check that spawns two Start-ThreadJob racers across 5 rounds and asserts both entries survive every round. Plus CLI smoke: script parse + dispatcher wiring.

Scope note
team add / list / get only. remove / update / set-availability and role-* land in [#631](https://github.com/tarikcosovic97/dotbot/issues/631) on v4.2. Mothership sync of the local registry lives in [#601](https://github.com/tarikcosovic97/dotbot/issues/601). Deployment / hosting is documented in [#576](https://github.com/tarikcosovic97/dotbot/issues/576). This PR is intentionally minimal — the write surface downstream tickets need to exist.

## Checklist

- [x] Tests added or updated
- [x] Docs updated (if behaviour changed)
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
