### PR TITLE
feat(workflow): auto-migrate legacy v3.5 YAML manifests to v4 JSON (#654)

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -183,7 +183,43 @@ UI writers (`Set-AnalysisConfig`, `Set-CostConfig`, `Set-EditorConfig`, `Set-Mot
 
 ---
 
-## 6. Upgrading the framework
+## 6. YAML manifests are retired — JSON is the standard
+
+v3.5 read workflow and registry manifests from YAML:
+
+| v3.5                                      | v4                                            |
+|-------------------------------------------|-----------------------------------------------|
+| `.bot/workflow.yaml`                      | `.bot/content/workflows/<name>/workflow.json` |
+| `.bot/workflows/<name>/workflow.yaml`     | `.bot/content/workflows/<name>/workflow.json` |
+| `<registry>/registry.yaml`                | `<registry>/registry.json`                    |
+
+v4 reads **only** the JSON files, and project workflows moved from
+`.bot/workflows/<name>/` to `.bot/content/workflows/<name>/`.
+
+You do not have to convert anything by hand. Any workflow or registry
+command (`dotbot workflow list`, `dotbot run`, `dotbot registry list`, ...)
+detects legacy YAML manifests on startup, converts them to JSON in the v4
+layout, renames the originals to `*.migrated`, and warns once about each
+conversion. `dotbot init` offers the same migration interactively and
+respects `-DryRun`.
+
+Conversion uses the `powershell-yaml` module — the same parser v3.5 used.
+dotbot installs it automatically (CurrentUser scope) when missing; if that
+fails, install it manually and re-run the command:
+
+```powershell
+Install-Module powershell-yaml -Scope CurrentUser
+```
+
+If both a `.yaml` manifest and its `.json` equivalent exist, **JSON wins**:
+nothing is converted or overwritten, and dotbot warns on every run until you
+remove or rename the YAML file. The `*.migrated` files are kept only so you
+can diff the conversion — delete them (and commit the moves/renames if your
+`.bot/` is tracked) once you have verified the result.
+
+---
+
+## 7. Upgrading the framework
 
 Once you're on v4, upgrade the install that supplies the runtime:
 
@@ -198,7 +234,7 @@ No test framework rebuild is required. `dotbot status` reflects the active insta
 
 ---
 
-## 7. Retired entry points (quick reference)
+## 8. Retired entry points (quick reference)
 
 | v3                                                            | v4                                                            |
 |---------------------------------------------------------------|---------------------------------------------------------------|

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -204,11 +204,18 @@ conversion. `dotbot init` offers the same migration interactively and
 respects `-DryRun`.
 
 Conversion uses the `powershell-yaml` module — the same parser v3.5 used.
-dotbot installs it automatically (CurrentUser scope) when missing; if that
-fails, install it manually and re-run the command:
+Because workflow and registry discovery are read operations, dotbot never
+changes package repositories or installs modules implicitly. Install the
+parser explicitly with either supported package manager, then re-run the
+command:
 
 ```powershell
-Install-Module powershell-yaml -Scope CurrentUser
+# PowerShellGet
+Register-PSRepository -Default
+Install-Module powershell-yaml -Repository PSGallery -Scope CurrentUser
+
+# PSResourceGet
+Install-PSResource powershell-yaml -Repository PSGallery -Scope CurrentUser -TrustRepository
 ```
 
 If both a `.yaml` manifest and its `.json` equivalent exist, **JSON wins**:

--- a/src/cli/RegistryManager.psm1
+++ b/src/cli/RegistryManager.psm1
@@ -10,6 +10,8 @@
 
 $ErrorActionPreference = "Stop"
 
+Import-Module (Join-Path $PSScriptRoot ".." "runtime" "Modules" "Dotbot.LegacyYaml" "Dotbot.LegacyYaml.psd1") -DisableNameChecking
+
 function Get-DotbotRegistries {
     <#
     .SYNOPSIS
@@ -52,6 +54,8 @@ function Update-StaleRegistries {
         [Parameter(Mandatory)][string]$DotbotBase,
         [int]$MaxAgeSecs = 3600
     )
+
+    Invoke-DotbotRegistryYamlMigration -DotbotBase $DotbotBase
 
     $configPath   = Join-Path $DotbotBase "registries.json"
     $registries   = Get-DotbotRegistries -DotbotBase $DotbotBase

--- a/src/cli/RegistryManager.psm1
+++ b/src/cli/RegistryManager.psm1
@@ -55,8 +55,6 @@ function Update-StaleRegistries {
         [int]$MaxAgeSecs = 3600
     )
 
-    Invoke-DotbotRegistryYamlMigration -DotbotBase $DotbotBase
-
     $configPath   = Join-Path $DotbotBase "registries.json"
     $registries   = Get-DotbotRegistries -DotbotBase $DotbotBase
     if ($registries.Count -eq 0) { return }
@@ -115,6 +113,15 @@ function Update-StaleRegistries {
         $null = & git -C $registryPath merge --ff-only "origin/$branch" 2>&1
         if ($LASTEXITCODE -ne 0) {
             Write-DotbotWarning "Auto-update failed for registry '$safeName' (cannot fast-forward) — using cached copy"
+            continue
+        }
+
+        # Migrate only after the cached clone is at the requested revision.
+        # A later fetch/reset therefore cannot erase the generated JSON before
+        # validation, and linked local sources are never mutated by this
+        # automatic update path.
+        if (-not (Invoke-DotbotSingleRegistryYamlMigration -RegistryPath $registryPath -ExpectedName $safeName)) {
+            Write-DotbotWarning "Registry '$safeName' contains legacy YAML that could not be migrated — using cached copy"
             continue
         }
 

--- a/src/cli/init-project.ps1
+++ b/src/cli/init-project.ps1
@@ -116,6 +116,7 @@ if (-not (Test-Path -LiteralPath $cliMarker) -or -not (Test-Path -LiteralPath $c
 # ---------------------------------------------------------------------------
 Import-Module (Join-Path $resolvedHome 'src/cli/Platform-Functions.psm1') -Force
 Import-Module (Join-Path $resolvedHome 'src/runtime/Modules/Dotbot.Theme/Dotbot.Theme.psd1') -Force -DisableNameChecking
+Import-Module (Join-Path $resolvedHome 'src/runtime/Modules/Dotbot.LegacyYaml/Dotbot.LegacyYaml.psd1') -Force -DisableNameChecking
 
 $ProjectDir = (Get-Location).Path
 $BotDir     = Join-Path $ProjectDir '.bot'
@@ -149,6 +150,27 @@ if (-not (Test-Path (Join-Path $ProjectDir '.git'))) {
         }
         Write-Success 'Initialized git repository'
     }
+}
+
+# ---------------------------------------------------------------------------
+# Legacy v3.5 YAML manifest migration offer
+# ---------------------------------------------------------------------------
+$legacyYamlFiles = @(Get-DotbotLegacyYamlFile -BotRoot $BotDir)
+if ($legacyYamlFiles.Count -gt 0) {
+    Write-DotbotWarning 'Legacy v3.5 YAML manifests found:'
+    foreach ($file in $legacyYamlFiles) {
+        Write-DotbotCommand "  $file"
+    }
+    if ($DryRun) {
+        Write-DotbotWarning 'Dry run — would convert these to the v4 JSON layout'
+    } elseif (Read-DotbotConfirmation -Message 'Convert them to the v4 JSON layout now?' -Default $true) {
+        Invoke-DotbotWorkflowYamlMigration -BotRoot $BotDir -Force
+        Write-Success 'Legacy YAML migration finished'
+        Write-DotbotCommand 'Review the changes and commit them if .bot/ is tracked.'
+    } else {
+        Write-DotbotWarning 'dotbot v4 does not read YAML manifests — these workflows stay invisible until converted. See MIGRATING.md.'
+    }
+    Write-BlankLine
 }
 
 if ((Test-Path $BotDir) -and -not $Force) {

--- a/src/cli/registry-add.ps1
+++ b/src/cli/registry-add.ps1
@@ -50,6 +50,7 @@ if (-not (Test-Path $PlatformFunctionsModule)) {
 }
 Import-Module $PlatformFunctionsModule -Force -ErrorAction Stop
 Import-Module (Join-Path (Get-DotbotInstallPath) "src" "runtime" "Modules" "Dotbot.Theme" "Dotbot.Theme.psd1") -Force -DisableNameChecking
+Import-Module (Join-Path (Get-DotbotInstallPath) "src" "runtime" "Modules" "Dotbot.LegacyYaml" "Dotbot.LegacyYaml.psd1") -Force -DisableNameChecking
 
 Write-DotbotBanner -Title "D O T B O T" -Subtitle "Registry: Add"
 
@@ -138,6 +139,8 @@ Write-BlankLine
 Write-DotbotSection -Title "VALIDATION"
 
 $registryJsonPath = Join-Path $RegistryPath "registry.json"
+
+Invoke-DotbotSingleRegistryYamlMigration -RegistryPath $RegistryPath
 
 # 4a. File must exist
 if (-not (Test-Path $registryJsonPath)) {

--- a/src/cli/registry-add.ps1
+++ b/src/cli/registry-add.ps1
@@ -140,7 +140,7 @@ Write-DotbotSection -Title "VALIDATION"
 
 $registryJsonPath = Join-Path $RegistryPath "registry.json"
 
-Invoke-DotbotSingleRegistryYamlMigration -RegistryPath $RegistryPath
+Invoke-DotbotSingleRegistryYamlMigration -RegistryPath $RegistryPath -AllowExternalLink -ExpectedName $Name | Out-Null
 
 # 4a. File must exist
 if (-not (Test-Path $registryJsonPath)) {

--- a/src/cli/registry-list.ps1
+++ b/src/cli/registry-list.ps1
@@ -31,8 +31,11 @@ if (-not (Test-Path $PlatformFunctionsModule)) {
 Import-Module $PlatformFunctionsModule -Force -ErrorAction Stop
 Import-Module (Join-Path (Get-DotbotInstallPath) "src" "runtime" "Modules" "Dotbot.Theme" "Dotbot.Theme.psd1") -Force -DisableNameChecking
 Import-Module (Join-Path (Get-DotbotInstallPath) "src" "runtime" "Modules" "Dotbot.Workflow" "Dotbot.Workflow.psd1") -Force -DisableNameChecking
+Import-Module (Join-Path (Get-DotbotInstallPath) "src" "runtime" "Modules" "Dotbot.LegacyYaml" "Dotbot.LegacyYaml.psd1") -Force -DisableNameChecking
 
 Write-DotbotBanner -Title "D O T B O T" -Subtitle "Registries"
+
+Invoke-DotbotRegistryYamlMigration -DotbotBase $DotbotBase
 
 # ---------------------------------------------------------------------------
 # 1. Read registries.json

--- a/src/cli/registry-update.ps1
+++ b/src/cli/registry-update.ps1
@@ -43,6 +43,7 @@ if (-not (Test-Path $PlatformFunctionsModule)) {
 }
 Import-Module $PlatformFunctionsModule -Force -ErrorAction Stop
 Import-Module (Join-Path (Get-DotbotInstallPath) "src" "runtime" "Modules" "Dotbot.Theme" "Dotbot.Theme.psd1") -Force -DisableNameChecking
+Import-Module (Join-Path (Get-DotbotInstallPath) "src" "runtime" "Modules" "Dotbot.LegacyYaml" "Dotbot.LegacyYaml.psd1") -Force -DisableNameChecking
 
 Write-DotbotBanner -Title "D O T B O T" -Subtitle "Registry: Update"
 
@@ -174,6 +175,7 @@ foreach ($entry in $targets) {
     if ($entry.type -eq 'local') {
         # Local: symlink/junction is always current — just re-validate
         Write-Status "Local registry — re-validating (symlink tracks source automatically)"
+        $null = Invoke-DotbotSingleRegistryYamlMigration -RegistryPath $registryPath -AllowExternalLink -ExpectedName $entryName
         $result = Invoke-RegistryValidation -RegistryPath $registryPath -RegistryName $entryName
         if ($result -eq $false) {
             $failedCount++
@@ -240,6 +242,7 @@ foreach ($entry in $targets) {
 
         Write-BlankLine
         Write-DotbotSection -Title "VALIDATION"
+        $null = Invoke-DotbotSingleRegistryYamlMigration -RegistryPath $registryPath -ExpectedName $entryName
         $result = Invoke-RegistryValidation -RegistryPath $registryPath -RegistryName $entryName
         if ($result -eq $false) {
             $failedCount++

--- a/src/runtime/Modules/Dotbot.LegacyYaml/Dotbot.LegacyYaml.psd1
+++ b/src/runtime/Modules/Dotbot.LegacyYaml/Dotbot.LegacyYaml.psd1
@@ -1,0 +1,27 @@
+@{
+    RootModule        = 'Dotbot.LegacyYaml.psm1'
+    ModuleVersion     = '1.0.0'
+    GUID              = '8f2c6a1d-4b7e-4c93-9d15-3e8a5f0b6c24'
+    Author            = 'dotbot contributors'
+    Description       = 'Legacy v3.5 YAML manifest detection and one-time migration to the v4 JSON layout for workflows and registries.'
+    PowerShellVersion = '7.0'
+
+    ScriptsToProcess  = @(
+        'Private/Imports.ps1'
+    )
+
+    FunctionsToExport = @(
+        'Import-DotbotYamlSupport'
+        'Convert-DotbotYamlFileToJson'
+        'Update-DotbotManifestFromYaml'
+        'Get-DotbotLegacyYamlFile'
+        'Test-DotbotLegacyYamlPresent'
+        'Invoke-DotbotWorkflowYamlMigration'
+        'Invoke-DotbotSingleRegistryYamlMigration'
+        'Invoke-DotbotRegistryYamlMigration'
+    )
+
+    CmdletsToExport   = @()
+    VariablesToExport = @()
+    AliasesToExport   = @()
+}

--- a/src/runtime/Modules/Dotbot.LegacyYaml/Dotbot.LegacyYaml.psm1
+++ b/src/runtime/Modules/Dotbot.LegacyYaml/Dotbot.LegacyYaml.psm1
@@ -1,0 +1,410 @@
+<#
+.SYNOPSIS
+Legacy v3.5 YAML manifest migration — detect workflow.yaml / manifest.yaml /
+registry.yaml, convert to the v4 JSON layout, and warn on ambiguous state.
+
+.DESCRIPTION
+dotbot v3.5 read YAML manifests (.bot/workflow.yaml, .bot/workflows/<name>/workflow.yaml,
+<registry>/registry.yaml). v4 reads only JSON from .bot/content/workflows/<name>/workflow.json
+and <registry>/registry.json. This module owns the one-time fallback: parse legacy YAML with
+the powershell-yaml module, write the JSON equivalent into the v4 layout, rename the source
+to *.migrated, and warn the operator. A .yaml file alongside its .json equivalent is never
+silently resolved — JSON wins and a warning repeats until the operator removes the YAML.
+Consumed by Dotbot.Workflow (Find-Workflow / Discover-Workflows), the registry CLI scripts,
+and dotbot init.
+#>
+
+$script:WorkflowYamlMigrationDone = @{}
+$script:RegistryYamlMigrationDone = @{}
+$script:YamlSupportLoaded = $false
+
+$script:ManualInstallCommand = 'Install-Module powershell-yaml -Scope CurrentUser'
+$script:MigrationDocPointer = "See MIGRATING.md section 'YAML manifests are retired'."
+
+function Write-LegacyYamlWarning {
+    param([Parameter(Mandatory)][string]$Message)
+
+    if (Get-Command Write-DotbotWarning -ErrorAction SilentlyContinue) {
+        Write-DotbotWarning $Message
+    } else {
+        [Console]::Error.WriteLine("WARNING: $Message")
+    }
+}
+
+function Write-LegacyYamlError {
+    param([Parameter(Mandatory)][string]$Message)
+
+    if (Get-Command Write-DotbotError -ErrorAction SilentlyContinue) {
+        Write-DotbotError $Message
+    } else {
+        [Console]::Error.WriteLine("ERROR: $Message")
+    }
+}
+
+function Write-LegacyYamlLog {
+    param(
+        [Parameter(Mandatory)][ValidateSet('Debug','Info','Warn','Error','Fatal')][string]$Level,
+        [Parameter(Mandatory)][string]$Message,
+        [hashtable]$Context,
+        [System.Management.Automation.ErrorRecord]$Exception
+    )
+
+    if (-not (Get-Command Write-BotLog -ErrorAction SilentlyContinue)) { return }
+    $params = @{ Level = $Level; Message = $Message }
+    if ($Context) { $params.Context = $Context }
+    if ($Exception) { $params.Exception = $Exception }
+    Write-BotLog @params
+}
+
+function Import-DotbotYamlSupport {
+    <#
+    .SYNOPSIS
+    Load the powershell-yaml module, installing it (CurrentUser scope) when absent.
+
+    .DESCRIPTION
+    Called lazily, only after legacy YAML files have been detected. Throws with the
+    manual install command when neither import nor install succeeds.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if ($script:YamlSupportLoaded) { return }
+
+    if (Get-Module -ListAvailable powershell-yaml) {
+        Import-Module powershell-yaml -ErrorAction Stop
+        $script:YamlSupportLoaded = $true
+        return
+    }
+
+    Write-LegacyYamlWarning "Legacy YAML manifests found — installing the powershell-yaml module (CurrentUser scope) to convert them..."
+    try {
+        Install-Module powershell-yaml -Scope CurrentUser -Force -ErrorAction Stop
+        Import-Module powershell-yaml -ErrorAction Stop
+    } catch {
+        throw "Legacy YAML manifests were found but the powershell-yaml module could not be installed automatically. Install it manually with: $script:ManualInstallCommand — then re-run this command. $script:MigrationDocPointer Underlying error: $($_.Exception.Message)"
+    }
+    $script:YamlSupportLoaded = $true
+}
+
+function Convert-DotbotYamlFileToJson {
+    <#
+    .SYNOPSIS
+    Convert one YAML manifest to JSON and rename the source to <file>.migrated.
+
+    .DESCRIPTION
+    Writes the JSON to a temp name first and moves it into place so a concurrent
+    process never observes a partial file. Throws on unparseable or empty YAML,
+    leaving the source untouched.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$YamlPath,
+        [Parameter(Mandatory)][string]$JsonPath
+    )
+
+    Import-DotbotYamlSupport
+
+    $parsed = Get-Content -LiteralPath $YamlPath -Raw | ConvertFrom-Yaml -Ordered
+    if (-not $parsed) {
+        throw "YAML manifest is empty or does not contain a mapping: $YamlPath"
+    }
+
+    $json = $parsed | ConvertTo-Json -Depth 20
+
+    $jsonDir = Split-Path -Parent $JsonPath
+    if ($jsonDir -and -not (Test-Path -LiteralPath $jsonDir)) {
+        New-Item -ItemType Directory -Path $jsonDir -Force | Out-Null
+    }
+
+    $tempPath = "$JsonPath.tmp-$PID"
+    [System.IO.File]::WriteAllText($tempPath, $json, [System.Text.UTF8Encoding]::new($false))
+    Move-Item -LiteralPath $tempPath -Destination $JsonPath -Force
+    Move-Item -LiteralPath $YamlPath -Destination "$YamlPath.migrated" -Force
+}
+
+function Update-DotbotManifestFromYaml {
+    <#
+    .SYNOPSIS
+    Reconcile one directory: convert its YAML manifest to JSON, or warn when both exist.
+
+    .DESCRIPTION
+    Returns 'migrated' when a YAML source was converted, 'ambiguous' when the JSON
+    manifest already exists alongside a YAML file (JSON wins, nothing is written,
+    the warning repeats every run until the YAML is removed), and 'none' when there
+    is no YAML to act on. YamlNames order is the source precedence.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Dir,
+        [Parameter(Mandatory)][string]$JsonName,
+        [Parameter(Mandatory)][string[]]$YamlNames
+    )
+
+    $presentYaml = @($YamlNames |
+        ForEach-Object { Join-Path $Dir $_ } |
+        Where-Object { Test-Path -LiteralPath $_ -PathType Leaf })
+    if ($presentYaml.Count -eq 0) { return 'none' }
+
+    $jsonPath = Join-Path $Dir $JsonName
+    if (Test-Path -LiteralPath $jsonPath -PathType Leaf) {
+        $yamlLeaf = Split-Path -Leaf $presentYaml[0]
+        Write-LegacyYamlWarning "Both $JsonName and $yamlLeaf exist in $Dir. dotbot v4 reads only $JsonName — the YAML file is ignored. Delete it or rename it to $yamlLeaf.migrated to clear this warning."
+        Write-LegacyYamlLog -Level Warn -Message 'Legacy YAML manifest coexists with its JSON equivalent' -Context @{ event = 'legacy_yaml_ambiguous'; path = $Dir; winner = $JsonName; ignored = $yamlLeaf }
+        return 'ambiguous'
+    }
+
+    $source = $presentYaml[0]
+    Convert-DotbotYamlFileToJson -YamlPath $source -JsonPath $jsonPath
+    Write-LegacyYamlWarning "Migrated legacy YAML manifest to JSON: $source -> $jsonPath (original kept as $(Split-Path -Leaf $source).migrated)"
+    Write-LegacyYamlLog -Level Warn -Message 'Migrated legacy YAML manifest to JSON' -Context @{ event = 'legacy_yaml_migrated'; source = $source; target = $jsonPath }
+    return 'migrated'
+}
+
+function Get-DotbotLegacyYamlFile {
+    <#
+    .SYNOPSIS
+    Enumerate legacy v3.5 YAML manifest paths under a project's .bot root. No writes.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$BotRoot
+    )
+
+    $found = [System.Collections.Generic.List[string]]::new()
+
+    $baseYaml = Join-Path $BotRoot 'workflow.yaml'
+    if (Test-Path -LiteralPath $baseYaml -PathType Leaf) { $found.Add($baseYaml) }
+
+    foreach ($parent in @((Join-Path $BotRoot 'workflows'), (Join-Path $BotRoot 'content' 'workflows'))) {
+        if (-not (Test-Path -LiteralPath $parent)) { continue }
+        foreach ($dir in Get-ChildItem -LiteralPath $parent -Directory -ErrorAction SilentlyContinue) {
+            foreach ($name in @('workflow.yaml', 'manifest.yaml')) {
+                $candidate = Join-Path $dir.FullName $name
+                if (Test-Path -LiteralPath $candidate -PathType Leaf) { $found.Add($candidate) }
+            }
+        }
+    }
+    return @($found)
+}
+
+function Test-DotbotLegacyYamlPresent {
+    <#
+    .SYNOPSIS
+    Detect whether legacy v3.5 YAML manifests exist under a project's .bot root. No writes.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$BotRoot
+    )
+
+    return (@(Get-DotbotLegacyYamlFile -BotRoot $BotRoot).Count -gt 0)
+}
+
+function Get-LegacyYamlMigrationKey {
+    param([Parameter(Mandatory)][string]$Path)
+
+    try {
+        return [System.IO.Path]::GetFullPath($Path)
+    } catch {
+        return $Path
+    }
+}
+
+function Invoke-LegacyYamlDirReconciliation {
+    param(
+        [Parameter(Mandatory)][string]$Dir
+    )
+
+    try {
+        Update-DotbotManifestFromYaml -Dir $Dir -JsonName 'workflow.json' -YamlNames @('workflow.yaml', 'manifest.yaml') | Out-Null
+    } catch {
+        Write-LegacyYamlError "Could not migrate legacy YAML manifest in ${Dir}: $($_.Exception.Message) The YAML file was left untouched."
+        Write-LegacyYamlLog -Level Error -Message 'Legacy YAML manifest migration failed' -Context @{ event = 'legacy_yaml_parse_failed'; path = $Dir } -Exception $_
+    }
+}
+
+function Invoke-DotbotWorkflowYamlMigration {
+    <#
+    .SYNOPSIS
+    One-time migration of a project's legacy v3.5 YAML workflow manifests to the v4 JSON layout.
+
+    .DESCRIPTION
+    Handles, in order: legacy .bot/workflows/<name>/ directories (moved whole to
+    .bot/content/workflows/<name>/ then converted), the legacy base .bot/workflow.yaml
+    (converted into .bot/content/workflows/<slug>/workflow.json), YAML strays already
+    inside .bot/content/workflows/, and the framework tier (detected and warned about,
+    never written — it may be a read-only package-manager install).
+    Idempotent: a process-scope flag keyed by BotRoot short-circuits repeat calls
+    (reset with -Force), and converted sources are renamed to *.migrated so later
+    processes find nothing to do. One failing file never hides the others.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$BotRoot,
+        [switch]$Force
+    )
+
+    $key = Get-LegacyYamlMigrationKey -Path $BotRoot
+    if ($script:WorkflowYamlMigrationDone[$key] -and -not $Force) { return }
+    $script:WorkflowYamlMigrationDone[$key] = $true
+
+    $frameworkWorkflows = Join-Path (Get-DotbotInstallPath) 'content' 'workflows'
+    if (Test-Path -LiteralPath $frameworkWorkflows) {
+        foreach ($dir in Get-ChildItem -LiteralPath $frameworkWorkflows -Directory -ErrorAction SilentlyContinue) {
+            $yaml = @('workflow.yaml', 'manifest.yaml') |
+                ForEach-Object { Join-Path $dir.FullName $_ } |
+                Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } |
+                Select-Object -First 1
+            if ($yaml) {
+                Write-LegacyYamlWarning "Legacy YAML manifest found in the installed framework: $yaml. dotbot never modifies the framework install — convert it to workflow.json manually or remove it. $script:MigrationDocPointer"
+                Write-LegacyYamlLog -Level Warn -Message 'Legacy YAML manifest found in framework tier' -Context @{ event = 'legacy_yaml_framework_tier'; path = $yaml }
+            }
+        }
+    }
+
+    if (-not (Test-DotbotLegacyYamlPresent -BotRoot $BotRoot)) { return }
+
+    try {
+        Import-DotbotYamlSupport
+    } catch {
+        Write-LegacyYamlError $_.Exception.Message
+        Write-LegacyYamlLog -Level Error -Message 'powershell-yaml unavailable — legacy YAML manifests were not converted' -Context @{ event = 'legacy_yaml_module_unavailable'; bot_root = $BotRoot } -Exception $_
+        return
+    }
+
+    $contentWorkflows = Join-Path $BotRoot 'content' 'workflows'
+
+    $legacyParent = Join-Path $BotRoot 'workflows'
+    if (Test-Path -LiteralPath $legacyParent) {
+        foreach ($dir in Get-ChildItem -LiteralPath $legacyParent -Directory -ErrorAction SilentlyContinue) {
+            $hasYaml = @('workflow.yaml', 'manifest.yaml') |
+                Where-Object { Test-Path -LiteralPath (Join-Path $dir.FullName $_) -PathType Leaf }
+            if (-not $hasYaml) { continue }
+
+            $target = Join-Path $contentWorkflows $dir.Name
+            if (Test-Path -LiteralPath $target) {
+                Write-LegacyYamlWarning "Legacy workflow directory $($dir.FullName) was not moved: $target already exists. dotbot v4 reads only the existing directory — merge or remove the legacy one manually."
+                Write-LegacyYamlLog -Level Warn -Message 'Legacy workflow directory conflicts with existing v4 directory' -Context @{ event = 'legacy_yaml_ambiguous'; path = $dir.FullName; conflict = $target }
+                continue
+            }
+
+            try {
+                if (-not (Test-Path -LiteralPath $contentWorkflows)) {
+                    New-Item -ItemType Directory -Path $contentWorkflows -Force | Out-Null
+                }
+                Move-Item -LiteralPath $dir.FullName -Destination $target
+            } catch {
+                Write-LegacyYamlError "Could not move legacy workflow directory $($dir.FullName) to ${target}: $($_.Exception.Message)"
+                Write-LegacyYamlLog -Level Error -Message 'Legacy workflow directory move failed' -Context @{ event = 'legacy_yaml_write_failed'; path = $dir.FullName; target = $target } -Exception $_
+                continue
+            }
+            Invoke-LegacyYamlDirReconciliation -Dir $target
+        }
+
+        if (-not (Get-ChildItem -LiteralPath $legacyParent -Force -ErrorAction SilentlyContinue)) {
+            Remove-Item -LiteralPath $legacyParent -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    $baseYaml = Join-Path $BotRoot 'workflow.yaml'
+    if (Test-Path -LiteralPath $baseYaml -PathType Leaf) {
+        try {
+            $parsed = Get-Content -LiteralPath $baseYaml -Raw | ConvertFrom-Yaml -Ordered
+            $slug = ''
+            if ($parsed -and $parsed['name']) {
+                $slug = (([string]$parsed['name'] -replace '[^\w\s-]', '' -replace '\s+', '-').ToLowerInvariant())
+            }
+            if (-not $slug) { $slug = 'default' }
+
+            $targetDir = Join-Path $contentWorkflows $slug
+            $targetJson = Join-Path $targetDir 'workflow.json'
+            if (Test-Path -LiteralPath $targetJson -PathType Leaf) {
+                Write-LegacyYamlWarning "Both $targetJson and $baseYaml exist. dotbot v4 reads only workflow.json — the YAML file is ignored. Delete it or rename it to workflow.yaml.migrated to clear this warning."
+                Write-LegacyYamlLog -Level Warn -Message 'Legacy base manifest coexists with its JSON equivalent' -Context @{ event = 'legacy_yaml_ambiguous'; path = $baseYaml; winner = $targetJson }
+            } else {
+                Convert-DotbotYamlFileToJson -YamlPath $baseYaml -JsonPath $targetJson
+                Write-LegacyYamlWarning "Migrated legacy YAML manifest to JSON: $baseYaml -> $targetJson (original kept as workflow.yaml.migrated)"
+                Write-LegacyYamlLog -Level Warn -Message 'Migrated legacy YAML manifest to JSON' -Context @{ event = 'legacy_yaml_migrated'; source = $baseYaml; target = $targetJson }
+            }
+        } catch {
+            Write-LegacyYamlError "Could not migrate legacy base manifest ${baseYaml}: $($_.Exception.Message) The YAML file was left untouched."
+            Write-LegacyYamlLog -Level Error -Message 'Legacy base manifest migration failed' -Context @{ event = 'legacy_yaml_parse_failed'; path = $baseYaml } -Exception $_
+        }
+    }
+
+    if (Test-Path -LiteralPath $contentWorkflows) {
+        foreach ($dir in Get-ChildItem -LiteralPath $contentWorkflows -Directory -ErrorAction SilentlyContinue) {
+            Invoke-LegacyYamlDirReconciliation -Dir $dir.FullName
+        }
+    }
+}
+
+function Invoke-DotbotSingleRegistryYamlMigration {
+    <#
+    .SYNOPSIS
+    Migrate one registry's legacy YAML manifests (registry.yaml and nested workflow.yaml) to JSON.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$RegistryPath
+    )
+
+    if (-not (Test-Path -LiteralPath $RegistryPath)) { return }
+
+    $rootYaml = Join-Path $RegistryPath 'registry.yaml'
+    $workflowsParent = Join-Path $RegistryPath 'workflows'
+    $nestedYaml = @()
+    if (Test-Path -LiteralPath $workflowsParent) {
+        $nestedYaml = @(Get-ChildItem -LiteralPath $workflowsParent -Directory -ErrorAction SilentlyContinue |
+            Where-Object {
+                (Test-Path -LiteralPath (Join-Path $_.FullName 'workflow.yaml') -PathType Leaf) -or
+                (Test-Path -LiteralPath (Join-Path $_.FullName 'manifest.yaml') -PathType Leaf)
+            })
+    }
+    $hasRootYaml = Test-Path -LiteralPath $rootYaml -PathType Leaf
+    if (-not $hasRootYaml -and $nestedYaml.Count -eq 0) { return }
+
+    try {
+        Import-DotbotYamlSupport
+    } catch {
+        Write-LegacyYamlError $_.Exception.Message
+        Write-LegacyYamlLog -Level Error -Message 'powershell-yaml unavailable — legacy registry YAML was not converted' -Context @{ event = 'legacy_yaml_module_unavailable'; registry = $RegistryPath } -Exception $_
+        return
+    }
+
+    if ($hasRootYaml) {
+        try {
+            Update-DotbotManifestFromYaml -Dir $RegistryPath -JsonName 'registry.json' -YamlNames @('registry.yaml') | Out-Null
+        } catch {
+            Write-LegacyYamlError "Could not migrate legacy registry manifest in ${RegistryPath}: $($_.Exception.Message) The YAML file was left untouched."
+            Write-LegacyYamlLog -Level Error -Message 'Legacy registry manifest migration failed' -Context @{ event = 'legacy_yaml_parse_failed'; path = $rootYaml } -Exception $_
+        }
+    }
+
+    foreach ($dir in $nestedYaml) {
+        Invoke-LegacyYamlDirReconciliation -Dir $dir.FullName
+    }
+}
+
+function Invoke-DotbotRegistryYamlMigration {
+    <#
+    .SYNOPSIS
+    One-time migration of every registered registry's legacy YAML manifests under <DotbotBase>/registries.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$DotbotBase,
+        [switch]$Force
+    )
+
+    $key = Get-LegacyYamlMigrationKey -Path $DotbotBase
+    if ($script:RegistryYamlMigrationDone[$key] -and -not $Force) { return }
+    $script:RegistryYamlMigrationDone[$key] = $true
+
+    $registriesRoot = Join-Path $DotbotBase 'registries'
+    if (-not (Test-Path -LiteralPath $registriesRoot)) { return }
+
+    foreach ($dir in Get-ChildItem -LiteralPath $registriesRoot -Directory -ErrorAction SilentlyContinue) {
+        Invoke-DotbotSingleRegistryYamlMigration -RegistryPath $dir.FullName
+    }
+}

--- a/src/runtime/Modules/Dotbot.LegacyYaml/Dotbot.LegacyYaml.psm1
+++ b/src/runtime/Modules/Dotbot.LegacyYaml/Dotbot.LegacyYaml.psm1
@@ -17,8 +17,10 @@ and dotbot init.
 $script:WorkflowYamlMigrationDone = @{}
 $script:RegistryYamlMigrationDone = @{}
 $script:YamlSupportLoaded = $false
+$script:MigrationFailureInjector = $null
 
-$script:ManualInstallCommand = 'Install-Module powershell-yaml -Scope CurrentUser'
+$script:PowerShellGetInstallCommand = 'Register-PSRepository -Default; Install-Module powershell-yaml -Repository PSGallery -Scope CurrentUser'
+$script:PSResourceGetInstallCommand = 'Install-PSResource powershell-yaml -Repository PSGallery -Scope CurrentUser -TrustRepository'
 $script:MigrationDocPointer = "See MIGRATING.md section 'YAML manifests are retired'."
 
 function Write-LegacyYamlWarning {
@@ -59,16 +61,23 @@ function Write-LegacyYamlLog {
 function Import-DotbotYamlSupport {
     <#
     .SYNOPSIS
-    Load the powershell-yaml module, installing it (CurrentUser scope) when absent.
+    Load the powershell-yaml module when available.
 
     .DESCRIPTION
-    Called lazily, only after legacy YAML files have been detected. Throws with the
-    manual install command when neither import nor install succeeds.
+    Called lazily, only after legacy YAML files have been detected. Migration is
+    also reached from read-only discovery commands, so this function never changes
+    package repositories or installs code. It throws with explicit guidance for
+    both supported PowerShell package managers when the parser is unavailable.
     #>
     [CmdletBinding()]
     param()
 
     if ($script:YamlSupportLoaded) { return }
+
+    if (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue) {
+        $script:YamlSupportLoaded = $true
+        return
+    }
 
     if (Get-Module -ListAvailable powershell-yaml) {
         Import-Module powershell-yaml -ErrorAction Stop
@@ -76,14 +85,98 @@ function Import-DotbotYamlSupport {
         return
     }
 
-    Write-LegacyYamlWarning "Legacy YAML manifests found — installing the powershell-yaml module (CurrentUser scope) to convert them..."
-    try {
-        Install-Module powershell-yaml -Scope CurrentUser -Force -ErrorAction Stop
-        Import-Module powershell-yaml -ErrorAction Stop
-    } catch {
-        throw "Legacy YAML manifests were found but the powershell-yaml module could not be installed automatically. Install it manually with: $script:ManualInstallCommand — then re-run this command. $script:MigrationDocPointer Underlying error: $($_.Exception.Message)"
+    throw "Legacy YAML manifests were found but powershell-yaml is not installed. dotbot does not install packages during workflow or registry discovery. Install it explicitly with PowerShellGet: $script:PowerShellGetInstallCommand — or PSResourceGet: $script:PSResourceGetInstallCommand — then re-run this command. $script:MigrationDocPointer"
+}
+
+function Invoke-DotbotMigrationFailureInjector {
+    param(
+        [Parameter(Mandatory)][string]$Operation,
+        [Parameter(Mandatory)][string]$Source,
+        [string]$Destination
+    )
+    if ($script:MigrationFailureInjector) {
+        & $script:MigrationFailureInjector $Operation $Source $Destination
     }
-    $script:YamlSupportLoaded = $true
+}
+
+function Move-DotbotMigrationItem {
+    param(
+        [Parameter(Mandatory)][string]$Operation,
+        [Parameter(Mandatory)][string]$Source,
+        [Parameter(Mandatory)][string]$Destination
+    )
+    Invoke-DotbotMigrationFailureInjector -Operation $Operation -Source $Source -Destination $Destination
+    Move-Item -LiteralPath $Source -Destination $Destination -ErrorAction Stop
+}
+
+function Test-DotbotYamlManifestStructure {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]$Manifest,
+        [Parameter(Mandatory)][ValidateSet('Workflow','Registry')][string]$Kind,
+        [Parameter(Mandatory)][string]$SourcePath,
+        [switch]$AllowMissingName,
+        [string]$ExpectedName
+    )
+
+    if ($Manifest -isnot [System.Collections.IDictionary]) {
+        throw "$Kind YAML manifest must have a mapping at its root: $SourcePath"
+    }
+
+    $name = if ($Manifest.Contains('name')) { [string]$Manifest['name'] } else { '' }
+    if (-not $AllowMissingName -and [string]::IsNullOrWhiteSpace($name)) {
+        throw "$Kind YAML manifest must declare a non-empty 'name': $SourcePath"
+    }
+    if ($ExpectedName -and $name -ne $ExpectedName) {
+        throw "$Kind YAML manifest name '$name' does not match expected name '$ExpectedName': $SourcePath"
+    }
+
+    if ($Kind -eq 'Workflow' -and $Manifest.Contains('tasks')) {
+        $tasks = $Manifest['tasks']
+        if ($null -ne $tasks -and ($tasks -is [string] -or $tasks -isnot [System.Collections.IEnumerable])) {
+            throw "Workflow YAML manifest 'tasks' must be a sequence: $SourcePath"
+        }
+        foreach ($task in @($tasks)) {
+            if ($task -isnot [System.Collections.IDictionary]) {
+                throw "Every workflow YAML task must be a mapping: $SourcePath"
+            }
+        }
+    }
+
+    if ($Kind -eq 'Registry') {
+        $content = if ($Manifest.Contains('content')) { $Manifest['content'] } else { $null }
+        if ($content -isnot [System.Collections.IDictionary] -or $content.Count -eq 0) {
+            throw "Registry YAML manifest must declare a non-empty 'content' mapping: $SourcePath"
+        }
+        $declaredItems = 0
+        foreach ($key in $content.Keys) {
+            $items = $content[$key]
+            if ($items -is [string] -or $items -isnot [System.Collections.IEnumerable]) {
+                throw "Registry YAML content '$key' must be a sequence: $SourcePath"
+            }
+            $declaredItems += @($items).Count
+        }
+        if ($declaredItems -eq 0) {
+            throw "Registry YAML manifest must declare at least one content item: $SourcePath"
+        }
+    }
+
+    return $true
+}
+
+function Read-DotbotValidatedYamlManifest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$YamlPath,
+        [Parameter(Mandatory)][ValidateSet('Workflow','Registry')][string]$Kind,
+        [switch]$AllowMissingName,
+        [string]$ExpectedName
+    )
+
+    Import-DotbotYamlSupport
+    $parsed = Get-Content -LiteralPath $YamlPath -Raw | ConvertFrom-Yaml -Ordered
+    $null = Test-DotbotYamlManifestStructure -Manifest $parsed -Kind $Kind -SourcePath $YamlPath -AllowMissingName:$AllowMissingName -ExpectedName $ExpectedName
+    return $parsed
 }
 
 function Convert-DotbotYamlFileToJson {
@@ -99,27 +192,59 @@ function Convert-DotbotYamlFileToJson {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$YamlPath,
-        [Parameter(Mandatory)][string]$JsonPath
+        [Parameter(Mandatory)][string]$JsonPath,
+        [ValidateSet('Workflow','Registry')][string]$ManifestKind = 'Workflow',
+        [switch]$AllowMissingName,
+        [string]$ExpectedName
     )
 
-    Import-DotbotYamlSupport
-
-    $parsed = Get-Content -LiteralPath $YamlPath -Raw | ConvertFrom-Yaml -Ordered
-    if (-not $parsed) {
-        throw "YAML manifest is empty or does not contain a mapping: $YamlPath"
-    }
+    $parsed = Read-DotbotValidatedYamlManifest -YamlPath $YamlPath -Kind $ManifestKind -AllowMissingName:$AllowMissingName -ExpectedName $ExpectedName
 
     $json = $parsed | ConvertTo-Json -Depth 20
 
-    $jsonDir = Split-Path -Parent $JsonPath
-    if ($jsonDir -and -not (Test-Path -LiteralPath $jsonDir)) {
-        New-Item -ItemType Directory -Path $jsonDir -Force | Out-Null
+    $migratedPath = "$YamlPath.migrated"
+    if (Test-Path -LiteralPath $JsonPath) {
+        throw "Refusing to overwrite existing JSON manifest: $JsonPath"
+    }
+    if (Test-Path -LiteralPath $migratedPath) {
+        throw "Refusing to overwrite existing migration backup: $migratedPath"
     }
 
-    $tempPath = "$JsonPath.tmp-$PID"
-    [System.IO.File]::WriteAllText($tempPath, $json, [System.Text.UTF8Encoding]::new($false))
-    Move-Item -LiteralPath $tempPath -Destination $JsonPath -Force
-    Move-Item -LiteralPath $YamlPath -Destination "$YamlPath.migrated" -Force
+    $jsonDir = Split-Path -Parent $JsonPath
+    $jsonDirCreated = $false
+    if ($jsonDir -and -not (Test-Path -LiteralPath $jsonDir)) {
+        New-Item -ItemType Directory -Path $jsonDir -Force | Out-Null
+        $jsonDirCreated = $true
+    }
+
+    $tempPath = "$JsonPath.tmp-$PID-$([guid]::NewGuid().ToString('N'))"
+    $jsonPublished = $false
+    try {
+        [System.IO.File]::WriteAllText($tempPath, $json, [System.Text.UTF8Encoding]::new($false))
+        $roundTrip = Get-Content -LiteralPath $tempPath -Raw | ConvertFrom-Json -AsHashtable
+        $null = Test-DotbotYamlManifestStructure -Manifest $roundTrip -Kind $ManifestKind -SourcePath $tempPath -AllowMissingName:$AllowMissingName -ExpectedName $ExpectedName
+
+        Move-DotbotMigrationItem -Operation 'publish-json' -Source $tempPath -Destination $JsonPath
+        $jsonPublished = $true
+        try {
+            Move-DotbotMigrationItem -Operation 'archive-yaml' -Source $YamlPath -Destination $migratedPath
+        } catch {
+            Remove-Item -LiteralPath $JsonPath -Force -ErrorAction Stop
+            $jsonPublished = $false
+            throw
+        }
+    } finally {
+        if (Test-Path -LiteralPath $tempPath) {
+            Remove-Item -LiteralPath $tempPath -Force -ErrorAction SilentlyContinue
+        }
+        if ($jsonPublished -and (Test-Path -LiteralPath $YamlPath) -and -not (Test-Path -LiteralPath $migratedPath)) {
+            Remove-Item -LiteralPath $JsonPath -Force -ErrorAction SilentlyContinue
+        }
+        if ($jsonDirCreated -and (Test-Path -LiteralPath $jsonDir) -and
+            -not (Get-ChildItem -LiteralPath $jsonDir -Force -ErrorAction SilentlyContinue | Select-Object -First 1)) {
+            Remove-Item -LiteralPath $jsonDir -Force -ErrorAction SilentlyContinue
+        }
+    }
 }
 
 function Update-DotbotManifestFromYaml {
@@ -137,13 +262,18 @@ function Update-DotbotManifestFromYaml {
     param(
         [Parameter(Mandatory)][string]$Dir,
         [Parameter(Mandatory)][string]$JsonName,
-        [Parameter(Mandatory)][string[]]$YamlNames
+        [Parameter(Mandatory)][string[]]$YamlNames,
+        [ValidateSet('Workflow','Registry')][string]$ManifestKind = 'Workflow',
+        [string]$ExpectedName
     )
 
     $presentYaml = @($YamlNames |
         ForEach-Object { Join-Path $Dir $_ } |
         Where-Object { Test-Path -LiteralPath $_ -PathType Leaf })
     if ($presentYaml.Count -eq 0) { return 'none' }
+    if ($presentYaml.Count -gt 1) {
+        throw "Multiple legacy YAML manifests exist in ${Dir}: $($presentYaml -join ', '). Resolve the ambiguity before migration."
+    }
 
     $jsonPath = Join-Path $Dir $JsonName
     if (Test-Path -LiteralPath $jsonPath -PathType Leaf) {
@@ -154,7 +284,7 @@ function Update-DotbotManifestFromYaml {
     }
 
     $source = $presentYaml[0]
-    Convert-DotbotYamlFileToJson -YamlPath $source -JsonPath $jsonPath
+    Convert-DotbotYamlFileToJson -YamlPath $source -JsonPath $jsonPath -ManifestKind $ManifestKind -ExpectedName $ExpectedName
     Write-LegacyYamlWarning "Migrated legacy YAML manifest to JSON: $source -> $jsonPath (original kept as $(Split-Path -Leaf $source).migrated)"
     Write-LegacyYamlLog -Level Warn -Message 'Migrated legacy YAML manifest to JSON' -Context @{ event = 'legacy_yaml_migrated'; source = $source; target = $jsonPath }
     return 'migrated'
@@ -217,9 +347,11 @@ function Invoke-LegacyYamlDirReconciliation {
 
     try {
         Update-DotbotManifestFromYaml -Dir $Dir -JsonName 'workflow.json' -YamlNames @('workflow.yaml', 'manifest.yaml') | Out-Null
+        return $true
     } catch {
         Write-LegacyYamlError "Could not migrate legacy YAML manifest in ${Dir}: $($_.Exception.Message) The YAML file was left untouched."
         Write-LegacyYamlLog -Level Error -Message 'Legacy YAML manifest migration failed' -Context @{ event = 'legacy_yaml_parse_failed'; path = $Dir } -Exception $_
+        return $false
     }
 }
 
@@ -246,7 +378,7 @@ function Invoke-DotbotWorkflowYamlMigration {
 
     $key = Get-LegacyYamlMigrationKey -Path $BotRoot
     if ($script:WorkflowYamlMigrationDone[$key] -and -not $Force) { return }
-    $script:WorkflowYamlMigrationDone[$key] = $true
+    $allSucceeded = $true
 
     $frameworkWorkflows = Join-Path (Get-DotbotInstallPath) 'content' 'workflows'
     if (Test-Path -LiteralPath $frameworkWorkflows) {
@@ -262,7 +394,10 @@ function Invoke-DotbotWorkflowYamlMigration {
         }
     }
 
-    if (-not (Test-DotbotLegacyYamlPresent -BotRoot $BotRoot)) { return }
+    if (-not (Test-DotbotLegacyYamlPresent -BotRoot $BotRoot)) {
+        $script:WorkflowYamlMigrationDone[$key] = $true
+        return
+    }
 
     try {
         Import-DotbotYamlSupport
@@ -280,25 +415,48 @@ function Invoke-DotbotWorkflowYamlMigration {
             $hasYaml = @('workflow.yaml', 'manifest.yaml') |
                 Where-Object { Test-Path -LiteralPath (Join-Path $dir.FullName $_) -PathType Leaf }
             if (-not $hasYaml) { continue }
+            if ($dir.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+                Write-LegacyYamlWarning "Legacy workflow link $($dir.FullName) was not migrated because it resolves outside the project layout. Replace it with a real directory or convert the linked source explicitly."
+                $allSucceeded = $false
+                continue
+            }
 
             $target = Join-Path $contentWorkflows $dir.Name
             if (Test-Path -LiteralPath $target) {
                 Write-LegacyYamlWarning "Legacy workflow directory $($dir.FullName) was not moved: $target already exists. dotbot v4 reads only the existing directory — merge or remove the legacy one manually."
                 Write-LegacyYamlLog -Level Warn -Message 'Legacy workflow directory conflicts with existing v4 directory' -Context @{ event = 'legacy_yaml_ambiguous'; path = $dir.FullName; conflict = $target }
+                $allSucceeded = $false
                 continue
             }
 
+            $sourceYaml = @('workflow.yaml', 'manifest.yaml') |
+                ForEach-Object { Join-Path $dir.FullName $_ } |
+                Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } |
+                Select-Object -First 1
             try {
+                # Validate before changing the legacy layout. Conversion is
+                # repeated after the directory move so all final paths and
+                # backups are committed together.
+                $null = Read-DotbotValidatedYamlManifest -YamlPath $sourceYaml -Kind Workflow
                 if (-not (Test-Path -LiteralPath $contentWorkflows)) {
                     New-Item -ItemType Directory -Path $contentWorkflows -Force | Out-Null
                 }
-                Move-Item -LiteralPath $dir.FullName -Destination $target
+                Move-DotbotMigrationItem -Operation 'move-workflow-directory' -Source $dir.FullName -Destination $target
             } catch {
                 Write-LegacyYamlError "Could not move legacy workflow directory $($dir.FullName) to ${target}: $($_.Exception.Message)"
                 Write-LegacyYamlLog -Level Error -Message 'Legacy workflow directory move failed' -Context @{ event = 'legacy_yaml_write_failed'; path = $dir.FullName; target = $target } -Exception $_
+                $allSucceeded = $false
                 continue
             }
-            Invoke-LegacyYamlDirReconciliation -Dir $target
+            if (-not (Invoke-LegacyYamlDirReconciliation -Dir $target)) {
+                try {
+                    Move-DotbotMigrationItem -Operation 'rollback-workflow-directory' -Source $target -Destination $dir.FullName
+                } catch {
+                    Write-LegacyYamlError "Rollback failed after migrating $($dir.FullName): $($_.Exception.Message). Recover the workflow directory from $target."
+                    Write-LegacyYamlLog -Level Fatal -Message 'Legacy workflow directory rollback failed' -Context @{ event = 'legacy_yaml_rollback_failed'; path = $dir.FullName; target = $target } -Exception $_
+                }
+                $allSucceeded = $false
+            }
         }
 
         if (-not (Get-ChildItem -LiteralPath $legacyParent -Force -ErrorAction SilentlyContinue)) {
@@ -309,7 +467,7 @@ function Invoke-DotbotWorkflowYamlMigration {
     $baseYaml = Join-Path $BotRoot 'workflow.yaml'
     if (Test-Path -LiteralPath $baseYaml -PathType Leaf) {
         try {
-            $parsed = Get-Content -LiteralPath $baseYaml -Raw | ConvertFrom-Yaml -Ordered
+            $parsed = Read-DotbotValidatedYamlManifest -YamlPath $baseYaml -Kind Workflow -AllowMissingName
             $slug = ''
             if ($parsed -and $parsed['name']) {
                 $slug = (([string]$parsed['name'] -replace '[^\w\s-]', '' -replace '\s+', '-').ToLowerInvariant())
@@ -322,20 +480,36 @@ function Invoke-DotbotWorkflowYamlMigration {
                 Write-LegacyYamlWarning "Both $targetJson and $baseYaml exist. dotbot v4 reads only workflow.json — the YAML file is ignored. Delete it or rename it to workflow.yaml.migrated to clear this warning."
                 Write-LegacyYamlLog -Level Warn -Message 'Legacy base manifest coexists with its JSON equivalent' -Context @{ event = 'legacy_yaml_ambiguous'; path = $baseYaml; winner = $targetJson }
             } else {
-                Convert-DotbotYamlFileToJson -YamlPath $baseYaml -JsonPath $targetJson
+                Convert-DotbotYamlFileToJson -YamlPath $baseYaml -JsonPath $targetJson -ManifestKind Workflow -AllowMissingName
                 Write-LegacyYamlWarning "Migrated legacy YAML manifest to JSON: $baseYaml -> $targetJson (original kept as workflow.yaml.migrated)"
                 Write-LegacyYamlLog -Level Warn -Message 'Migrated legacy YAML manifest to JSON' -Context @{ event = 'legacy_yaml_migrated'; source = $baseYaml; target = $targetJson }
             }
         } catch {
             Write-LegacyYamlError "Could not migrate legacy base manifest ${baseYaml}: $($_.Exception.Message) The YAML file was left untouched."
             Write-LegacyYamlLog -Level Error -Message 'Legacy base manifest migration failed' -Context @{ event = 'legacy_yaml_parse_failed'; path = $baseYaml } -Exception $_
+            $allSucceeded = $false
         }
     }
 
     if (Test-Path -LiteralPath $contentWorkflows) {
         foreach ($dir in Get-ChildItem -LiteralPath $contentWorkflows -Directory -ErrorAction SilentlyContinue) {
-            Invoke-LegacyYamlDirReconciliation -Dir $dir.FullName
+            if ($dir.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+                $linkedYaml = @('workflow.yaml', 'manifest.yaml') |
+                    Where-Object { Test-Path -LiteralPath (Join-Path $dir.FullName $_) -PathType Leaf }
+                if ($linkedYaml) {
+                    Write-LegacyYamlWarning "Legacy workflow YAML under linked directory $($dir.FullName) was not migrated. Convert the linked source explicitly."
+                    $allSucceeded = $false
+                }
+                continue
+            }
+            if (-not (Invoke-LegacyYamlDirReconciliation -Dir $dir.FullName)) {
+                $allSucceeded = $false
+            }
         }
+    }
+
+    if ($allSucceeded) {
+        $script:WorkflowYamlMigrationDone[$key] = $true
     }
 }
 
@@ -346,10 +520,19 @@ function Invoke-DotbotSingleRegistryYamlMigration {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][string]$RegistryPath
+        [Parameter(Mandatory)][string]$RegistryPath,
+        [switch]$AllowExternalLink,
+        [string]$ExpectedName
     )
 
-    if (-not (Test-Path -LiteralPath $RegistryPath)) { return }
+    if (-not (Test-Path -LiteralPath $RegistryPath)) { return $true }
+
+    $registryItem = Get-Item -LiteralPath $RegistryPath -Force -ErrorAction SilentlyContinue
+    if ($registryItem -and ($registryItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -and -not $AllowExternalLink) {
+        Write-LegacyYamlWarning "Legacy YAML migration skipped for linked registry $RegistryPath. Run 'dotbot registry update' to explicitly migrate the linked source, or convert it manually."
+        Write-LegacyYamlLog -Level Warn -Message 'Legacy registry link requires explicit migration' -Context @{ event = 'legacy_yaml_external_link'; registry = $RegistryPath }
+        return $false
+    }
 
     $rootYaml = Join-Path $RegistryPath 'registry.yaml'
     $workflowsParent = Join-Path $RegistryPath 'workflows'
@@ -362,28 +545,38 @@ function Invoke-DotbotSingleRegistryYamlMigration {
             })
     }
     $hasRootYaml = Test-Path -LiteralPath $rootYaml -PathType Leaf
-    if (-not $hasRootYaml -and $nestedYaml.Count -eq 0) { return }
+    if (-not $hasRootYaml -and $nestedYaml.Count -eq 0) { return $true }
 
     try {
         Import-DotbotYamlSupport
     } catch {
         Write-LegacyYamlError $_.Exception.Message
         Write-LegacyYamlLog -Level Error -Message 'powershell-yaml unavailable — legacy registry YAML was not converted' -Context @{ event = 'legacy_yaml_module_unavailable'; registry = $RegistryPath } -Exception $_
-        return
+        return $false
     }
 
+    $allSucceeded = $true
     if ($hasRootYaml) {
         try {
-            Update-DotbotManifestFromYaml -Dir $RegistryPath -JsonName 'registry.json' -YamlNames @('registry.yaml') | Out-Null
+            Update-DotbotManifestFromYaml -Dir $RegistryPath -JsonName 'registry.json' -YamlNames @('registry.yaml') -ManifestKind Registry -ExpectedName $ExpectedName | Out-Null
         } catch {
             Write-LegacyYamlError "Could not migrate legacy registry manifest in ${RegistryPath}: $($_.Exception.Message) The YAML file was left untouched."
             Write-LegacyYamlLog -Level Error -Message 'Legacy registry manifest migration failed' -Context @{ event = 'legacy_yaml_parse_failed'; path = $rootYaml } -Exception $_
+            $allSucceeded = $false
         }
     }
 
     foreach ($dir in $nestedYaml) {
-        Invoke-LegacyYamlDirReconciliation -Dir $dir.FullName
+        if ($dir.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+            Write-LegacyYamlWarning "Legacy workflow YAML under linked registry directory $($dir.FullName) was not migrated. Convert the linked source explicitly."
+            $allSucceeded = $false
+            continue
+        }
+        if (-not (Invoke-LegacyYamlDirReconciliation -Dir $dir.FullName)) {
+            $allSucceeded = $false
+        }
     }
+    return $allSucceeded
 }
 
 function Invoke-DotbotRegistryYamlMigration {
@@ -399,12 +592,45 @@ function Invoke-DotbotRegistryYamlMigration {
 
     $key = Get-LegacyYamlMigrationKey -Path $DotbotBase
     if ($script:RegistryYamlMigrationDone[$key] -and -not $Force) { return }
-    $script:RegistryYamlMigrationDone[$key] = $true
 
     $registriesRoot = Join-Path $DotbotBase 'registries'
-    if (-not (Test-Path -LiteralPath $registriesRoot)) { return }
+    $configPath = Join-Path $DotbotBase 'registries.json'
+    if (-not (Test-Path -LiteralPath $registriesRoot) -or -not (Test-Path -LiteralPath $configPath -PathType Leaf)) {
+        $script:RegistryYamlMigrationDone[$key] = $true
+        return
+    }
 
-    foreach ($dir in Get-ChildItem -LiteralPath $registriesRoot -Directory -ErrorAction SilentlyContinue) {
-        Invoke-DotbotSingleRegistryYamlMigration -RegistryPath $dir.FullName
+    try {
+        $config = Get-Content -LiteralPath $configPath -Raw | ConvertFrom-Json
+    } catch {
+        Write-LegacyYamlError "Could not read registry configuration for YAML migration: $($_.Exception.Message)"
+        return
+    }
+
+    $rootFull = [System.IO.Path]::GetFullPath($registriesRoot).TrimEnd(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar
+    ) + [System.IO.Path]::DirectorySeparatorChar
+    $allSucceeded = $true
+    foreach ($entry in @($config.registries)) {
+        $name = [string]$entry.name
+        $safeName = [System.IO.Path]::GetFileName($name)
+        if ($safeName -ne $name -or $safeName -in @('.', '..') -or $safeName -notmatch '^[A-Za-z0-9._-]+$') {
+            Write-LegacyYamlWarning "Registry name '$name' is invalid — skipping YAML migration"
+            $allSucceeded = $false
+            continue
+        }
+        $registryPath = [System.IO.Path]::GetFullPath((Join-Path $registriesRoot $safeName))
+        if (-not $registryPath.StartsWith($rootFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+            Write-LegacyYamlWarning "Registry '$name' resolves outside the registries directory — skipping YAML migration"
+            $allSucceeded = $false
+            continue
+        }
+        if (-not (Invoke-DotbotSingleRegistryYamlMigration -RegistryPath $registryPath -ExpectedName $name)) {
+            $allSucceeded = $false
+        }
+    }
+    if ($allSucceeded) {
+        $script:RegistryYamlMigrationDone[$key] = $true
     }
 }

--- a/src/runtime/Modules/Dotbot.LegacyYaml/Private/Imports.ps1
+++ b/src/runtime/Modules/Dotbot.LegacyYaml/Private/Imports.ps1
@@ -1,0 +1,4 @@
+$moduleRoot = Split-Path -Parent $PSScriptRoot
+$runtimeModules = Split-Path -Parent $moduleRoot
+
+Import-Module (Join-Path $runtimeModules 'Dotbot.Core' 'Dotbot.Core.psd1') -DisableNameChecking -Global

--- a/src/runtime/Modules/Dotbot.Workflow/Dotbot.Workflow.psm1
+++ b/src/runtime/Modules/Dotbot.Workflow/Dotbot.Workflow.psm1
@@ -244,6 +244,8 @@ function Find-Workflow {
         [string]$Name
     )
 
+    Invoke-DotbotWorkflowYamlMigration -BotRoot $BotRoot
+
     $roots = Get-WorkflowTierRoots -BotRoot $BotRoot
     $tried = @()
 
@@ -301,13 +303,17 @@ function Discover-Workflows {
             icon        = <string>
         }
 
-    Entries are sorted by name. Workflow folders without a valid workflow.json
-    are silently skipped — Test-ValidWorkflowDir filters them out.
+    Entries are sorted by name. Legacy v3.5 YAML manifests are migrated to the
+    v4 JSON layout (with an operator warning) before scanning; folders without
+    a valid workflow.json after that are skipped — Test-ValidWorkflowDir
+    filters them out.
     #>
     param(
         [Parameter(Mandatory)]
         [string]$BotRoot
     )
+
+    Invoke-DotbotWorkflowYamlMigration -BotRoot $BotRoot
 
     $roots = Get-WorkflowTierRoots -BotRoot $BotRoot
     $byName = [ordered]@{}

--- a/src/runtime/Modules/Dotbot.Workflow/Private/Imports.ps1
+++ b/src/runtime/Modules/Dotbot.Workflow/Private/Imports.ps1
@@ -6,3 +6,4 @@ Import-Module (Join-Path $runtimeModules 'Dotbot.Content' 'Dotbot.Content.psm1')
 Import-Module (Join-Path $runtimeModules 'Dotbot.Task' 'Dotbot.Task.psd1') -DisableNameChecking -Global
 Import-Module (Join-Path $runtimeModules 'Dotbot.TaskFile' 'Dotbot.TaskFile.psd1') -DisableNameChecking -Global
 Import-Module (Join-Path $runtimeModules 'Dotbot.Settings' 'Dotbot.Settings.psd1') -DisableNameChecking -Global
+Import-Module (Join-Path $runtimeModules 'Dotbot.LegacyYaml' 'Dotbot.LegacyYaml.psd1') -DisableNameChecking -Global

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -133,6 +133,7 @@ if (1 -in $layersToRun) {
     $structureCode       = Invoke-TestFile -Layer '1' -FileName 'Test-Structure.ps1'
     $compilationCode     = Invoke-TestFile -Layer '1' -FileName 'Test-Compilation.ps1'
     $workflowManifestCode = Invoke-TestFile -Layer '1' -FileName 'Test-WorkflowManifest.ps1'
+    $legacyYamlCode       = Invoke-TestFile -Layer '1' -FileName 'Test-LegacyYamlMigration.ps1'
     $dataModelCode        = Invoke-TestFile -Layer '1' -FileName 'Test-DataModel.ps1'
     $runtimeCode          = Invoke-TestFile -Layer '1' -FileName 'Test-Runtime.ps1'
     $worktreeCode         = Invoke-TestFile -Layer '1' -FileName 'Test-Worktree.ps1'
@@ -148,7 +149,7 @@ if (1 -in $layersToRun) {
     $pathSanitizerCode   = Invoke-TestFile -Layer '1' -FileName 'Test-PathSanitizer.ps1'
     $mcpSurfaceCode      = Invoke-TestFile -Layer '1' -FileName 'Test-McpSurface.ps1'
 
-    $exitCode = if ($structureCode -ne 0 -or $compilationCode -ne 0 -or $workflowManifestCode -ne 0 -or $dataModelCode -ne 0 -or $runtimeCode -ne 0 -or $worktreeCode -ne 0 -or $executorCode -ne 0 -or $hooksCode -ne 0 -or $mdRefsCode -ne 0 -or $verifyQualityCode -ne 0 -or $legacyVocabularyCode -ne 0 -or $backslashPathsCode -ne 0 -or $clarificationCode -ne 0 -or $activityLogCode -ne 0 -or $privacyScanCode -ne 0 -or $pathSanitizerCode -ne 0 -or $mcpSurfaceCode -ne 0) { 1 } else { 0 }
+    $exitCode = if ($structureCode -ne 0 -or $compilationCode -ne 0 -or $workflowManifestCode -ne 0 -or $legacyYamlCode -ne 0 -or $dataModelCode -ne 0 -or $runtimeCode -ne 0 -or $worktreeCode -ne 0 -or $executorCode -ne 0 -or $hooksCode -ne 0 -or $mdRefsCode -ne 0 -or $verifyQualityCode -ne 0 -or $legacyVocabularyCode -ne 0 -or $backslashPathsCode -ne 0 -or $clarificationCode -ne 0 -or $activityLogCode -ne 0 -or $privacyScanCode -ne 0 -or $pathSanitizerCode -ne 0 -or $mcpSurfaceCode -ne 0) { 1 } else { 0 }
     $layerResults["1"] = ($exitCode -eq 0)
     if ($exitCode -ne 0) { $overallFailed = $true }
 }

--- a/tests/Test-LegacyYamlMigration.ps1
+++ b/tests/Test-LegacyYamlMigration.ps1
@@ -1,0 +1,447 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Layer 1: Unit tests for legacy v3.5 YAML manifest migration.
+.DESCRIPTION
+    Tests Dotbot.LegacyYaml functions directly from repo source: detection,
+    YAML-to-JSON conversion, layout migration (.bot/workflows -> .bot/content/workflows,
+    base .bot/workflow.yaml), ambiguous yaml+json handling, registry migration,
+    idempotency, malformed input, module-unavailable path, and the framework-tier
+    detect-only guarantee. Requires the powershell-yaml module (auto-installed by
+    the code under test on first use).
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+Import-Module "$PSScriptRoot/Test-Helpers.psm1" -Force
+
+$repoRoot = Get-RepoRoot
+
+Write-Host ""
+Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Blue
+Write-Host "  Layer 1: Legacy YAML Migration Unit Tests" -ForegroundColor Blue
+Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Blue
+Write-Host ""
+
+Reset-TestResults
+
+Import-Module (Join-Path $repoRoot "src/runtime/Modules/Dotbot.LegacyYaml/Dotbot.LegacyYaml.psd1") -Force -DisableNameChecking
+Import-Module (Join-Path $repoRoot "src/runtime/Modules/Dotbot.Workflow/Dotbot.Workflow.psd1") -Force -DisableNameChecking
+Import-Module (Join-Path $repoRoot "src/cli/Platform-Functions.psm1") -Force -DisableNameChecking
+
+$savedDotbotHome = $env:DOTBOT_HOME
+
+function New-TempRoot {
+    param([string]$Prefix)
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) "$Prefix-$([System.Guid]::NewGuid().ToString().Substring(0,8))"
+    New-Item -ItemType Directory -Path $root -Force | Out-Null
+    return $root
+}
+
+$workflowYaml = @"
+name: Demo Flow
+version: "2.1"
+description: A legacy v3.5 workflow
+requires:
+  env_vars:
+    - var: MY_PAT
+      name: My PAT
+      message: PAT required
+tasks:
+  - name: Task One
+    type: prompt
+    workflow: 01-task.md
+    priority: 0
+  - name: Task Two
+    type: barrier
+    depends_on:
+      - Task One
+"@
+
+try {
+    # An empty fake framework install so migrations never touch a real ~/dotbot
+    $fakeHome = New-TempRoot -Prefix "dotbot-lym-home"
+    $env:DOTBOT_HOME = $fakeHome
+
+    # ═══════════════════════════════════════════════════════════════════
+    # Convert-DotbotYamlFileToJson
+    # ═══════════════════════════════════════════════════════════════════
+
+    Write-Host "  Convert-DotbotYamlFileToJson" -ForegroundColor Cyan
+    Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+    $root = New-TempRoot -Prefix "dotbot-lym-conv"
+    try {
+        $yamlPath = Join-Path $root "workflow.yaml"
+        $jsonPath = Join-Path $root "out/workflow.json"
+        Set-Content -Path $yamlPath -Value $workflowYaml
+
+        Convert-DotbotYamlFileToJson -YamlPath $yamlPath -JsonPath $jsonPath 6>&1 | Out-Null
+
+        Assert-ValidJson -Name "Conversion writes valid JSON" -Path $jsonPath
+        Assert-PathNotExists -Name "Source YAML is renamed away" -Path $yamlPath
+        Assert-PathExists -Name "Source YAML kept as .migrated" -Path "$yamlPath.migrated"
+
+        $json = Get-Content $jsonPath -Raw | ConvertFrom-Json -AsHashtable
+        Assert-Equal -Name "Scalar field survives conversion" -Expected "Demo Flow" -Actual $json.name
+        Assert-Equal -Name "Quoted scalar survives conversion" -Expected "2.1" -Actual $json.version
+        Assert-Equal -Name "Nested requires list survives conversion" -Expected "MY_PAT" -Actual $json.requires.env_vars[0].var
+        Assert-Equal -Name "Task list survives conversion" -Expected 2 -Actual $json.tasks.Count
+        Assert-Equal -Name "Nested depends_on survives conversion" -Expected "Task One" -Actual $json.tasks[1].depends_on[0]
+
+        $emptyYaml = Join-Path $root "empty.yaml"
+        Set-Content -Path $emptyYaml -Value ""
+        $threw = $false
+        try {
+            Convert-DotbotYamlFileToJson -YamlPath $emptyYaml -JsonPath (Join-Path $root "empty.json") 6>&1 | Out-Null
+        } catch {
+            $threw = $true
+        }
+        Assert-True -Name "Empty YAML throws instead of writing null JSON" -Condition $threw
+        Assert-PathNotExists -Name "Empty YAML writes no JSON" -Path (Join-Path $root "empty.json")
+        Assert-PathExists -Name "Empty YAML source left untouched" -Path $emptyYaml
+    } finally {
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # ═══════════════════════════════════════════════════════════════════
+    # Detection: Get-DotbotLegacyYamlFile / Test-DotbotLegacyYamlPresent
+    # ═══════════════════════════════════════════════════════════════════
+
+    Write-Host ""
+    Write-Host "  Detection" -ForegroundColor Cyan
+    Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+    $root = New-TempRoot -Prefix "dotbot-lym-detect"
+    try {
+        $bot = Join-Path $root ".bot"
+        New-Item -ItemType Directory -Path $bot -Force | Out-Null
+
+        Assert-True -Name "Empty .bot reports no legacy YAML" -Condition (-not (Test-DotbotLegacyYamlPresent -BotRoot $bot))
+        Assert-Equal -Name "Empty .bot enumerates zero files" -Expected 0 -Actual @(Get-DotbotLegacyYamlFile -BotRoot $bot).Count
+
+        Set-Content -Path (Join-Path $bot "workflow.yaml") -Value "name: base"
+        New-Item -ItemType Directory -Path (Join-Path $bot "workflows/alpha") -Force | Out-Null
+        Set-Content -Path (Join-Path $bot "workflows/alpha/workflow.yaml") -Value "name: alpha"
+        New-Item -ItemType Directory -Path (Join-Path $bot "content/workflows/beta") -Force | Out-Null
+        Set-Content -Path (Join-Path $bot "content/workflows/beta/manifest.yaml") -Value "name: beta"
+
+        $found = @(Get-DotbotLegacyYamlFile -BotRoot $bot)
+        Assert-Equal -Name "All three legacy locations enumerated" -Expected 3 -Actual $found.Count
+        Assert-True -Name "Detection reports present" -Condition (Test-DotbotLegacyYamlPresent -BotRoot $bot)
+    } finally {
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # ═══════════════════════════════════════════════════════════════════
+    # Invoke-DotbotWorkflowYamlMigration — happy paths
+    # ═══════════════════════════════════════════════════════════════════
+
+    Write-Host ""
+    Write-Host "  Invoke-DotbotWorkflowYamlMigration" -ForegroundColor Cyan
+    Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+    # v4-layout yaml-only dir converts in place and is discovered
+    $root = New-TempRoot -Prefix "dotbot-lym-v4stray"
+    try {
+        $bot = Join-Path $root ".bot"
+        $wfDir = Join-Path $bot "content/workflows/stray"
+        New-Item -ItemType Directory -Path $wfDir -Force | Out-Null
+        Set-Content -Path (Join-Path $wfDir "workflow.yaml") -Value $workflowYaml
+
+        $warnings = @(Invoke-DotbotWorkflowYamlMigration -BotRoot $bot 6>&1)
+
+        Assert-ValidJson -Name "v4-layout stray YAML converted to workflow.json" -Path (Join-Path $wfDir "workflow.json")
+        Assert-PathExists -Name "v4-layout stray source kept as .migrated" -Path (Join-Path $wfDir "workflow.yaml.migrated")
+        Assert-True -Name "Migration warning emitted" -Condition (@($warnings | Where-Object { "$_" -match 'Migrated legacy YAML manifest' }).Count -eq 1)
+
+        $discovered = @(Discover-Workflows -BotRoot $bot)
+        Assert-True -Name "Converted workflow is discovered by v4 loader" -Condition (@($discovered | Where-Object { $_.name -eq 'stray' }).Count -eq 1)
+        Assert-Equal -Name "Discovered manifest carries YAML version" -Expected "2.1" -Actual (@($discovered | Where-Object { $_.name -eq 'stray' })[0].version)
+    } finally {
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # json-only project: nothing written, nothing warned
+    $root = New-TempRoot -Prefix "dotbot-lym-jsononly"
+    try {
+        $bot = Join-Path $root ".bot"
+        $wfDir = Join-Path $bot "content/workflows/pure"
+        New-Item -ItemType Directory -Path $wfDir -Force | Out-Null
+        Set-Content -Path (Join-Path $wfDir "workflow.json") -Value '{"name":"pure","version":"1.0"}'
+        $before = (Get-Item (Join-Path $wfDir "workflow.json")).LastWriteTimeUtc
+
+        $warnings = @(Invoke-DotbotWorkflowYamlMigration -BotRoot $bot 6>&1)
+
+        Assert-Equal -Name "JSON-only project emits no warnings" -Expected 0 -Actual $warnings.Count
+        Assert-Equal -Name "JSON-only manifest untouched" -Expected $before -Actual (Get-Item (Join-Path $wfDir "workflow.json")).LastWriteTimeUtc
+        Assert-PathNotExists -Name "JSON-only project gains no .migrated file" -Path (Join-Path $wfDir "workflow.yaml.migrated")
+    } finally {
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # yaml + json both present: JSON wins, warning emitted, nothing written
+    $root = New-TempRoot -Prefix "dotbot-lym-ambig"
+    try {
+        $bot = Join-Path $root ".bot"
+        $wfDir = Join-Path $bot "content/workflows/dual"
+        New-Item -ItemType Directory -Path $wfDir -Force | Out-Null
+        Set-Content -Path (Join-Path $wfDir "workflow.json") -Value '{"name":"dual","version":"9.9"}'
+        Set-Content -Path (Join-Path $wfDir "workflow.yaml") -Value "name: dual`nversion: `"1.1`""
+
+        $warnings = @(Invoke-DotbotWorkflowYamlMigration -BotRoot $bot 6>&1)
+
+        Assert-True -Name "Ambiguous state warns loudly" -Condition (@($warnings | Where-Object { "$_" -match 'reads only workflow.json' }).Count -eq 1)
+        Assert-PathExists -Name "Ambiguous YAML left untouched" -Path (Join-Path $wfDir "workflow.yaml")
+        $manifest = Read-WorkflowManifest -WorkflowDir $wfDir
+        Assert-Equal -Name "JSON wins over YAML" -Expected "9.9" -Actual $manifest.version
+
+        $warningsAgain = @(Invoke-DotbotWorkflowYamlMigration -BotRoot $bot -Force 6>&1)
+        Assert-True -Name "Ambiguity warning repeats until resolved" -Condition (@($warningsAgain | Where-Object { "$_" -match 'reads only workflow.json' }).Count -eq 1)
+    } finally {
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # legacy .bot/workflows/<name>/ moves whole directory into the v4 layout
+    $root = New-TempRoot -Prefix "dotbot-lym-legacydir"
+    try {
+        $bot = Join-Path $root ".bot"
+        $legacyDir = Join-Path $bot "workflows/azure-to-github"
+        New-Item -ItemType Directory -Path (Join-Path $legacyDir "prompts") -Force | Out-Null
+        Set-Content -Path (Join-Path $legacyDir "workflow.yaml") -Value $workflowYaml
+        Set-Content -Path (Join-Path $legacyDir "prompts/01-task.md") -Value "# Task prompt"
+
+        Invoke-DotbotWorkflowYamlMigration -BotRoot $bot 6>&1 | Out-Null
+
+        $target = Join-Path $bot "content/workflows/azure-to-github"
+        Assert-ValidJson -Name "Legacy dir converted in v4 location" -Path (Join-Path $target "workflow.json")
+        Assert-PathExists -Name "Sibling prompt file moved with the directory" -Path (Join-Path $target "prompts/01-task.md")
+        Assert-PathExists -Name "Legacy source kept as .migrated in new location" -Path (Join-Path $target "workflow.yaml.migrated")
+        Assert-PathNotExists -Name "Empty legacy workflows/ parent removed" -Path (Join-Path $bot "workflows")
+
+        $found = Find-Workflow -BotRoot $bot -Name "azure-to-github"
+        Assert-True -Name "Migrated legacy workflow resolvable via Find-Workflow" -Condition $found.ok
+    } finally {
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # base .bot/workflow.yaml lands in a slug-named v4 directory
+    $root = New-TempRoot -Prefix "dotbot-lym-base"
+    try {
+        $bot = Join-Path $root ".bot"
+        New-Item -ItemType Directory -Path $bot -Force | Out-Null
+        Set-Content -Path (Join-Path $bot "workflow.yaml") -Value "name: My Flow`nversion: `"3.0`""
+
+        Invoke-DotbotWorkflowYamlMigration -BotRoot $bot 6>&1 | Out-Null
+
+        Assert-ValidJson -Name "Base manifest converted into slug directory" -Path (Join-Path $bot "content/workflows/my-flow/workflow.json")
+        Assert-PathExists -Name "Base manifest kept as .migrated" -Path (Join-Path $bot "workflow.yaml.migrated")
+    } finally {
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # base manifest without a name falls back to 'default'
+    $root = New-TempRoot -Prefix "dotbot-lym-noname"
+    try {
+        $bot = Join-Path $root ".bot"
+        New-Item -ItemType Directory -Path $bot -Force | Out-Null
+        Set-Content -Path (Join-Path $bot "workflow.yaml") -Value "version: `"1.0`""
+
+        Invoke-DotbotWorkflowYamlMigration -BotRoot $bot 6>&1 | Out-Null
+
+        Assert-ValidJson -Name "Nameless base manifest lands in default/" -Path (Join-Path $bot "content/workflows/default/workflow.json")
+    } finally {
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # manifest.yaml fallback name converts too
+    $root = New-TempRoot -Prefix "dotbot-lym-manifest"
+    try {
+        $bot = Join-Path $root ".bot"
+        $wfDir = Join-Path $bot "content/workflows/oldname"
+        New-Item -ItemType Directory -Path $wfDir -Force | Out-Null
+        Set-Content -Path (Join-Path $wfDir "manifest.yaml") -Value "name: oldname`nversion: `"0.9`""
+
+        Invoke-DotbotWorkflowYamlMigration -BotRoot $bot 6>&1 | Out-Null
+
+        Assert-ValidJson -Name "manifest.yaml fallback converted" -Path (Join-Path $wfDir "workflow.json")
+        Assert-PathExists -Name "manifest.yaml kept as .migrated" -Path (Join-Path $wfDir "manifest.yaml.migrated")
+    } finally {
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # malformed YAML fails loudly without hiding the valid neighbour
+    $root = New-TempRoot -Prefix "dotbot-lym-malformed"
+    try {
+        $bot = Join-Path $root ".bot"
+        $badDir = Join-Path $bot "content/workflows/bad"
+        $goodDir = Join-Path $bot "content/workflows/good"
+        New-Item -ItemType Directory -Path $badDir -Force | Out-Null
+        New-Item -ItemType Directory -Path $goodDir -Force | Out-Null
+        Set-Content -Path (Join-Path $badDir "workflow.yaml") -Value "foo: [unclosed"
+        Set-Content -Path (Join-Path $goodDir "workflow.yaml") -Value "name: good`nversion: `"1.0`""
+
+        $output = @(Invoke-DotbotWorkflowYamlMigration -BotRoot $bot 6>&1)
+
+        Assert-PathNotExists -Name "Malformed YAML writes no JSON" -Path (Join-Path $badDir "workflow.json")
+        Assert-PathExists -Name "Malformed YAML left untouched" -Path (Join-Path $badDir "workflow.yaml")
+        Assert-True -Name "Malformed YAML fails loudly" -Condition (@($output | Where-Object { "$_" -match 'Could not migrate' }).Count -ge 1)
+        Assert-ValidJson -Name "Valid neighbour still converts in same run" -Path (Join-Path $goodDir "workflow.json")
+    } finally {
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # idempotency: -Force re-run converts nothing and stays quiet
+    $root = New-TempRoot -Prefix "dotbot-lym-idem"
+    try {
+        $bot = Join-Path $root ".bot"
+        $wfDir = Join-Path $bot "content/workflows/once"
+        New-Item -ItemType Directory -Path $wfDir -Force | Out-Null
+        Set-Content -Path (Join-Path $wfDir "workflow.yaml") -Value "name: once`nversion: `"1.0`""
+
+        Invoke-DotbotWorkflowYamlMigration -BotRoot $bot -Force 6>&1 | Out-Null
+        $jsonItem = Get-Item (Join-Path $wfDir "workflow.json")
+        $before = $jsonItem.LastWriteTimeUtc
+
+        $second = @(Invoke-DotbotWorkflowYamlMigration -BotRoot $bot -Force 6>&1)
+
+        Assert-Equal -Name "Forced re-run emits no warnings" -Expected 0 -Actual $second.Count
+        Assert-Equal -Name "Forced re-run rewrites nothing" -Expected $before -Actual (Get-Item (Join-Path $wfDir "workflow.json")).LastWriteTimeUtc
+
+        New-Item -ItemType Directory -Path (Join-Path $bot "content/workflows/later") -Force | Out-Null
+        Set-Content -Path (Join-Path $bot "content/workflows/later/workflow.yaml") -Value "name: later"
+        $third = @(Invoke-DotbotWorkflowYamlMigration -BotRoot $bot 6>&1)
+        Assert-Equal -Name "Process-scope guard short-circuits without -Force" -Expected 0 -Actual $third.Count
+        Assert-PathNotExists -Name "Guarded call converts nothing" -Path (Join-Path $bot "content/workflows/later/workflow.json")
+    } finally {
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # ═══════════════════════════════════════════════════════════════════
+    # Registry migration
+    # ═══════════════════════════════════════════════════════════════════
+
+    Write-Host ""
+    Write-Host "  Registry migration" -ForegroundColor Cyan
+    Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+    $root = New-TempRoot -Prefix "dotbot-lym-registry"
+    try {
+        $registriesRoot = Join-Path $root "registries"
+        $acme = Join-Path $registriesRoot "acme"
+        New-Item -ItemType Directory -Path (Join-Path $acme "workflows/deploy") -Force | Out-Null
+        @"
+name: acme
+display_name: Acme Corp
+version: "1.2.0"
+content:
+  workflows: [deploy]
+"@ | Set-Content -Path (Join-Path $acme "registry.yaml")
+        Set-Content -Path (Join-Path $acme "workflows/deploy/workflow.yaml") -Value "name: deploy`nversion: `"1.0`""
+
+        Invoke-DotbotRegistryYamlMigration -DotbotBase $root -Force 6>&1 | Out-Null
+
+        Assert-ValidJson -Name "registry.yaml converted to registry.json" -Path (Join-Path $acme "registry.json")
+        Assert-PathExists -Name "registry.yaml kept as .migrated" -Path (Join-Path $acme "registry.yaml.migrated")
+        $regMeta = Get-Content (Join-Path $acme "registry.json") -Raw | ConvertFrom-Json -AsHashtable
+        Assert-Equal -Name "Registry name survives conversion" -Expected "acme" -Actual $regMeta.name
+        Assert-Equal -Name "Registry content map survives conversion" -Expected "deploy" -Actual $regMeta.content.workflows[0]
+        Assert-ValidJson -Name "Nested registry workflow converted" -Path (Join-Path $acme "workflows/deploy/workflow.json")
+    } finally {
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # registry yaml + json both present: JSON wins, warning emitted
+    $root = New-TempRoot -Prefix "dotbot-lym-regambig"
+    try {
+        $acme = Join-Path $root "registries/acme"
+        New-Item -ItemType Directory -Path $acme -Force | Out-Null
+        Set-Content -Path (Join-Path $acme "registry.json") -Value '{"name":"acme","content":{"workflows":["a"]}}'
+        Set-Content -Path (Join-Path $acme "registry.yaml") -Value "name: acme"
+        $before = (Get-Item (Join-Path $acme "registry.json")).LastWriteTimeUtc
+
+        $warnings = @(Invoke-DotbotRegistryYamlMigration -DotbotBase $root -Force 6>&1)
+
+        Assert-True -Name "Registry ambiguity warns loudly" -Condition (@($warnings | Where-Object { "$_" -match 'reads only registry.json' }).Count -eq 1)
+        Assert-Equal -Name "Existing registry.json untouched" -Expected $before -Actual (Get-Item (Join-Path $acme "registry.json")).LastWriteTimeUtc
+        Assert-PathExists -Name "Ambiguous registry.yaml left untouched" -Path (Join-Path $acme "registry.yaml")
+    } finally {
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # ═══════════════════════════════════════════════════════════════════
+    # Framework tier: detect and warn, never write
+    # ═══════════════════════════════════════════════════════════════════
+
+    Write-Host ""
+    Write-Host "  Framework tier" -ForegroundColor Cyan
+    Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+    $root = New-TempRoot -Prefix "dotbot-lym-fw"
+    try {
+        $fwHome = Join-Path $root "framework"
+        $fwDir = Join-Path $fwHome "content/workflows/shipped"
+        New-Item -ItemType Directory -Path $fwDir -Force | Out-Null
+        Set-Content -Path (Join-Path $fwDir "workflow.yaml") -Value "name: shipped"
+        $bot = Join-Path $root ".bot"
+        New-Item -ItemType Directory -Path $bot -Force | Out-Null
+
+        $env:DOTBOT_HOME = $fwHome
+        $warnings = @(Invoke-DotbotWorkflowYamlMigration -BotRoot $bot -Force 6>&1)
+        $env:DOTBOT_HOME = $fakeHome
+
+        Assert-True -Name "Framework-tier YAML warns" -Condition (@($warnings | Where-Object { "$_" -match 'never modifies the framework install' }).Count -eq 1)
+        Assert-PathNotExists -Name "Framework tier gets no JSON written" -Path (Join-Path $fwDir "workflow.json")
+        Assert-PathExists -Name "Framework-tier YAML not renamed" -Path (Join-Path $fwDir "workflow.yaml")
+    } finally {
+        $env:DOTBOT_HOME = $fakeHome
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # ═══════════════════════════════════════════════════════════════════
+    # powershell-yaml unavailable: loud, actionable, non-fatal
+    # ═══════════════════════════════════════════════════════════════════
+
+    Write-Host ""
+    Write-Host "  Module-unavailable path" -ForegroundColor Cyan
+    Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+    $root = New-TempRoot -Prefix "dotbot-lym-nomod"
+    try {
+        $bot = Join-Path $root ".bot"
+        $wfDir = Join-Path $bot "content/workflows/blocked"
+        New-Item -ItemType Directory -Path $wfDir -Force | Out-Null
+        Set-Content -Path (Join-Path $wfDir "workflow.yaml") -Value "name: blocked"
+
+        $modulePath = Join-Path $repoRoot "src/runtime/Modules/Dotbot.LegacyYaml/Dotbot.LegacyYaml.psd1"
+        $script = @"
+function global:Get-Module { param([switch]`$ListAvailable, [string[]]`$Name) return `$null }
+function global:Install-Module { throw 'install blocked by test' }
+Import-Module '$modulePath' -Force -DisableNameChecking
+`$env:DOTBOT_HOME = '$fakeHome'
+Invoke-DotbotWorkflowYamlMigration -BotRoot '$bot' -Force 6>&1 | ForEach-Object { "`$_" }
+exit 0
+"@
+        $output = & pwsh -NoProfile -Command $script 2>&1 | Out-String
+        $exitCode = $LASTEXITCODE
+
+        Assert-Equal -Name "Command completes despite missing module" -Expected 0 -Actual $exitCode
+        Assert-True -Name "Error names the manual install command" -Condition ($output -match 'Install-Module powershell-yaml -Scope CurrentUser')
+        Assert-PathNotExists -Name "No JSON written without the module" -Path (Join-Path $wfDir "workflow.json")
+        Assert-PathExists -Name "YAML untouched without the module" -Path (Join-Path $wfDir "workflow.yaml")
+    } finally {
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+} finally {
+    $env:DOTBOT_HOME = $savedDotbotHome
+    Remove-Item $fakeHome -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+$allPassed = Write-TestSummary -LayerName "Layer 1: Legacy YAML Migration"
+if (-not $allPassed) {
+    exit 1
+}
+exit 0

--- a/tests/Test-LegacyYamlMigration.ps1
+++ b/tests/Test-LegacyYamlMigration.ps1
@@ -103,6 +103,42 @@ try {
         Assert-True -Name "Empty YAML throws instead of writing null JSON" -Condition $threw
         Assert-PathNotExists -Name "Empty YAML writes no JSON" -Path (Join-Path $root "empty.json")
         Assert-PathExists -Name "Empty YAML source left untouched" -Path $emptyYaml
+
+        foreach ($wrongRoot in @(
+            @{ Name = 'scalar'; Content = 'just-a-string' },
+            @{ Name = 'sequence'; Content = "- one`n- two" }
+        )) {
+            $wrongYaml = Join-Path $root "$($wrongRoot.Name).yaml"
+            $wrongJson = Join-Path $root "$($wrongRoot.Name).json"
+            Set-Content -Path $wrongYaml -Value $wrongRoot.Content
+            $wrongThrew = $false
+            try {
+                Convert-DotbotYamlFileToJson -YamlPath $wrongYaml -JsonPath $wrongJson 6>&1 | Out-Null
+            } catch { $wrongThrew = $true }
+            Assert-True -Name "$($wrongRoot.Name) YAML root is rejected" -Condition $wrongThrew
+            Assert-PathNotExists -Name "$($wrongRoot.Name) YAML writes no JSON" -Path $wrongJson
+            Assert-PathExists -Name "$($wrongRoot.Name) YAML remains retryable" -Path $wrongYaml
+        }
+
+        $rollbackYaml = Join-Path $root "rollback.yaml"
+        $rollbackJson = Join-Path $root "rollback.json"
+        Set-Content -Path $rollbackYaml -Value "name: rollback"
+        & (Get-Module Dotbot.LegacyYaml) {
+            $script:MigrationFailureInjector = {
+                param($Operation, $Source, $Destination)
+                if ($Operation -eq 'archive-yaml') { throw 'injected archive failure' }
+            }
+        }
+        $rollbackThrew = $false
+        try {
+            Convert-DotbotYamlFileToJson -YamlPath $rollbackYaml -JsonPath $rollbackJson 6>&1 | Out-Null
+        } catch { $rollbackThrew = $true }
+        & (Get-Module Dotbot.LegacyYaml) { $script:MigrationFailureInjector = $null }
+        Assert-True -Name "Archive failure is surfaced" -Condition $rollbackThrew
+        Assert-PathNotExists -Name "Archive failure rolls back published JSON" -Path $rollbackJson
+        Assert-PathExists -Name "Archive failure leaves YAML in place" -Path $rollbackYaml
+        Assert-PathNotExists -Name "Archive failure creates no misleading backup" -Path "$rollbackYaml.migrated"
+        Assert-Equal -Name "Archive failure cleans staged files" -Expected 0 -Actual @(Get-ChildItem $root -Filter 'rollback.json.tmp-*').Count
     } finally {
         Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
     }
@@ -290,7 +326,61 @@ try {
         Assert-PathExists -Name "Malformed YAML left untouched" -Path (Join-Path $badDir "workflow.yaml")
         Assert-True -Name "Malformed YAML fails loudly" -Condition (@($output | Where-Object { "$_" -match 'Could not migrate' }).Count -ge 1)
         Assert-ValidJson -Name "Valid neighbour still converts in same run" -Path (Join-Path $goodDir "workflow.json")
+
+        Set-Content -Path (Join-Path $badDir "workflow.yaml") -Value "name: repaired"
+        Invoke-DotbotWorkflowYamlMigration -BotRoot $bot 6>&1 | Out-Null
+        Assert-ValidJson -Name "Failed migration retries in the same process after repair" -Path (Join-Path $badDir "workflow.json")
     } finally {
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # A failure after the legacy directory move restores the entire v3 layout.
+    $root = New-TempRoot -Prefix "dotbot-lym-dirrollback"
+    try {
+        $bot = Join-Path $root ".bot"
+        $legacyDir = Join-Path $bot "workflows/rollback-flow"
+        $targetDir = Join-Path $bot "content/workflows/rollback-flow"
+        New-Item -ItemType Directory -Path $legacyDir -Force | Out-Null
+        Set-Content -Path (Join-Path $legacyDir "workflow.yaml") -Value "name: rollback-flow"
+        Set-Content -Path (Join-Path $legacyDir "sibling.txt") -Value "preserve me"
+        & (Get-Module Dotbot.LegacyYaml) {
+            $script:MigrationFailureInjector = {
+                param($Operation, $Source, $Destination)
+                if ($Operation -eq 'archive-yaml') { throw 'injected directory conversion failure' }
+            }
+        }
+        Invoke-DotbotWorkflowYamlMigration -BotRoot $bot -Force 6>&1 | Out-Null
+        & (Get-Module Dotbot.LegacyYaml) { $script:MigrationFailureInjector = $null }
+        Assert-PathExists -Name "Failed directory conversion restores legacy directory" -Path $legacyDir
+        Assert-PathExists -Name "Directory rollback preserves sibling files" -Path (Join-Path $legacyDir "sibling.txt")
+        Assert-PathExists -Name "Directory rollback restores source YAML" -Path (Join-Path $legacyDir "workflow.yaml")
+        Assert-PathNotExists -Name "Failed directory conversion leaves no v4 directory" -Path $targetDir
+    } finally {
+        & (Get-Module Dotbot.LegacyYaml) { $script:MigrationFailureInjector = $null }
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # Project workflow discovery must not mutate a linked external directory.
+    $root = New-TempRoot -Prefix "dotbot-lym-wflink"
+    $link = $null
+    try {
+        $bot = Join-Path $root ".bot"
+        $external = Join-Path $root "external-workflow"
+        $link = Join-Path $bot "content/workflows/linked"
+        New-Item -ItemType Directory -Path $external -Force | Out-Null
+        New-Item -ItemType Directory -Path (Split-Path -Parent $link) -Force | Out-Null
+        Set-Content -Path (Join-Path $external "workflow.yaml") -Value "name: linked"
+        if ($IsWindows) {
+            New-Item -ItemType Junction -Path $link -Target $external | Out-Null
+        } else {
+            New-Item -ItemType SymbolicLink -Path $link -Target $external | Out-Null
+        }
+        $linkedOutput = Invoke-DotbotWorkflowYamlMigration -BotRoot $bot -Force 6>&1 | Out-String
+        Assert-True -Name "Linked project workflow warns and skips" -Condition ($linkedOutput -match 'linked directory')
+        Assert-PathExists -Name "Linked project workflow leaves external YAML untouched" -Path (Join-Path $external "workflow.yaml")
+        Assert-PathNotExists -Name "Linked project workflow writes no external JSON" -Path (Join-Path $external "workflow.json")
+    } finally {
+        if ($link -and (Test-Path -LiteralPath $link)) { Remove-Item -LiteralPath $link -Force -ErrorAction SilentlyContinue }
         Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
     }
 
@@ -342,6 +432,9 @@ content:
 "@ | Set-Content -Path (Join-Path $acme "registry.yaml")
         Set-Content -Path (Join-Path $acme "workflows/deploy/workflow.yaml") -Value "name: deploy`nversion: `"1.0`""
 
+        @{ registries = @(@{ name = 'acme'; type = 'git'; source = 'test'; auto_update = $false }) } |
+            ConvertTo-Json -Depth 5 | Set-Content (Join-Path $root "registries.json")
+
         Invoke-DotbotRegistryYamlMigration -DotbotBase $root -Force 6>&1 | Out-Null
 
         Assert-ValidJson -Name "registry.yaml converted to registry.json" -Path (Join-Path $acme "registry.json")
@@ -350,6 +443,66 @@ content:
         Assert-Equal -Name "Registry name survives conversion" -Expected "acme" -Actual $regMeta.name
         Assert-Equal -Name "Registry content map survives conversion" -Expected "deploy" -Actual $regMeta.content.workflows[0]
         Assert-ValidJson -Name "Nested registry workflow converted" -Path (Join-Path $acme "workflows/deploy/workflow.json")
+
+        $invalidYaml = Join-Path $acme "invalid-registry.yaml"
+        $invalidJson = Join-Path $acme "invalid-registry.json"
+        Set-Content -Path $invalidYaml -Value "name: invalid-registry"
+        $invalidThrew = $false
+        try {
+            Convert-DotbotYamlFileToJson -YamlPath $invalidYaml -JsonPath $invalidJson -ManifestKind Registry 6>&1 | Out-Null
+        } catch { $invalidThrew = $true }
+        Assert-True -Name "Registry without content mapping is rejected" -Condition $invalidThrew
+        Assert-PathNotExists -Name "Invalid registry publishes no JSON" -Path $invalidJson
+        Assert-PathExists -Name "Invalid registry YAML remains retryable" -Path $invalidYaml
+    } finally {
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # Automatic registry discovery never follows a configured local link.
+    $root = New-TempRoot -Prefix "dotbot-lym-reglink"
+    try {
+        $external = Join-Path $root "external-source"
+        $registries = Join-Path $root "home/registries"
+        $link = Join-Path $registries "linked"
+        New-Item -ItemType Directory -Path (Join-Path $external "workflows/deploy") -Force | Out-Null
+        New-Item -ItemType Directory -Path $registries -Force | Out-Null
+        "name: linked`ncontent:`n  workflows: [deploy]" | Set-Content (Join-Path $external "registry.yaml")
+        "name: deploy" | Set-Content (Join-Path $external "workflows/deploy/workflow.yaml")
+        if ($IsWindows) {
+            New-Item -ItemType Junction -Path $link -Target $external | Out-Null
+        } else {
+            New-Item -ItemType SymbolicLink -Path $link -Target $external | Out-Null
+        }
+        @{ registries = @(@{ name = 'linked'; type = 'local'; source = $external; auto_update = $false }) } |
+            ConvertTo-Json -Depth 5 | Set-Content (Join-Path $root "home/registries.json")
+
+        $linkedOutput = Invoke-DotbotRegistryYamlMigration -DotbotBase (Join-Path $root 'home') -Force 6>&1 | Out-String
+        Assert-True -Name "Automatic linked registry migration warns and skips" -Condition ($linkedOutput -match 'skipped for linked registry')
+        Assert-PathExists -Name "Automatic discovery leaves external YAML untouched" -Path (Join-Path $external "registry.yaml")
+        Assert-PathNotExists -Name "Automatic discovery writes no external JSON" -Path (Join-Path $external "registry.json")
+
+        Invoke-DotbotSingleRegistryYamlMigration -RegistryPath $link -AllowExternalLink 6>&1 | Out-Null
+        Assert-PathExists -Name "Explicit linked registry update may migrate source" -Path (Join-Path $external "registry.json")
+    } finally {
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # Only configured registries migrate; unrelated directories stay untouched.
+    $root = New-TempRoot -Prefix "dotbot-lym-regscope"
+    try {
+        $registered = Join-Path $root "registries/registered"
+        $unregistered = Join-Path $root "registries/unregistered"
+        foreach ($path in @($registered, $unregistered)) {
+            New-Item -ItemType Directory -Path (Join-Path $path "workflows/deploy") -Force | Out-Null
+            "name: $([IO.Path]::GetFileName($path))`ncontent:`n  workflows: [deploy]" | Set-Content (Join-Path $path "registry.yaml")
+            "name: deploy" | Set-Content (Join-Path $path "workflows/deploy/workflow.yaml")
+        }
+        @{ registries = @(@{ name = 'registered'; type = 'git'; source = 'test'; auto_update = $false }) } |
+            ConvertTo-Json -Depth 5 | Set-Content (Join-Path $root "registries.json")
+        Invoke-DotbotRegistryYamlMigration -DotbotBase $root -Force 6>&1 | Out-Null
+        Assert-PathExists -Name "Configured registry is migrated" -Path (Join-Path $registered "registry.json")
+        Assert-PathExists -Name "Unregistered registry YAML is untouched" -Path (Join-Path $unregistered "registry.yaml")
+        Assert-PathNotExists -Name "Unregistered registry gets no JSON" -Path (Join-Path $unregistered "registry.json")
     } finally {
         Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
     }
@@ -361,6 +514,8 @@ content:
         New-Item -ItemType Directory -Path $acme -Force | Out-Null
         Set-Content -Path (Join-Path $acme "registry.json") -Value '{"name":"acme","content":{"workflows":["a"]}}'
         Set-Content -Path (Join-Path $acme "registry.yaml") -Value "name: acme"
+        @{ registries = @(@{ name = 'acme'; type = 'git'; source = 'test'; auto_update = $false }) } |
+            ConvertTo-Json -Depth 5 | Set-Content (Join-Path $root "registries.json")
         $before = (Get-Item (Join-Path $acme "registry.json")).LastWriteTimeUtc
 
         $warnings = @(Invoke-DotbotRegistryYamlMigration -DotbotBase $root -Force 6>&1)
@@ -418,9 +573,10 @@ content:
 
         $modulePath = Join-Path $repoRoot "src/runtime/Modules/Dotbot.LegacyYaml/Dotbot.LegacyYaml.psd1"
         $script = @"
-function global:Get-Module { param([switch]`$ListAvailable, [string[]]`$Name) return `$null }
-function global:Install-Module { throw 'install blocked by test' }
+`$env:PSModulePath = Join-Path `$PSHOME 'Modules'
 Import-Module '$modulePath' -Force -DisableNameChecking
+function global:Install-Module { throw 'Install-Module must not be invoked during discovery' }
+function global:Install-PSResource { throw 'Install-PSResource must not be invoked during discovery' }
 `$env:DOTBOT_HOME = '$fakeHome'
 Invoke-DotbotWorkflowYamlMigration -BotRoot '$bot' -Force 6>&1 | ForEach-Object { "`$_" }
 exit 0
@@ -429,7 +585,9 @@ exit 0
         $exitCode = $LASTEXITCODE
 
         Assert-Equal -Name "Command completes despite missing module" -Expected 0 -Actual $exitCode
-        Assert-True -Name "Error names the manual install command" -Condition ($output -match 'Install-Module powershell-yaml -Scope CurrentUser')
+        Assert-True -Name "Error names PowerShellGet installation" -Condition ($output -match 'Install-Module powershell-yaml')
+        Assert-True -Name "Error names PSResourceGet installation" -Condition ($output -match 'Install-PSResource powershell-yaml')
+        Assert-True -Name "Discovery performs no implicit package installation" -Condition ($output -notmatch 'must not be invoked during discovery')
         Assert-PathNotExists -Name "No JSON written without the module" -Path (Join-Path $wfDir "workflow.json")
         Assert-PathExists -Name "YAML untouched without the module" -Path (Join-Path $wfDir "workflow.yaml")
     } finally {

--- a/tests/Test-RegistryCLI.ps1
+++ b/tests/Test-RegistryCLI.ps1
@@ -318,6 +318,61 @@ Assert-True -Name "registry-remove.ps1 exits non-zero for unregistered name" `
 Restore-RegistriesJson
 
 # ===================================================================
+# Update-StaleRegistries — legacy registry.yaml migration hook
+# ===================================================================
+
+Write-Host ""
+Write-Host "  UPDATE-STALEREGISTRIES (legacy YAML migration)" -ForegroundColor Cyan
+Write-Host "  --------------------------------------------" -ForegroundColor DarkGray
+
+$legacyHome = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-test-regyaml-$(Get-Random)"
+$legacyOrg = Join-Path $legacyHome "registries/legacyorg"
+New-Item -Path (Join-Path $legacyOrg "workflows/deploy") -ItemType Directory -Force | Out-Null
+@"
+name: legacyorg
+version: "1.0"
+content:
+  workflows: [deploy]
+"@ | Set-Content (Join-Path $legacyOrg "registry.yaml")
+"name: deploy" | Set-Content (Join-Path $legacyOrg "workflows/deploy/workflow.yaml")
+
+Update-StaleRegistries -DotbotBase $legacyHome *>&1 | Out-Null
+
+Assert-PathExists -Name "Update-StaleRegistries converts legacy registry.yaml" `
+    -Path (Join-Path $legacyOrg "registry.json")
+Assert-PathExists -Name "Legacy registry.yaml kept as .migrated" `
+    -Path (Join-Path $legacyOrg "registry.yaml.migrated")
+Assert-PathExists -Name "Nested legacy workflow.yaml converted" `
+    -Path (Join-Path $legacyOrg "workflows/deploy/workflow.json")
+
+$regMeta = Get-Content (Join-Path $legacyOrg "registry.json") -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json -AsHashtable -ErrorAction SilentlyContinue
+Assert-True -Name "Converted registry.json carries YAML content map" `
+    -Condition ($null -ne $regMeta -and $regMeta.name -eq "legacyorg" -and $regMeta.content.workflows[0] -eq "deploy") `
+    -Message "registry.json missing or does not match the source YAML"
+
+Remove-Item $legacyHome -Recurse -Force -ErrorAction SilentlyContinue
+
+$ambigHome = Join-Path ([System.IO.Path]::GetTempPath()) "dotbot-test-regambig-$(Get-Random)"
+$ambigOrg = Join-Path $ambigHome "registries/ambigorg"
+New-Item -Path $ambigOrg -ItemType Directory -Force | Out-Null
+'{"name":"ambigorg","content":{"workflows":["a"]}}' | Set-Content (Join-Path $ambigOrg "registry.json")
+"name: ambigorg" | Set-Content (Join-Path $ambigOrg "registry.yaml")
+$jsonBefore = (Get-Item (Join-Path $ambigOrg "registry.json")).LastWriteTimeUtc
+
+$ambigOutput = Update-StaleRegistries -DotbotBase $ambigHome *>&1 | ForEach-Object { "$_" } | Out-String
+
+Assert-True -Name "Ambiguous registry.yaml + registry.json warns loudly" `
+    -Condition ($ambigOutput -match 'reads only registry.json') `
+    -Message "Expected ambiguity warning, got: $ambigOutput"
+Assert-True -Name "Ambiguous registry.json left untouched" `
+    -Condition ((Get-Item (Join-Path $ambigOrg "registry.json")).LastWriteTimeUtc -eq $jsonBefore) `
+    -Message "registry.json was modified in ambiguous state"
+Assert-PathExists -Name "Ambiguous registry.yaml left in place" `
+    -Path (Join-Path $ambigOrg "registry.yaml")
+
+Remove-Item $ambigHome -Recurse -Force -ErrorAction SilentlyContinue
+
+# ===================================================================
 # CLEANUP
 # ===================================================================
 

--- a/tests/Test-RegistryCLI.ps1
+++ b/tests/Test-RegistryCLI.ps1
@@ -54,6 +54,17 @@ Assert-True -Name "registry-remove.ps1 exists on disk" `
     -Condition (Test-Path $registryRemovePath) `
     -Message "Not found: $registryRemovePath"
 
+$registryUpdateSource = Get-Content (Join-Path $dotbotDir 'src/cli/registry-update.ps1') -Raw
+$gitUpdateOrder = [regex]::Match(
+    $registryUpdateSource,
+    'reset\s+--hard[\s\S]{0,3500}?Invoke-DotbotSingleRegistryYamlMigration[\s\S]{0,500}?Invoke-RegistryValidation')
+Assert-True -Name "registry update force-reset migrates after reset and before validation" `
+    -Condition $gitUpdateOrder.Success `
+    -Message "Expected reset -> YAML migration -> validation ordering in registry-update.ps1"
+Assert-True -Name "registry update explicitly permits linked-source migration" `
+    -Condition ($registryUpdateSource -match 'Invoke-DotbotSingleRegistryYamlMigration[^\r\n]+-AllowExternalLink') `
+    -Message "Local registry update must be the explicit opt-in path for linked source mutation"
+
 # Load a platform-functions stub so Write-DotbotWarning doesn't break module load
 $platformFunctions = Join-Path $dotbotDir "src/cli/Platform-Functions.psm1"
 if (Test-Path $platformFunctions) {
@@ -64,6 +75,7 @@ if (Test-Path $platformFunctions) {
 
 try {
     Import-Module $registryManagerPath -Force -DisableNameChecking
+    Import-Module (Join-Path $dotbotDir 'src/runtime/Modules/Dotbot.LegacyYaml/Dotbot.LegacyYaml.psd1') -Force -DisableNameChecking
     Write-TestResult -Name "RegistryManager.psm1 imports without error" -Status Pass
 } catch {
     Write-TestResult -Name "RegistryManager.psm1 imports without error" -Status Fail -Message $_.Exception.Message
@@ -336,6 +348,18 @@ content:
 "@ | Set-Content (Join-Path $legacyOrg "registry.yaml")
 "name: deploy" | Set-Content (Join-Path $legacyOrg "workflows/deploy/workflow.yaml")
 
+$null = & git -C $legacyOrg init -b main 2>&1
+$null = & git -C $legacyOrg config user.email 'dotbot-tests@example.invalid' 2>&1
+$null = & git -C $legacyOrg config user.name 'dotbot tests' 2>&1
+$null = & git -C $legacyOrg add . 2>&1
+$null = & git -C $legacyOrg commit -m 'legacy registry fixture' 2>&1
+$legacyRemote = Join-Path $legacyHome 'legacyorg-remote.git'
+$null = & git clone --bare $legacyOrg $legacyRemote 2>&1
+$null = & git -C $legacyOrg remote add origin $legacyRemote 2>&1
+@{ registries = @(@{
+    name = 'legacyorg'; type = 'git'; source = $legacyRemote; branch = 'main'; auto_update = $true
+}) } | ConvertTo-Json -Depth 5 | Set-Content (Join-Path $legacyHome 'registries.json')
+
 Update-StaleRegistries -DotbotBase $legacyHome *>&1 | Out-Null
 
 Assert-PathExists -Name "Update-StaleRegistries converts legacy registry.yaml" `
@@ -357,9 +381,12 @@ $ambigOrg = Join-Path $ambigHome "registries/ambigorg"
 New-Item -Path $ambigOrg -ItemType Directory -Force | Out-Null
 '{"name":"ambigorg","content":{"workflows":["a"]}}' | Set-Content (Join-Path $ambigOrg "registry.json")
 "name: ambigorg" | Set-Content (Join-Path $ambigOrg "registry.yaml")
+@{ registries = @(@{
+    name = 'ambigorg'; type = 'git'; source = 'test'; branch = 'main'; auto_update = $false
+}) } | ConvertTo-Json -Depth 5 | Set-Content (Join-Path $ambigHome 'registries.json')
 $jsonBefore = (Get-Item (Join-Path $ambigOrg "registry.json")).LastWriteTimeUtc
 
-$ambigOutput = Update-StaleRegistries -DotbotBase $ambigHome *>&1 | ForEach-Object { "$_" } | Out-String
+$ambigOutput = Invoke-DotbotRegistryYamlMigration -DotbotBase $ambigHome -Force *>&1 | ForEach-Object { "$_" } | Out-String
 
 Assert-True -Name "Ambiguous registry.yaml + registry.json warns loudly" `
     -Condition ($ambigOutput -match 'reads only registry.json') `

--- a/tests/Test-WorkflowIntegration.ps1
+++ b/tests/Test-WorkflowIntegration.ps1
@@ -946,6 +946,80 @@ Assert-True -Name "Get-ActiveWorkflowManifest fallback uses Test-ValidWorkflowDi
     -Message "Get-ActiveWorkflowManifest must apply Test-ValidWorkflowDir on both the named-workflow path and the alphabetic-first scan (directly or via Find-Workflow + Discover-Workflows)"
 
 # ═══════════════════════════════════════════════════════════════════
+# INIT LEGACY YAML MIGRATION OFFER
+# ═══════════════════════════════════════════════════════════════════
+
+Write-Host ""
+Write-Host "  INIT LEGACY YAML MIGRATION OFFER" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+$initScript = Join-Path $dotbotDir "src/cli/init-project.ps1"
+
+function New-LegacyYamlProject {
+    $project = New-TestProject
+    $legacyDir = Join-Path $project ".bot/workflows/azure-to-github"
+    New-Item -ItemType Directory -Path $legacyDir -Force | Out-Null
+    "name: azure-to-github`nversion: `"1.0`"" | Set-Content (Join-Path $legacyDir "workflow.yaml")
+    return $project
+}
+
+# Accept path (-y auto-confirms): legacy YAML converted into the v4 layout
+$testProject = New-LegacyYamlProject
+try {
+    Push-Location $testProject
+    $acceptOutput = & pwsh -NoProfile -ExecutionPolicy Bypass -File $initScript -Force -y 2>&1 | Out-String
+    Pop-Location
+
+    Assert-True -Name "Init accept: offer names the legacy manifest" `
+        -Condition ($acceptOutput -match 'Legacy v3.5 YAML manifests found') `
+        -Message "Expected offer text, got: $acceptOutput"
+    Assert-PathExists -Name "Init accept: workflow.json written in v4 layout" `
+        -Path (Join-Path $testProject ".bot/content/workflows/azure-to-github/workflow.json")
+    Assert-PathExists -Name "Init accept: source YAML kept as .migrated" `
+        -Path (Join-Path $testProject ".bot/content/workflows/azure-to-github/workflow.yaml.migrated")
+    Assert-PathNotExists -Name "Init accept: legacy workflows/ dir gone" `
+        -Path (Join-Path $testProject ".bot/workflows")
+} finally {
+    Remove-TestProject -Path $testProject
+}
+
+# Decline path ('n' on stdin): YAML untouched, explicit warning shown
+$testProject = New-LegacyYamlProject
+try {
+    Push-Location $testProject
+    $declineOutput = 'n' | & pwsh -NoProfile -ExecutionPolicy Bypass -File $initScript -Force 2>&1 | Out-String
+    Pop-Location
+
+    Assert-PathExists -Name "Init decline: YAML left untouched" `
+        -Path (Join-Path $testProject ".bot/workflows/azure-to-github/workflow.yaml")
+    Assert-PathNotExists -Name "Init decline: nothing converted" `
+        -Path (Join-Path $testProject ".bot/content/workflows/azure-to-github/workflow.json")
+    Assert-True -Name "Init decline: warns workflows stay invisible" `
+        -Condition ($declineOutput -match 'stay invisible until converted') `
+        -Message "Expected decline warning, got: $declineOutput"
+} finally {
+    Remove-TestProject -Path $testProject
+}
+
+# Dry run: reports the finding, writes nothing
+$testProject = New-LegacyYamlProject
+try {
+    Push-Location $testProject
+    $dryRunOutput = & pwsh -NoProfile -ExecutionPolicy Bypass -File $initScript -DryRun 2>&1 | Out-String
+    Pop-Location
+
+    Assert-True -Name "Init dry run: reports would-convert" `
+        -Condition ($dryRunOutput -match 'would convert') `
+        -Message "Expected dry-run report, got: $dryRunOutput"
+    Assert-PathExists -Name "Init dry run: YAML left untouched" `
+        -Path (Join-Path $testProject ".bot/workflows/azure-to-github/workflow.yaml")
+    Assert-PathNotExists -Name "Init dry run: nothing converted" `
+        -Path (Join-Path $testProject ".bot/content/workflows/azure-to-github/workflow.json")
+} finally {
+    Remove-TestProject -Path $testProject
+}
+
+# ═══════════════════════════════════════════════════════════════════
 # INSTALL SCRIPTS (workflow-add, init-project)
 # ═══════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Linked issue

Closes #654

## Summary of changes

dotbot v4 silently ignored all v3.5 YAML manifests (`workflow.yaml`, `manifest.yaml`, `registry.yaml`) after the switch to JSON — workflows just vanished with no warning. This PR adds:

- **New `Dotbot.LegacyYaml` runtime module** — detects legacy YAML, converts it to JSON with `powershell-yaml` (auto-installed to CurrentUser, loud actionable error if that fails), and renames sources to `*.yaml.migrated`. Handles both the format change and the layout change (`.bot/workflow.yaml` and `.bot/workflows/<name>/` → `.bot/content/workflows/<name>/workflow.json`).
- **Startup fallback** in `Find-Workflow` / `Discover-Workflows` and the registry CLI (`Update-StaleRegistries`, `registry-list`, `registry-add`) — any workflow/registry command migrates on first use and warns once.
- **Interactive offer on `dotbot init`** — lists found legacy manifests, converts on confirm (honors `-y` and `-DryRun`).
- **Ambiguity warning** — if `.yaml` and `.json` coexist, JSON wins, nothing is written, and a warning repeats every run until the YAML is removed. Never a silent skip.
- **Docs** — new MIGRATING.md §6 with the v3.5 → v4 path mapping and migration behavior.
- Framework tier (`DOTBOT_HOME`) is detect-and-warn only — never writes to a possibly read-only install.

## Testing notes

- `pwsh tests/Run-Tests.ps1 -Layer 1` and `-Layer 2` — all passed.
- New `tests/Test-LegacyYamlMigration.ps1` (60 assertions): conversion fidelity, all three legacy locations, ambiguity, malformed YAML (fails loudly without hiding valid neighbours), powershell-yaml-unavailable path, idempotency, registry cases, framework-tier read-only guarantee.
- Layer 2 extensions: `Update-StaleRegistries` migration hook, init offer accept/decline/dry-run through the real `init-project.ps1`.
- Manually verified against the last YAML-era commit (`f68f802`) via git worktree: a genuine v3.5 project (real `start-from-jira` manifest, 17 tasks) is invisible on stock v4, fully listed after this fix, and a 14-field comparison between v3.5's parse of the YAML and v4's parse of the generated JSON matches exactly (nested `requires`/`tasks`/`form`/`domain`, UTF-8 intact).
- PSScriptAnalyzer with repo settings: no new findings.

## Checklist

- [x] Tests added or updated
- [x] Docs updated (if behaviour changed)
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)
