### PR TITLE
fix: resolve dependencies via registry Machine/User PATH on Windows(#504)

### DIFF
--- a/bin/dotbot.ps1
+++ b/bin/dotbot.ps1
@@ -85,6 +85,14 @@ foreach ($arg in $RawArgs) {
 $Command = $FilteredArgs[0]
 [array]$SubArgs = if ($FilteredArgs.Count -gt 1) { $FilteredArgs[1..($FilteredArgs.Count-1)] } else { @() }
 
+# Merge registry Machine/User PATH into this process (Windows split-PATH fix).
+# Skipped for 'doctor': doctor must observe the raw inherited PATH to detect
+# and report the split. Guarded because a project-vendored runtime may ship an
+# older Dotbot.Core without the repair function.
+if ($Command -ne 'doctor' -and (Get-Command Repair-DotbotProcessPath -ErrorAction SilentlyContinue)) {
+    $null = Repair-DotbotProcessPath
+}
+
 # Convert CLI args to a hashtable for proper named-parameter splatting.
 # Array splatting only does positional binding; hashtable splatting is
 # required for named parameters like -Workflow / -Stack.
@@ -728,7 +736,11 @@ switch ($Command) {
 
         & pwsh -NoProfile -File $serverScript
     }
-    "doctor" { & (Join-Path $ScriptsDir 'doctor.ps1') @SplatArgs }
+    "doctor" {
+        $global:LASTEXITCODE = 0
+        & (Join-Path $ScriptsDir 'doctor.ps1') @SplatArgs
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    }
     "serve"          { & (Join-Path $ScriptsDir 'serve.ps1')          @SplatArgs }
     "runtime-status" { & (Join-Path $ScriptsDir 'runtime-status.ps1') @SplatArgs }
     "logs"           { & (Join-Path $ScriptsDir 'logs.ps1')           @SplatArgs }

--- a/src/cli/doctor.ps1
+++ b/src/cli/doctor.ps1
@@ -25,6 +25,9 @@ if (-not (Test-Path $PlatformFunctionsModule)) {
 }
 Import-Module $PlatformFunctionsModule -Force -ErrorAction Stop
 
+# Dotbot.Core provides Resolve-DotbotExternalCommand (split-PATH detection).
+Import-Module (Join-Path $PSScriptRoot ".." "runtime" "Modules" "Dotbot.Core" "Dotbot.Core.psm1") -Force -DisableNameChecking
+
 # Dotbot.Theme is optional here — it lights up the summary grid and separators.
 # If a project ships without it (e.g. doctor invoked before .bot is fully
 # materialized) the script must still run with Platform-Functions alone.
@@ -77,28 +80,46 @@ if (-not (Test-Path $BotRoot)) {
 
 Write-DotbotSection -Title "DEPENDENCIES"
 
+# Emits the Warn + fix guidance for a dependency that is registered in the
+# Machine/User registry PATH but missing from this process PATH. Doctor
+# diagnoses the split instead of repairing it - repairing here would erase
+# the very condition being reported.
+function Write-SplitPathCheck {
+    param([string]$Label, [hashtable]$Resolution)
+    Write-Check $Label "found via $($Resolution.Scope) PATH but missing from this process PATH (split PATH detected)" Warn
+    Write-DotbotCommand "Fix this session:  `$env:PATH += ';$($Resolution.Directory)'"
+    Write-DotbotCommand "Fix permanently:   restart your terminal (or the app that launched it) so it re-merges the $($Resolution.Scope) PATH"
+}
+
 # git
-if (Get-Command git -ErrorAction SilentlyContinue) {
+$gitRes = Resolve-DotbotExternalCommand -Name 'git'
+if ($gitRes.Found -and $gitRes.Scope -eq 'Process') {
     Write-Check "git" "found" Pass
+} elseif ($gitRes.Found) {
+    Write-SplitPathCheck -Label "git" -Resolution $gitRes
 } else {
-    Write-Check "git" "not found on PATH" Fail
+    Write-Check "git" "not found in process, Machine, or User PATH" Fail
 }
 
 # Provider CLI (claude, codex, Antigravity's agy, OpenCode, or GitHub Copilot CLI)
 $providerFound = $false
 foreach ($exe in @('claude', 'claude.exe', 'codex', 'codex.exe', 'agy', 'agy.exe', 'opencode', 'opencode.exe', 'copilot', 'copilot.exe')) {
-    if (Get-Command $exe -ErrorAction SilentlyContinue) {
+    $provRes = Resolve-DotbotExternalCommand -Name $exe
+    if (-not $provRes.Found) { continue }
+    if ($provRes.Scope -eq 'Process') {
         Write-Check "Provider CLI" "$exe found" Pass
-        $providerFound = $true
-        break
+    } else {
+        Write-SplitPathCheck -Label "Provider CLI ($exe)" -Resolution $provRes
     }
+    $providerFound = $true
+    break
 }
-if (-not $providerFound -and (Get-Command gh -ErrorAction SilentlyContinue)) {
+if (-not $providerFound -and (Resolve-DotbotExternalCommand -Name 'gh').Found) {
     Write-Check "Provider CLI" "gh found (can run preview 'gh copilot')" Pass
     $providerFound = $true
 }
 if (-not $providerFound) {
-    Write-Check "Provider CLI" "no provider CLI found (claude/codex/agy/opencode/copilot)" Fail
+    Write-Check "Provider CLI" "no provider CLI found (claude/codex/agy/opencode/copilot) in process, Machine, or User PATH" Fail
 }
 
 Write-BlankLine

--- a/src/cli/doctor.ps1
+++ b/src/cli/doctor.ps1
@@ -26,7 +26,9 @@ if (-not (Test-Path $PlatformFunctionsModule)) {
 Import-Module $PlatformFunctionsModule -Force -ErrorAction Stop
 
 # Dotbot.Core provides Resolve-DotbotExternalCommand (split-PATH detection).
-Import-Module (Join-Path $PSScriptRoot ".." "runtime" "Modules" "Dotbot.Core" "Dotbot.Core.psm1") -Force -DisableNameChecking
+if (-not (Get-Module Dotbot.Core)) {
+    Import-Module (Join-Path $PSScriptRoot ".." "runtime" "Modules" "Dotbot.Core" "Dotbot.Core.psm1") -DisableNameChecking -Global
+}
 
 # Dotbot.Theme is optional here — it lights up the summary grid and separators.
 # If a project ships without it (e.g. doctor invoked before .bot is fully
@@ -114,9 +116,15 @@ foreach ($exe in @('claude', 'claude.exe', 'codex', 'codex.exe', 'agy', 'agy.exe
     $providerFound = $true
     break
 }
-if (-not $providerFound -and (Resolve-DotbotExternalCommand -Name 'gh').Found) {
-    Write-Check "Provider CLI" "gh found (can run preview 'gh copilot')" Pass
-    $providerFound = $true
+if (-not $providerFound) {
+    $ghRes = Resolve-DotbotExternalCommand -Name 'gh'
+    if ($ghRes.Found -and $ghRes.Scope -eq 'Process') {
+        Write-Check "Provider CLI" "gh found (can run preview 'gh copilot')" Pass
+        $providerFound = $true
+    } elseif ($ghRes.Found) {
+        Write-SplitPathCheck -Label "Provider CLI (gh)" -Resolution $ghRes
+        $providerFound = $true
+    }
 }
 if (-not $providerFound) {
     Write-Check "Provider CLI" "no provider CLI found (claude/codex/agy/opencode/copilot) in process, Machine, or User PATH" Fail

--- a/src/runtime/Modules/Dotbot.Core/Dotbot.Core.psd1
+++ b/src/runtime/Modules/Dotbot.Core/Dotbot.Core.psd1
@@ -22,6 +22,8 @@
         'Remove-AbsolutePaths'
         'ConvertTo-SanitizedConsoleText'
         'Update-ProcessHeartbeatFields'
+        'Resolve-DotbotExternalCommand'
+        'Repair-DotbotProcessPath'
     )
 
     CmdletsToExport   = @()

--- a/src/runtime/Modules/Dotbot.Core/Dotbot.Core.psm1
+++ b/src/runtime/Modules/Dotbot.Core/Dotbot.Core.psm1
@@ -413,6 +413,151 @@ function Update-ProcessHeartbeatFields {
 
 #endregion
 
+#region External Command Resolution
+
+# On Windows, Machine PATH and User PATH are merged into the process PATH at
+# login, but a spawned process can inherit a PATH missing one scope (e.g. Git
+# installed system-wide -> Machine PATH, a provider CLI installed per-user ->
+# User PATH). Get-Command only searches the process PATH, so tools that are
+# installed and registered on the machine get reported as missing. These
+# helpers resolve commands across all three scopes and can repair the session
+# PATH so downstream Get-Command calls and process spawns succeed.
+
+$script:ExternalCommandProbeExtensions = @('exe', 'cmd', 'bat', 'ps1')
+
+function Get-DotbotRegistryPathDirectories {
+    # Windows-only: PATH directories registered in a registry scope.
+    param([Parameter(Mandatory)][ValidateSet('Machine', 'User')][string]$Scope)
+
+    if (-not $IsWindows) { return @() }
+    $raw = [Environment]::GetEnvironmentVariable('Path', $Scope)
+    if ([string]::IsNullOrWhiteSpace($raw)) { return @() }
+    return @($raw -split [IO.Path]::PathSeparator | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+}
+
+function Find-DotbotCommandInDirectory {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Directory
+    )
+
+    $probes = if ([IO.Path]::GetExtension($Name)) {
+        @($Name)
+    } else {
+        @($script:ExternalCommandProbeExtensions | ForEach-Object { "$Name.$_" })
+    }
+    foreach ($probe in $probes) {
+        try {
+            $candidate = Join-Path $Directory $probe
+            if (Test-Path -LiteralPath $candidate -PathType Leaf) { return $candidate }
+        } catch {
+            # Malformed PATH entries throw on Join-Path/Test-Path; skip them.
+        }
+    }
+    return $null
+}
+
+function Resolve-DotbotExternalCommand {
+    <#
+    .SYNOPSIS
+    Resolves an external command via the process PATH, falling back to the
+    registry Machine and User PATH scopes on Windows.
+
+    .DESCRIPTION
+    Returns a hashtable: @{ Found; Name; Source; Directory; Scope; Repaired }
+    where Scope is 'Process', 'Machine', or 'User'. With -RepairSessionPath,
+    a registry-scope hit appends the containing directory to the process
+    $env:PATH so later Get-Command calls and spawns in this process succeed.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [switch]$RepairSessionPath
+    )
+
+    $cmd = Get-Command -Name $Name -CommandType Application, ExternalScript -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($cmd) {
+        $source = if ($cmd.PSObject.Properties['Source'] -and $cmd.Source) { $cmd.Source } else { $cmd.Path }
+        return @{
+            Found     = $true
+            Name      = $Name
+            Source    = $source
+            Directory = (Split-Path $source -Parent)
+            Scope     = 'Process'
+            Repaired  = $false
+        }
+    }
+
+    if (-not $IsWindows) {
+        return @{ Found = $false; Name = $Name }
+    }
+
+    foreach ($scope in @('Machine', 'User')) {
+        foreach ($dir in (Get-DotbotRegistryPathDirectories -Scope $scope)) {
+            $hit = Find-DotbotCommandInDirectory -Name $Name -Directory $dir
+            if (-not $hit) { continue }
+
+            $repaired = $false
+            if ($RepairSessionPath) {
+                $normalized = $dir.TrimEnd('\', '/')
+                $present = @($env:PATH -split [IO.Path]::PathSeparator) |
+                    Where-Object { $_ -and ($_.TrimEnd('\', '/') -ieq $normalized) }
+                if (-not $present) {
+                    $env:PATH = $env:PATH + [IO.Path]::PathSeparator + $dir
+                }
+                $repaired = $true
+            }
+
+            return @{
+                Found     = $true
+                Name      = $Name
+                Source    = $hit
+                Directory = $dir
+                Scope     = $scope
+                Repaired  = $repaired
+            }
+        }
+    }
+
+    return @{ Found = $false; Name = $Name }
+}
+
+function Repair-DotbotProcessPath {
+    <#
+    .SYNOPSIS
+    Merges registry Machine/User PATH directories missing from the process
+    PATH into $env:PATH (Windows split-PATH repair).
+
+    .DESCRIPTION
+    Returns the list of appended directories. No-op on non-Windows platforms
+    and when DOTBOT_SKIP_PATH_REPAIR is set. Runs once per module load unless
+    -Force is passed; the merge is append-only, so repeats are harmless.
+    #>
+    param([switch]$Force)
+
+    if (-not $IsWindows) { return @() }
+    if ($env:DOTBOT_SKIP_PATH_REPAIR) { return @() }
+    if ($script:DotbotProcessPathRepaired -and -not $Force) { return @() }
+    $script:DotbotProcessPathRepaired = $true
+
+    $processDirs = @($env:PATH -split [IO.Path]::PathSeparator |
+        Where-Object { $_ } | ForEach-Object { $_.TrimEnd('\', '/') })
+    $appended = @()
+    foreach ($scope in @('Machine', 'User')) {
+        foreach ($dir in (Get-DotbotRegistryPathDirectories -Scope $scope)) {
+            $normalized = $dir.TrimEnd('\', '/')
+            $known = @($processDirs) | Where-Object { $_ -ieq $normalized }
+            if ($known) { continue }
+            $env:PATH = $env:PATH + [IO.Path]::PathSeparator + $dir
+            $processDirs += $normalized
+            $appended += $dir
+        }
+    }
+    return $appended
+}
+
+#endregion
+
 Export-ModuleMember -Function @(
     'Get-DotbotInstallPath'
     'Get-DotbotProjectLocalInstallPath'
@@ -429,4 +574,6 @@ Export-ModuleMember -Function @(
     'Remove-AbsolutePaths'
     'ConvertTo-SanitizedConsoleText'
     'Update-ProcessHeartbeatFields'
+    'Resolve-DotbotExternalCommand'
+    'Repair-DotbotProcessPath'
 )

--- a/src/runtime/Modules/Dotbot.Core/Dotbot.Core.psm1
+++ b/src/runtime/Modules/Dotbot.Core/Dotbot.Core.psm1
@@ -423,16 +423,76 @@ function Update-ProcessHeartbeatFields {
 # helpers resolve commands across all three scopes and can repair the session
 # PATH so downstream Get-Command calls and process spawns succeed.
 
-$script:ExternalCommandProbeExtensions = @('exe', 'cmd', 'bat', 'ps1')
+$script:DotbotRegistryPathReader = {
+    param([string]$Scope)
+    [Environment]::GetEnvironmentVariable('Path', $Scope)
+}
+$script:DotbotProcessElevationReader = {
+    $elevated = $false
+    if ($IsWindows) {
+        $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+        $principal = [Security.Principal.WindowsPrincipal]::new($identity)
+        $elevated = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    }
+    return $elevated
+}
+
+function Test-DotbotPathRepairScopeAllowed {
+    param([Parameter(Mandatory)][ValidateSet('Machine', 'User')][string]$Scope)
+
+    if ($Scope -eq 'Machine') { return $true }
+    # Never introduce user-writable search directories into an elevated
+    # process. A non-elevated restart can safely pick up the User PATH.
+    return -not [bool](& $script:DotbotProcessElevationReader)
+}
+
+function ConvertTo-DotbotNormalizedPathDirectory {
+    param([string]$Directory)
+
+    if ([string]::IsNullOrWhiteSpace($Directory)) { return $null }
+    $expanded = [Environment]::ExpandEnvironmentVariables($Directory).Trim().Trim('"')
+    if ([string]::IsNullOrWhiteSpace($expanded)) { return $null }
+
+    # Registry PATH entries should be absolute. Refusing relative entries keeps
+    # a repaired PATH from making command resolution depend on the current
+    # working directory of a privileged or long-running dotbot process.
+    if (-not [IO.Path]::IsPathFullyQualified($expanded)) { return $null }
+    $root = [IO.Path]::GetPathRoot($expanded)
+    if ($expanded.Length -le $root.Length) { return $expanded }
+    return $expanded.TrimEnd('\', '/')
+}
+
+function Get-DotbotCommandProbeExtensions {
+    # PowerShell resolves .ps1 external scripts before native PATHEXT entries.
+    # Preserve the host's PATHEXT order rather than maintaining a partial,
+    # divergent list (notably .COM and administrator-defined extensions).
+    $extensions = @('.ps1')
+    $pathExt = if ([string]::IsNullOrWhiteSpace($env:PATHEXT)) {
+        @('.COM', '.EXE', '.BAT', '.CMD')
+    } else {
+        @($env:PATHEXT -split ';')
+    }
+    foreach ($extension in $pathExt) {
+        if ([string]::IsNullOrWhiteSpace($extension)) { continue }
+        $normalized = $extension.Trim()
+        if (-not $normalized.StartsWith('.')) { $normalized = ".$normalized" }
+        if ($extensions -inotcontains $normalized) { $extensions += $normalized }
+    }
+    return $extensions
+}
 
 function Get-DotbotRegistryPathDirectories {
     # Windows-only: PATH directories registered in a registry scope.
     param([Parameter(Mandatory)][ValidateSet('Machine', 'User')][string]$Scope)
 
     if (-not $IsWindows) { return @() }
-    $raw = [Environment]::GetEnvironmentVariable('Path', $Scope)
+    $raw = & $script:DotbotRegistryPathReader $Scope
     if ([string]::IsNullOrWhiteSpace($raw)) { return @() }
-    return @($raw -split [IO.Path]::PathSeparator | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    $directories = foreach ($entry in ($raw -split [IO.Path]::PathSeparator)) {
+        $normalized = ConvertTo-DotbotNormalizedPathDirectory -Directory $entry
+        if ($normalized) { $normalized }
+    }
+    return @($directories)
 }
 
 function Find-DotbotCommandInDirectory {
@@ -444,7 +504,7 @@ function Find-DotbotCommandInDirectory {
     $probes = if ([IO.Path]::GetExtension($Name)) {
         @($Name)
     } else {
-        @($script:ExternalCommandProbeExtensions | ForEach-Object { "$Name.$_" })
+        @(Get-DotbotCommandProbeExtensions | ForEach-Object { "$Name$_" })
     }
     foreach ($probe in $probes) {
         try {
@@ -498,14 +558,15 @@ function Resolve-DotbotExternalCommand {
             if (-not $hit) { continue }
 
             $repaired = $false
+            $repairBlocked = $null
             if ($RepairSessionPath) {
-                $normalized = $dir.TrimEnd('\', '/')
-                $present = @($env:PATH -split [IO.Path]::PathSeparator) |
-                    Where-Object { $_ -and ($_.TrimEnd('\', '/') -ieq $normalized) }
-                if (-not $present) {
-                    $env:PATH = $env:PATH + [IO.Path]::PathSeparator + $dir
+                if ($env:DOTBOT_SKIP_PATH_REPAIR) {
+                    $repairBlocked = 'opt_out'
+                } elseif (-not (Test-DotbotPathRepairScopeAllowed -Scope $scope)) {
+                    $repairBlocked = 'elevated_user_path'
+                } else {
+                    $repaired = Add-DotbotProcessPathDirectory -Directory $dir -Scope $scope
                 }
-                $repaired = $true
             }
 
             return @{
@@ -515,11 +576,36 @@ function Resolve-DotbotExternalCommand {
                 Directory = $dir
                 Scope     = $scope
                 Repaired  = $repaired
+                RepairBlocked = $repairBlocked
             }
         }
     }
 
     return @{ Found = $false; Name = $Name }
+}
+
+function Add-DotbotProcessPathDirectory {
+    param(
+        [Parameter(Mandatory)][string]$Directory,
+        [Parameter(Mandatory)][ValidateSet('Machine', 'User')][string]$Scope
+    )
+
+    if ($env:DOTBOT_SKIP_PATH_REPAIR) { return $false }
+    if (-not (Test-DotbotPathRepairScopeAllowed -Scope $Scope)) { return $false }
+    $normalized = ConvertTo-DotbotNormalizedPathDirectory -Directory $Directory
+    if (-not $normalized) { return $false }
+
+    $present = @($env:PATH -split [IO.Path]::PathSeparator) | ForEach-Object {
+        ConvertTo-DotbotNormalizedPathDirectory -Directory $_
+    } | Where-Object { $_ -and ($_ -ieq $normalized) }
+    if ($present) { return $true }
+
+    if ([string]::IsNullOrWhiteSpace($env:PATH)) {
+        $env:PATH = $normalized
+    } else {
+        $env:PATH = $env:PATH + [IO.Path]::PathSeparator + $normalized
+    }
+    return $true
 }
 
 function Repair-DotbotProcessPath {
@@ -540,17 +626,13 @@ function Repair-DotbotProcessPath {
     if ($script:DotbotProcessPathRepaired -and -not $Force) { return @() }
     $script:DotbotProcessPathRepaired = $true
 
-    $processDirs = @($env:PATH -split [IO.Path]::PathSeparator |
-        Where-Object { $_ } | ForEach-Object { $_.TrimEnd('\', '/') })
     $appended = @()
     foreach ($scope in @('Machine', 'User')) {
         foreach ($dir in (Get-DotbotRegistryPathDirectories -Scope $scope)) {
-            $normalized = $dir.TrimEnd('\', '/')
-            $known = @($processDirs) | Where-Object { $_ -ieq $normalized }
-            if ($known) { continue }
-            $env:PATH = $env:PATH + [IO.Path]::PathSeparator + $dir
-            $processDirs += $normalized
-            $appended += $dir
+            $before = $env:PATH
+            if ((Add-DotbotProcessPathDirectory -Directory $dir -Scope $scope) -and $env:PATH -ne $before) {
+                $appended += $dir
+            }
         }
     }
     return $appended

--- a/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
+++ b/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
@@ -278,15 +278,44 @@ function Remove-ProcessLock {
     Remove-Item $lockPath -Force -ErrorAction SilentlyContinue
 }
 
+function Test-DotbotPreflightCommand {
+    # Resolves a dependency across process + registry Machine/User PATH scopes
+    # (Windows split-PATH fix), repairing the session PATH on a registry hit so
+    # downstream spawns work. Falls back to plain Get-Command when the resolver
+    # is unavailable (stale vendored Dotbot.Core).
+    param([Parameter(Mandatory)][string]$Name)
+
+    if (Get-Command Resolve-DotbotExternalCommand -ErrorAction SilentlyContinue) {
+        return Resolve-DotbotExternalCommand -Name $Name -RepairSessionPath
+    }
+    $cmd = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($cmd) { return @{ Found = $true; Name = $Name; Scope = 'Process' } }
+    return @{ Found = $false; Name = $Name }
+}
+
+function Get-DotbotPreflightCheckText {
+    # Check line for a resolved dependency. Registry-scope hits name the tool,
+    # the PATH scope it was found in, and how to fix the split permanently.
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][hashtable]$Resolution
+    )
+
+    if ($Resolution.Scope -in @('Machine', 'User')) {
+        return "${Name}: OK (found via $($Resolution.Scope) PATH: $($Resolution.Directory); missing from this process PATH - session PATH repaired; restart your terminal to fix it permanently)"
+    }
+    return "${Name}: OK"
+}
+
 function Test-Preflight {
     param([string]$BotRoot)
     $root = Resolve-DotbotBotRoot -BotRoot $BotRoot
     $checks = @()
     $allPassed = $true
 
-    $gitCmd = Get-Command git -ErrorAction SilentlyContinue
-    if ($gitCmd) {
-        $checks += "git: OK"
+    $gitRes = Test-DotbotPreflightCommand -Name 'git'
+    if ($gitRes.Found) {
+        $checks += Get-DotbotPreflightCheckText -Name 'git' -Resolution $gitRes
     } else {
         $checks += "git: MISSING - git not found on PATH"
         $allPassed = $false
@@ -302,9 +331,9 @@ function Test-Preflight {
     if ($providerConfig) {
         $providerExe = $providerConfig.executable
         $providerDisplay = $providerConfig.display_name
-        $providerCmd = Get-Command $providerExe -ErrorAction SilentlyContinue
-        if ($providerCmd) {
-            $checks += "${providerExe}: OK"
+        $providerRes = Test-DotbotPreflightCommand -Name $providerExe
+        if ($providerRes.Found) {
+            $checks += Get-DotbotPreflightCheckText -Name $providerExe -Resolution $providerRes
         } else {
             $checks += "${providerExe}: MISSING - $providerDisplay CLI not found on PATH"
             $allPassed = $false

--- a/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
+++ b/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
@@ -286,7 +286,13 @@ function Test-DotbotPreflightCommand {
     param([Parameter(Mandatory)][string]$Name)
 
     if (Get-Command Resolve-DotbotExternalCommand -ErrorAction SilentlyContinue) {
-        return Resolve-DotbotExternalCommand -Name $Name -RepairSessionPath
+        $resolution = Resolve-DotbotExternalCommand -Name $Name -RepairSessionPath
+        if ($resolution.Found -and $resolution.Scope -in @('Machine', 'User') -and -not $resolution.Repaired) {
+            $resolution.Found = $false
+            $resolution.RepairSkipped = $resolution.RepairBlocked -eq 'opt_out'
+            $resolution.RepairBlockedElevated = $resolution.RepairBlocked -eq 'elevated_user_path'
+        }
+        return $resolution
     }
     $cmd = Get-Command $Name -ErrorAction SilentlyContinue
     if ($cmd) { return @{ Found = $true; Name = $Name; Scope = 'Process' } }
@@ -317,7 +323,13 @@ function Test-Preflight {
     if ($gitRes.Found) {
         $checks += Get-DotbotPreflightCheckText -Name 'git' -Resolution $gitRes
     } else {
-        $checks += "git: MISSING - git not found on PATH"
+        $checks += if ($gitRes.RepairSkipped) {
+            "git: MISSING - found via $($gitRes.Scope) PATH, but session PATH repair is disabled by DOTBOT_SKIP_PATH_REPAIR"
+        } elseif ($gitRes.RepairBlockedElevated) {
+            "git: MISSING - found via User PATH, but user-writable PATH entries are not added to an elevated process; restart dotbot without elevation"
+        } else {
+            "git: MISSING - git not found on PATH"
+        }
         $allPassed = $false
     }
 
@@ -335,7 +347,13 @@ function Test-Preflight {
         if ($providerRes.Found) {
             $checks += Get-DotbotPreflightCheckText -Name $providerExe -Resolution $providerRes
         } else {
-            $checks += "${providerExe}: MISSING - $providerDisplay CLI not found on PATH"
+            $checks += if ($providerRes.RepairSkipped) {
+                "${providerExe}: MISSING - found via $($providerRes.Scope) PATH, but session PATH repair is disabled by DOTBOT_SKIP_PATH_REPAIR"
+            } elseif ($providerRes.RepairBlockedElevated) {
+                "${providerExe}: MISSING - found via User PATH, but user-writable PATH entries are not added to an elevated process; restart dotbot without elevation"
+            } else {
+                "${providerExe}: MISSING - $providerDisplay CLI not found on PATH"
+            }
             $allPassed = $false
         }
     } else {

--- a/src/runtime/Modules/Dotbot.Workflow/Dotbot.Workflow.psm1
+++ b/src/runtime/Modules/Dotbot.Workflow/Dotbot.Workflow.psm1
@@ -1498,8 +1498,15 @@ function Test-GitReadyForWorktree {
         }
     }
 
-    $gitExe = Get-Command git -ErrorAction SilentlyContinue
-    if (-not $gitExe) {
+    # Resolve git across process + registry Machine/User PATH scopes when the
+    # resolver is available (Windows split-PATH fix); repair the session PATH
+    # on a registry hit so the `& git` calls below work.
+    $gitAvailable = if (Get-Command Resolve-DotbotExternalCommand -ErrorAction SilentlyContinue) {
+        (Resolve-DotbotExternalCommand -Name 'git' -RepairSessionPath).Found
+    } else {
+        [bool](Get-Command git -ErrorAction SilentlyContinue)
+    }
+    if (-not $gitAvailable) {
         return @{
             ok      = $false
             reason  = 'git_unavailable'

--- a/src/runtime/Modules/Dotbot.Workflow/Dotbot.Workflow.psm1
+++ b/src/runtime/Modules/Dotbot.Workflow/Dotbot.Workflow.psm1
@@ -1502,7 +1502,8 @@ function Test-GitReadyForWorktree {
     # resolver is available (Windows split-PATH fix); repair the session PATH
     # on a registry hit so the `& git` calls below work.
     $gitAvailable = if (Get-Command Resolve-DotbotExternalCommand -ErrorAction SilentlyContinue) {
-        (Resolve-DotbotExternalCommand -Name 'git' -RepairSessionPath).Found
+        $gitResolution = Resolve-DotbotExternalCommand -Name 'git' -RepairSessionPath
+        $gitResolution.Found -and ($gitResolution.Scope -eq 'Process' -or $gitResolution.Repaired)
     } else {
         [bool](Get-Command git -ErrorAction SilentlyContinue)
     }

--- a/src/runtime/Scripts/Invoke-DotbotProcess.ps1
+++ b/src/runtime/Scripts/Invoke-DotbotProcess.ps1
@@ -97,6 +97,9 @@ $env:DOTBOT_CURRENT_PHASE = $phaseMap[$Type]
 
 # Resolve paths
 Import-Module (Join-Path $PSScriptRoot ".." "Modules" "Dotbot.Core" "Dotbot.Core.psm1") -Force -DisableNameChecking
+# Merge registry Machine/User PATH into this process before any preflight
+# check or provider spawn (Windows split-PATH fix).
+$null = Repair-DotbotProcessPath
 $botRoot = Get-DotbotProjectBotPath
 $controlDir = Join-Path $botRoot ".control"
 $processesDir = Join-Path $controlDir "processes"

--- a/src/ui/server.ps1
+++ b/src/ui/server.ps1
@@ -34,6 +34,10 @@ Import-Module (Join-Path $PSScriptRoot ".." "runtime" "Modules" "Dotbot.Core" "D
 Import-Module (Join-Path $PSScriptRoot ".." "runtime" "Modules" "Dotbot.Process" "Dotbot.Process.psd1") -Force -DisableNameChecking
 Import-Module (Join-Path $PSScriptRoot ".." "cli" "Platform-Functions.psm1") -Force
 
+# Merge registry Machine/User PATH into this process so provider/editor
+# probes in the API modules see every installed tool (Windows split-PATH fix).
+$null = Repair-DotbotProcessPath
+
 # Establish a stable correlation_id for the UI server's lifetime so events
 # emitted from request handlers (e.g. /api/aether/scan) carry a value that
 # joins them to the rest of the server's activity stream. Unconditional —

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -166,8 +166,9 @@ if (2 -in $layersToRun) {
     $mcpHandshakeCode        = Invoke-TestFile -Layer '2' -FileName 'Test-MCPHandshake.ps1'
     $registryCLICode         = Invoke-TestFile -Layer '2' -FileName 'Test-RegistryCLI.ps1'
     $logsCLICode             = Invoke-TestFile -Layer '2' -FileName 'Test-LogsCLI.ps1'
+    $depPathResolutionCode   = Invoke-TestFile -Layer '2' -FileName 'Test-DependencyPathResolution.ps1'
 
-    $exitCode = if ($componentsCode -ne 0 -or $taskActionsCode -ne 0 -or $serverStartupCode -ne 0 -or $workflowIntegrationCode -ne 0 -or $processRegistryCode -ne 0 -or $processDispatchCode -ne 0 -or $studioAPICode -ne 0 -or $toolLocalCode -ne 0 -or $mcpHandshakeCode -ne 0 -or $registryCLICode -ne 0 -or $logsCLICode -ne 0) { 1 } else { 0 }
+    $exitCode = if ($componentsCode -ne 0 -or $taskActionsCode -ne 0 -or $serverStartupCode -ne 0 -or $workflowIntegrationCode -ne 0 -or $processRegistryCode -ne 0 -or $processDispatchCode -ne 0 -or $studioAPICode -ne 0 -or $toolLocalCode -ne 0 -or $mcpHandshakeCode -ne 0 -or $registryCLICode -ne 0 -or $logsCLICode -ne 0 -or $depPathResolutionCode -ne 0) { 1 } else { 0 }
     $layerResults["2"] = ($exitCode -eq 0)
     if ($exitCode -ne 0) { $overallFailed = $true }
 }

--- a/tests/Test-DependencyPathResolution.ps1
+++ b/tests/Test-DependencyPathResolution.ps1
@@ -1,0 +1,363 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Layer 2: Dependency resolution across Windows PATH scopes (Machine/User registry vs process).
+.DESCRIPTION
+    Reproduces the split-PATH bug: on Windows, Machine PATH and User PATH are
+    merged at login, but a dotbot child process can inherit a process PATH that
+    is missing one scope (e.g. Git installed system-wide -> Machine PATH,
+    Claude installed per-user -> User PATH). Detection via Get-Command then
+    reports the tools MISSING even though they are registered on the machine.
+
+    These tests encode the FIXED behavior and fail until the fix lands:
+      - Test-Preflight must resolve git/claude via the registry Machine/User
+        PATH when the process PATH lacks them (issue checkbox 1).
+      - The failure/detection output must name the tool and the PATH scope it
+        was found in (issue checkbox 2, asserted loosely).
+      - 'dotbot doctor' must detect the split instead of reporting
+        "not found on PATH" (issue checkbox 3).
+      - 'dotbot doctor' must propagate doctor.ps1's exit code through
+        bin/dotbot.ps1 (secondary bug: the dispatcher swallows it).
+
+    The split is simulated per-process only: child pwsh processes are spawned
+    with the tool directories filtered out of $env:PATH. The registry
+    Machine/User PATH is read-only here and NEVER modified.
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+Import-Module "$PSScriptRoot\Test-Helpers.psm1" -Force
+
+$dotbotDir = Get-DotbotInstallDir
+
+Write-Host ""
+Write-Host "-----------------------------------------------------------" -ForegroundColor Blue
+Write-Host "  Layer 2: Dependency PATH Resolution Tests" -ForegroundColor Blue
+Write-Host "-----------------------------------------------------------" -ForegroundColor Blue
+Write-Host ""
+
+Reset-TestResults
+
+# ===================================================================
+# GUARDS
+# ===================================================================
+
+if (-not $IsWindows) {
+    Write-TestResult -Name "Dependency PATH resolution" -Status Skip -Message "Windows-only (registry Machine/User PATH scopes)"
+    Write-TestSummary -LayerName "Layer 2: Dependency PATH Resolution"
+    exit 0
+}
+
+$dotbotInstalled = Test-Path (Join-Path $dotbotDir "src")
+if (-not $dotbotInstalled) {
+    Write-TestResult -Name "Layer 2 prerequisites" -Status Fail -Message "dotbot not installed globally - set DOTBOT_HOME to a dotbot checkout (src/ + content/ must exist)"
+    Write-TestSummary -LayerName "Layer 2: Dependency PATH Resolution"
+    exit 1
+}
+
+# ===================================================================
+# HELPERS (file-private; only $env:PATH is ever modified, with restore)
+# ===================================================================
+
+$script:PwshExe = (Get-Command pwsh).Source
+$script:ProbeExtensions = @('exe', 'cmd', 'bat', 'ps1')
+
+function Get-RegistryPathDirectories {
+    param([Parameter(Mandatory)][ValidateSet('Machine', 'User')][string[]]$Scope)
+    $dirs = foreach ($s in $Scope) {
+        ([Environment]::GetEnvironmentVariable('Path', $s) -split ';') |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    }
+    return @($dirs)
+}
+
+function Find-CommandInDirectories {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [string[]]$Directories
+    )
+    foreach ($d in @($Directories)) {
+        foreach ($ext in $script:ProbeExtensions) {
+            try {
+                $candidate = Join-Path $d "$Name.$ext"
+                if (Test-Path -LiteralPath $candidate) { return $candidate }
+            } catch { }   # malformed PATH entries throw on Join-Path/Test-Path
+        }
+    }
+    return $null
+}
+
+function Get-ProcessPathWithoutCommands {
+    # Drops every process-PATH entry that ships one of the given commands,
+    # simulating a child process that did not inherit those PATH segments.
+    param([Parameter(Mandatory)][string[]]$Commands)
+    $kept = foreach ($entry in ($env:PATH -split ';')) {
+        if ([string]::IsNullOrWhiteSpace($entry)) { continue }
+        $ships = $false
+        foreach ($cmd in $Commands) {
+            if (Find-CommandInDirectories -Name $cmd -Directories @($entry)) { $ships = $true; break }
+        }
+        if (-not $ships) { $entry }
+    }
+    return ($kept -join ';')
+}
+
+function Invoke-ChildPwsh {
+    # Runs pwsh with a controlled process PATH; restores the caller's PATH.
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string[]]$ArgumentList
+    )
+    $old = $env:PATH
+    $env:PATH = $Path
+    try {
+        $output = & $script:PwshExe -NoProfile -NonInteractive @ArgumentList 2>&1
+        $code = $LASTEXITCODE
+    } finally {
+        $env:PATH = $old
+    }
+    return @{ Output = @($output | ForEach-Object { "$_" }); ExitCode = $code }
+}
+
+function Test-AnyLineNamesToolAndScope {
+    # Issue checkbox 2, asserted loosely: some single line must name the tool
+    # AND a PATH scope (Machine/User). Per-line matching keeps path noise like
+    # C:\Users\... in other lines from green-lighting the assertion.
+    param(
+        [Parameter(Mandatory)][string]$Tool,
+        [string[]]$Lines
+    )
+    foreach ($line in @($Lines)) {
+        if ($null -eq $line) { continue }
+        if ($line -match "(?i)$Tool" -and $line -match '(?i)\b(machine|user)\b') { return $true }
+    }
+    return $false
+}
+
+# Registry PATH preconditions (read-only probes)
+$registryDirs = Get-RegistryPathDirectories -Scope @('Machine', 'User')
+$gitInRegistry = Find-CommandInDirectories -Name 'git' -Directories $registryDirs
+if (-not $gitInRegistry) {
+    Write-TestResult -Name "Dependency PATH resolution" -Status Skip -Message "git not found in registry Machine/User PATH on this machine"
+    Write-TestSummary -LayerName "Layer 2: Dependency PATH Resolution"
+    exit 0
+}
+
+$userRegistryDirs = Get-RegistryPathDirectories -Scope @('User')
+$claudeInUserRegistry = Find-CommandInDirectories -Name 'claude' -Directories $userRegistryDirs
+
+# Dotbot.Core provides ConvertTo-SanitizedConsoleText (doctor output has ANSI escapes)
+Import-Module (Join-Path $dotbotDir "src/runtime/Modules/Dotbot.Core/Dotbot.Core.psd1") -Force -DisableNameChecking
+
+# ===================================================================
+# SETUP: temp project fixture (bare .bot is enough for Test-Preflight
+# to resolve the framework-tier claude provider config via DOTBOT_HOME)
+# ===================================================================
+
+$proj = New-TestProject -Prefix "dotbot-test-pathres"
+$botRoot = Join-Path $proj ".bot"
+New-Item -ItemType Directory -Path $botRoot -Force | Out-Null
+
+# Child script: reports what Get-Command sees, runs Test-Preflight, writes JSON
+$childScript = Join-Path $proj "run-preflight.ps1"
+@'
+param(
+    [Parameter(Mandatory)][string]$DotbotHome,
+    [Parameter(Mandatory)][string]$BotRoot,
+    [Parameter(Mandatory)][string]$WorkDir,
+    [Parameter(Mandatory)][string]$ResultPath
+)
+$ErrorActionPreference = 'Stop'
+Set-Location -LiteralPath $WorkDir
+"SANITY-GIT: $([bool](Get-Command git -ErrorAction SilentlyContinue))"
+"SANITY-CLAUDE: $([bool](Get-Command claude -ErrorAction SilentlyContinue))"
+$modules = Join-Path $DotbotHome 'src/runtime/Modules'
+Import-Module (Join-Path $modules 'Dotbot.Core/Dotbot.Core.psd1')         -Force -DisableNameChecking
+Import-Module (Join-Path $modules 'Dotbot.Settings/Dotbot.Settings.psd1') -Force -DisableNameChecking
+Import-Module (Join-Path $modules 'Dotbot.Logging/Dotbot.Logging.psd1')   -Force -DisableNameChecking
+Import-Module (Join-Path $modules 'Dotbot.Process/Dotbot.Process.psd1')   -Force -DisableNameChecking
+$r = Test-Preflight -BotRoot $BotRoot
+@{ passed = [bool]$r.passed; checks = @($r.checks) } | ConvertTo-Json | Set-Content -LiteralPath $ResultPath
+'@ | Set-Content -Path $childScript
+
+function Invoke-PreflightChild {
+    param([Parameter(Mandatory)][string]$Path)
+    $resultPath = Join-Path $proj "preflight-result.json"
+    Remove-Item $resultPath -Force -ErrorAction SilentlyContinue
+    $child = Invoke-ChildPwsh -Path $Path -ArgumentList @(
+        '-File', $childScript,
+        '-DotbotHome', $dotbotDir,
+        '-BotRoot', $botRoot,
+        '-WorkDir', $proj,
+        '-ResultPath', $resultPath
+    )
+    $result = $null
+    if (Test-Path $resultPath) {
+        $result = Get-Content $resultPath -Raw | ConvertFrom-Json
+    }
+    return @{ Output = $child.Output; ExitCode = $child.ExitCode; Result = $result }
+}
+
+try {
+
+# ===================================================================
+# SECTION 1+2: Test-Preflight must resolve git via registry Machine PATH
+# (child PATH: git+claude stripped; tests dir appended so the mock
+#  claude.cmd shim isolates the provider check from the git assertion)
+# ===================================================================
+
+Write-Host "  PREFLIGHT: GIT VIA REGISTRY PATH (process PATH stripped)" -ForegroundColor Cyan
+Write-Host "  --------------------------------------------" -ForegroundColor DarkGray
+
+Assert-True -Name "git launcher present in registry Machine/User PATH" `
+    -Condition ([bool]$gitInRegistry) `
+    -Message "expected git in registry PATH (found: $gitInRegistry)"
+
+$gitStrippedPath = (Get-ProcessPathWithoutCommands -Commands @('git', 'claude')) + ";$PSScriptRoot"
+$gitRun = Invoke-PreflightChild -Path $gitStrippedPath
+
+Assert-True -Name "stripped child cannot resolve git via Get-Command (simulation sanity)" `
+    -Condition ($gitRun.Output -contains 'SANITY-GIT: False') `
+    -Message "child output: $($gitRun.Output -join ' | ')"
+
+Assert-True -Name "stripped child resolves mock claude shim (provider isolation sanity)" `
+    -Condition ($gitRun.Output -contains 'SANITY-CLAUDE: True') `
+    -Message "child output: $($gitRun.Output -join ' | ')"
+
+Assert-True -Name "Test-Preflight passes when git is only on registry Machine/User PATH" `
+    -Condition ($null -ne $gitRun.Result -and $gitRun.Result.passed -eq $true) `
+    -Message "checks: $(@($gitRun.Result.checks) -join ' | ')"
+
+Assert-True -Name "Test-Preflight emits no 'git: MISSING' when git is in registry PATH" `
+    -Condition ($null -ne $gitRun.Result -and -not (@($gitRun.Result.checks) -match 'git:\s*MISSING')) `
+    -Message "checks: $(@($gitRun.Result.checks) -join ' | ')"
+
+$gitLines = @($gitRun.Result.checks) + @($gitRun.Output | ForEach-Object { ConvertTo-SanitizedConsoleText $_ })
+Assert-True -Name "preflight output names git and the PATH scope it was found in" `
+    -Condition (Test-AnyLineNamesToolAndScope -Tool 'git' -Lines $gitLines) `
+    -Message "no line names both git and Machine/User scope. Lines: $($gitLines -join ' | ')"
+
+# ===================================================================
+# SECTION 3: Test-Preflight must resolve claude via registry User PATH
+# (child PATH: claude stripped, git untouched, no shim)
+# ===================================================================
+
+Write-Host ""
+Write-Host "  PREFLIGHT: CLAUDE VIA REGISTRY USER PATH" -ForegroundColor Cyan
+Write-Host "  --------------------------------------------" -ForegroundColor DarkGray
+
+if (-not $claudeInUserRegistry) {
+    Write-TestResult -Name "claude via registry User PATH" -Status Skip -Message "claude not found in registry User PATH on this machine"
+} else {
+    $claudeStrippedPath = Get-ProcessPathWithoutCommands -Commands @('claude')
+    $claudeRun = Invoke-PreflightChild -Path $claudeStrippedPath
+
+    Assert-True -Name "stripped child resolves git but not claude (simulation sanity)" `
+        -Condition (($claudeRun.Output -contains 'SANITY-GIT: True') -and ($claudeRun.Output -contains 'SANITY-CLAUDE: False')) `
+        -Message "child output: $($claudeRun.Output -join ' | ')"
+
+    Assert-True -Name "Test-Preflight passes when claude is only on registry User PATH" `
+        -Condition ($null -ne $claudeRun.Result -and $claudeRun.Result.passed -eq $true) `
+        -Message "checks: $(@($claudeRun.Result.checks) -join ' | ')"
+
+    Assert-True -Name "Test-Preflight emits no 'claude: MISSING' when claude is in registry User PATH" `
+        -Condition ($null -ne $claudeRun.Result -and -not (@($claudeRun.Result.checks) -match 'claude:\s*MISSING')) `
+        -Message "checks: $(@($claudeRun.Result.checks) -join ' | ')"
+
+    $claudeLines = @($claudeRun.Result.checks) + @($claudeRun.Output | ForEach-Object { ConvertTo-SanitizedConsoleText $_ })
+    Assert-True -Name "preflight output names claude and the PATH scope it was found in" `
+        -Condition (Test-AnyLineNamesToolAndScope -Tool 'claude' -Lines $claudeLines) `
+        -Message "no line names both claude and Machine/User scope. Lines: $($claudeLines -join ' | ')"
+}
+
+# ===================================================================
+# SECTION 4: 'dotbot doctor' must detect the split, not report MISSING
+# ===================================================================
+
+Write-Host ""
+Write-Host "  DOCTOR: SPLIT-PATH DETECTION" -ForegroundColor Cyan
+Write-Host "  --------------------------------------------" -ForegroundColor DarkGray
+
+$doctorScript = Join-Path $dotbotDir "src/cli/doctor.ps1"
+$doctorRun = Invoke-ChildPwsh -Path $gitStrippedPath -ArgumentList @('-File', $doctorScript, '-BotRoot', $botRoot)
+$doctorLines = @($doctorRun.Output | ForEach-Object { ConvertTo-SanitizedConsoleText $_ } | Where-Object { $_ })
+$doctorText = $doctorLines -join "`n"
+
+Assert-True -Name "doctor runs its dependency checks (sanity)" `
+    -Condition ($doctorText -match 'DEPENDENCIES') `
+    -Message "doctor output did not contain the DEPENDENCIES section"
+
+Assert-True -Name "doctor does not report git missing when git is in registry PATH" `
+    -Condition ($doctorText -notmatch 'git\W*not found on PATH') `
+    -Message "doctor still reports git as not found on PATH"
+
+Assert-True -Name "doctor names git and the PATH scope it was found in (split detection)" `
+    -Condition (Test-AnyLineNamesToolAndScope -Tool 'git' -Lines $doctorLines) `
+    -Message "no doctor line names both git and Machine/User scope"
+
+# ===================================================================
+# SECTION 5: 'dotbot doctor' exit code must propagate through the CLI
+# (normal PATH — deliberately decoupled from the PATH fix; both
+#  scenarios make doctor exit non-zero even after the PATH fix)
+# ===================================================================
+
+Write-Host ""
+Write-Host "  DOCTOR: EXIT CODE PROPAGATION VIA bin/dotbot.ps1" -ForegroundColor Cyan
+Write-Host "  --------------------------------------------" -ForegroundColor DarkGray
+
+$dotbotCli = Join-Path $dotbotDir "bin/dotbot.ps1"
+
+# Scenario A: missing .bot -> doctor.ps1 exits 2 immediately
+$missingBot = Join-Path $proj "no-such/.bot"
+$null = & $script:PwshExe -NoProfile -NonInteractive -File $doctorScript -BotRoot $missingBot 2>&1
+$directExitA = $LASTEXITCODE
+$null = & $script:PwshExe -NoProfile -NonInteractive -File $dotbotCli doctor -BotRoot $missingBot 2>&1
+$cliExitA = $LASTEXITCODE
+
+Assert-True -Name "direct doctor.ps1 exits non-zero when .bot is missing (sanity)" `
+    -Condition ($directExitA -ne 0) `
+    -Message "direct exit was $directExitA"
+
+Assert-Equal -Name "'dotbot doctor' exit code equals direct doctor.ps1 exit (missing .bot)" `
+    -Expected $directExitA -Actual $cliExitA `
+    -Message "bin/dotbot.ps1 swallows doctor.ps1's exit code"
+
+Assert-True -Name "'dotbot doctor' exits non-zero when .bot is missing" `
+    -Condition ($cliExitA -ne 0) `
+    -Message "CLI exit was $cliExitA"
+
+# Scenario B: invalid task JSON inside a valid project -> doctor exits 2
+# via its normal end-of-script exit path
+$queueDir = Join-Path $botRoot "workspace/tasks/queue"
+New-Item -ItemType Directory -Path $queueDir -Force | Out-Null
+"this is not json" | Set-Content -Path (Join-Path $queueDir "bad-task.json")
+
+$null = & $script:PwshExe -NoProfile -NonInteractive -File $doctorScript -BotRoot $botRoot 2>&1
+$directExitB = $LASTEXITCODE
+$null = & $script:PwshExe -NoProfile -NonInteractive -File $dotbotCli doctor -BotRoot $botRoot 2>&1
+$cliExitB = $LASTEXITCODE
+
+Assert-True -Name "direct doctor.ps1 exits non-zero on invalid task JSON (sanity)" `
+    -Condition ($directExitB -ne 0) `
+    -Message "direct exit was $directExitB"
+
+Assert-Equal -Name "'dotbot doctor' exit code equals direct doctor.ps1 exit (invalid task JSON)" `
+    -Expected $directExitB -Actual $cliExitB `
+    -Message "bin/dotbot.ps1 swallows doctor.ps1's exit code"
+
+} finally {
+    # ===================================================================
+    # CLEANUP
+    # ===================================================================
+    Remove-TestProject -Path $proj
+}
+
+# ===================================================================
+# SUMMARY
+# ===================================================================
+
+$allPassed = Write-TestSummary -LayerName "Layer 2: Dependency PATH Resolution"
+if (-not $allPassed) { exit 1 }

--- a/tests/Test-DependencyPathResolution.ps1
+++ b/tests/Test-DependencyPathResolution.ps1
@@ -41,16 +41,6 @@ Write-Host ""
 
 Reset-TestResults
 
-# ===================================================================
-# GUARDS
-# ===================================================================
-
-if (-not $IsWindows) {
-    Write-TestResult -Name "Dependency PATH resolution" -Status Skip -Message "Windows-only (registry Machine/User PATH scopes)"
-    Write-TestSummary -LayerName "Layer 2: Dependency PATH Resolution"
-    exit 0
-}
-
 $dotbotInstalled = Test-Path (Join-Path $dotbotDir "src")
 if (-not $dotbotInstalled) {
     Write-TestResult -Name "Layer 2 prerequisites" -Status Fail -Message "dotbot not installed globally - set DOTBOT_HOME to a dotbot checkout (src/ + content/ must exist)"
@@ -58,21 +48,31 @@ if (-not $dotbotInstalled) {
     exit 1
 }
 
+# Dotbot.Core provides the resolver and ConvertTo-SanitizedConsoleText.
+$coreModule = Import-Module (Join-Path $dotbotDir "src/runtime/Modules/Dotbot.Core/Dotbot.Core.psd1") -Force -DisableNameChecking -PassThru
+
+# ===================================================================
+# GUARDS
+# ===================================================================
+
+if (-not $IsWindows) {
+    $before = $env:PATH
+    $resolution = Resolve-DotbotExternalCommand -Name "dotbot-command-that-does-not-exist-$PID" -RepairSessionPath
+    $appended = @(Repair-DotbotProcessPath -Force)
+    Assert-True -Name "non-Windows resolver reports registry-only command missing" -Condition (-not $resolution.Found)
+    Assert-Equal -Name "non-Windows repair is a no-op" -Expected 0 -Actual $appended.Count
+    Assert-Equal -Name "non-Windows repair does not mutate PATH" -Expected $before -Actual $env:PATH
+    $allPassed = Write-TestSummary -LayerName "Layer 2: Dependency PATH Resolution"
+    if (-not $allPassed) { exit 1 }
+    exit 0
+}
+
 # ===================================================================
 # HELPERS (file-private; only $env:PATH is ever modified, with restore)
 # ===================================================================
 
 $script:PwshExe = (Get-Command pwsh).Source
-$script:ProbeExtensions = @('exe', 'cmd', 'bat', 'ps1')
-
-function Get-RegistryPathDirectories {
-    param([Parameter(Mandatory)][ValidateSet('Machine', 'User')][string[]]$Scope)
-    $dirs = foreach ($s in $Scope) {
-        ([Environment]::GetEnvironmentVariable('Path', $s) -split ';') |
-            Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
-    }
-    return @($dirs)
-}
+$script:ProbeExtensions = @('ps1', 'com', 'exe', 'bat', 'cmd')
 
 function Find-CommandInDirectories {
     param(
@@ -137,21 +137,6 @@ function Test-AnyLineNamesToolAndScope {
     return $false
 }
 
-# Registry PATH preconditions (read-only probes)
-$registryDirs = Get-RegistryPathDirectories -Scope @('Machine', 'User')
-$gitInRegistry = Find-CommandInDirectories -Name 'git' -Directories $registryDirs
-if (-not $gitInRegistry) {
-    Write-TestResult -Name "Dependency PATH resolution" -Status Skip -Message "git not found in registry Machine/User PATH on this machine"
-    Write-TestSummary -LayerName "Layer 2: Dependency PATH Resolution"
-    exit 0
-}
-
-$userRegistryDirs = Get-RegistryPathDirectories -Scope @('User')
-$claudeInUserRegistry = Find-CommandInDirectories -Name 'claude' -Directories $userRegistryDirs
-
-# Dotbot.Core provides ConvertTo-SanitizedConsoleText (doctor output has ANSI escapes)
-Import-Module (Join-Path $dotbotDir "src/runtime/Modules/Dotbot.Core/Dotbot.Core.psd1") -Force -DisableNameChecking
-
 # ===================================================================
 # SETUP: temp project fixture (bare .bot is enough for Test-Preflight
 # to resolve the framework-tier claude provider config via DOTBOT_HOME)
@@ -161,6 +146,91 @@ $proj = New-TestProject -Prefix "dotbot-test-pathres"
 $botRoot = Join-Path $proj ".bot"
 New-Item -ItemType Directory -Path $botRoot -Force | Out-Null
 
+$machineDir = Join-Path $proj 'machine-bin'
+$userDir = Join-Path $proj 'user-bin'
+$safeProcessDir = Join-Path $proj 'safe-process-bin'
+$ghUserDir = Join-Path $proj 'gh-user-bin'
+New-Item -ItemType Directory -Path $machineDir, $userDir, $safeProcessDir, $ghUserDir -Force | Out-Null
+'' | Set-Content -LiteralPath (Join-Path $machineDir 'git.exe')
+'"machine"' | Set-Content -LiteralPath (Join-Path $machineDir 'precedence.ps1')
+'@echo machine-custom' | Set-Content -LiteralPath (Join-Path $machineDir 'native.custom')
+'"user"' | Set-Content -LiteralPath (Join-Path $userDir 'claude.ps1')
+'"user"' | Set-Content -LiteralPath (Join-Path $userDir 'precedence.ps1')
+'' | Set-Content -LiteralPath (Join-Path $ghUserDir 'gh.exe')
+
+$global:DotbotTestRegistryPaths = @{
+    Machine = "`"$machineDir`";relative-bin"
+    User    = $userDir
+}
+$originalRegistryPathReader = $coreModule.SessionState.PSVariable.GetValue('DotbotRegistryPathReader')
+$originalElevationReader = $coreModule.SessionState.PSVariable.GetValue('DotbotProcessElevationReader')
+$coreModule.SessionState.PSVariable.Set('DotbotRegistryPathReader', {
+    param([string]$Scope)
+    $global:DotbotTestRegistryPaths[$Scope]
+})
+$coreModule.SessionState.PSVariable.Set('DotbotProcessElevationReader', { $false })
+
+Write-Host "  CORE: DETERMINISTIC PATH SCOPE + MUTATION RULES" -ForegroundColor Cyan
+Write-Host "  --------------------------------------------" -ForegroundColor DarkGray
+
+$oldPath = $env:PATH
+$oldPathExt = $env:PATHEXT
+$oldSkipRepair = $env:DOTBOT_SKIP_PATH_REPAIR
+try {
+    $env:PATH = ''
+    $env:PATHEXT = '.CUSTOM;.EXE;.BAT;.CMD'
+    Remove-Item Env:DOTBOT_SKIP_PATH_REPAIR -ErrorAction SilentlyContinue
+
+    $beforeResolve = $env:PATH
+    $machineResolution = Resolve-DotbotExternalCommand -Name 'precedence'
+    Assert-Equal -Name "Machine PATH wins over User PATH" -Expected 'Machine' -Actual $machineResolution.Scope
+    Assert-Equal -Name "resolution without repair does not mutate PATH" -Expected $beforeResolve -Actual $env:PATH
+
+    $nativeResolution = Resolve-DotbotExternalCommand -Name 'native'
+    Assert-True -Name "resolver honors custom PATHEXT entries" -Condition ($nativeResolution.Found)
+    Assert-True -Name "resolver reports the PATHEXT-selected source" -Condition ($nativeResolution.Source -like '*.custom')
+
+    $repairResolution = Resolve-DotbotExternalCommand -Name 'precedence' -RepairSessionPath
+    Assert-True -Name "targeted registry resolution repairs the session" -Condition $repairResolution.Repaired
+    Assert-Equal -Name "empty PATH repair has no leading empty segment" -Expected $machineDir -Actual $env:PATH
+    Assert-True -Name "targeted repair does not add unrelated User PATH" -Condition ($env:PATH -notlike "*$userDir*")
+
+    $env:PATH = ''
+    $appended = @(Repair-DotbotProcessPath -Force)
+    $expectedMergedPath = "$machineDir;$userDir"
+    Assert-Equal -Name "full repair preserves Machine then User precedence" -Expected $expectedMergedPath -Actual $env:PATH
+    Assert-Equal -Name "full repair reports only accepted absolute directories" -Expected 2 -Actual $appended.Count
+    Assert-True -Name "relative registry entries are not added to PATH" -Condition ($env:PATH -notmatch 'relative-bin')
+
+    $env:PATH = $safeProcessDir
+    $env:DOTBOT_SKIP_PATH_REPAIR = '1'
+    $skipBefore = $env:PATH
+    $skippedResolution = Resolve-DotbotExternalCommand -Name 'claude' -RepairSessionPath
+    $skippedFullRepair = @(Repair-DotbotProcessPath -Force)
+    Assert-True -Name "opt-out still detects a User PATH command" -Condition ($skippedResolution.Found -and $skippedResolution.Scope -eq 'User')
+    Assert-True -Name "opt-out prevents targeted repair" -Condition (-not $skippedResolution.Repaired)
+    Assert-Equal -Name "opt-out prevents every PATH mutation path" -Expected $skipBefore -Actual $env:PATH
+    Assert-Equal -Name "opt-out full repair appends nothing" -Expected 0 -Actual $skippedFullRepair.Count
+
+    Remove-Item Env:DOTBOT_SKIP_PATH_REPAIR -ErrorAction SilentlyContinue
+    $coreModule.SessionState.PSVariable.Set('DotbotProcessElevationReader', { $true })
+    $env:PATH = $safeProcessDir
+    $elevatedResolution = Resolve-DotbotExternalCommand -Name 'claude' -RepairSessionPath
+    $elevatedRepair = @(Repair-DotbotProcessPath -Force)
+    Assert-True -Name "elevated process detects User PATH command without repairing" `
+        -Condition ($elevatedResolution.Found -and -not $elevatedResolution.Repaired -and $elevatedResolution.RepairBlocked -eq 'elevated_user_path')
+    Assert-True -Name "elevated full repair excludes User PATH" -Condition ($env:PATH -notlike "*$userDir*")
+    Assert-True -Name "elevated full repair may still add Machine PATH" -Condition ($elevatedRepair -contains $machineDir)
+} finally {
+    $env:PATH = $oldPath
+    $env:PATHEXT = $oldPathExt
+    if ($null -eq $oldSkipRepair) { Remove-Item Env:DOTBOT_SKIP_PATH_REPAIR -ErrorAction SilentlyContinue }
+    else { $env:DOTBOT_SKIP_PATH_REPAIR = $oldSkipRepair }
+    $coreModule.SessionState.PSVariable.Set('DotbotRegistryPathReader', $originalRegistryPathReader)
+    $coreModule.SessionState.PSVariable.Set('DotbotProcessElevationReader', $originalElevationReader)
+    Remove-Variable DotbotTestRegistryPaths -Scope Global -ErrorAction SilentlyContinue
+}
+
 # Child script: reports what Get-Command sees, runs Test-Preflight, writes JSON
 $childScript = Join-Path $proj "run-preflight.ps1"
 @'
@@ -168,14 +238,24 @@ param(
     [Parameter(Mandatory)][string]$DotbotHome,
     [Parameter(Mandatory)][string]$BotRoot,
     [Parameter(Mandatory)][string]$WorkDir,
-    [Parameter(Mandatory)][string]$ResultPath
+    [Parameter(Mandatory)][string]$ResultPath,
+    [Parameter(Mandatory)][string]$MachinePath,
+    [Parameter(Mandatory)][string]$UserPath,
+    [switch]$SkipRepair
 )
 $ErrorActionPreference = 'Stop'
 Set-Location -LiteralPath $WorkDir
 "SANITY-GIT: $([bool](Get-Command git -ErrorAction SilentlyContinue))"
 "SANITY-CLAUDE: $([bool](Get-Command claude -ErrorAction SilentlyContinue))"
 $modules = Join-Path $DotbotHome 'src/runtime/Modules'
-Import-Module (Join-Path $modules 'Dotbot.Core/Dotbot.Core.psd1')         -Force -DisableNameChecking
+$core = Import-Module (Join-Path $modules 'Dotbot.Core/Dotbot.Core.psd1') -Force -DisableNameChecking -PassThru
+$global:DotbotTestRegistryPaths = @{ Machine = $MachinePath; User = $UserPath }
+$core.SessionState.PSVariable.Set('DotbotRegistryPathReader', {
+    param([string]$Scope)
+    $global:DotbotTestRegistryPaths[$Scope]
+})
+$core.SessionState.PSVariable.Set('DotbotProcessElevationReader', { $false })
+if ($SkipRepair) { $env:DOTBOT_SKIP_PATH_REPAIR = '1' }
 Import-Module (Join-Path $modules 'Dotbot.Settings/Dotbot.Settings.psd1') -Force -DisableNameChecking
 Import-Module (Join-Path $modules 'Dotbot.Logging/Dotbot.Logging.psd1')   -Force -DisableNameChecking
 Import-Module (Join-Path $modules 'Dotbot.Process/Dotbot.Process.psd1')   -Force -DisableNameChecking
@@ -184,22 +264,46 @@ $r = Test-Preflight -BotRoot $BotRoot
 '@ | Set-Content -Path $childScript
 
 function Invoke-PreflightChild {
-    param([Parameter(Mandatory)][string]$Path)
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [switch]$SkipRepair
+    )
     $resultPath = Join-Path $proj "preflight-result.json"
     Remove-Item $resultPath -Force -ErrorAction SilentlyContinue
-    $child = Invoke-ChildPwsh -Path $Path -ArgumentList @(
+    $childArgs = @(
         '-File', $childScript,
         '-DotbotHome', $dotbotDir,
         '-BotRoot', $botRoot,
         '-WorkDir', $proj,
-        '-ResultPath', $resultPath
+        '-ResultPath', $resultPath,
+        '-MachinePath', $machineDir,
+        '-UserPath', $userDir
     )
+    if ($SkipRepair) { $childArgs += '-SkipRepair' }
+    $child = Invoke-ChildPwsh -Path $Path -ArgumentList $childArgs
     $result = $null
     if (Test-Path $resultPath) {
         $result = Get-Content $resultPath -Raw | ConvertFrom-Json
     }
     return @{ Output = $child.Output; ExitCode = $child.ExitCode; Result = $result }
 }
+
+$doctorBootstrap = Join-Path $proj 'run-doctor.ps1'
+@'
+param(
+    [Parameter(Mandatory)][string]$DotbotHome,
+    [Parameter(Mandatory)][string]$BotRoot,
+    [Parameter(Mandatory)][string]$MachinePath,
+    [Parameter(Mandatory)][string]$UserPath
+)
+$core = Import-Module (Join-Path $DotbotHome 'src/runtime/Modules/Dotbot.Core/Dotbot.Core.psd1') -Force -DisableNameChecking -PassThru
+$global:DotbotTestRegistryPaths = @{ Machine = $MachinePath; User = $UserPath }
+$core.SessionState.PSVariable.Set('DotbotRegistryPathReader', {
+    param([string]$Scope)
+    $global:DotbotTestRegistryPaths[$Scope]
+})
+& (Join-Path $DotbotHome 'src/cli/doctor.ps1') -BotRoot $BotRoot
+'@ | Set-Content -LiteralPath $doctorBootstrap
 
 try {
 
@@ -212,9 +316,8 @@ try {
 Write-Host "  PREFLIGHT: GIT VIA REGISTRY PATH (process PATH stripped)" -ForegroundColor Cyan
 Write-Host "  --------------------------------------------" -ForegroundColor DarkGray
 
-Assert-True -Name "git launcher present in registry Machine/User PATH" `
-    -Condition ([bool]$gitInRegistry) `
-    -Message "expected git in registry PATH (found: $gitInRegistry)"
+Assert-True -Name "mock git launcher present in Machine PATH fixture" `
+    -Condition (Test-Path -LiteralPath (Join-Path $machineDir 'git.exe'))
 
 $gitStrippedPath = (Get-ProcessPathWithoutCommands -Commands @('git', 'claude')) + ";$PSScriptRoot"
 $gitRun = Invoke-PreflightChild -Path $gitStrippedPath
@@ -249,29 +352,32 @@ Write-Host ""
 Write-Host "  PREFLIGHT: CLAUDE VIA REGISTRY USER PATH" -ForegroundColor Cyan
 Write-Host "  --------------------------------------------" -ForegroundColor DarkGray
 
-if (-not $claudeInUserRegistry) {
-    Write-TestResult -Name "claude via registry User PATH" -Status Skip -Message "claude not found in registry User PATH on this machine"
-} else {
-    $claudeStrippedPath = Get-ProcessPathWithoutCommands -Commands @('claude')
-    $claudeRun = Invoke-PreflightChild -Path $claudeStrippedPath
+$claudeStrippedPath = $machineDir
+$claudeRun = Invoke-PreflightChild -Path $claudeStrippedPath
 
-    Assert-True -Name "stripped child resolves git but not claude (simulation sanity)" `
-        -Condition (($claudeRun.Output -contains 'SANITY-GIT: True') -and ($claudeRun.Output -contains 'SANITY-CLAUDE: False')) `
-        -Message "child output: $($claudeRun.Output -join ' | ')"
+Assert-True -Name "stripped child resolves git but not claude (simulation sanity)" `
+    -Condition (($claudeRun.Output -contains 'SANITY-GIT: True') -and ($claudeRun.Output -contains 'SANITY-CLAUDE: False')) `
+    -Message "child output: $($claudeRun.Output -join ' | ')"
 
-    Assert-True -Name "Test-Preflight passes when claude is only on registry User PATH" `
-        -Condition ($null -ne $claudeRun.Result -and $claudeRun.Result.passed -eq $true) `
-        -Message "checks: $(@($claudeRun.Result.checks) -join ' | ')"
+Assert-True -Name "Test-Preflight passes when claude is only on registry User PATH" `
+    -Condition ($null -ne $claudeRun.Result -and $claudeRun.Result.passed -eq $true) `
+    -Message "checks: $(@($claudeRun.Result.checks) -join ' | ')"
 
-    Assert-True -Name "Test-Preflight emits no 'claude: MISSING' when claude is in registry User PATH" `
-        -Condition ($null -ne $claudeRun.Result -and -not (@($claudeRun.Result.checks) -match 'claude:\s*MISSING')) `
-        -Message "checks: $(@($claudeRun.Result.checks) -join ' | ')"
+Assert-True -Name "Test-Preflight emits no 'claude: MISSING' when claude is in registry User PATH" `
+    -Condition ($null -ne $claudeRun.Result -and -not (@($claudeRun.Result.checks) -match 'claude:\s*MISSING')) `
+    -Message "checks: $(@($claudeRun.Result.checks) -join ' | ')"
 
-    $claudeLines = @($claudeRun.Result.checks) + @($claudeRun.Output | ForEach-Object { ConvertTo-SanitizedConsoleText $_ })
-    Assert-True -Name "preflight output names claude and the PATH scope it was found in" `
-        -Condition (Test-AnyLineNamesToolAndScope -Tool 'claude' -Lines $claudeLines) `
-        -Message "no line names both claude and Machine/User scope. Lines: $($claudeLines -join ' | ')"
-}
+$claudeLines = @($claudeRun.Result.checks) + @($claudeRun.Output | ForEach-Object { ConvertTo-SanitizedConsoleText $_ })
+Assert-True -Name "preflight output names claude and the PATH scope it was found in" `
+    -Condition (Test-AnyLineNamesToolAndScope -Tool 'claude' -Lines $claudeLines) `
+    -Message "no line names both claude and Machine/User scope. Lines: $($claudeLines -join ' | ')"
+
+$optOutRun = Invoke-PreflightChild -Path $machineDir -SkipRepair
+Assert-True -Name "preflight fails cleanly when User PATH repair is opted out" `
+    -Condition ($null -ne $optOutRun.Result -and $optOutRun.Result.passed -eq $false)
+Assert-True -Name "preflight explains the PATH-repair opt-out" `
+    -Condition ([bool](@($optOutRun.Result.checks) -match 'DOTBOT_SKIP_PATH_REPAIR')) `
+    -Message "checks: $(@($optOutRun.Result.checks) -join ' | ')"
 
 # ===================================================================
 # SECTION 4: 'dotbot doctor' must detect the split, not report MISSING
@@ -297,6 +403,22 @@ Assert-True -Name "doctor does not report git missing when git is in registry PA
 Assert-True -Name "doctor names git and the PATH scope it was found in (split detection)" `
     -Condition (Test-AnyLineNamesToolAndScope -Tool 'git' -Lines $doctorLines) `
     -Message "no doctor line names both git and Machine/User scope"
+
+$ghDoctorRun = Invoke-ChildPwsh -Path $safeProcessDir -ArgumentList @(
+    '-File', $doctorBootstrap,
+    '-DotbotHome', $dotbotDir,
+    '-BotRoot', $botRoot,
+    '-MachinePath', $machineDir,
+    '-UserPath', $ghUserDir
+)
+$ghDoctorLines = @($ghDoctorRun.Output | ForEach-Object { ConvertTo-SanitizedConsoleText $_ } | Where-Object { $_ })
+$ghDoctorText = $ghDoctorLines -join "`n"
+Assert-True -Name "doctor diagnoses registry-only gh as split PATH" `
+    -Condition ($ghDoctorText -match 'Provider CLI \(gh\).*split PATH detected') `
+    -Message "doctor output: $ghDoctorText"
+Assert-True -Name "doctor does not report registry-only gh as an ordinary pass" `
+    -Condition ($ghDoctorText -notmatch "Provider CLI.*gh found \(can run preview") `
+    -Message "doctor output: $ghDoctorText"
 
 # ===================================================================
 # SECTION 5: 'dotbot doctor' exit code must propagate through the CLI


### PR DESCRIPTION
## Linked issue

Closes #658

## Summary of changes

On Windows, dotbot reported `git: MISSING` / `claude: MISSING` and the workflow child window flashed and died whenever the process inherited a PATH missing the Machine or User registry scope (e.g. Git installed system-wide, Claude installed per-user) — even though both tools worked in the user's terminal. Every detection site used `Get-Command`, which only searches the process PATH.

**Fix:**

- New in `Dotbot.Core` (dependency-free, imported first by every entry point):
  - `Resolve-DotbotExternalCommand` — resolves a command via the process PATH, falling back to a registry `Machine` → `User` PATH scan on Windows; reports which scope the tool was found in and can repair the session PATH.
  - `Repair-DotbotProcessPath` — one-time, append-only merge of registry PATH directories missing from `$env:PATH`; opt-out via `DOTBOT_SKIP_PATH_REPAIR`; no-op on non-Windows.
- `Test-Preflight` and the `Test-GitReadyForWorktree` git gate resolve through the new resolver with session repair. Registry-scope hits produce an actionable check line naming the tool, the PATH scope, the directory, and the permanent fix. The exact `MISSING` strings are unchanged for truly-absent tools.
- The three entry-point preambles (`bin/dotbot.ps1`, `Invoke-DotbotProcess.ps1`, `src/ui/server.ps1`) call `Repair-DotbotProcessPath` once, transparently healing all downstream spawn sites (harness adapters, `ProcessStream`) and UI capability probes without modifying them.
- `dotbot doctor` detects the split instead of healing it (the CLI preamble deliberately skips repair for `doctor` so it observes the raw inherited PATH): a registry-only hit emits a `split PATH detected` **Warn** plus session and permanent fix commands.
- Secondary bug fixed: `bin/dotbot.ps1` swallowed `doctor.ps1`'s exit code — `dotbot doctor` exited 0 even with failing checks. The dispatcher now propagates it (same pattern as `dotbot run`).

## Testing notes

`tests/Test-DependencyPathResolution.ps1` encodes the issue's acceptance criteria and was failing 11/18 before the fix — it now passes **18/18**. It simulates the split by spawning child pwsh processes with tool directories stripped from the process PATH while the registry PATH stays intact, and covers: preflight resolution via Machine and User scopes, the actionable scope-naming messages, doctor's split detection, and doctor exit-code propagation (with two scenarios that stay non-zero even after the PATH fix, so the propagation assertion can't trivially pass).

- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/Test-DependencyPathResolution.ps1` → 18 passed, 0 failed.
- `pwsh tests/Run-Tests.ps1 -Layer all` → Layers 1–3 all passed (including the static scanners and both Layer-3 mock-provider suites; the append-only repair preserves mock-first PATH ordering).
- Live verification on a real split-PATH machine (git in Machine PATH, claude in User PATH): preflight passes from stripped shells naming the correct scope; post-preflight `Get-Command` succeeds in the same process (session-repair proof); a directory freshly added to the real User PATH is picked up; removing the tool everywhere still yields the exact `MISSING` failure; end-to-end `dotbot run smoke-test` from a claude-stripped shell survives preflight and runs, while `dotbot doctor` from the same shell reports the split and exits 1.

## Checklist

- [x] Tests added or updated
- [ ] Docs updated (if behaviour changed)
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
