### PR TITLE
test(hooks): canonicalize CWD paths across platforms

### DIFF
--- a/tests/Test-Hooks.ps1
+++ b/tests/Test-Hooks.ps1
@@ -443,6 +443,32 @@ function Invoke-EnterDoneOutOfProcess {
     try { return ($out -join "`n") | ConvertFrom-Json -ErrorAction Stop } catch { return $null }
 }
 
+function Resolve-Issue628CanonicalPath {
+    # Compare filesystem locations rather than their textual aliases.
+    # Get-Item expands Windows short-name segments where supported. On POSIX,
+    # pwd -P follows symlinked path components (notably macOS
+    # /var -> /private/var) to match the cwd reported by child pwsh.
+    param([Parameter(Mandatory)] [string]$Path)
+
+    $resolved = (Resolve-Path -LiteralPath $Path -ErrorAction Stop).ProviderPath
+    if ($IsWindows) {
+        $resolved = (Get-Item -LiteralPath $resolved -ErrorAction Stop).FullName
+    } elseif ($IsMacOS -or $IsLinux) {
+        Push-Location -LiteralPath $resolved
+        try {
+            $physical = & /bin/pwd -P 2>$null
+            $physicalExit = $LASTEXITCODE
+        } finally {
+            Pop-Location
+        }
+        if ($physicalExit -eq 0 -and $physical) {
+            $resolved = ([string]$physical).Trim()
+        }
+    }
+
+    return [System.IO.Path]::TrimEndingDirectorySeparator($resolved)
+}
+
 function Assert-VerifyCwdMarker {
     # Asserts the whole verify chain (all 5 stubs) ran in exactly $ExpectedDir.
     param(
@@ -452,10 +478,12 @@ function Assert-VerifyCwdMarker {
     )
     $lines = if (Test-Path -LiteralPath $MarkerFile) { @(Get-Content -LiteralPath $MarkerFile) } else { @() }
     Assert-Equal -Name "$Name`: verify chain ran (5 stub hooks recorded cwd)" -Expected 5 -Actual $lines.Count
-    Assert-Equal -Name "$Name`: verify chain cwd" -Expected $ExpectedDir -Actual ($lines | Select-Object -First 1) `
-        -Message "Expected every stub to run in '$ExpectedDir', got: $($lines -join ', ')"
+    $canonicalExpected = Resolve-Issue628CanonicalPath -Path $ExpectedDir
+    $canonicalLines = @($lines | ForEach-Object { Resolve-Issue628CanonicalPath -Path ([string]$_).Trim() })
+    Assert-Equal -Name "$Name`: verify chain cwd" -Expected $canonicalExpected -Actual ($canonicalLines | Select-Object -First 1) `
+        -Message "Expected every stub to run in '$ExpectedDir' ('$canonicalExpected' canonical), got: $($lines -join ', ')"
     Assert-True -Name "$Name`: cwd consistent across the whole chain" `
-        -Condition (@($lines | Select-Object -Unique).Count -eq 1)
+        -Condition (@($canonicalLines | Select-Object -Unique).Count -eq 1)
 }
 
 # --- Scenario 1: worktree registry entry exists and is valid → worktree_path wins


### PR DESCRIPTION
## Summary

- canonicalize expected and recorded verify-hook CWD paths before comparison
- use `pwd -P` on macOS/Linux so `/var/...` and `/private/var/...` resolve to the same physical directory
- use `Get-Item.FullName` on Windows to expand short-name aliases where supported
- preserve the five-marker, intended-directory, and single-consistent-CWD assertions

Closes #672.

## Validation

- `pwsh tests/Test-Hooks.ps1` — 71 passed
- `pwsh tests/Test-ProcessDispatch.ps1` — 44 passed
- `pwsh tests/Test-Structure.ps1` — 356 passed, 2 optional skips
- `pwsh tests/Run-Tests.ps1` — layers 1–3 all passed

This is intentionally limited to the #642 test regression; #669 remains separate.