### PR TITLE
fix(process): reap orphaned process tree via kill-on-close Job Object (#645)

### DIFF
--- a/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psd1
+++ b/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psd1
@@ -27,6 +27,8 @@
         'Test-WorkflowComplete'
         # Child process spawning
         'Start-DotbotChildProcess'
+        # Process-tree lifetime binding
+        'Register-DotbotKillOnCloseJob'
     )
 
     CmdletsToExport   = @()

--- a/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
+++ b/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
@@ -944,6 +944,170 @@ function Start-DotbotChildProcess {
 
 #endregion
 
+#region Kill-on-close Job Object (Windows)
+
+# Sole handle to the process's kill-on-close job, held open for the whole
+# process lifetime. IntPtr::Zero means "not bound yet". Never CloseHandle this:
+# the OS closing it on process death is precisely what reaps the subtree.
+$script:DotbotKillJobHandle = [IntPtr]::Zero
+
+function Register-DotbotKillOnCloseJob {
+    <#
+    .SYNOPSIS
+    Bind the current process's child subtree to its own lifetime via a Windows
+    kill-on-close Job Object, so an abrupt death of this process reaps every
+    descendant instead of orphaning them (#645).
+
+    .DESCRIPTION
+    Creates a Job Object with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, assigns the
+    current process to it, and keeps the sole job handle open for the process
+    lifetime. Child processes automatically inherit job membership, so when this
+    process dies -- however abruptly (console close, Stop-Process -Force, crash)
+    -- the OS closes the handle and the kernel terminates the whole subtree.
+
+    This is a belt-and-braces backstop for the in-process 'finally' cleanup in
+    the harness adapters (ClaudeCodeAdapter.ps1), which is skipped entirely on
+    abrupt termination. Graceful teardown keeps using that existing cleanup path.
+
+    Windows-only and strictly best-effort: on a non-Windows OS, or on any failure
+    (P/Invoke unavailable, incompatible existing job membership), it logs at debug
+    level and returns $false. Callers must treat $false as "not bound -- existing
+    cleanup paths still apply" and must never fail because of it.
+
+    Idempotent: a second call after a successful bind is a no-op that returns
+    $true.
+
+    .OUTPUTS
+    [bool] $true when the current process is bound to a kill-on-close job,
+    otherwise $false.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    # Job Objects are a Windows kernel construct. On Linux/macOS a force-killed
+    # parent's children re-parent to init and are reachable via pkill at teardown,
+    # so this returns $false there and the existing cleanup path stands.
+    if (-not $IsWindows) { return $false }
+    if ($script:DotbotKillJobHandle -ne [IntPtr]::Zero) { return $true }
+
+    try {
+        if (-not ('Dotbot.JobObjectNative' -as [type])) {
+            # Add-Type -MemberDefinition already injects `using System;` and
+            # `using System.Runtime.InteropServices;` -- passing -UsingNamespace
+            # for either would duplicate the directive and fail to compile (CS0105).
+            Add-Type -Namespace 'Dotbot' -Name 'JobObjectNative' -MemberDefinition @'
+[StructLayout(LayoutKind.Sequential)]
+public struct JOBOBJECT_BASIC_LIMIT_INFORMATION {
+    public long PerProcessUserTimeLimit;
+    public long PerJobUserTimeLimit;
+    public uint LimitFlags;
+    public UIntPtr MinimumWorkingSetSize;
+    public UIntPtr MaximumWorkingSetSize;
+    public uint ActiveProcessLimit;
+    public UIntPtr Affinity;
+    public uint PriorityClass;
+    public uint SchedulingClass;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct IO_COUNTERS {
+    public ulong ReadOperationCount;
+    public ulong WriteOperationCount;
+    public ulong OtherOperationCount;
+    public ulong ReadTransferCount;
+    public ulong WriteTransferCount;
+    public ulong OtherTransferCount;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
+    public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+    public IO_COUNTERS IoInfo;
+    public UIntPtr ProcessMemoryLimit;
+    public UIntPtr JobMemoryLimit;
+    public UIntPtr PeakProcessMemoryUsed;
+    public UIntPtr PeakJobMemoryUsed;
+}
+
+private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000;
+private const int JobObjectExtendedLimitInformation = 9;
+
+[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+private static extern IntPtr CreateJobObjectW(IntPtr lpJobAttributes, string lpName);
+
+[DllImport("kernel32.dll", SetLastError = true)]
+private static extern bool SetInformationJobObject(IntPtr hJob, int JobObjectInfoClass, IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
+
+[DllImport("kernel32.dll", SetLastError = true)]
+private static extern bool AssignProcessToJobObject(IntPtr hJob, IntPtr hProcess);
+
+[DllImport("kernel32.dll")]
+private static extern IntPtr GetCurrentProcess();
+
+[DllImport("kernel32.dll", SetLastError = true)]
+public static extern bool CloseHandle(IntPtr hObject);
+
+public static IntPtr CreateKillOnCloseJob() {
+    IntPtr job = CreateJobObjectW(IntPtr.Zero, null);
+    if (job == IntPtr.Zero) { return IntPtr.Zero; }
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION info = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION();
+    info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    int length = Marshal.SizeOf(info);
+    IntPtr ptr = Marshal.AllocHGlobal(length);
+    try {
+        Marshal.StructureToPtr(info, ptr, false);
+        if (!SetInformationJobObject(job, JobObjectExtendedLimitInformation, ptr, (uint)length)) {
+            CloseHandle(job);
+            return IntPtr.Zero;
+        }
+    } finally {
+        Marshal.FreeHGlobal(ptr);
+    }
+    return job;
+}
+
+public static bool AssignCurrentProcess(IntPtr job) {
+    return AssignProcessToJobObject(job, GetCurrentProcess());
+}
+'@
+        }
+
+        $job = [Dotbot.JobObjectNative]::CreateKillOnCloseJob()
+        if ($job -eq [IntPtr]::Zero) {
+            if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
+                Write-BotLog -Level Debug -Message "Kill-on-close job: CreateJobObject/SetInformationJobObject failed; relying on existing cleanup"
+            }
+            return $false
+        }
+
+        if (-not [Dotbot.JobObjectNative]::AssignCurrentProcess($job)) {
+            [void][Dotbot.JobObjectNative]::CloseHandle($job)
+            if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
+                Write-BotLog -Level Debug -Message "Kill-on-close job: AssignProcessToJobObject failed; relying on existing cleanup"
+            }
+            return $false
+        }
+
+        # Keep the handle open for the whole process lifetime. Do NOT close it:
+        # the OS closes it on process death (however abrupt), and that is exactly
+        # what fires KILL_ON_JOB_CLOSE and reaps the subtree. Held in a
+        # script-scoped var as an explicit strong reference.
+        $script:DotbotKillJobHandle = $job
+        if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
+            Write-BotLog -Level Debug -Message "Kill-on-close job: current process (PID $PID) bound; descendants reaped on exit"
+        }
+        return $true
+    } catch {
+        if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
+            Write-BotLog -Level Debug -Message "Kill-on-close job: setup failed; relying on existing cleanup" -Exception $_
+        }
+        return $false
+    }
+}
+
+#endregion
+
 Export-ModuleMember -Function @(
     # Process registry (business-level)
     'New-ProcessId'
@@ -961,4 +1125,6 @@ Export-ModuleMember -Function @(
     'Test-WorkflowComplete'
     # Child process spawning (low-level)
     'Start-DotbotChildProcess'
+    # Process-tree lifetime binding (Windows)
+    'Register-DotbotKillOnCloseJob'
 )

--- a/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
+++ b/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
@@ -989,6 +989,7 @@ function Register-DotbotKillOnCloseJob {
     # parent's children re-parent to init and are reachable via pkill at teardown,
     # so this returns $false there and the existing cleanup path stands.
     if (-not $IsWindows) { return $false }
+    # Fast path: already bound in this module instance.
     if ($script:DotbotKillJobHandle -ne [IntPtr]::Zero) { return $true }
 
     try {
@@ -1033,6 +1034,15 @@ public struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
 private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000;
 private const int JobObjectExtendedLimitInformation = 9;
 
+// Win32 error captured at the point a P/Invoke below failed, so the
+// best-effort PowerShell caller can log *why* the OS declined to bind.
+public static int LastError;
+
+// Set once the current process is bound. Lives on the type, so it survives an
+// Import-Module -Force (which recreates the module's $script: scope but leaves
+// the compiled type in the AppDomain), keeping the bind truly idempotent.
+public static bool Bound;
+
 [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
 private static extern IntPtr CreateJobObjectW(IntPtr lpJobAttributes, string lpName);
 
@@ -1049,8 +1059,9 @@ private static extern IntPtr GetCurrentProcess();
 public static extern bool CloseHandle(IntPtr hObject);
 
 public static IntPtr CreateKillOnCloseJob() {
+    LastError = 0;
     IntPtr job = CreateJobObjectW(IntPtr.Zero, null);
-    if (job == IntPtr.Zero) { return IntPtr.Zero; }
+    if (job == IntPtr.Zero) { LastError = Marshal.GetLastWin32Error(); return IntPtr.Zero; }
     JOBOBJECT_EXTENDED_LIMIT_INFORMATION info = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION();
     info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
     int length = Marshal.SizeOf(info);
@@ -1058,6 +1069,8 @@ public static IntPtr CreateKillOnCloseJob() {
     try {
         Marshal.StructureToPtr(info, ptr, false);
         if (!SetInformationJobObject(job, JobObjectExtendedLimitInformation, ptr, (uint)length)) {
+            // Capture the failure code before CloseHandle overwrites it.
+            LastError = Marshal.GetLastWin32Error();
             CloseHandle(job);
             return IntPtr.Zero;
         }
@@ -1068,15 +1081,22 @@ public static IntPtr CreateKillOnCloseJob() {
 }
 
 public static bool AssignCurrentProcess(IntPtr job) {
-    return AssignProcessToJobObject(job, GetCurrentProcess());
+    LastError = 0;
+    bool ok = AssignProcessToJobObject(job, GetCurrentProcess());
+    if (!ok) { LastError = Marshal.GetLastWin32Error(); }
+    return ok;
 }
 '@
         }
 
+        # Survives Import-Module -Force: the flag lives on the type, which stays in
+        # the AppDomain even though the fast-path $script: var above was reset.
+        if ([Dotbot.JobObjectNative]::Bound) { return $true }
+
         $job = [Dotbot.JobObjectNative]::CreateKillOnCloseJob()
         if ($job -eq [IntPtr]::Zero) {
             if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
-                Write-BotLog -Level Debug -Message "Kill-on-close job: CreateJobObject/SetInformationJobObject failed; relying on existing cleanup"
+                Write-BotLog -Level Debug -Message "Kill-on-close job: CreateJobObject/SetInformationJobObject failed (Win32 error $([Dotbot.JobObjectNative]::LastError)); relying on existing cleanup"
             }
             return $false
         }
@@ -1084,15 +1104,17 @@ public static bool AssignCurrentProcess(IntPtr job) {
         if (-not [Dotbot.JobObjectNative]::AssignCurrentProcess($job)) {
             [void][Dotbot.JobObjectNative]::CloseHandle($job)
             if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
-                Write-BotLog -Level Debug -Message "Kill-on-close job: AssignProcessToJobObject failed; relying on existing cleanup"
+                Write-BotLog -Level Debug -Message "Kill-on-close job: AssignProcessToJobObject failed (Win32 error $([Dotbot.JobObjectNative]::LastError)); relying on existing cleanup"
             }
             return $false
         }
 
         # Keep the handle open for the whole process lifetime. Do NOT close it:
         # the OS closes it on process death (however abrupt), and that is exactly
-        # what fires KILL_ON_JOB_CLOSE and reaps the subtree. Held in a
-        # script-scoped var as an explicit strong reference.
+        # what fires KILL_ON_JOB_CLOSE and reaps the subtree. The OS owns the
+        # handle's lifetime; the script-scoped var is the in-session idempotency
+        # marker (a raw IntPtr is not GC-tracked, so no strong ref is needed).
+        [Dotbot.JobObjectNative]::Bound = $true
         $script:DotbotKillJobHandle = $job
         if (Get-Command Write-BotLog -ErrorAction SilentlyContinue) {
             Write-BotLog -Level Debug -Message "Kill-on-close job: current process (PID $PID) bound; descendants reaped on exit"

--- a/src/runtime/Scripts/Invoke-DotbotProcess.ps1
+++ b/src/runtime/Scripts/Invoke-DotbotProcess.ps1
@@ -255,6 +255,16 @@ $env:DOTBOT_MODEL_TIER = $modelTier
 # Callers may pass -BotRoot to override.
 Import-Module "$PSScriptRoot\..\Modules\Dotbot.Process\Dotbot.Process.psd1" -Force
 
+# Bind this worker's whole child subtree (claude.exe -> MCP server -> tool
+# children, plus git/preflight helpers) to the worker's lifetime via a Windows
+# kill-on-close Job Object (#645). The harness adapters clean up their process
+# tree in a 'finally' block, but that is skipped on an abrupt worker death
+# (console close, Stop-Process -Force, crash), leaking orphans that keep running
+# and consuming tokens. The job guarantees the kernel reaps the subtree however
+# the worker dies. Best-effort: a $false return means the OS wouldn't bind the
+# job, and the existing finally cleanup remains the graceful-exit path.
+$null = Register-DotbotKillOnCloseJob
+
 # InterviewLoop is imported from Invoke-WorkflowProcess.ps1 (the only consumer
 # after the legacy execution engine was removed), so it does not need to be loaded here.
 

--- a/tests/Test-ProcessRegistry.ps1
+++ b/tests/Test-ProcessRegistry.ps1
@@ -246,6 +246,118 @@ Assert-True -Name "Add-JsonFrontMatter prepends JSON block" `
     -Message "Front matter not correctly prepended"
 
 # ===================================================================
+# Register-DotbotKillOnCloseJob (#645)
+# ===================================================================
+
+Write-Host "  REGISTER-DOTBOTKILLONCLOSEJOB" -ForegroundColor Cyan
+Write-Host "  --------------------------------------------" -ForegroundColor DarkGray
+
+Assert-True -Name "Register-DotbotKillOnCloseJob is exported" `
+    -Condition ([bool](Get-Command Register-DotbotKillOnCloseJob -Module Dotbot.Process -ErrorAction SilentlyContinue)) `
+    -Message "Register-DotbotKillOnCloseJob should be exported from Dotbot.Process"
+
+if (-not $IsWindows) {
+    # Job Objects are Windows-only; the helper is a documented no-op elsewhere.
+    Assert-Equal -Name "Register-DotbotKillOnCloseJob returns false on non-Windows" `
+        -Expected $false -Actual (Register-DotbotKillOnCloseJob)
+} else {
+    # End-to-end: a worker binds itself to a kill-on-close job, spawns a
+    # child subtree (mid -> leaf, modelling claude.exe -> MCP server), then is
+    # force-killed WITHOUT running any cleanup. The kernel must reap the subtree.
+    $jobTestDir = Join-Path $testRoot "killjob"
+    New-Item -Path $jobTestDir -ItemType Directory -Force | Out-Null
+
+    $leafScript = Join-Path $jobTestDir "leaf.ps1"
+    $midScript = Join-Path $jobTestDir "mid.ps1"
+    $workerScript = Join-Path $jobTestDir "worker.ps1"
+    $pidFile = Join-Path $jobTestDir "pids.txt"
+    $bindResultFile = Join-Path $jobTestDir "bind.txt"
+
+    Set-Content -LiteralPath $leafScript -Encoding utf8NoBOM -Value 'Start-Sleep -Seconds 300'
+
+    Set-Content -LiteralPath $midScript -Encoding utf8NoBOM -Value @'
+param([string]$LeafScript, [string]$PidFile)
+$leaf = Start-Process pwsh -ArgumentList '-NoProfile', '-File', $LeafScript -WindowStyle Hidden -PassThru
+Set-Content -LiteralPath $PidFile -Value @("$PID", "$($leaf.Id)")
+Start-Sleep -Seconds 300
+'@
+
+    Set-Content -LiteralPath $workerScript -Encoding utf8NoBOM -Value @'
+param([string]$LoggingPsd1, [string]$ProcessPsd1, [string]$MidScript, [string]$LeafScript, [string]$PidFile, [string]$BindResultFile)
+Import-Module $LoggingPsd1 -Force -DisableNameChecking
+Import-Module $ProcessPsd1 -Force
+$bound = Register-DotbotKillOnCloseJob
+Set-Content -LiteralPath $BindResultFile -Value ([string]$bound)
+Start-Process pwsh -ArgumentList '-NoProfile', '-File', $MidScript, '-LeafScript', $LeafScript, '-PidFile', $PidFile -WindowStyle Hidden
+Start-Sleep -Seconds 300
+'@
+
+    $worker = $null
+    try {
+        $worker = Start-Process pwsh -PassThru -WindowStyle Hidden -ArgumentList @(
+            '-NoProfile', '-File', $workerScript,
+            '-LoggingPsd1', $dotBotLogPath,
+            '-ProcessPsd1', $modulePath,
+            '-MidScript', $midScript,
+            '-LeafScript', $leafScript,
+            '-PidFile', $pidFile,
+            '-BindResultFile', $bindResultFile
+        )
+
+        # Wait until the subtree records its PIDs (module compile + 3x pwsh spawn).
+        $descendants = $null
+        $readyDeadline = (Get-Date).AddSeconds(45)
+        while ((Get-Date) -lt $readyDeadline) {
+            if (Test-Path $pidFile) {
+                $lines = @(Get-Content $pidFile -ErrorAction SilentlyContinue | Where-Object { $_ -match '^\d+$' })
+                if ($lines.Count -ge 2) { $descendants = $lines | ForEach-Object { [int]$_ }; break }
+            }
+            Start-Sleep -Milliseconds 250
+        }
+
+        $bindResult = if (Test-Path $bindResultFile) { (Get-Content $bindResultFile -Raw).Trim() } else { "" }
+        Assert-Equal -Name "Register-DotbotKillOnCloseJob binds the worker (returns true)" `
+            -Expected "True" -Actual $bindResult
+
+        Assert-True -Name "Worker subtree started (descendant PIDs recorded)" `
+            -Condition ($null -ne $descendants) `
+            -Message "Worker never recorded its descendant PIDs within the timeout"
+
+        if ($descendants) {
+            $midPid, $leafPid = $descendants[0], $descendants[1]
+
+            # Abrupt kill -- the worker's in-process cleanup never runs.
+            Stop-Process -Id $worker.Id -Force
+
+            # Poll for the subtree to be reaped by the kernel.
+            $reapDeadline = (Get-Date).AddSeconds(20)
+            do {
+                $midAlive = [bool](Get-Process -Id $midPid -ErrorAction SilentlyContinue)
+                $leafAlive = [bool](Get-Process -Id $leafPid -ErrorAction SilentlyContinue)
+                if (-not $midAlive -and -not $leafAlive) { break }
+                Start-Sleep -Milliseconds 250
+            } while ((Get-Date) -lt $reapDeadline)
+
+            Assert-True -Name "Force-killing worker reaps child (claude.exe stand-in)" `
+                -Condition (-not $midAlive) `
+                -Message "Child PID $midPid survived as an orphan after worker was force-killed"
+            Assert-True -Name "Force-killing worker reaps grandchild (MCP stand-in)" `
+                -Condition (-not $leafAlive) `
+                -Message "Grandchild PID $leafPid survived as an orphan after worker was force-killed"
+
+            # Belt-and-braces cleanup in case an assertion above failed.
+            # Stop-Process -ErrorAction SilentlyContinue does not throw on an
+            # already-dead PID, so no try/catch is needed.
+            foreach ($p in @($midPid, $leafPid)) {
+                Stop-Process -Id $p -Force -ErrorAction SilentlyContinue
+            }
+        }
+    } finally {
+        if ($worker) { Stop-Process -Id $worker.Id -Force -ErrorAction SilentlyContinue }
+    }
+}
+
+# ===================================================================
 # CLEANUP
 # ===================================================================
 


### PR DESCRIPTION
## Linked issue

Closes #645

## Summary of changes

On an **abrupt** worker death (console close, `Stop-Process -Force`, crash), the
in-process `finally` cleanup in the harness adapters never runs, so the worker's
child subtree (`claude.exe` → MCP server → tool children, plus git/preflight
helpers) is orphaned and keeps running — consuming tokens.

This binds each worker's whole subtree to the worker's own lifetime via a Windows
**kill-on-close Job Object**:

- New `Register-DotbotKillOnCloseJob` in `Dotbot.Process` creates a job with
  `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, assigns the current process to it, and
  holds the sole job handle open for the process lifetime. Child processes inherit
  job membership, so whenever the worker dies the OS closes the handle and the
  kernel terminates the whole subtree.
- `Invoke-DotbotProcess.ps1` calls it right after importing `Dotbot.Process`.
- Strictly **best-effort** and a **backstop**, not a replacement: graceful teardown
  still uses the existing `finally` cleanup. On non-Windows (children re-parent to
  init and are reaped via `pkill`) or on any failure, it logs at Debug and returns
  `$false`; callers must never fail because of it. Idempotent across repeated
  calls and `Import-Module -Force`.
- Failure paths log the captured `Win32` error code to aid field diagnosis.

## Testing notes

- `pwsh tests/Test-ProcessRegistry.ps1` — adds an end-to-end case that binds a
  worker, spawns a `mid → leaf` subtree (modelling `claude.exe → MCP server`),
  force-kills the worker **without** running any cleanup, and asserts the kernel
  reaps both descendants. Non-Windows asserts the documented `$false` no-op.
- Full Layer 1–3 suite is green apart from the pre-existing, unrelated
  `New-TaskWorktree` Windows long-path failure (`Filename too long`), which also
  fails on `main` and is untouched by this PR.

## Checklist

- [x] Tests added or updated
- [x] Docs updated (if behaviour changed) — n/a (internal backstop; documented in-code)
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)