### PR TITLE
feat(hooks): add optional quality gate before task can enter done

### DIFF
--- a/content/settings/settings.default.json
+++ b/content/settings/settings.default.json
@@ -56,6 +56,11 @@
   "git": {
     "base_branch": null
   },
+  "quality_gate": {
+    "enabled": false,
+    "test_command": null,
+    "lint_command": null
+  },
   "editor": {
     "name": "off",
     "custom_command": ""

--- a/src/hooks/verify/05-verify-quality.ps1
+++ b/src/hooks/verify/05-verify-quality.ps1
@@ -73,7 +73,11 @@ if (-not $settingsModulePath) {
 }
 Import-Module $settingsModulePath -Force -DisableNameChecking
 
-$botRoot = Join-Path (Get-Location).Path ".bot"
+$botRoot = if (Get-Command Get-DotbotProjectBotPath -ErrorAction SilentlyContinue) {
+    Get-DotbotProjectBotPath
+} else {
+    Join-Path (Get-Location).Path ".bot"
+}
 $settings = Get-MergedSettings -BotRoot $botRoot
 $gate = $settings.quality_gate
 
@@ -106,8 +110,11 @@ foreach ($check in $checks) {
         # Run in a child pwsh rather than Invoke-Expression in-process: the
         # command string is project-supplied config (same trust level as a
         # CI yaml step), and a child process keeps it from touching this
-        # runspace's variables/functions.
-        $output = & pwsh -NoProfile -Command "$($check.command) 2>&1" | Out-String
+        # runspace's variables/functions. Redirect stderr at this call site
+        # (not inside the -Command string) so it also catches the child
+        # pwsh's own parser/startup errors, and so quotes/redirections in
+        # the configured command itself don't need double-escaping.
+        $output = & pwsh -NoProfile -Command $check.command 2>&1 | Out-String
         $exitCode = $LASTEXITCODE
     } catch {
         $output = $_.Exception.Message
@@ -124,8 +131,18 @@ foreach ($check in $checks) {
     }
 }
 
+# enter-done only surfaces the JSON 'message' field on failure (not the
+# 'failures' array), so name the failing check(s) here rather than a
+# generic "failed" — that's the only detail that reaches the agent/caller.
+$resultMessage = if ($failures.Count -eq 0) {
+    "Quality gate passed ($($ranChecks.Count) check(s))"
+} else {
+    $failedNames = @($ranChecks | Where-Object { $_.exit_code -ne 0 } | ForEach-Object { "$($_.name) (exit $($_.exit_code))" })
+    "Quality gate failed: " + ($failedNames -join ", ")
+}
+
 Write-QualityResult -Success ($failures.Count -eq 0) `
-    -Message $(if ($failures.Count -eq 0) { "Quality gate passed ($($ranChecks.Count) check(s))" } else { "Quality gate failed" }) `
+    -Message $resultMessage `
     -Details @{ enabled = $true; checks = $ranChecks } `
     -Failures $failures
 

--- a/src/hooks/verify/05-verify-quality.ps1
+++ b/src/hooks/verify/05-verify-quality.ps1
@@ -1,0 +1,136 @@
+# ═══════════════════════════════════════════════════════════════
+# FRAMEWORK FILE — DO NOT MODIFY IN TARGET PROJECTS
+# Managed by dotbot. Overwritten on 'dotbot init --force'.
+# ═══════════════════════════════════════════════════════════════
+param(
+    [string]$TaskId,
+    [string]$Category
+)
+
+# Optional quality gate (#656). Runs the project's configured test/lint
+# commands before a task can enter 'done', so failing tests/lint don't
+# reach 'done' (and a PR) on the framework's word alone. Disabled by
+# default via quality_gate.enabled in settings.default.json — a project
+# opts in by setting quality_gate.enabled + test_command/lint_command in
+# its own settings override (e.g. .bot/.control/settings.json).
+
+function Resolve-FirstExistingPath {
+    param([string[]]$Candidates)
+
+    foreach ($candidate in $Candidates) {
+        if ($candidate -and (Test-Path -LiteralPath $candidate)) {
+            return $candidate
+        }
+    }
+    return $null
+}
+
+function Write-QualityResult {
+    param(
+        [Parameter(Mandatory)][bool]$Success,
+        [Parameter(Mandatory)][string]$Message,
+        [hashtable]$Details = @{},
+        [array]$Failures = @()
+    )
+    @{
+        success  = $Success
+        script   = "05-verify-quality.ps1"
+        message  = $Message
+        details  = $Details
+        failures = $Failures
+    } | ConvertTo-Json -Depth 10
+}
+
+function Resolve-DotbotModulePath {
+    param([Parameter(Mandatory)][string]$ModuleName)
+
+    $frameworkRoot = Join-Path $PSScriptRoot ".." ".."
+    $found = Resolve-FirstExistingPath @(
+        (Join-Path $frameworkRoot "runtime" "Modules" $ModuleName "$ModuleName.psm1"),
+        (Join-Path $frameworkRoot "src" "runtime" "Modules" $ModuleName "$ModuleName.psm1")
+    )
+    if ($found) { return $found }
+
+    $root = (& git -C $PSScriptRoot rev-parse --show-toplevel 2>$null | Select-Object -First 1)
+    if ($root) {
+        return Resolve-FirstExistingPath @(
+            (Join-Path $root ".bot" "src" "runtime" "Modules" $ModuleName "$ModuleName.psm1"),
+            (Join-Path $root "src" "runtime" "Modules" $ModuleName "$ModuleName.psm1")
+        )
+    }
+    return $null
+}
+
+# Dotbot.Settings depends on Dotbot.Core (Get-DotbotInstallPath,
+# Get-DotbotUserSettingsPath) being importable in the same session.
+$corePath = Resolve-DotbotModulePath -ModuleName "Dotbot.Core"
+if ($corePath) { Import-Module $corePath -Force -DisableNameChecking }
+
+$settingsModulePath = Resolve-DotbotModulePath -ModuleName "Dotbot.Settings"
+if (-not $settingsModulePath) {
+    Write-QualityResult -Success $true -Message "Quality gate settings module not found; skipped." -Details @{ enabled = $false }
+    exit 0
+}
+Import-Module $settingsModulePath -Force -DisableNameChecking
+
+$botRoot = Join-Path (Get-Location).Path ".bot"
+$settings = Get-MergedSettings -BotRoot $botRoot
+$gate = $settings.quality_gate
+
+if (-not $gate -or -not [bool]$gate.enabled) {
+    Write-QualityResult -Success $true -Message "Quality gate not enabled; skipped." -Details @{ enabled = $false }
+    exit 0
+}
+
+$checks = @()
+if (-not [string]::IsNullOrWhiteSpace([string]$gate.test_command)) {
+    $checks += @{ name = "test"; command = [string]$gate.test_command }
+}
+if (-not [string]::IsNullOrWhiteSpace([string]$gate.lint_command)) {
+    $checks += @{ name = "lint"; command = [string]$gate.lint_command }
+}
+
+if ($checks.Count -eq 0) {
+    Write-QualityResult -Success $true `
+        -Message "Quality gate enabled but no test_command/lint_command configured; skipped." `
+        -Details @{ enabled = $true }
+    exit 0
+}
+
+$failures = @()
+$ranChecks = @()
+foreach ($check in $checks) {
+    $output = $null
+    $exitCode = $null
+    try {
+        # Run in a child pwsh rather than Invoke-Expression in-process: the
+        # command string is project-supplied config (same trust level as a
+        # CI yaml step), and a child process keeps it from touching this
+        # runspace's variables/functions.
+        $output = & pwsh -NoProfile -Command "$($check.command) 2>&1" | Out-String
+        $exitCode = $LASTEXITCODE
+    } catch {
+        $output = $_.Exception.Message
+        $exitCode = 1
+    }
+    $ranChecks += @{ name = $check.name; command = $check.command; exit_code = $exitCode }
+    if ($exitCode -ne 0) {
+        $tail = if ($output) { (($output -split "`r?`n" | Select-Object -Last 40) -join "`n") } else { "" }
+        $failures += @{
+            issue    = "$($check.name) command failed (exit $exitCode): $($check.command)"
+            severity = "error"
+            context  = $tail
+        }
+    }
+}
+
+Write-QualityResult -Success ($failures.Count -eq 0) `
+    -Message $(if ($failures.Count -eq 0) { "Quality gate passed ($($ranChecks.Count) check(s))" } else { "Quality gate failed" }) `
+    -Details @{ enabled = $true; checks = $ranChecks } `
+    -Failures $failures
+
+# Signal failure via the JSON 'success' field only, not the process exit
+# code — the last check command's own nonzero exit would otherwise leak
+# through as this script's exit code and short-circuit enter-done's JSON
+# parsing (it treats a nonzero exit code as a harder, pre-JSON failure).
+exit 0

--- a/src/hooks/verify/README.md
+++ b/src/hooks/verify/README.md
@@ -138,6 +138,27 @@ Scans codebase for mock data patterns:
 **Required**: Yes
 **Skip for**: infrastructure (database setup may have seed data)
 
+## Quality Gate (#656)
+
+`05-verify-quality.ps1` is a framework-shipped, opt-in check: it runs a
+project's configured `quality_gate.test_command` / `quality_gate.lint_command`
+and blocks the `done` transition if either exits non-zero. Off by default
+(`quality_gate.enabled: false` in `content/settings/settings.default.json`);
+a project opts in by setting `quality_gate.enabled: true` plus one or both
+commands in its own settings override (e.g. `.bot/.control/settings.json`):
+
+```json
+{
+  "quality_gate": {
+    "enabled": true,
+    "test_command": "npm test",
+    "lint_command": "npm run lint"
+  }
+}
+```
+
+With neither `enabled` nor the commands set, the script is a no-op.
+
 ## Adding Custom Scripts
 
 1. **Create script file**: `##-your-script.ps1` (## = execution order)

--- a/src/hooks/verify/config.json
+++ b/src/hooks/verify/config.json
@@ -34,6 +34,13 @@
       "required": true,
       "core": true,
       "timeout_seconds": 30
+    },
+    {
+      "name": "05-verify-quality.ps1",
+      "description": "Run configured test/lint commands (quality_gate setting); no-op when not configured",
+      "required": false,
+      "core": false,
+      "timeout_seconds": 300
     }
   ]
 }

--- a/src/runtime/Plugins/Hooks/Transitions/enter-done/metadata.json
+++ b/src/runtime/Plugins/Hooks/Transitions/enter-done/metadata.json
@@ -4,6 +4,6 @@
   "target_statuses": [
     "done"
   ],
-  "max_duration": 120,
+  "max_duration": 600,
   "abort_on_failure": true
 }

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -139,6 +139,7 @@ if (1 -in $layersToRun) {
     $executorCode         = Invoke-TestFile -Layer '1' -FileName 'Test-Executor.ps1'
     $hooksCode            = Invoke-TestFile -Layer '1' -FileName 'Test-Hooks.ps1'
     $mdRefsCode          = Invoke-TestFile -Layer '1' -FileName 'Test-MdRefs.ps1'
+    $verifyQualityCode   = Invoke-TestFile -Layer '1' -FileName 'Test-VerifyQuality.ps1'
     $legacyVocabularyCode = Invoke-TestFile -Layer '1' -FileName 'Test-NoLegacyVocabulary.ps1'
     $backslashPathsCode   = Invoke-TestFile -Layer '1' -FileName 'Test-NoBackslashPaths.ps1'
     $clarificationCode    = Invoke-TestFile -Layer '1' -FileName 'Test-StartFromPromptClarification.ps1'
@@ -147,7 +148,7 @@ if (1 -in $layersToRun) {
     $pathSanitizerCode   = Invoke-TestFile -Layer '1' -FileName 'Test-PathSanitizer.ps1'
     $mcpSurfaceCode      = Invoke-TestFile -Layer '1' -FileName 'Test-McpSurface.ps1'
 
-    $exitCode = if ($structureCode -ne 0 -or $compilationCode -ne 0 -or $workflowManifestCode -ne 0 -or $dataModelCode -ne 0 -or $runtimeCode -ne 0 -or $worktreeCode -ne 0 -or $executorCode -ne 0 -or $hooksCode -ne 0 -or $mdRefsCode -ne 0 -or $legacyVocabularyCode -ne 0 -or $backslashPathsCode -ne 0 -or $clarificationCode -ne 0 -or $activityLogCode -ne 0 -or $privacyScanCode -ne 0 -or $pathSanitizerCode -ne 0 -or $mcpSurfaceCode -ne 0) { 1 } else { 0 }
+    $exitCode = if ($structureCode -ne 0 -or $compilationCode -ne 0 -or $workflowManifestCode -ne 0 -or $dataModelCode -ne 0 -or $runtimeCode -ne 0 -or $worktreeCode -ne 0 -or $executorCode -ne 0 -or $hooksCode -ne 0 -or $mdRefsCode -ne 0 -or $verifyQualityCode -ne 0 -or $legacyVocabularyCode -ne 0 -or $backslashPathsCode -ne 0 -or $clarificationCode -ne 0 -or $activityLogCode -ne 0 -or $privacyScanCode -ne 0 -or $pathSanitizerCode -ne 0 -or $mcpSurfaceCode -ne 0) { 1 } else { 0 }
     $layerResults["1"] = ($exitCode -eq 0)
     if ($exitCode -ne 0) { $overallFailed = $true }
 }

--- a/tests/Test-Structure.ps1
+++ b/tests/Test-Structure.ps1
@@ -1286,6 +1286,26 @@ if (Test-Path $verifyConfig) {
             -Condition ($entry.core -eq $true) `
             -Message "Expected core=true"
     }
+
+    # #656: optional quality gate — configurable test/lint commands, off by
+    # default, so it must not be "core" (a project can't opt out of core checks).
+    $qualityEntry = $cfg.scripts | Where-Object { $_.name -eq '05-verify-quality.ps1' }
+    Assert-True -Name "config.json registers 05-verify-quality.ps1" `
+        -Condition ($null -ne $qualityEntry) `
+        -Message "Entry for 05-verify-quality.ps1 missing from config.json"
+    if ($qualityEntry) {
+        Assert-True -Name "05-verify-quality.ps1 marked core=false" `
+            -Condition ($qualityEntry.core -eq $false) `
+            -Message "Expected core=false"
+    }
+}
+
+$qualityGateSettingsFile = Join-Path $repoRoot "content" "settings" "settings.default.json"
+if (Test-Path $qualityGateSettingsFile) {
+    $qualityGateSettings = Get-Content $qualityGateSettingsFile -Raw | ConvertFrom-Json
+    Assert-True -Name "#656: settings.default.json declares quality_gate.enabled=false by default" `
+        -Condition ($null -ne $qualityGateSettings.quality_gate -and $qualityGateSettings.quality_gate.enabled -eq $false) `
+        -Message "Expected quality_gate.enabled=false in settings.default.json"
 }
 
 # removed the task-mark-* MCP tools; the FrameworkIntegrity gate
@@ -1308,6 +1328,7 @@ $bannerTargets = @(
     'src/hooks/verify/02-git-pushed.ps1',
     'src/hooks/verify/03-check-md-refs.ps1',
     'src/hooks/verify/04-framework-integrity.ps1',
+    'src/hooks/verify/05-verify-quality.ps1',
     'src/hooks/scripts/commit-bot-state.ps1',
     'src/hooks/scripts/steering.ps1',
     'src/hooks/dev/Start-Dev.ps1',

--- a/tests/Test-VerifyQuality.ps1
+++ b/tests/Test-VerifyQuality.ps1
@@ -1,0 +1,172 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Layer 1: Quality gate verify hook tests (#656).
+.DESCRIPTION
+    Tests the 05-verify-quality.ps1 verify hook: disabled/no-op by default,
+    skips when enabled but unconfigured, and runs+reports configured
+    test/lint commands, failing the gate when either command exits non-zero.
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+Import-Module "$PSScriptRoot\Test-Helpers.psm1" -Force
+
+$repoRoot = Get-RepoRoot
+$scriptPath = Join-Path $repoRoot "src/hooks/verify/05-verify-quality.ps1"
+
+Write-Host ""
+Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Blue
+Write-Host "  Layer 1: Quality Gate Verify Hook Tests (#656)" -ForegroundColor Blue
+Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Blue
+Write-Host ""
+
+Reset-TestResults
+
+Write-Host "  SCRIPT EXISTENCE" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+Assert-PathExists -Name "05-verify-quality.ps1 exists" -Path $scriptPath
+Assert-ValidPowerShell -Name "05-verify-quality.ps1 is valid PowerShell" -Path $scriptPath
+
+function Invoke-QualityGate {
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot
+    )
+    Push-Location $ProjectRoot
+    try {
+        $raw = & pwsh -NoProfile -ExecutionPolicy Bypass -File $scriptPath -TaskId "t_quality1" -Category "test" 2>$null
+        return ($raw | ConvertFrom-Json)
+    } finally {
+        Pop-Location
+    }
+}
+
+function New-QualityGateProject {
+    param($QualityGate)
+
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) ("dotbot-test-quality-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+    $bot = Join-Path $root ".bot"
+    $control = Join-Path $bot ".control"
+    New-Item -ItemType Directory -Path $control -Force | Out-Null
+
+    if ($null -ne $QualityGate) {
+        @{ quality_gate = $QualityGate } | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $control "settings.json") -Encoding UTF8
+    }
+
+    return $root
+}
+
+$prevDotbotHome = $env:DOTBOT_HOME
+$env:DOTBOT_HOME = $repoRoot
+
+try {
+    Write-Host ""
+    Write-Host "  DISABLED BY DEFAULT" -ForegroundColor Cyan
+    Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+    $disabledRoot = New-QualityGateProject -QualityGate $null
+    try {
+        $result = Invoke-QualityGate -ProjectRoot $disabledRoot
+        Assert-True -Name "No project override: gate reports success" -Condition ($result.success -eq $true)
+        Assert-Equal -Name "No project override: script field" -Expected "05-verify-quality.ps1" -Actual $result.script
+        Assert-True -Name "No project override: details.enabled is false" -Condition ($result.details.enabled -eq $false)
+    } finally {
+        Remove-Item -LiteralPath $disabledRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    Write-Host ""
+    Write-Host "  ENABLED BUT UNCONFIGURED" -ForegroundColor Cyan
+    Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+    $unconfiguredRoot = New-QualityGateProject -QualityGate @{ enabled = $true }
+    try {
+        $result = Invoke-QualityGate -ProjectRoot $unconfiguredRoot
+        Assert-True -Name "Enabled without commands: gate reports success" -Condition ($result.success -eq $true)
+        Assert-True -Name "Enabled without commands: message mentions unconfigured" `
+            -Condition ($result.message -match 'no test_command/lint_command configured')
+    } finally {
+        Remove-Item -LiteralPath $unconfiguredRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    Write-Host ""
+    Write-Host "  PASSING TEST + LINT COMMANDS" -ForegroundColor Cyan
+    Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+    $passRoot = New-QualityGateProject -QualityGate @{
+        enabled      = $true
+        test_command = "exit 0"
+        lint_command = "exit 0"
+    }
+    try {
+        $result = Invoke-QualityGate -ProjectRoot $passRoot
+        Assert-True -Name "Passing commands: gate reports success" -Condition ($result.success -eq $true)
+        Assert-Equal -Name "Passing commands: two checks ran" -Expected 2 -Actual @($result.details.checks).Count
+        Assert-Equal -Name "Passing commands: no failures reported" -Expected 0 -Actual @($result.failures).Count
+    } finally {
+        Remove-Item -LiteralPath $passRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    Write-Host ""
+    Write-Host "  FAILING TEST COMMAND BLOCKS THE GATE" -ForegroundColor Cyan
+    Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+    $failTestRoot = New-QualityGateProject -QualityGate @{
+        enabled      = $true
+        test_command = "exit 1"
+        lint_command = "exit 0"
+    }
+    try {
+        $result = Invoke-QualityGate -ProjectRoot $failTestRoot
+        Assert-True -Name "Failing test command: gate reports failure" -Condition ($result.success -eq $false)
+        Assert-Equal -Name "Failing test command: exactly one failure" -Expected 1 -Actual @($result.failures).Count
+        Assert-True -Name "Failing test command: failure names the test check" `
+            -Condition ($result.failures[0].issue -match '^test command failed')
+    } finally {
+        Remove-Item -LiteralPath $failTestRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    Write-Host ""
+    Write-Host "  FAILING LINT COMMAND BLOCKS THE GATE" -ForegroundColor Cyan
+    Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+    $failLintRoot = New-QualityGateProject -QualityGate @{
+        enabled      = $true
+        test_command = "exit 0"
+        lint_command = "exit 1"
+    }
+    try {
+        $result = Invoke-QualityGate -ProjectRoot $failLintRoot
+        Assert-True -Name "Failing lint command: gate reports failure" -Condition ($result.success -eq $false)
+        Assert-Equal -Name "Failing lint command: exactly one failure" -Expected 1 -Actual @($result.failures).Count
+        Assert-True -Name "Failing lint command: failure names the lint check" `
+            -Condition ($result.failures[0].issue -match '^lint command failed')
+    } finally {
+        Remove-Item -LiteralPath $failLintRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    Write-Host ""
+    Write-Host "  TEST_COMMAND ONLY (LINT UNCONFIGURED)" -ForegroundColor Cyan
+    Write-Host "  ────────────────────────────────────────────" -ForegroundColor DarkGray
+
+    $testOnlyRoot = New-QualityGateProject -QualityGate @{
+        enabled      = $true
+        test_command = "exit 0"
+    }
+    try {
+        $result = Invoke-QualityGate -ProjectRoot $testOnlyRoot
+        Assert-True -Name "test_command only: gate reports success" -Condition ($result.success -eq $true)
+        Assert-Equal -Name "test_command only: exactly one check ran" -Expected 1 -Actual @($result.details.checks).Count
+        Assert-Equal -Name "test_command only: ran check is named 'test'" -Expected "test" -Actual $result.details.checks[0].name
+    } finally {
+        Remove-Item -LiteralPath $testOnlyRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+} finally {
+    $env:DOTBOT_HOME = $prevDotbotHome
+}
+
+$success = Write-TestSummary -LayerName "Layer 1: Quality Gate"
+if (-not $success) { exit 1 }

--- a/tests/Test-VerifyQuality.ps1
+++ b/tests/Test-VerifyQuality.ps1
@@ -125,6 +125,9 @@ try {
         Assert-Equal -Name "Failing test command: exactly one failure" -Expected 1 -Actual @($result.failures).Count
         Assert-True -Name "Failing test command: failure names the test check" `
             -Condition ($result.failures[0].issue -match '^test command failed')
+        Assert-True -Name "Failing test command: top-level message names the failing check" `
+            -Condition ($result.message -match 'test \(exit 1\)') `
+            -Message "enter-done only surfaces 'message' on failure, not 'failures' — got: $($result.message)"
     } finally {
         Remove-Item -LiteralPath $failTestRoot -Recurse -Force -ErrorAction SilentlyContinue
     }
@@ -144,6 +147,9 @@ try {
         Assert-Equal -Name "Failing lint command: exactly one failure" -Expected 1 -Actual @($result.failures).Count
         Assert-True -Name "Failing lint command: failure names the lint check" `
             -Condition ($result.failures[0].issue -match '^lint command failed')
+        Assert-True -Name "Failing lint command: top-level message names the failing check" `
+            -Condition ($result.message -match 'lint \(exit 1\)') `
+            -Message "enter-done only surfaces 'message' on failure, not 'failures' — got: $($result.message)"
     } finally {
         Remove-Item -LiteralPath $failLintRoot -Recurse -Force -ErrorAction SilentlyContinue
     }


### PR DESCRIPTION
## Linked issue

Closes #656

## Summary of changes

- The `enter-done` verify chain checks git hygiene (clean tree, pushed branch, markdown refs, framework integrity) but never runs tests or a linter — a task can reach `done` (and open a PR) with failing tests, only to fail CI later.
- Add `src/hooks/verify/05-verify-quality.ps1`: an opt-in verify hook that runs a project's configured `test_command`/`lint_command` and blocks the `done` transition when either fails. Off by default (`quality_gate.enabled: false` in `content/settings/settings.default.json`) — a project opts in via its own settings override (e.g. `.bot/.control/settings.json`).
- Register the new script in `src/hooks/verify/config.json` (`core: false`, `required: false` — must stay optional since it's off by default).
- Bump `enter-done`'s `max_duration` from 120s to 600s so a real test suite has room to run once a project enables the gate.
- Document the new setting in `src/hooks/verify/README.md`.

Check commands run in a child `pwsh` process (not `Invoke-Expression` in-process) — same trust level as a CI yaml step, without touching the hook's own runspace.

## Screenshots / recordings

N/A — backend-only change, no UI.

## Testing notes

- Added `tests/Test-VerifyQuality.ps1` (19 assertions): disabled by default, enabled-but-unconfigured (no-op), passing test+lint, failing test only, failing lint only, test-only configuration.
- `tests/Test-VerifyQuality.ps1` — 19 passed, 0 failed
- `tests/Test-Structure.ps1` — 360 passed, 0 failed, 2 skipped
- `tests/Test-Hooks.ps1` — 51 passed, 0 failed
- `tests/Test-Components.ps1` — 851 passed, 0 failed, 1 skipped (pre-existing, unrelated skip)
- `tests/Test-ProcessDispatch.ps1` — 44 passed, 0 failed

## Checklist

- [x] Tests added or updated
- [x] Docs updated (if behaviour changed)
- [x] Linked issue exists
- [x] Follows the [contribution guide](https://github.com/andresharpe/dotbot/blob/main/CONTRIBUTING.md)



## Follow-up hardening

- #671 tracks quality-gate ordering, enforceable timeouts, and combined worktree integration coverage.
- #669 tracks the broader generic hook execution-context and project-root fallback work accepted with #642.

