### PR TITLE
fix(worktree): push integration branch once per run, not once per task

### DIFF
--- a/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1
+++ b/src/runtime/Modules/Dotbot.Worktree/Dotbot.Worktree.psm1
@@ -1625,7 +1625,13 @@ function Complete-TaskWorktree {
     param(
         [Parameter(Mandatory)][string]$TaskId,
         [Parameter(Mandatory)][string]$ProjectRoot,
-        [Parameter(Mandatory)][string]$BotRoot
+        [Parameter(Mandatory)][string]$BotRoot,
+        # Skip the auto-push to remote. Set by callers running a multi-task
+        # workflow run, where the base branch is a shared integration branch
+        # that only needs to reach origin once — after the last task — instead
+        # of on every single task completion (each push fires the remote's
+        # full CI pipeline).
+        [switch]$SkipRemotePush
     )
 
     $map = Read-WorktreeMap -BotRoot $BotRoot
@@ -1891,16 +1897,22 @@ function Complete-TaskWorktree {
             }
         }
 
-        # Auto-push to remote if one is configured
+        # Auto-push to remote if one is configured. Skipped when the caller is
+        # driving a multi-task run against a shared integration branch — that
+        # branch is pushed once at the end of the run instead (see
+        # Invoke-WorkflowProcess.ps1), so intermediate task completions don't
+        # each trigger a remote CI run against it.
         $pushResult = @{ attempted = $false; success = $false; error = $null }
-        $remoteUrl = git -C $ProjectRoot remote get-url origin 2>$null
-        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($remoteUrl)) {
-            $pushResult.attempted = $true
-            $pushOutput = git -C $ProjectRoot push origin $baseBranch 2>&1
-            if ($LASTEXITCODE -eq 0) {
-                $pushResult.success = $true
-            } else {
-                $pushResult.error = ($pushOutput | Out-String).Trim()
+        if (-not $SkipRemotePush) {
+            $remoteUrl = git -C $ProjectRoot remote get-url origin 2>$null
+            if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($remoteUrl)) {
+                $pushResult.attempted = $true
+                $pushOutput = git -C $ProjectRoot push origin $baseBranch 2>&1
+                if ($LASTEXITCODE -eq 0) {
+                    $pushResult.success = $true
+                } else {
+                    $pushResult.error = ($pushOutput | Out-String).Trim()
+                }
             }
         }
 

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -1706,11 +1706,12 @@ try {
             }
 
             if ($typeSuccess) {
-                Write-Status "Merging task branch to main..." -Type Process
+                $mergeTargetLabel = if ($integrationBranch) { $integrationBranch } else { 'main' }
+                Write-Status "Merging task branch to $mergeTargetLabel..." -Type Process
                 $mergeResult = Complete-TaskWorktree -TaskId $task.id -ProjectRoot $projectRoot -BotRoot $botRoot -SkipRemotePush:($null -ne $integrationBranch)
                 if ($mergeResult.success) {
                     Write-Status "Merged: $($mergeResult.message)" -Type Complete
-                    Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Squash-merged to main: $($task.name)"
+                    Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Squash-merged to ${mergeTargetLabel}: $($task.name)"
                     if ($mergeResult.push_result.attempted) {
                         if ($mergeResult.push_result.success) {
                             Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Pushed to remote: $($task.name)"
@@ -2281,13 +2282,14 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
         } elseif ($taskSuccess) {
             $mergeCompleted = $true
 
-            # Squash-merge task branch to main
+            # Squash-merge task branch to main (or the run's integration branch)
             if ($worktreePath) {
-                Write-Status "Merging task branch to main..." -Type Process
+                $mergeTargetLabel = if ($integrationBranch) { $integrationBranch } else { 'main' }
+                Write-Status "Merging task branch to $mergeTargetLabel..." -Type Process
                 $mergeResult = Complete-TaskWorktree -TaskId $task.id -ProjectRoot $projectRoot -BotRoot $botRoot -SkipRemotePush:($null -ne $integrationBranch)
                 if ($mergeResult.success) {
                     Write-Status "Merged: $($mergeResult.message)" -Type Complete
-                    Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Squash-merged to main: $($task.name)"
+                    Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Squash-merged to ${mergeTargetLabel}: $($task.name)"
                     if ($mergeResult.push_result.attempted) {
                         if ($mergeResult.push_result.success) {
                             Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Pushed to remote: $($task.name)"

--- a/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
+++ b/src/runtime/Scripts/Invoke-WorkflowProcess.ps1
@@ -1707,7 +1707,7 @@ try {
 
             if ($typeSuccess) {
                 Write-Status "Merging task branch to main..." -Type Process
-                $mergeResult = Complete-TaskWorktree -TaskId $task.id -ProjectRoot $projectRoot -BotRoot $botRoot
+                $mergeResult = Complete-TaskWorktree -TaskId $task.id -ProjectRoot $projectRoot -BotRoot $botRoot -SkipRemotePush:($null -ne $integrationBranch)
                 if ($mergeResult.success) {
                     Write-Status "Merged: $($mergeResult.message)" -Type Complete
                     Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Squash-merged to main: $($task.name)"
@@ -2284,7 +2284,7 @@ Work on this task autonomously. When complete, ensure you call ``task_set_status
             # Squash-merge task branch to main
             if ($worktreePath) {
                 Write-Status "Merging task branch to main..." -Type Process
-                $mergeResult = Complete-TaskWorktree -TaskId $task.id -ProjectRoot $projectRoot -BotRoot $botRoot
+                $mergeResult = Complete-TaskWorktree -TaskId $task.id -ProjectRoot $projectRoot -BotRoot $botRoot -SkipRemotePush:($null -ne $integrationBranch)
                 if ($mergeResult.success) {
                     Write-Status "Merged: $($mergeResult.message)" -Type Complete
                     Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Squash-merged to main: $($task.name)"

--- a/tests/Test-Components.ps1
+++ b/tests/Test-Components.ps1
@@ -694,6 +694,82 @@ if (Test-Path $worktreeManagerModule) {
         Remove-TestProject -Path $completeRoot
     }
 
+    # Regression (#655): a multi-task workflow run passes -SkipRemotePush so
+    # the shared base branch is pushed once at the end of the run instead of
+    # once per task completion — each push fires the remote's full CI
+    # pipeline, so N tasks previously meant N CI runs.
+    $pushProj = New-TestProjectFromGolden -Flavor 'default' -Prefix 'dotbot-test-complete-push'
+    $pushRoot = $pushProj.ProjectRoot
+    $pushBot = $pushProj.BotDir
+    $pushBareRemote = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-test-push-remote-$([System.Guid]::NewGuid().ToString().Substring(0,8)).git"
+    $pushResultA = $null
+    $pushResultB = $null
+    try {
+        Push-Location $pushRoot
+        & git branch -M main 2>&1 | Out-Null
+        Pop-Location
+
+        & git init --bare --quiet $pushBareRemote 2>&1 | Out-Null
+        & git -C $pushRoot remote add origin $pushBareRemote 2>&1 | Out-Null
+
+        $pushTaskIdA = "t_pushA001"
+        $pushResultA = New-TaskWorktree -TaskId $pushTaskIdA -TaskName "skip remote push task" `
+            -ProjectRoot $pushRoot -BotRoot $pushBot
+        Assert-True -Name "SkipRemotePush regression: first New-TaskWorktree returns success" `
+            -Condition ($pushResultA -and $pushResultA.success -eq $true) `
+            -Message "Expected New-TaskWorktree success, got: $($pushResultA | ConvertTo-Json -Compress)"
+
+        if ($pushResultA -and $pushResultA.success -and (Test-Path $pushResultA.worktree_path)) {
+            "skip push artifact" | Set-Content -Path (Join-Path $pushResultA.worktree_path "skip-push-artifact.txt") -Encoding UTF8
+
+            $pushMergeA = Complete-TaskWorktree -TaskId $pushTaskIdA -ProjectRoot $pushRoot -BotRoot $pushBot -SkipRemotePush
+            Assert-True -Name "SkipRemotePush regression: merge succeeds with -SkipRemotePush" `
+                -Condition ($pushMergeA.success -eq $true) `
+                -Message "Expected success, got: $($pushMergeA | ConvertTo-Json -Depth 10 -Compress)"
+            Assert-True -Name "SkipRemotePush regression: push not attempted" `
+                -Condition ($pushMergeA.push_result.attempted -eq $false) `
+                -Message "Expected push_result.attempted false, got: $($pushMergeA.push_result | ConvertTo-Json -Compress)"
+
+            & git -C $pushBareRemote rev-parse --verify main 2>$null | Out-Null
+            Assert-True -Name "SkipRemotePush regression: origin main ref not created" `
+                -Condition ($LASTEXITCODE -ne 0)
+        }
+
+        $pushTaskIdB = "t_pushB002"
+        $pushResultB = New-TaskWorktree -TaskId $pushTaskIdB -TaskName "default push task" `
+            -ProjectRoot $pushRoot -BotRoot $pushBot
+        Assert-True -Name "SkipRemotePush regression: second New-TaskWorktree returns success" `
+            -Condition ($pushResultB -and $pushResultB.success -eq $true) `
+            -Message "Expected New-TaskWorktree success, got: $($pushResultB | ConvertTo-Json -Compress)"
+
+        if ($pushResultB -and $pushResultB.success -and (Test-Path $pushResultB.worktree_path)) {
+            "default push artifact" | Set-Content -Path (Join-Path $pushResultB.worktree_path "default-push-artifact.txt") -Encoding UTF8
+
+            $pushMergeB = Complete-TaskWorktree -TaskId $pushTaskIdB -ProjectRoot $pushRoot -BotRoot $pushBot
+            Assert-True -Name "SkipRemotePush regression: default merge succeeds" `
+                -Condition ($pushMergeB.success -eq $true) `
+                -Message "Expected success, got: $($pushMergeB | ConvertTo-Json -Depth 10 -Compress)"
+            Assert-True -Name "SkipRemotePush regression: default push attempted and succeeds" `
+                -Condition ($pushMergeB.push_result.attempted -eq $true -and $pushMergeB.push_result.success -eq $true) `
+                -Message "Expected push attempted+success, got: $($pushMergeB.push_result | ConvertTo-Json -Compress)"
+
+            & git -C $pushBareRemote rev-parse --verify main 2>$null | Out-Null
+            Assert-True -Name "SkipRemotePush regression: origin main ref created after default push" `
+                -Condition ($LASTEXITCODE -eq 0)
+        }
+    } finally {
+        foreach ($pr in @($pushResultA, $pushResultB)) {
+            if ($pr -and $pr.worktree_path -and (Test-Path $pr.worktree_path)) {
+                & git -C $pushRoot worktree remove -f $pr.worktree_path 2>&1 | Out-Null
+            }
+            if ($pr -and $pr.branch_name) {
+                & git -C $pushRoot branch -D $pr.branch_name 2>&1 | Out-Null
+            }
+        }
+        Remove-TestProject -Path $pushRoot
+        Remove-Item -LiteralPath $pushBareRemote -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
     $unbornRoot = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-test-unborn-complete-$([System.Guid]::NewGuid().ToString().Substring(0,8))"
     $unbornBot = Join-Path $unbornRoot ".bot"
     $earlierUnbornResult = $null


### PR DESCRIPTION
## Summary
- `Complete-TaskWorktree` auto-pushed the base branch to `origin` after every single task completion. During a multi-task workflow run the base branch for each task is the shared integration branch, so an N-task run pushed it N times — firing the remote's full CI pipeline N times over (the impact the issue described, though the issue's proposed mechanism was `task/*` branch pushes; those branches are actually never pushed, only merged and deleted locally).
- Add a `-SkipRemotePush` switch to `Complete-TaskWorktree`; `Invoke-WorkflowProcess.ps1` now passes it whenever an integration branch is active, so the integration branch is pushed once, at the end of the run (existing behavior), instead of after every task. Standalone task completion (outside a multi-task run) is unaffected — it still pushes immediately, since there's no later push to consolidate into.

## Test plan
- [x] Added a regression test in `tests/Test-Components.ps1` using a local bare-repo remote: verifies `-SkipRemotePush` merges without pushing, and that default (no switch) behavior still pushes.
- [x] `tests/Test-Components.ps1` — 859 passed, 0 failed, 1 skipped
- [x] `tests/Test-ProcessDispatch.ps1` — 44 passed, 0 failed
- [x] `tests/Test-WorkflowManifest.ps1` — 546 passed, 0 failed
- [x] `tests/Test-Structure.ps1` — 356 passed, 0 failed, 2 skipped

Fixes #655
