### PR TITLE
feat(cli): add `dotbot logs` to view activity and the last crash (#657)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ dotbot doctor                  # Run project health checks
 dotbot go                      # Launch runtime + dashboard for an initialized project
 dotbot serve                   # Launch only the low-level runtime
 dotbot runtime-status          # Show runtime PID, URL, active workflow runs
+dotbot logs                    # Show recent activity, or the last crash (--last, --follow)
 ```
 
 To upgrade a source checkout, run `git pull` inside that checkout. For packaged installs, use `brew upgrade dotbot` or `scoop update dotbot`. Vendored project runtimes are refreshed explicitly with `dotbot install runtime`.

--- a/bin/dotbot.ps1
+++ b/bin/dotbot.ps1
@@ -141,6 +141,7 @@ function Show-Help {
     Write-DotbotLabel "    doctor            " "Scan project for health issues"
     Write-DotbotLabel "    serve             " "Start only the low-level HTTP runtime in the foreground"
     Write-DotbotLabel "    runtime-status    " "Show runtime PID, URL, and active workflow runs"
+    Write-DotbotLabel "    logs              " "Show recent activity, or the last crash (--last, --follow)"
     Write-DotbotLabel "    prune-branches    " "Delete stale workflow/* and task/* branches"
     Write-DotbotLabel "    help              " "Show this help message"
     Write-BlankLine
@@ -730,6 +731,7 @@ switch ($Command) {
     "doctor" { & (Join-Path $ScriptsDir 'doctor.ps1') @SplatArgs }
     "serve"          { & (Join-Path $ScriptsDir 'serve.ps1')          @SplatArgs }
     "runtime-status" { & (Join-Path $ScriptsDir 'runtime-status.ps1') @SplatArgs }
+    "logs"           { & (Join-Path $ScriptsDir 'logs.ps1')           @SplatArgs }
     "prune-branches" { & (Join-Path $ScriptsDir 'prune-branches.ps1') @SplatArgs }
     "update" { Invoke-Update }
     "help" { Show-Help }

--- a/src/cli/logs.ps1
+++ b/src/cli/logs.ps1
@@ -1,0 +1,249 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    dotbot logs — surface recent activity-log events, or the last crash summary.
+
+.DESCRIPTION
+    Reads <BotRoot>/.control/activity.jsonl and prints the last N events in a
+    human-readable format so an operator can see what happened after the run's
+    terminal window has closed.
+
+      dotbot logs                 last 50 events from activity.jsonl
+      dotbot logs --tail 200      last 200 events
+      dotbot logs --last          the crash summary written on the last fatal exit
+      dotbot logs --follow        tail the activity log in real time (Ctrl+C stops)
+
+    activity.jsonl is a mixed-shape JSONL file: structured-logging events carry a
+    `message`/`msg` field, while typed state-change events carry `from`/`to`/
+    `reason` instead. The formatter tolerates both.
+
+    Output uses the standard CLI theme helpers from Platform-Functions.psm1
+    (AGENTS.md terminal-output rule).
+
+    Exit codes:
+      0  success (including --last when no crash has been recorded)
+      1  no .bot/ directory, or the activity log is missing / unreadable
+#>
+
+[CmdletBinding()]
+param(
+    [ValidateRange(1, 100000)]
+    [int]$Tail = 50,
+
+    [switch]$Last,
+
+    [switch]$Follow,
+
+    [ValidateRange(100, 60000)]
+    [int]$PollIntervalMs = 1000
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Off
+
+Import-Module (Join-Path $PSScriptRoot 'Platform-Functions.psm1') -Force
+
+function Find-BotRoot {
+    # Walk up from the current directory to the nearest .bot/, stopping at the
+    # git-repo boundary so `dotbot logs` never escapes the project it is run in
+    # (mirrors Find-DotbotProjectBotDir in bin/dotbot.ps1).
+    $cur = (Get-Location).Path
+    while ($cur) {
+        $candidate = Join-Path $cur '.bot'
+        if (Test-Path -LiteralPath $candidate -PathType Container) { return $candidate }
+        if (Test-Path -LiteralPath (Join-Path $cur '.git')) { return $null }
+        $parent = Split-Path $cur -Parent
+        if (-not $parent -or $parent -eq $cur) { return $null }
+        $cur = $parent
+    }
+    return $null
+}
+
+function Read-ActivityLine {
+    <#
+    .SYNOPSIS
+    Read every non-empty line of a JSONL file. FileShare::ReadWrite because the
+    runtime may hold the file open for appends while we read.
+    #>
+    param([Parameter(Mandatory)] [string]$Path)
+
+    $stream = [System.IO.FileStream]::new($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    try {
+        $reader = [System.IO.StreamReader]::new($stream, [System.Text.Encoding]::UTF8)
+        try { $text = $reader.ReadToEnd() } finally { $reader.Dispose() }
+    } finally {
+        $stream.Dispose()
+    }
+    return @($text -split "`n" | Where-Object { $_.Trim() })
+}
+
+function Format-ActivityEvent {
+    <#
+    .SYNOPSIS
+    Turn one parsed activity event into a { Type; Line } pair. Handles both the
+    logging shape (message/msg) and the typed state-change shape (from/to/reason).
+    #>
+    param([Parameter(Mandatory)] [object]$Event)
+
+    $ts = ''
+    if ($Event.PSObject.Properties['timestamp'] -and $Event.timestamp) {
+        try { $ts = ([datetime]$Event.timestamp).ToLocalTime().ToString('HH:mm:ss') }
+        catch { $ts = [string]$Event.timestamp }
+    }
+
+    $type = if ($Event.PSObject.Properties['type'] -and $Event.type) { [string]$Event.type } else { 'event' }
+
+    $text = $null
+    if ($Event.PSObject.Properties['message'] -and $Event.message) {
+        $text = [string]$Event.message
+    } elseif ($Event.PSObject.Properties['msg'] -and $Event.msg) {
+        $text = [string]$Event.msg
+    } elseif ($Event.PSObject.Properties['from'] -and $Event.PSObject.Properties['to']) {
+        $text = "$($Event.from) -> $($Event.to)"
+    }
+    if ($Event.PSObject.Properties['reason'] -and $Event.reason) {
+        $text = if ($text) { "$text ($($Event.reason))" } else { [string]$Event.reason }
+    }
+    if (-not $text) { $text = '' }
+
+    $phase = if ($Event.PSObject.Properties['phase'] -and $Event.phase) { "[$($Event.phase)] " } else { '' }
+
+    return [pscustomobject]@{
+        Type = $type
+        Line = ("{0}  {1}{2}  {3}" -f $ts, $phase, $type, $text).TrimEnd()
+    }
+}
+
+function Write-ActivityEventLine {
+    <#
+    .SYNOPSIS
+    Print one activity event, colour-coded by level via the theme helpers.
+    #>
+    param([Parameter(Mandatory)] [object]$Event)
+
+    $formatted = Format-ActivityEvent -Event $Event
+    $t = $formatted.Type.ToLowerInvariant()
+    if ($t -in @('error', 'fatal', 'workflow_run_failed', 'hook_failed')) {
+        Write-DotbotError $formatted.Line
+    } elseif ($t -in @('warn', 'warning', 'workflow_run_cancelled')) {
+        Write-DotbotWarning $formatted.Line
+    } else {
+        Write-DotbotCommand $formatted.Line
+    }
+}
+
+$botRoot = Find-BotRoot
+if (-not $botRoot) {
+    Write-DotbotError "Could not find a .bot/ directory in this or any parent path."
+    Write-DotbotCommand "Run 'dotbot init' first."
+    exit 1
+}
+
+$controlDir = Join-Path $botRoot '.control'
+
+# --- Crash summary mode (--last) ---
+if ($Last) {
+    $crashPath = Join-Path $controlDir 'last-crash.json'
+    if (-not (Test-Path -LiteralPath $crashPath)) {
+        Write-DotbotSection "LAST CRASH"
+        Write-DotbotLabel "Status:" "No crash recorded" -ValueType Success
+        Write-BlankLine
+        Write-DotbotCommand "Nothing has crashed since .bot/.control/last-crash.json was last cleared."
+        exit 0
+    }
+
+    try {
+        $crash = Get-Content -LiteralPath $crashPath -Raw -ErrorAction Stop | ConvertFrom-Json
+    } catch {
+        Write-DotbotError "Could not read last-crash.json: $($_.Exception.Message)"
+        exit 1
+    }
+
+    Write-DotbotSection "LAST CRASH"
+    Write-DotbotLabel "Time:"   ([string]$crash.timestamp)
+    Write-DotbotLabel "Reason:" ([string]$crash.exit_reason) -ValueType Error
+    if ($crash.process_id) { Write-DotbotLabel "Process:" ([string]$crash.process_id) }
+    if ($crash.run_id)     { Write-DotbotLabel "Run:"     ([string]$crash.run_id) }
+    if ($crash.last_task -and ($crash.last_task.id -or $crash.last_task.name)) {
+        $taskLabel = @($crash.last_task.name, $crash.last_task.id, $crash.last_task.status |
+            Where-Object { $_ }) -join ' · '
+        Write-DotbotLabel "Last task:" $taskLabel
+    }
+    Write-BlankLine
+
+    $events = @($crash.last_events)
+    if ($events.Count -gt 0) {
+        Write-DotbotSection "LAST EVENTS"
+        foreach ($ev in $events) { Write-ActivityEventLine -Event $ev }
+        Write-BlankLine
+    }
+    exit 0
+}
+
+# --- Activity log (tail / follow) ---
+$activityPath = Join-Path $controlDir 'activity.jsonl'
+if (-not (Test-Path -LiteralPath $activityPath)) {
+    Write-DotbotSection "LOGS"
+    Write-DotbotLabel "Status:" "No activity log yet" -ValueType Warning
+    Write-BlankLine
+    Write-DotbotCommand "Nothing has been logged to .bot/.control/activity.jsonl yet."
+    exit 1
+}
+
+Write-DotbotSection "LOGS"
+
+try {
+    $lines = Read-ActivityLine -Path $activityPath
+} catch {
+    Write-DotbotError "Could not read activity log: $($_.Exception.Message)"
+    exit 1
+}
+
+$total = $lines.Count
+$startIdx = [Math]::Max(0, $total - $Tail)
+for ($i = $startIdx; $i -lt $total; $i++) {
+    try { Write-ActivityEventLine -Event ($lines[$i] | ConvertFrom-Json) } catch { $null = $_ }
+}
+$position = $total
+
+if (-not $Follow) {
+    Write-BlankLine
+    exit 0
+}
+
+# --- Follow mode: poll for appends (mirrors the watch loop in workflow-run.ps1) ---
+Write-BlankLine
+Write-DotbotCommand "Following activity log — press Ctrl+C to stop."
+Write-BlankLine
+
+$script:DotbotLogsStopRequested = $false
+try {
+    [Console]::CancelKeyPress.Add({
+        param($sender, $eventArgs)
+        $eventArgs.Cancel = $true
+        $script:DotbotLogsStopRequested = $true
+    })
+} catch {
+    $null = $_
+}
+
+while (-not $script:DotbotLogsStopRequested) {
+    Start-Sleep -Milliseconds $PollIntervalMs
+    try {
+        $lines = Read-ActivityLine -Path $activityPath
+    } catch {
+        continue
+    }
+    $total = $lines.Count
+    # A rotated / truncated log resets our cursor so we don't skip its new tail.
+    if ($total -lt $position) { $position = 0 }
+    if ($total -gt $position) {
+        for ($i = $position; $i -lt $total; $i++) {
+            try { Write-ActivityEventLine -Event ($lines[$i] | ConvertFrom-Json) } catch { $null = $_ }
+        }
+        $position = $total
+    }
+}
+
+Write-BlankLine
+exit 0

--- a/src/cli/runtime-status.ps1
+++ b/src/cli/runtime-status.ps1
@@ -37,6 +37,36 @@ function Find-BotRoot {
     return $null
 }
 
+function Show-LastCrash {
+    <#
+    .SYNOPSIS
+    When the runtime is not running, surface the summary written to
+    <BotRoot>/.control/last-crash.json on the last fatal exit. Best-effort:
+    a missing or unreadable file is simply not shown.
+    #>
+    param([Parameter(Mandatory)] [string]$BotRoot)
+
+    $crashPath = Join-Path $BotRoot (Join-Path '.control' 'last-crash.json')
+    if (-not (Test-Path -LiteralPath $crashPath)) { return }
+    try {
+        $crash = Get-Content -LiteralPath $crashPath -Raw -ErrorAction Stop | ConvertFrom-Json
+    } catch {
+        return
+    }
+
+    Write-BlankLine
+    Write-DotbotSection "LAST CRASH"
+    Write-DotbotLabel "Time:"   ([string]$crash.timestamp)
+    Write-DotbotLabel "Reason:" ([string]$crash.exit_reason) -ValueType Error
+    if ($crash.last_task -and ($crash.last_task.id -or $crash.last_task.name)) {
+        $taskLabel = @($crash.last_task.name, $crash.last_task.id, $crash.last_task.status |
+            Where-Object { $_ }) -join ' · '
+        Write-DotbotLabel "Last task:" $taskLabel
+    }
+    Write-BlankLine
+    Write-DotbotCommand "Run 'dotbot logs --last' for the full crash summary."
+}
+
 $botRoot = Find-BotRoot
 if (-not $botRoot) {
     Write-DotbotError "Could not find a .bot/ directory in this or any parent path."
@@ -60,6 +90,7 @@ if (-not (Test-Path -LiteralPath $connPath)) {
     Write-DotbotLabel "Reason:" "no .bot/.control/runtime.json"
     Write-BlankLine
     Write-DotbotWarning "Start the runtime with 'dotbot serve'."
+    Show-LastCrash -BotRoot $botRoot
     exit 1
 }
 
@@ -78,6 +109,7 @@ Write-BlankLine
 if (-not $alive) {
     Write-DotbotWarning "The PID recorded in runtime.json is no longer running."
     Write-DotbotWarning "The next 'dotbot serve' will rewrite runtime.json with a fresh token."
+    Show-LastCrash -BotRoot $botRoot
     exit 1
 }
 

--- a/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psd1
+++ b/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psd1
@@ -29,6 +29,8 @@
         'Start-DotbotChildProcess'
         # Process-tree lifetime binding
         'Register-DotbotKillOnCloseJob'
+        # Crash diagnostics
+        'Write-DotbotCrashSummary'
     )
 
     CmdletsToExport   = @()

--- a/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
+++ b/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
@@ -960,6 +960,7 @@ function Write-DotbotCrashSummary {
         [Parameter(Mandatory)] [string]$ProcessId,
         [object]$Process,
         [string]$Reason,
+        [ValidateRange(1, 1000)]
         [int]$MaxEvents = 20,
         [string]$BotRoot
     )

--- a/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
+++ b/src/runtime/Modules/Dotbot.Process/Dotbot.Process.psm1
@@ -942,6 +942,75 @@ function Start-DotbotChildProcess {
     Start-Process @params
 }
 
+function Write-DotbotCrashSummary {
+    <#
+    .SYNOPSIS
+    Persist a best-effort crash summary for `dotbot logs --last` and
+    `dotbot runtime-status`.
+
+    .DESCRIPTION
+    Writes <BotRoot>/.control/last-crash.json with the exit reason, the last
+    task, and the tail of the crashed process's activity log so an operator can
+    see what happened after the terminal window has closed. Overwrites any
+    previous summary — only the most recent crash is kept. Never throws: it runs
+    from the process crash trap, where a secondary failure must not mask the
+    original error.
+    #>
+    param(
+        [Parameter(Mandatory)] [string]$ProcessId,
+        [object]$Process,
+        [string]$Reason,
+        [int]$MaxEvents = 20,
+        [string]$BotRoot
+    )
+
+    try {
+        $controlDir   = Get-ProcessControlDir -BotRoot $BotRoot
+        $processesDir = Get-ProcessesDir -BotRoot $BotRoot
+
+        $lastEvents = @()
+        $activityPath = Join-Path $processesDir "$ProcessId.activity.jsonl"
+        if (Test-Path -LiteralPath $activityPath) {
+            try {
+                $stream = [System.IO.FileStream]::new($activityPath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+                try {
+                    $reader = [System.IO.StreamReader]::new($stream, [System.Text.Encoding]::UTF8)
+                    try { $text = $reader.ReadToEnd() } finally { $reader.Dispose() }
+                } finally { $stream.Dispose() }
+
+                $lines = @($text -split "`n" | Where-Object { $_.Trim() })
+                $tail = if ($lines.Count -gt $MaxEvents) { $lines[($lines.Count - $MaxEvents)..($lines.Count - 1)] } else { $lines }
+                foreach ($ln in $tail) {
+                    try { $lastEvents += ($ln | ConvertFrom-Json) } catch { $null = $_ }
+                }
+            } catch { $null = $_ }
+        }
+
+        $summary = [ordered]@{
+            timestamp   = (Get-Date).ToUniversalTime().ToString("o")
+            process_id  = $ProcessId
+            run_id      = if ($Process -and $Process.run_id) { $Process.run_id } else { $null }
+            exit_reason = $Reason
+            last_task   = [ordered]@{
+                id     = if ($Process) { $Process.task_id } else { $null }
+                name   = if ($Process) { $Process.task_name } else { $null }
+                status = if ($Process) { $Process.status } else { $null }
+            }
+            last_events = @($lastEvents)
+        }
+
+        if (-not (Test-Path -LiteralPath $controlDir)) {
+            New-Item -ItemType Directory -Path $controlDir -Force | Out-Null
+        }
+        $crashPath = Join-Path $controlDir "last-crash.json"
+        $json = $summary | ConvertTo-Json -Depth 8
+        [System.IO.File]::WriteAllText($crashPath, $json, [System.Text.UTF8Encoding]::new($false))
+    } catch {
+        # Best-effort only — never let crash-summary writing mask the original failure.
+        $null = $_
+    }
+}
+
 #endregion
 
 #region Kill-on-close Job Object (Windows)
@@ -1149,4 +1218,6 @@ Export-ModuleMember -Function @(
     'Start-DotbotChildProcess'
     # Process-tree lifetime binding (Windows)
     'Register-DotbotKillOnCloseJob'
+    # Crash diagnostics
+    'Write-DotbotCrashSummary'
 )

--- a/src/runtime/Scripts/Invoke-DotbotProcess.ps1
+++ b/src/runtime/Scripts/Invoke-DotbotProcess.ps1
@@ -328,6 +328,7 @@ trap {
         $processData.error = "Unexpected termination: $($_.Exception.Message)"
         try { Write-ProcessFile -Id $procId -Data $processData } catch { Write-BotLog -Level Debug -Message "Non-critical operation failed" -Exception $_ }
         try { Write-ProcessActivity -Id $procId -ActivityType "text" -Message "Process terminated unexpectedly: $($_.Exception.Message)" } catch { Write-BotLog -Level Warn -Message "Failed to write process activity" -Exception $_ }
+        try { Write-DotbotCrashSummary -BotRoot $botRoot -ProcessId $procId -Process $processData -Reason $processData.error } catch { Write-BotLog -Level Debug -Message "Non-critical operation failed" -Exception $_ }
     }
     if (Test-Path variable:lockKey) {
         try { Remove-ProcessLock -LockType $lockKey } catch { Write-BotLog -Level Debug -Message "Logging operation failed" -Exception $_ }

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -164,8 +164,9 @@ if (2 -in $layersToRun) {
     $toolLocalCode           = Invoke-TestFile -Layer '2' -FileName 'Test-ToolLocal.ps1'
     $mcpHandshakeCode        = Invoke-TestFile -Layer '2' -FileName 'Test-MCPHandshake.ps1'
     $registryCLICode         = Invoke-TestFile -Layer '2' -FileName 'Test-RegistryCLI.ps1'
+    $logsCLICode             = Invoke-TestFile -Layer '2' -FileName 'Test-LogsCLI.ps1'
 
-    $exitCode = if ($componentsCode -ne 0 -or $taskActionsCode -ne 0 -or $serverStartupCode -ne 0 -or $workflowIntegrationCode -ne 0 -or $processRegistryCode -ne 0 -or $processDispatchCode -ne 0 -or $studioAPICode -ne 0 -or $toolLocalCode -ne 0 -or $mcpHandshakeCode -ne 0 -or $registryCLICode -ne 0) { 1 } else { 0 }
+    $exitCode = if ($componentsCode -ne 0 -or $taskActionsCode -ne 0 -or $serverStartupCode -ne 0 -or $workflowIntegrationCode -ne 0 -or $processRegistryCode -ne 0 -or $processDispatchCode -ne 0 -or $studioAPICode -ne 0 -or $toolLocalCode -ne 0 -or $mcpHandshakeCode -ne 0 -or $registryCLICode -ne 0 -or $logsCLICode -ne 0) { 1 } else { 0 }
     $layerResults["2"] = ($exitCode -eq 0)
     if ($exitCode -ne 0) { $overallFailed = $true }
 }

--- a/tests/Test-Hooks.ps1
+++ b/tests/Test-Hooks.ps1
@@ -443,6 +443,49 @@ function Invoke-EnterDoneOutOfProcess {
     try { return ($out -join "`n") | ConvertFrom-Json -ErrorAction Stop } catch { return $null }
 }
 
+function Resolve-Issue628CanonicalPath {
+    # Compare filesystem locations rather than their textual aliases.
+    # GetLongPathName expands Windows short-name segments. On POSIX, pwd -P
+    # follows symlinked path components (notably macOS
+    # /var -> /private/var) to match the cwd reported by child pwsh.
+    param([Parameter(Mandatory)] [string]$Path)
+
+    $resolved = (Resolve-Path -LiteralPath $Path -ErrorAction Stop).ProviderPath
+    if ($IsWindows) {
+        if (-not ('DotbotTestNativePath' -as [type])) {
+            Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class DotbotTestNativePath
+{
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    public static extern uint GetLongPathName(string shortPath, StringBuilder longPath, uint bufferLength);
+}
+'@
+        }
+        $buffer = [System.Text.StringBuilder]::new(32768)
+        $length = [DotbotTestNativePath]::GetLongPathName($resolved, $buffer, [uint32]$buffer.Capacity)
+        if ($length -gt 0 -and $length -lt $buffer.Capacity) {
+            $resolved = $buffer.ToString()
+        }
+    } elseif ($IsMacOS -or $IsLinux) {
+        Push-Location -LiteralPath $resolved
+        try {
+            $physical = & /bin/pwd -P 2>$null
+            $physicalExit = $LASTEXITCODE
+        } finally {
+            Pop-Location
+        }
+        if ($physicalExit -eq 0 -and $physical) {
+            $resolved = ([string]$physical).Trim()
+        }
+    }
+
+    return [System.IO.Path]::TrimEndingDirectorySeparator($resolved)
+}
+
 function Assert-VerifyCwdMarker {
     # Asserts the whole verify chain (all 5 stubs) ran in exactly $ExpectedDir.
     param(
@@ -452,10 +495,12 @@ function Assert-VerifyCwdMarker {
     )
     $lines = if (Test-Path -LiteralPath $MarkerFile) { @(Get-Content -LiteralPath $MarkerFile) } else { @() }
     Assert-Equal -Name "$Name`: verify chain ran (5 stub hooks recorded cwd)" -Expected 5 -Actual $lines.Count
-    Assert-Equal -Name "$Name`: verify chain cwd" -Expected $ExpectedDir -Actual ($lines | Select-Object -First 1) `
-        -Message "Expected every stub to run in '$ExpectedDir', got: $($lines -join ', ')"
+    $canonicalExpected = Resolve-Issue628CanonicalPath -Path $ExpectedDir
+    $canonicalLines = @($lines | ForEach-Object { Resolve-Issue628CanonicalPath -Path ([string]$_).Trim() })
+    Assert-Equal -Name "$Name`: verify chain cwd" -Expected $canonicalExpected -Actual ($canonicalLines | Select-Object -First 1) `
+        -Message "Expected every stub to run in '$ExpectedDir' ('$canonicalExpected' canonical), got: $($lines -join ', ')"
     Assert-True -Name "$Name`: cwd consistent across the whole chain" `
-        -Condition (@($lines | Select-Object -Unique).Count -eq 1)
+        -Condition (@($canonicalLines | Select-Object -Unique).Count -eq 1)
 }
 
 # --- Scenario 1: worktree registry entry exists and is valid → worktree_path wins

--- a/tests/Test-Hooks.ps1
+++ b/tests/Test-Hooks.ps1
@@ -465,11 +465,23 @@ public static class DotbotTestNativePath
 }
 '@
         }
-        $buffer = [System.Text.StringBuilder]::new(32768)
-        $length = [DotbotTestNativePath]::GetLongPathName($resolved, $buffer, [uint32]$buffer.Capacity)
-        if ($length -gt 0 -and $length -lt $buffer.Capacity) {
-            $resolved = $buffer.ToString()
+        # Expand one existing component at a time. GetLongPathName can return
+        # access denied for a deeper child even though an earlier 8.3 segment
+        # (for example the user profile) is resolvable. Keeping each successful
+        # prefix expansion still gives both aliases the same canonical spelling.
+        $root = [System.IO.Path]::GetPathRoot($resolved)
+        $expanded = $root
+        foreach ($segment in @($resolved.Substring($root.Length) -split '[\\/]' | Where-Object { $_ })) {
+            $candidate = Join-Path $expanded $segment
+            $buffer = [System.Text.StringBuilder]::new(32768)
+            $length = [DotbotTestNativePath]::GetLongPathName($candidate, $buffer, [uint32]$buffer.Capacity)
+            $expanded = if ($length -gt 0 -and $length -lt $buffer.Capacity) {
+                $buffer.ToString()
+            } else {
+                $candidate
+            }
         }
+        $resolved = $expanded
     } elseif ($IsMacOS -or $IsLinux) {
         Push-Location -LiteralPath $resolved
         try {

--- a/tests/Test-LogsCLI.ps1
+++ b/tests/Test-LogsCLI.ps1
@@ -1,0 +1,198 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Layer 2: Tests for `dotbot logs` (src/cli/logs.ps1) and the last-crash
+    summary surfaced by `dotbot runtime-status` (issue #657).
+.DESCRIPTION
+    Exercises the read side of the log-surfacing feature against fixture files:
+      - tail of a mixed-shape activity.jsonl (logging events with `message`
+        vs. typed state events with from/to/reason),
+      - --tail N limiting,
+      - --last reading .control/last-crash.json,
+      - runtime-status surfacing the crash summary when the runtime isn't running,
+      - graceful behaviour when no .bot / no activity log / no crash exists,
+      - wiring through bin/dotbot.ps1 (the --flag → splat path).
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+Import-Module "$PSScriptRoot\Test-Helpers.psm1" -Force
+
+$dotbotDir = Get-DotbotInstallDir
+
+Write-Host ""
+Write-Host "-----------------------------------------------------------" -ForegroundColor Blue
+Write-Host "  Layer 2: Logs CLI Tests (#657)" -ForegroundColor Blue
+Write-Host "-----------------------------------------------------------" -ForegroundColor Blue
+Write-Host ""
+
+Reset-TestResults
+
+$logsScript          = Join-Path $dotbotDir 'src/cli/logs.ps1'
+$runtimeStatusScript = Join-Path $dotbotDir 'src/cli/runtime-status.ps1'
+$dotbotCli           = Join-Path $dotbotDir 'bin/dotbot.ps1'
+
+# Run a CLI script inside $WorkDir (child pwsh inherits the pushed location),
+# returning merged stdout+stderr as one string plus the exit code. Write-Host
+# output in a child process lands on stdout, so theme-helper output is captured.
+function Invoke-Cli {
+    param(
+        [Parameter(Mandatory)] [string]$Script,
+        [Parameter(Mandatory)] [string]$WorkDir,
+        [string[]]$CliArgs = @()
+    )
+    Push-Location $WorkDir
+    try {
+        $out = & pwsh -NoProfile -ExecutionPolicy Bypass -File $Script @CliArgs 2>&1
+        $code = $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+    return @{ Output = ($out | Out-String); Code = $code }
+}
+
+$projA = $null   # has activity.jsonl + last-crash.json
+$projB = $null   # has .bot/.control but no log files
+$projC = $null   # no .bot at all
+$projD = $null   # write-path: Write-DotbotCrashSummary produces last-crash.json
+
+try {
+    # -------------------------------------------------------------------
+    # Static checks
+    # -------------------------------------------------------------------
+    Assert-True -Name "logs.ps1 exists on disk" -Condition (Test-Path $logsScript) -Message "Not found: $logsScript"
+    Assert-ValidPowerShellAst -Name "logs.ps1 parses without syntax errors" -Path $logsScript
+
+    # -------------------------------------------------------------------
+    # Fixtures
+    # -------------------------------------------------------------------
+    $projA = New-TestProject
+    $controlA = Join-Path $projA '.bot/.control'
+    New-Item -ItemType Directory -Path $controlA -Force | Out-Null
+
+    # Mixed-shape activity log: logging-shape events carry `message`; typed
+    # state-change events carry from/to/reason instead.
+    $activityLines = @(
+        '{"timestamp":"2026-07-21T10:00:00Z","type":"info","message":"ALPHA-info-event","phase":"analysis"}'
+        '{"timestamp":"2026-07-21T10:00:01Z","type":"workflow_run_started","run_id":"wr_test123","actor":"cli"}'
+        '{"timestamp":"2026-07-21T10:00:02Z","type":"error","message":"BRAVO-error-event"}'
+        '{"timestamp":"2026-07-21T10:00:03Z","type":"workflow_run_failed","run_id":"wr_test123","from":"running","to":"failed","reason":"CHARLIE-fail-reason"}'
+    )
+    Set-Content -Path (Join-Path $controlA 'activity.jsonl') -Value $activityLines -Encoding UTF8
+
+    $crash = [ordered]@{
+        timestamp   = '2026-07-21T10:05:00Z'
+        process_id  = 'proc_abc'
+        run_id      = 'wr_test123'
+        exit_reason = 'Unexpected termination: DELTA-crash-reason'
+        last_task   = [ordered]@{ id = 't_task01'; name = 'ECHO-task-name'; status = 'in-progress' }
+        last_events = @(
+            [ordered]@{ timestamp = '2026-07-21T10:04:59Z'; type = 'text'; message = 'FOXTROT-last-event' }
+        )
+    }
+    $crash | ConvertTo-Json -Depth 8 | Set-Content -Path (Join-Path $controlA 'last-crash.json') -Encoding UTF8
+
+    # -------------------------------------------------------------------
+    # dotbot logs — tail (mixed-shape rendering)
+    # -------------------------------------------------------------------
+    $r = Invoke-Cli -Script $logsScript -WorkDir $projA -CliArgs @('-Tail', '10')
+    Assert-Equal -Name "logs tail exits 0" -Expected 0 -Actual $r.Code -Message $r.Output
+    Assert-True -Name "logs tail renders logging-shape message" -Condition ($r.Output -match 'ALPHA-info-event') -Message $r.Output
+    Assert-True -Name "logs tail renders error-shape message"   -Condition ($r.Output -match 'BRAVO-error-event') -Message $r.Output
+    Assert-True -Name "logs tail renders typed-event reason"    -Condition ($r.Output -match 'CHARLIE-fail-reason') -Message $r.Output
+    Assert-True -Name "logs tail renders from->to transition"   -Condition ($r.Output -match 'running -> failed') -Message $r.Output
+
+    # --tail N limiting: N=1 shows only the last line.
+    $r = Invoke-Cli -Script $logsScript -WorkDir $projA -CliArgs @('-Tail', '1')
+    Assert-True -Name "logs --tail 1 keeps the last event"      -Condition ($r.Output -match 'CHARLIE-fail-reason') -Message $r.Output
+    Assert-True -Name "logs --tail 1 drops earlier events"      -Condition (-not ($r.Output -match 'ALPHA-info-event')) -Message $r.Output
+
+    # -------------------------------------------------------------------
+    # dotbot logs --last (crash summary)
+    # -------------------------------------------------------------------
+    $r = Invoke-Cli -Script $logsScript -WorkDir $projA -CliArgs @('-Last')
+    Assert-Equal -Name "logs --last exits 0" -Expected 0 -Actual $r.Code -Message $r.Output
+    Assert-True -Name "logs --last shows the crash section"     -Condition ($r.Output -match 'LAST CRASH') -Message $r.Output
+    Assert-True -Name "logs --last shows the exit reason"       -Condition ($r.Output -match 'DELTA-crash-reason') -Message $r.Output
+    Assert-True -Name "logs --last shows the last task"         -Condition ($r.Output -match 'ECHO-task-name') -Message $r.Output
+    Assert-True -Name "logs --last shows the last events tail"  -Condition ($r.Output -match 'FOXTROT-last-event') -Message $r.Output
+
+    # -------------------------------------------------------------------
+    # runtime-status surfaces the crash summary when not running
+    # -------------------------------------------------------------------
+    $r = Invoke-Cli -Script $runtimeStatusScript -WorkDir $projA
+    Assert-True -Name "runtime-status surfaces LAST CRASH section" -Condition ($r.Output -match 'LAST CRASH') -Message $r.Output
+    Assert-True -Name "runtime-status surfaces the crash reason"   -Condition ($r.Output -match 'DELTA-crash-reason') -Message $r.Output
+
+    # -------------------------------------------------------------------
+    # Wiring through bin/dotbot.ps1 (--flag → splat path)
+    # -------------------------------------------------------------------
+    $r = Invoke-Cli -Script $dotbotCli -WorkDir $projA -CliArgs @('logs', '--tail', '3')
+    Assert-Equal -Name "dotbot logs (via CLI dispatch) exits 0" -Expected 0 -Actual $r.Code -Message $r.Output
+    Assert-True -Name "dotbot logs (via CLI dispatch) renders events" -Condition ($r.Output -match 'CHARLIE-fail-reason') -Message $r.Output
+
+    # -------------------------------------------------------------------
+    # Empty-state behaviour: .bot/.control present but no log files
+    # -------------------------------------------------------------------
+    $projB = New-TestProject
+    New-Item -ItemType Directory -Path (Join-Path $projB '.bot/.control') -Force | Out-Null
+
+    $r = Invoke-Cli -Script $logsScript -WorkDir $projB
+    Assert-Equal -Name "logs with no activity log exits 1" -Expected 1 -Actual $r.Code -Message $r.Output
+    Assert-True -Name "logs with no activity log explains why" -Condition ($r.Output -match 'No activity log') -Message $r.Output
+
+    $r = Invoke-Cli -Script $logsScript -WorkDir $projB -CliArgs @('-Last')
+    Assert-Equal -Name "logs --last with no crash exits 0" -Expected 0 -Actual $r.Code -Message $r.Output
+    Assert-True -Name "logs --last with no crash reports none" -Condition ($r.Output -match 'No crash recorded') -Message $r.Output
+
+    # -------------------------------------------------------------------
+    # No .bot/ at all
+    # -------------------------------------------------------------------
+    $projC = New-TestProject
+    $r = Invoke-Cli -Script $logsScript -WorkDir $projC
+    Assert-Equal -Name "logs with no .bot exits 1" -Expected 1 -Actual $r.Code -Message $r.Output
+    Assert-True -Name "logs with no .bot points at 'dotbot init'" -Condition ($r.Output -match 'Could not find a \.bot') -Message $r.Output
+
+    # -------------------------------------------------------------------
+    # Write path: Write-DotbotCrashSummary (the crash-trap hook) produces a
+    # summary that `dotbot logs --last` can read back.
+    # -------------------------------------------------------------------
+    Import-Module (Join-Path $dotbotDir 'src/runtime/Modules/Dotbot.Process/Dotbot.Process.psd1') -Force -DisableNameChecking
+
+    $projD = New-TestProject
+    $botD = Join-Path $projD '.bot'
+    $procDir = Join-Path $botD '.control/processes'
+    New-Item -ItemType Directory -Path $procDir -Force | Out-Null
+
+    $procId = 'proc_writetest'
+    $procActivity = @(
+        '{"timestamp":"2026-07-21T11:00:00Z","type":"text","message":"GOLF-early-event"}'
+        '{"timestamp":"2026-07-21T11:00:01Z","type":"text","message":"HOTEL-terminated-event"}'
+    )
+    Set-Content -Path (Join-Path $procDir "$procId.activity.jsonl") -Value $procActivity -Encoding UTF8
+
+    $proc = @{ run_id = 'wr_write1'; task_id = 't_wt01'; task_name = 'INDIA-task'; status = 'stopped' }
+    Write-DotbotCrashSummary -BotRoot $botD -ProcessId $procId -Process $proc -Reason 'Unexpected termination: JULIET-reason'
+
+    $crashFile = Join-Path $botD '.control/last-crash.json'
+    Assert-PathExists   -Name "Write-DotbotCrashSummary creates last-crash.json" -Path $crashFile
+    Assert-ValidJson    -Name "last-crash.json is valid JSON" -Path $crashFile
+    Assert-FileContains -Name "crash summary carries the exit reason"      -Path $crashFile -Pattern 'JULIET-reason'
+    Assert-FileContains -Name "crash summary carries the last events tail"  -Path $crashFile -Pattern 'HOTEL-terminated-event'
+    Assert-FileContains -Name "crash summary carries the last task"        -Path $crashFile -Pattern 'INDIA-task'
+
+    $r = Invoke-Cli -Script $logsScript -WorkDir $projD -CliArgs @('-Last')
+    Assert-True -Name "logs --last renders the written crash summary" -Condition ($r.Output -match 'JULIET-reason') -Message $r.Output
+}
+finally {
+    if ($projA) { Remove-TestProject -Path $projA }
+    if ($projB) { Remove-TestProject -Path $projB }
+    if ($projC) { Remove-TestProject -Path $projC }
+    if ($projD) { Remove-TestProject -Path $projD }
+}
+
+$ok = Write-TestSummary -LayerName "Layer 2: Logs CLI (#657)"
+if ($ok) { exit 0 } else { exit 1 }


### PR DESCRIPTION
## Linked issue

Closes #657

## Summary of changes

Adds a `dotbot logs` CLI command so operators can inspect a run after its
terminal window has closed.

- `dotbot logs` — tail the last N events (default 50) of
  `.bot/.control/activity.jsonl`, human-readable. Tolerates the mixed-shape
  log: logging events carry `message`, typed state-change events carry
  `from`/`to`/`reason`.
- `--tail N` — override the number of events shown.
- `--follow` — tail the log live (Ctrl+C stops).
- `--last` — print the crash summary from the last fatal exit.
- The process crash trap now writes `.bot/.control/last-crash.json`
  (exit reason, last task, last 20 activity events) via a new
  `Write-DotbotCrashSummary` helper in the `Dotbot.Process` module.
- `dotbot runtime-status` surfaces the last crash summary when the runtime
  is not running (missing `runtime.json` or a stale PID).

Kept scoped to #657: `last-crash.json` is written only from the existing
crash trap (not from foreground CLI exits).

## Screenshots / recordings
<img width="1137" height="328" alt="image" src="https://github.com/user-attachments/assets/6f1cf4c3-c28d-4808-8c6e-482da84c40a4" />

## Testing notes

- New `tests/Test-LogsCLI.ps1` (Layer 2, 30 assertions): tail rendering of
  both event shapes, `--tail` limiting, `--last`, runtime-status surfacing,
  CLI dispatch wiring, empty-state / no-`.bot` handling, and the
  `Write-DotbotCrashSummary` write path (read back via `dotbot logs --last`).
- Green locally: Layer 1 Compilation 373/0; Layer 2 Test-LogsCLI 30/30,
  ProcessDispatch 44/44, ProcessRegistry 20/20; Layer 3 MockClaude 19/19.
  (One unrelated Components failure is pre-existing MAX_PATH worktree noise
  on Windows.)

To try it: from an initialized project, `dotbot logs`, `dotbot logs --tail 5`,
`dotbot logs --follow`, and `dotbot logs --last`.

## Checklist

- [x] Tests added or updated
- [x] Docs updated (if behaviour changed)
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)